### PR TITLE
Add rotating buffer

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -522,6 +522,10 @@ try
          value<bool>(&arg.print_kernel_info)->default_value(false),
          "Print solution, kernel name and solution index.")
 
+        ("block_count",
+         value<int32_t>(&arg.block_count)->default_value(1),
+         "Use rotating memory blocks for each iteration. Only works for api_method = 0.")
+
         ("help,h", "produces this help message")
 
         ("version", "Prints the version number");

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -522,9 +522,9 @@ try
          value<bool>(&arg.print_kernel_info)->default_value(false),
          "Print solution, kernel name and solution index.")
 
-        ("block_count",
-         value<int32_t>(&arg.block_count)->default_value(1),
-         "Use rotating memory blocks for each iteration. Only works for api_method = 0.")
+        ("rotating",
+         value<int32_t>(&arg.rotating)->default_value(0),
+         "Use rotating memory blocks for each iteration, size in MB. (Only supports GEMM + api_method c)")
 
         ("help,h", "produces this help message")
 
@@ -581,6 +581,14 @@ try
     else
     {
         hipblaslt_cerr << "Invalid algo method: " << algo_method_str << std::endl;
+        return 1;
+    }
+
+    // Unblock this after rotating supports all modes
+    if((arg.rotating > 0) && (api_method != 0 || arg.grouped_gemm))
+    {
+        hipblaslt_cerr << "Currently rotating buffer only supports GEMM + api_method c."
+                       << std::endl;
         return 1;
     }
 

--- a/clients/common/hipblaslt_arguments.cpp
+++ b/clients/common/hipblaslt_arguments.cpp
@@ -149,6 +149,7 @@ void Arguments::init()
     use_ext_setproblem = false;
     algo_method        = 0;
     use_user_args      = false;
+    block_count        = 1;
 
     print_solution_found = false;
 }

--- a/clients/common/hipblaslt_arguments.cpp
+++ b/clients/common/hipblaslt_arguments.cpp
@@ -149,7 +149,7 @@ void Arguments::init()
     use_ext_setproblem = false;
     algo_method        = 0;
     use_user_args      = false;
