### PR TITLE
Add option for gpu kernel time

### DIFF
--- a/clients/benchmarks/README.md
+++ b/clients/benchmarks/README.md
@@ -67,6 +67,7 @@ cd hipBLASLt; cd build/release
 --api_method <value>       Use extension API. c: C style API. mix: declaration with C hipblasLtMatmul Layout/Desc but set, initialize, and run the problem with C++ extension API. cpp: Using C++ extension API only. Options: c, mix, cpp.  (Default value is: c)
 --print_kernel_info        Print solution, kernel name and solution index.
 --rotating <value>         Use rotating memory blocks for each iteration, size in MB.                          (Default value is: 0)
+--use_gpu_timer            Use hipEventElapsedTime to profile elapsed time.                                    (Default value is: false)
 --splitk <value>           [Tuning parameter] Set split K for a solution, 0 is use solution's default value. (Only support GEMM + api_method mix or cpp)
 --help |-h                 produces this help message
 --version <value>          Prints the version number

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -527,6 +527,10 @@ try
          value<int32_t>(&arg.rotating)->default_value(0),
          "Use rotating memory blocks for each iteration, size in MB.")
 
+        ("use_gpu_timer",
+         value<bool>(&arg.use_gpu_timer)->default_value(false),
+         "Whether to use hipEventElapsedTime or not.")
+
         ("splitk",
          valueVec<uint32_t>(&gsu_vector),
          "[Tuning parameter] Set split K for a solution, 0 is use solution's default value. (Only support GEMM + api_method mix or cpp)")

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -529,7 +529,7 @@ try
 
         ("use_gpu_timer",
          value<bool>(&arg.use_gpu_timer)->default_value(false),
-         "Whether to use hipEventElapsedTime or not.")
+         "Use hipEventElapsedTime to profile elapsed time.")
 
         ("splitk",
          valueVec<uint32_t>(&gsu_vector),

--- a/clients/common/hipblaslt_arguments.cpp
+++ b/clients/common/hipblaslt_arguments.cpp
@@ -150,6 +150,7 @@ void Arguments::init()
     algo_method        = 0;
     use_user_args      = false;
     rotating           = 0;
+    use_gpu_timer      = false;
 
     // tuning
     gsu_vector[0] = 0;

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -150,6 +150,7 @@ struct Arguments
     int     algo_method; // 0 for getheuristic, 1 for get all algos, 2 for algo index
     bool    use_user_args;
     int32_t rotating;
+    bool use_gpu_timer;
 
     // tuning
     int32_t gsu_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
@@ -238,6 +239,7 @@ struct Arguments
     OPER(algo_method) SEP            \
     OPER(use_user_args) SEP          \
     OPER(rotating) SEP               \
+    OPER(use_gpu_timer) SEP          \
     OPER(gsu_vector) SEP             \
     OPER(print_solution_found) SEP   \
     OPER(print_kernel_info) SEP

--- a/clients/include/hipblaslt_common.yaml
+++ b/clients/include/hipblaslt_common.yaml
@@ -199,6 +199,7 @@ Arguments:
   - algo_method: c_int32
   - use_user_args: c_bool
   - rotating: c_int32
+  - use_gpu_timer: c_bool
   - gsu_vector: c_int32*32
   - print_solution_found: c_bool
   - print_kernel_info: c_bool
@@ -292,6 +293,7 @@ Defaults:
   algo_method: 0
   use_user_args: false
   rotating: 0
+  use_gpu_timer: false
   gsu_vector: 0
   print_solution_found: false
   print_kernel_info: false

--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -110,6 +110,7 @@ For more information:
    --api_method <value>       Use extension API. c: C style API. mix: declaration with C hipblasLtMatmul Layout/Desc but set, initialize, and run the problem with C++ extension API. cpp: Using C++ extension API only. Options: c, mix, cpp.  (Default value is: c)
    --print_kernel_info        Print solution, kernel name and solution index.
    --rotating <value>         Use rotating memory blocks for each iteration, size in MB.                          (Default value is: 0)
+   --use_gpu_timer            Use hipEventElapsedTime to profile elapsed time.                                    (Default value is: false)
    --splitk <value>           [Tuning parameter] Set split K for a solution, 0 is use solution's default value. (Only support GEMM + api_method mix or cpp)
    --help |-h                 produces this help message
    --version <value>          Prints the version number


### PR DESCRIPTION
From: https://ontrack-internal.amd.com/browse/SWDEV-430621
Instead of using cpu time to measure kernel elapsed time, use gpu timer hipEventElapsedTime.
Add user option --use_gpu_timer to enable this new feature or not.