### PR TITLE
Force GemmInstance move only

### DIFF
--- a/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
+++ b/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
@@ -26,6 +26,7 @@
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <iostream>
+#include <vector>
 
 #include "helper.h"
 

--- a/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
+++ b/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
@@ -26,7 +26,6 @@
 #include <hip/hip_runtime.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <iostream>
-#include <vector>
 
 #include "helper.h"
 

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -193,7 +193,11 @@ namespace hipblaslt_ext
     class GemmInstance
     {
     public:
-        virtual ~GemmInstance() {}
+        HIPBLASLT_EXPORT virtual ~GemmInstance();
+        HIPBLASLT_EXPORT GemmInstance(const GemmInstance &rhs);
+        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance &rhs);
+        HIPBLASLT_EXPORT GemmInstance(GemmInstance &&rhs);
+        HIPBLASLT_EXPORT GemmInstance& operator=(GemmInstance &&rhs);
 
         /*! \ingroup library_module
         *  \brief Retrieve the possible algorithms
@@ -303,9 +307,8 @@ namespace hipblaslt_ext
 
         hipblasLtHandle_t     m_handle;
         std::shared_ptr<void> m_data;
-        //                             src           dst           srcType              dstType              numElements  scale
-        using Conversions = std::tuple<HipBufferPtr, HipBufferPtr, hipblasltDatatype_t, hipblasltDatatype_t, std::size_t, HipBufferPtr>;
-        std::vector<std::vector<Conversions>> m_auxiliary_conversion_buffers;
+        struct ConversionHelper;
+        std::unique_ptr<ConversionHelper> m_conversion_helper;
     };
 
     /*! \ingroup types_module
@@ -381,6 +384,11 @@ namespace hipblaslt_ext
                                        hipblasLtMatrixLayout_t matC,
                                        void*                   D,
                                        hipblasLtMatrixLayout_t matD);
+
+        HIPBLASLT_EXPORT Gemm(const Gemm &);
+        HIPBLASLT_EXPORT Gemm(Gemm &&);
+        HIPBLASLT_EXPORT Gemm& operator=(const Gemm &);
+        HIPBLASLT_EXPORT Gemm& operator=(Gemm &&);
 
         /*! \ingroup library_module
         *  \brief Sets the problem for a gemm problem.
@@ -549,6 +557,10 @@ namespace hipblaslt_ext
                                               hipblasltDatatype_t    typeC,
                                               hipblasltDatatype_t    typeD,
                                               hipblasLtComputeType_t typeCompute);
+        HIPBLASLT_EXPORT GroupedGemm(const GroupedGemm &);
+        HIPBLASLT_EXPORT GroupedGemm(GroupedGemm &&);
+        HIPBLASLT_EXPORT GroupedGemm& operator=(const GroupedGemm &);
+        HIPBLASLT_EXPORT GroupedGemm& operator=(GroupedGemm &&);
 
         /*! \ingroup library_module
         *  \brief Constructor that sets the grouped gemm problem from hipblasLt structures

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -45,8 +45,8 @@
 
 namespace hipblaslt_ext
 {
-    using HipBufferDeleter = hipError_t(*)(void *);
-    using HipBufferPtr = std::unique_ptr<void, HipBufferDeleter>;
+    using HipBufferDeleter = hipError_t (*)(void*);
+    using HipBufferPtr     = std::unique_ptr<void, HipBufferDeleter>;
 
     /*! \ingroup types_module
      *  \brief It is an enumerated type used to specific the type of the gemm problem in hipblasLtExt APIs.
@@ -194,10 +194,10 @@ namespace hipblaslt_ext
     {
     public:
         HIPBLASLT_EXPORT virtual ~GemmInstance();
-        HIPBLASLT_EXPORT GemmInstance(const GemmInstance &rhs);
-        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance &rhs);
-        HIPBLASLT_EXPORT GemmInstance(GemmInstance &&rhs);
-        HIPBLASLT_EXPORT GemmInstance& operator=(GemmInstance &&rhs);
+        HIPBLASLT_EXPORT               GemmInstance(const GemmInstance& rhs) = delete;
+        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance& rhs)    = delete;
+        HIPBLASLT_EXPORT               GemmInstance(GemmInstance&& rhs) noexcept;
+        HIPBLASLT_EXPORT GemmInstance& operator=(GemmInstance&& rhs) noexcept;
 
         /*! \ingroup library_module
         *  \brief Retrieve the possible algorithms
@@ -385,10 +385,10 @@ namespace hipblaslt_ext
                                        void*                   D,
                                        hipblasLtMatrixLayout_t matD);
 
-        HIPBLASLT_EXPORT Gemm(const Gemm &);
-        HIPBLASLT_EXPORT Gemm(Gemm &&);
-        HIPBLASLT_EXPORT Gemm& operator=(const Gemm &);
-        HIPBLASLT_EXPORT Gemm& operator=(Gemm &&);
+        HIPBLASLT_EXPORT       Gemm(const Gemm&) = delete;
+        HIPBLASLT_EXPORT       Gemm(Gemm&&) noexcept;
+        HIPBLASLT_EXPORT Gemm& operator=(const Gemm&) = delete;
+        HIPBLASLT_EXPORT Gemm& operator=(Gemm&&) noexcept;
 
         /*! \ingroup library_module
         *  \brief Sets the problem for a gemm problem.
@@ -557,10 +557,10 @@ namespace hipblaslt_ext
                                               hipblasltDatatype_t    typeC,
                                               hipblasltDatatype_t    typeD,
                                               hipblasLtComputeType_t typeCompute);
-        HIPBLASLT_EXPORT GroupedGemm(const GroupedGemm &);
-        HIPBLASLT_EXPORT GroupedGemm(GroupedGemm &&);
-        HIPBLASLT_EXPORT GroupedGemm& operator=(const GroupedGemm &);
-        HIPBLASLT_EXPORT GroupedGemm& operator=(GroupedGemm &&);
+        HIPBLASLT_EXPORT              GroupedGemm(const GroupedGemm&) = delete;
+        HIPBLASLT_EXPORT              GroupedGemm(GroupedGemm&&) noexcept;
+        HIPBLASLT_EXPORT GroupedGemm& operator=(const GroupedGemm&) = delete;
+        HIPBLASLT_EXPORT GroupedGemm& operator=(GroupedGemm&&) noexcept;
 
         /*! \ingroup library_module
         *  \brief Constructor that sets the grouped gemm problem from hipblasLt structures

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -193,57 +193,12 @@ namespace hipblaslt_ext
             }
         }
 
-        ~ConversionHelper() = default;
-
-        ConversionHelper(const ConversionHelper& rhs)
-        {
-            const auto numGemms = rhs.m_auxiliary_conversion_buffers.size();
-
-            if(m_auxiliary_conversion_buffers.size() != numGemms)
-            {
-                m_auxiliary_conversion_buffers.resize(numGemms);
-            }
-
-            for(std::size_t j = 0; j < m_auxiliary_conversion_buffers.size(); ++j)
-            {
-                auto& srcConversions = rhs.m_auxiliary_conversion_buffers.at(j);
-                auto& dstConversions = m_auxiliary_conversion_buffers.at(j);
-                dstConversions.clear();
-
-                //inputs
-                for(std::size_t i = 0; i < 3; ++i)
-                {
-                    auto& srcConversion = srcConversions.at(i);
-                    auto  srcPtr        = std::get<0>(srcConversion).get();
-                    auto  dstNumBytes   = std::get<4>(srcConversion) * 2;
-                    dstConversions.emplace_back(std::make_tuple(
-                        std::move(HipBufferPtr(srcPtr, NullDeleter)),
-                        std::move(makeHipBuffer(dstNumBytes)),
-                        std::get<2>(srcConversion),
-                        std::get<3>(srcConversion),
-                        std::get<4>(srcConversion),
-                        std::move(HipBufferPtr(std::get<5>(srcConversion).get(), NullDeleter))));
-                }
-
-                //outputs
-                for(std::size_t i = 3; i < srcConversions.size(); ++i)
-                {
-                    auto& srcConversion = srcConversions.at(i);
-                    auto  dstPtr        = std::get<1>(srcConversion).get();
-                    auto  srcNumBytes   = std::get<4>(srcConversion) * 2;
-                    dstConversions.emplace_back(std::make_tuple(
-                        std::move(makeHipBuffer(srcNumBytes)),
-                        std::move(HipBufferPtr(dstPtr, NullDeleter)),
-                        std::get<2>(srcConversion),
-                        std::get<3>(srcConversion),
-                        std::get<4>(srcConversion),
-                        std::move(HipBufferPtr(std::get<5>(srcConversion).get(), NullDeleter))));
-                }
-            }
-        }
-
-        //We should not use this internally.
+        ~ConversionHelper()                               = default;
+        ConversionHelper(ConversionHelper&& rhs) noexcept = default;
+        //force move
+        ConversionHelper(const ConversionHelper& rhs)        = delete;
         ConversionHelper& operator=(const ConversionHelper&) = delete;
+        ConversionHelper& operator=(ConversionHelper&&)      = default;
 
         void convertInputs(hipStream_t stream)
         {
@@ -344,39 +299,8 @@ namespace hipblaslt_ext
     }
 
     GemmInstance::~GemmInstance() {}
-
-    GemmInstance::GemmInstance(const GemmInstance& rhs)
-    {
-        m_gemm_type     = rhs.m_gemm_type;
-        m_gemm_count    = rhs.m_gemm_count;
-        m_problem_types = rhs.m_problem_types;
-        m_data          = rhs.m_data;
-
-        if(rhs.m_conversion_helper)
-        {
-            m_conversion_helper = std::make_unique<ConversionHelper>(*rhs.m_conversion_helper);
-        }
-    }
-
-    GemmInstance& GemmInstance::operator=(const GemmInstance& rhs)
-    {
-        if (this != &rhs) {
-            m_gemm_type     = rhs.m_gemm_type;
-            m_gemm_count    = rhs.m_gemm_count;
-            m_problem_types = rhs.m_problem_types;
-            m_data          = rhs.m_data;
-
-            if(rhs.m_conversion_helper)
-            {
-                m_conversion_helper = std::make_unique<ConversionHelper>(*rhs.m_conversion_helper);
-            }
-        }
-
-        return *this;
-    }
-
-    GemmInstance::GemmInstance(GemmInstance&& rhs)            = default;
-    GemmInstance& GemmInstance::operator=(GemmInstance&& rhs) = default;
+    GemmInstance::GemmInstance(GemmInstance&& rhs) noexcept            = default;
+    GemmInstance& GemmInstance::operator=(GemmInstance&& rhs) noexcept = default;
 
     GemmType GemmInstance::getGemmType()
     {
@@ -517,10 +441,8 @@ namespace hipblaslt_ext
         }
     }
 
-    Gemm::Gemm(const Gemm&)            = default;
-    Gemm::Gemm(Gemm&&)                 = default;
-    Gemm& Gemm::operator=(const Gemm&) = default;
-    Gemm& Gemm::operator=(Gemm&&)      = default;
+    Gemm::Gemm(Gemm&&) noexcept            = default;
+    Gemm& Gemm::operator=(Gemm&&) noexcept = default;
 
     hipblasStatus_t Gemm::setProblem(int64_t       m,
                                      int64_t       n,
@@ -718,10 +640,8 @@ namespace hipblaslt_ext
                                 m_data);
     }
 
-    GroupedGemm::GroupedGemm(const GroupedGemm&)            = default;
-    GroupedGemm::GroupedGemm(GroupedGemm&&)                 = default;
-    GroupedGemm& GroupedGemm::operator=(const GroupedGemm&) = default;
-    GroupedGemm& GroupedGemm::operator=(GroupedGemm&&)      = default;
+    GroupedGemm::GroupedGemm(GroupedGemm&&) noexcept            = default;
+    GroupedGemm& GroupedGemm::operator=(GroupedGemm&&) noexcept = default;
 
     HIPBLASLT_EXPORT GroupedGemm::GroupedGemm(hipblasLtHandle_t                     handle,
                                               std::vector<hipblasLtMatmulDesc_t>&   matmul_descr,

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -195,7 +195,7 @@ namespace hipblaslt_ext
 
         ~ConversionHelper() = default;
 
-        ConversionHelper(ConversionHelper& rhs)
+        ConversionHelper(const ConversionHelper& rhs)
         {
             const auto numGemms = rhs.m_auxiliary_conversion_buffers.size();
 
@@ -360,14 +360,16 @@ namespace hipblaslt_ext
 
     GemmInstance& GemmInstance::operator=(const GemmInstance& rhs)
     {
-        m_gemm_type     = rhs.m_gemm_type;
-        m_gemm_count    = rhs.m_gemm_count;
-        m_problem_types = rhs.m_problem_types;
-        m_data          = rhs.m_data;
+        if (this != &rhs) {
+            m_gemm_type     = rhs.m_gemm_type;
+            m_gemm_count    = rhs.m_gemm_count;
+            m_problem_types = rhs.m_problem_types;
+            m_data          = rhs.m_data;
 
-        if(rhs.m_conversion_helper)
-        {
-            m_conversion_helper = std::make_unique<ConversionHelper>(*rhs.m_conversion_helper);
+            if(rhs.m_conversion_helper)
+            {
+                m_conversion_helper = std::make_unique<ConversionHelper>(*rhs.m_conversion_helper);
+            }
         }
 
         return *this;


### PR DESCRIPTION
## Brief ##
Make `GemmInstance` and its derives move only.

## Details ##
The auto-conversion feature for gfx90a makes the `GemmInstance` non-copyable, this PR adds
 - Refactored conversion details to `ConversionHelper`
 - Forced `GemmInstance` and its derives to use their move constructor, this makes compiler generates move only codes.