-    block_count        = 1;
+    rotating           = 0;
 
     print_solution_found = false;
 }

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -130,21 +130,19 @@ public:
     //!
     hipError_t transfer_from(const host_vector<T>& that, const int32_t block_count = 1)
     {
-        for (int32_t i_block = 0; i_block < block_count; i_block ++) {
-            // hipblaslt_cout << "---- DEBUG: hipMemcpy dst = " << m_data + i_block * this->nmemb() / block_count << ", size = " << this->nmemb() * sizeof(T) / block_count << "\n";
-            hipError_t status = hipMemcpy(m_data + i_block * this->nmemb() / block_count,
-                (const T*)that,
-                this->nmemb() * sizeof(T) / block_count,
-                this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
-            if (status != hipSuccess) {
+        for(int32_t i_block = 0; i_block < block_count; i_block++)
+        {
+            hipError_t status
+                = hipMemcpy(m_data + i_block * this->nmemb() / block_count,
+                            (const T*)that,
+                            this->nmemb() * sizeof(T) / block_count,
+                            this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
+            if(status != hipSuccess)
+            {
                 return status;
             }
         }
         return hipSuccess;
-        // return hipMemcpy(m_data,
-        //                  (const T*)that,
-        //                  this->nmemb() * sizeof(T),
-        //                  this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
 
     hipError_t memcheck() const

--- a/clients/include/device_vector.hpp
+++ b/clients/include/device_vector.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2023 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -128,12 +128,23 @@ public:
     //! @param that The host vector.
     //! @return the hip error.
     //!
-    hipError_t transfer_from(const host_vector<T>& that)
+    hipError_t transfer_from(const host_vector<T>& that, const int32_t block_count = 1)
     {
-        return hipMemcpy(m_data,
-                         (const T*)that,
-                         this->nmemb() * sizeof(T),
-                         this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
+        for (int32_t i_block = 0; i_block < block_count; i_block ++) {
+            // hipblaslt_cout << "---- DEBUG: hipMemcpy dst = " << m_data + i_block * this->nmemb() / block_count << ", size = " << this->nmemb() * sizeof(T) / block_count << "\n";
+            hipError_t status = hipMemcpy(m_data + i_block * this->nmemb() / block_count,
+                (const T*)that,
+                this->nmemb() * sizeof(T) / block_count,
+                this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
+            if (status != hipSuccess) {
+                return status;
+            }
+        }
+        return hipSuccess;
+        // return hipMemcpy(m_data,
+        //                  (const T*)that,
+        //                  this->nmemb() * sizeof(T),
+        //                  this->use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
     }
 
     hipError_t memcheck() const

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -145,11 +145,11 @@ struct Arguments
     bool                  norm_check_assert;
 
     // API related
-    bool use_ext;
-    bool use_ext_setproblem;
-    int  algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
-    bool use_user_args;
-    int32_t block_count;
+    bool    use_ext;
+    bool    use_ext_setproblem;
+    int     algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
+    bool    use_user_args;
+    int32_t rotating;
 
     // print
     bool print_solution_found;
@@ -234,6 +234,7 @@ struct Arguments
     OPER(use_ext_setproblem) SEP     \
     OPER(algo_method) SEP            \
     OPER(use_user_args) SEP          \
+    OPER(rotating) SEP               \
     OPER(print_solution_found) SEP   \
     OPER(print_kernel_info) SEP
 

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -149,6 +149,7 @@ struct Arguments
     bool use_ext_setproblem;
     int  algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
     bool use_user_args;
+    int32_t block_count;
 
     // print
     bool print_solution_found;

--- a/clients/include/hipblaslt_common.yaml
+++ b/clients/include/hipblaslt_common.yaml
@@ -193,6 +193,7 @@ Arguments:
   - use_ext_setproblem: c_bool
   - algo_method: c_int32
   - use_user_args: c_bool
+  - rotating: c_int32
   - print_solution_found: c_bool
   - print_kernel_info: c_bool
 
@@ -284,5 +285,6 @@ Defaults:
   use_ext_setproblem: false
   algo_method: 0
   use_user_args: false
+  rotating: 0
   print_solution_found: false
   print_kernel_info: false

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -923,4 +923,19 @@ namespace hipblaslt_ext
                                           hipblasLtMatrixLayout_t Ddesc,
                                           hipblasLtMatmulAlgo_t&  algo,
                                           size_t&                 workspaceSizeInBytes);
+
+    /*! \ingroup library_module
+     *  \brief Copy the settings from A matmul to B matmul.
+     *
+     *  @param[in]
+     *  src Source matmul.
+     *  @param[out]
+     *  dst Return the copied matmul content.
+     *
+     *  \retval HIPBLAS_STATUS_SUCCESS           If query was successful. The problem is
+     * supported by the algorithm.
+     * results. \retval HIPBLAS_STATUS_NOT_INITIALIZED Source or dest matmul not initialized.
+     */
+    HIPBLASLT_EXPORT
+    hipblasStatus_t copyMatmul(hipblasLtMatmulDesc_t src, hipblasLtMatmulDesc_t dst);
 } // End of namespace hipblasltext

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -933,4 +933,10 @@ namespace hipblaslt_ext
             (rocblaslt_handle)handle, algoIndex, *results));
     }
 
+    hipblasStatus_t copyMatmul(hipblasLtMatmulDesc_t src, hipblasLtMatmulDesc_t dst)
+    {
+        return RocBlasLtStatusToHIPStatus(
+            rocblaslt_copy_matmul((rocblaslt_matmul_desc)src, (rocblaslt_matmul_desc)dst));
+    }
+
 } // End of namespace hipblasltext

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
@@ -387,15 +387,17 @@ rocblaslt_status
                                      const int              requestedAlgoCount,
                                      std::vector<rocblaslt_matmul_heuristic_result>& results);
 
