### PR TITLE
Fix sgpr undefine naming.

### DIFF
--- a/tensilelite/Tensile/Components/SumUnroll.py
+++ b/tensilelite/Tensile/Components/SumUnroll.py
@@ -124,7 +124,7 @@ class SumUnrollMfma(SumUnroll):
         # Unregister defined sgpr
         if kernel["ProblemType"]["DataType"].numRegisters() < 1:
             if kernel["ProblemType"]["DataType"].isHalf():
-                imod.add(writer.undefineSgpr("SumUnrollConstOne"))
+                writer.undefineSgpr("SumUnrollConstOne")
 
         # bias data type
         diasBpe        = kernel["ProblemType"]["ComputeDataType"].numBytes()

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -353,10 +353,9 @@ class KernelWriterAssembly(KernelWriter):
 
   def undefineSgpr(self, name):
     self.sgprPool.checkIn(self.sgprs[name])
-    # later references will result in compile-time error (with odd 'error: expected relocatable expression')
-    # and 'Kernel ... not found in any loaded module'
-    # TODO: temporarily disable undef as it seems to have issues
-    return ValueSet(name=name, value="UNDEF", format = -1)
+    # undefine a sgpr string twice will cause compiler error.
+    # User must not add the UNDEF code module except it is the last one.
+    return ValueSet(name="sgpr"+name, value="UNDEF", format = -1)
 
   def defineVariableSgprs(self, kernel):
     #------------------------
@@ -3887,7 +3886,10 @@ class KernelWriterAssembly(KernelWriter):
       if regTag != lastRegTag:
         lastRegTag = regTag
         if self.sgprPool.pool[i].status == RegisterPool.Status.InUse:
-          module.add(self.undefineSgpr(regTag))
+          if label == "Summation_End_OptNLL":
+            self.undefineSgpr(regTag)
+          else:
+            module.add(self.undefineSgpr(regTag))
 
     if self.db["InitVgpr"] & 0x2:
       module.add(self.vgprPool.initTmps(self.consts.initVgprValue,start=0, stop=100))


### PR DESCRIPTION
1. Fix undefineSgpr function with correct naming.
2. Fix multiple UNDEF bug in kernel. We cannot write multiple UNDEF for the same string name. Remove the UNDEF if it is not the last one.