### PR TITLE
fix make package errors

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -133,7 +133,7 @@ def getAssemblyCodeObjectFiles(kernels, kernelWriterAssembly, outputPath):
             splitFiles = 10000
             if numOfObjectFiles > splitFiles:
               slicedObjectFilesList = [objectFiles[x:x+splitFiles] for x in range(0, numOfObjectFiles, splitFiles)]
-              objectFileBasename = os.path.splitext(coFile)[0]
+              objectFileBasename = os.path.split(coFile)[-1].split('.')[0]
               numOfOneSliceOfObjectFiles = int(math.ceil(numOfObjectFiles / splitFiles))
               newObjectFiles = [ objectFileBasename + "_" + str(i) + ".o" for i in range(0, numOfOneSliceOfObjectFiles)]
               newObjectFilesOutput = []


### PR DESCRIPTION
caused by [Fix too much kernels cause clang++ unable to create .co files](https://github.com/ROCmSoftwarePlatform/hipBLASLt/pull/415/commits/a40563214c7f5dca3990296e0596268c7b39383e)
Solution: put temp .o files into temp folder but not library dest folder.