+rocblaslt_status rocblaslt_copy_matmul(rocblaslt_matmul_desc src, rocblaslt_matmul_desc dst);
+
 // for internal use during testing, fetch arch name
 std::string rocblaslt_internal_get_arch_name();
 
 // for internal use of testing existence of path
-bool rocblaslt_internal_test_path(const std::string &);
+bool rocblaslt_internal_test_path(const std::string&);
 
-std::string rocblaslt_internal_get_so_path(const std::string &keyword);
+std::string rocblaslt_internal_get_so_path(const std::string& keyword);
 
-void rocblaslt_log_error(const char *func, const char *var, const char *msg);
+void rocblaslt_log_error(const char* func, const char* var, const char* msg);
 #endif
 
 #endif /* _ROCBLASLT_AUXILIARY_H_ */

--- a/library/src/amd_detail/rocblaslt/src/include/handle.h
+++ b/library/src/amd_detail/rocblaslt/src/include/handle.h
@@ -160,6 +160,26 @@ struct _rocblaslt_matmul_desc
     hipblasltDatatype_t    scale_type;
 
     std::shared_ptr<void> m_data; // Tensile data
+
+    void copy(const _rocblaslt_matmul_desc& src)
+    {
+        this->op_A         = src.op_A;
+        this->op_B         = src.op_B;
+        this->epilogue     = src.epilogue;
+        this->bias         = src.bias;
+        this->scaleA       = src.scaleA;
+        this->scaleB       = src.scaleB;
+        this->scaleC       = src.scaleC;
+        this->scaleD       = src.scaleD;
+        this->scaleE       = src.scaleE;
+        this->pointermode  = src.pointermode;
+        this->bias_type    = src.bias_type;
+        this->e            = src.e;
+        this->lde          = src.lde;
+        this->stride_e     = src.stride_e;
+        this->compute_type = src.compute_type;
+        this->scale_type   = src.scale_type;
+    }
 };
 
 /********************************************************************************

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -481,7 +481,8 @@ rocblaslt_status rocblaslt_matrix_layout_get_attribute(rocblaslt_matrix_layout  
             switch(attr)
             {
             case ROCBLASLT_MATRIX_LAYOUT_BATCH_COUNT:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -490,7 +491,8 @@ rocblaslt_status rocblaslt_matrix_layout_get_attribute(rocblaslt_matrix_layout  
                 memcpy(buf, &matLayout->batch_count, sizeof(int32_t));
                 break;
             case ROCBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET:
-                if(sizeWritten) *sizeWritten = sizeof(int64_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int64_t);
                 if(sizeInBytes < sizeof(int64_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -842,7 +844,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
             switch(matmulAttr)
             {
             case ROCBLASLT_MATMUL_DESC_TRANSA:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -851,7 +854,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->op_A, sizeof(int32_t));
                 break;
             case ROCBLASLT_MATMUL_DESC_TRANSB:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -860,7 +864,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->op_B, sizeof(int32_t));
                 break;
             case ROCBLASLT_MATMUL_DESC_EPILOGUE:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -869,7 +874,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->epilogue, sizeof(int32_t));
                 break;
             case ROCBLASLT_MATMUL_DESC_BIAS_POINTER:
-                if(sizeWritten) *sizeWritten = sizeof(void*);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(void*);
                 if(sizeInBytes < sizeof(void*))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -878,7 +884,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->bias, sizeof(void*));
                 break;
             case ROCBLASLT_MATMUL_DESC_A_SCALE_POINTER:
-                if(sizeWritten) *sizeWritten = sizeof(void*);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(void*);
                 if(sizeInBytes < sizeof(void*))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -887,7 +894,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->scaleA, sizeof(void*));
                 break;
             case ROCBLASLT_MATMUL_DESC_B_SCALE_POINTER:
-                if(sizeWritten) *sizeWritten = sizeof(void*);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(void*);
                 if(sizeInBytes < sizeof(void*))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -896,7 +904,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->scaleB, sizeof(void*));
                 break;
             case ROCBLASLT_MATMUL_DESC_POINTER_MODE:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -905,7 +914,8 @@ rocblaslt_status rocblaslt_matmul_desc_get_attribute(rocblaslt_matmul_desc      
                 memcpy(buf, &matmulDesc->pointermode, sizeof(void*));
                 break;
             case ROCBLASLT_MATMUL_DESC_BIAS_DATA_TYPE:
-                if(sizeWritten) *sizeWritten = sizeof(int32_t);
+                if(sizeWritten)
+                    *sizeWritten = sizeof(int32_t);
                 if(sizeInBytes < sizeof(int32_t))
                 {
                     log_error(__func__, "invalid buf size", sizeInBytes);
@@ -1406,6 +1416,22 @@ rocblaslt_status
     return rocblaslt_status_success;
 }
 
+rocblaslt_status rocblaslt_copy_matmul(rocblaslt_matmul_desc src, rocblaslt_matmul_desc dst)
+{
+    if(src == nullptr)
+    {
+        log_error(__func__, "invalid src matmulDescr pointer", src);
+        return rocblaslt_status_invalid_pointer;
+    }
+    if(dst == nullptr)
+    {
+        log_error(__func__, "invalid dst matmulDescr pointer", dst);
+        return rocblaslt_status_invalid_pointer;
+    }
+    dst->copy(*src);
+    return rocblaslt_status_success;
+}
+
 /*******************************************************************************
  * GPU architecture-related functions
  ******************************************************************************/
@@ -1463,7 +1489,7 @@ std::string rocblaslt_internal_get_so_path(const std::string& keyword)
     return result.first;
 }
 
-void rocblaslt_log_error(const char *func, const char *var, const char *msg)
+void rocblaslt_log_error(const char* func, const char* var, const char* msg)
 {
     log_error(func, var, msg);
 }

--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -612,6 +612,7 @@ def writeClientConfigIni(problemSizes, biasTypeArgs, activationArgs, problemType
         param("library-update-comment",   globalParameters["LibraryUpdateComment"])
 
         param("use-user-args",            globalParameters["UseUserArgs"])
+        param("rotating-buffer-size",     globalParameters["RotatingBufferSize"])
 
 
 def writeClientConfig(forBenchmark, solutions, problemSizes, biasTypeArgs, activationArgs, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -270,6 +270,8 @@ globalParameters["LazyLibraryLoading"] = False # Load library and code object fi
 
 globalParameters["UseUserArgs"] = False
 
+globalParameters["RotatingBufferSize"] = 0 # Size in MB
+
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)
 

--- a/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
+++ b/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
@@ -348,6 +348,11 @@ namespace Tensile
                 return ConvertToProblemInputs(problem, true);
             }
 
+            std::vector<std::shared_ptr<ProblemInputs>>
+                prepareRotatingGPUOutput(int32_t                        maxRotatingBufferNum,
+                                         ContractionProblem const*      problem,
+                                         std::shared_ptr<ProblemInputs> inputs);
+
             template <typename S>
             void initArray(DataType dataType, InitMode initMode, void* array, S descriptor)
             {
@@ -977,6 +982,10 @@ namespace Tensile
             /// and must be reinitialized for each problem. Pristine copy on GPU
             /// cannot be used with problem dependent data.
             bool m_problemDependentData = false;
+
+            int64_t               m_rotatingBuffer        = 0;
+            int64_t               m_rotatingAllocatedSize = 0;
+            std::shared_ptr<void> m_rotatingPointer       = nullptr;
         };
 
         template <>


### PR DESCRIPTION
Auto calculated, only size in MB is needed.

### TensileLite
Supports groupedgemm/ gemm.

#### Usage
globalParameters["RotatingBufferSize"] # Size in MB

### hipBLASLt
Currently only supports gemm + api_method c only.

#### Usage
--rotating X (X is size in MB)

