### PR TITLE
add log level bench

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ HIPBLASLT_LOG_LEVEL=<level> - while level is one of the following levels:
 |"5" - API Trace - API calls will log their parameter and important information                                    |
 +------------------------------------------------------------------------------------------------------------------+
 
-HIPLASLT_LOG_MASK=<mask> - while mask is a combination of the following masks:
+HIPBLASLT_LOG_MASK=<mask> - while mask is a combination of the following masks:
 
 +-----------------+
 |"0" - Off        |
@@ -64,6 +64,8 @@ HIPLASLT_LOG_MASK=<mask> - while mask is a combination of the following masks:
 |"8" - Info       |
 +-----------------+
 |"16" - API Trace |
++-----------------+
+|"32" - Bench     |
 +-----------------+
 
 HIPBLASLT_LOG_FILE=<file_name> - while file name is a path to a logging file. File name may contain %i, that will be replaced with the process ID. For example, "<file_name>_%i.log".

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
@@ -196,6 +196,7 @@ typedef enum rocblaslt_layer_mode
     rocblaslt_layer_mode_log_hints = 4, /**< layer is in hints mode. */
     rocblaslt_layer_mode_log_info  = 8, /**< layer is in info mode. */
     rocblaslt_layer_mode_log_api   = 16, /**< layer is in api mode. */
+    rocblaslt_layer_mode_log_bench = 32, /**< layer is in bench mode. */
 } rocblaslt_layer_mode;
 
 /*! \ingroup types_module

--- a/library/src/amd_detail/rocblaslt/src/include/handle.h
+++ b/library/src/amd_detail/rocblaslt/src/include/handle.h
@@ -157,7 +157,7 @@ struct _rocblaslt_matmul_desc
     int64_t stride_e = 0;
     //
     rocblaslt_compute_type compute_type;
-    hipblasltDatatype_t    scale_type;
+    hipblasltDatatype_t    scale_type = HIPBLASLT_DATATYPE_INVALID;
 
     std::shared_ptr<void> m_data; // Tensile data
 

--- a/library/src/amd_detail/rocblaslt/src/include/logging.h
+++ b/library/src/amd_detail/rocblaslt/src/include/logging.h
@@ -255,54 +255,39 @@ private:
 
 template <typename T, typename... Ts>
 inline void log_arg_data(std::ostream& os, std::string& separator, T& x, Ts&&... xs);
-template <typename T, typename... Ts>
-inline void log_arg_head(std::ostream& os, std::string& separator, T& x, Ts&&... xs);
 
-inline void log_arg_data(std::ostream& os, std::string& separator) {}
-inline void log_arg_head(std::ostream& os, std::string& separator) {}
-
-template <typename T>
-inline void log_arg_head(std::ostream& os, std::string& separator, T& x)
-{
-    os << x;
-}
-template <typename T>
-inline void log_arg_data(std::ostream& os, std::string& separator, T& x)
-{
-    os << "=" << x << separator;
-}
 template <typename T, typename... Ts>
 inline void log_arg_head(std::ostream& os, std::string& separator, T& x, Ts&&... xs)
 {
     os << x;
-    log_arg_data(os, separator, xs...);
+    if constexpr (sizeof...(xs)) log_arg_data(os, separator, xs...);
 }
+
 template <typename T, typename... Ts>
 inline void log_arg_data(std::ostream& os, std::string& separator, T& x, Ts&&... xs)
 {
     os << "=" << x << separator;
-    log_arg_head(os, separator, xs...);
+    if constexpr (sizeof...(xs)) log_arg_head(os, separator, xs...);
 }
+
 template <typename H, typename... Ts>
 void log_arguments(
     std::ostream& os, std::string& separator, std::string& prefix, H head, Ts&&... xs)
 {
     os << prefix << " " << head;
-    log_arg_data(os, separator, xs...);
+    if constexpr (sizeof...(xs)) log_arg_data(os, separator, xs...);
     os << "\n";
 }
 
-template <typename H, typename T, typename... Ts>
-void log_bench_arguments(std::ostream& os, H head, T& x, Ts&&... xs)
+template <typename T, typename... Ts>
+void log_arguments_bench(std::ostream& os, T& x, Ts&&... xs)
 {
     if constexpr (std::is_same_v<T, const char*>) {
-        if (x != "Invalid")
-            os << head << " " << x << " " ;
+        if (strlen(x)) os << x << " ";
+    } else {
+        os << x << " ";
     }
-    else
-        os << head << " " << x << " " ;
-    if constexpr (sizeof...(xs))
-        log_bench_arguments(os, xs...);
+    if constexpr (sizeof...(xs)) log_arguments_bench(os, xs...);
 }
 
 

--- a/library/src/amd_detail/rocblaslt/src/include/logging.h
+++ b/library/src/amd_detail/rocblaslt/src/include/logging.h
@@ -291,6 +291,21 @@ void log_arguments(
     log_arg_data(os, separator, xs...);
     os << "\n";
 }
+
+template <typename H, typename T, typename... Ts>
+void log_bench_arguments(std::ostream& os, H head, T& x, Ts&&... xs)
+{
+    if constexpr (std::is_same_v<T, const char*>) {
+        if (x != "Invalid")
+            os << head << " " << x << " " ;
+    }
+    else
+        os << head << " " << x << " " ;
+    if constexpr (sizeof...(xs))
+        log_bench_arguments(os, xs...);
+}
+
+
 /**
  * @brief Logging function
  *

--- a/library/src/amd_detail/rocblaslt/src/include/logging.h
+++ b/library/src/amd_detail/rocblaslt/src/include/logging.h
@@ -283,8 +283,9 @@ template <typename T, typename... Ts>
 void log_arguments_bench(std::ostream& os, T& x, Ts&&... xs)
 {
     if constexpr (std::is_same_v<T, const char*>) {
-        if (strlen(x)) os << x << " ";
-    } else {
+        if (strlen(x) && strcmp(x, "invalid")) os << x << " ";
+    }
+    else {
         os << x << " ";
     }
     if constexpr (sizeof...(xs)) log_arguments_bench(os, xs...);

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -141,13 +141,19 @@ std::string prefix(const char* layer, const char* caller);
 
 const char* hipblasltDatatype_to_string(hipblasltDatatype_t type);
 
+const char* hipblasltDatatype_to_bench_string(hipblasltDatatype_t type);
+
 const char* rocblaslt_compute_type_to_string(rocblaslt_compute_type type);
+
+const char* rocblaslt_compute_type_to_bench_string(rocblaslt_compute_type type);
 
 const char* rocblaslt_matrix_layout_attributes_to_string(rocblaslt_matrix_layout_attribute_ type);
 
 const char* rocblaslt_matmul_desc_attributes_to_string(rocblaslt_matmul_desc_attributes type);
 
 const char* hipblasOperation_to_string(hipblasOperation_t op);
+
+const char* hipblasOperation_to_bench_string(hipblasOperation_t op);
 
 const char* rocblaslt_layer_mode2string(rocblaslt_layer_mode layer_mode);
 
@@ -236,29 +242,19 @@ void log_api(const char* func, H head, Ts&&... xs)
 {
     log_base(rocblaslt_layer_mode_log_api, func, head, std::forward<Ts>(xs)...);
 }
+
 // if bench logging is turned on with
 // (handle->layer_mode & rocblaslt_layer_mode_log_bench) == true
 // then
 // log_bench will call log_arguments to log a string that
 // can be input to the executable rocblaslt-bench.
-template <typename H, typename... Ts>
-void log_bench(const char* func, H head, std::string precision, Ts&&... xs)
+template <typename... Ts>
+void log_bench(const char* func, Ts&&... xs)
 {
-    // TODO
-    // if(nullptr != handle && nullptr != handle->log_bench_os)
-    //{
-    //    if(handle->log_bench)
-    //    {
-    //        std::string comma_separator = " ";
-
-    //        std::ostream* os = handle->log_bench_os;
-
-    //        std::string prefix_str = prefix("Bench", func);
-
-    //        log_arguments(*os, comma_separator, prefix_str, head,
-    //        std::forward<Ts>(xs)...);
-    //    }
-    //}
+    std::ostream* os = get_logger_os();
+    *os << "hipblaslt-bench ";
+    log_bench_arguments(*os, std::forward<Ts>(xs)...);
+    *os << std::endl;
 }
 // Convert the current C++ exception to rocblaslt_status
 // This allows extern "C" functions to return this function in a catch(...)

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -159,6 +159,8 @@ const char* rocblaslt_layer_mode2string(rocblaslt_layer_mode layer_mode);
 
 const char* rocblaslt_epilogue_to_string(rocblaslt_epilogue epilogue);
 
+const char* rocblaslt_epilogue_to_bench_string(rocblaslt_epilogue epilogue);
+
 std::string rocblaslt_matrix_layout_to_string(rocblaslt_matrix_layout mat);
 
 std::string rocblaslt_matmul_desc_to_string(rocblaslt_matmul_desc matmul_desc);
@@ -253,7 +255,7 @@ void log_bench(const char* func, Ts&&... xs)
 {
     std::ostream* os = get_logger_os();
     *os << "hipblaslt-bench ";
-    log_bench_arguments(*os, std::forward<Ts>(xs)...);
+    log_arguments_bench(*os, std::forward<Ts>(xs)...);
     *os << std::endl;
 }
 // Convert the current C++ exception to rocblaslt_status

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -200,7 +200,7 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
 
 // To deal with some arguments may be invalid
 #define GEN_BENCH_ARG(_fun, _type_str, _type) \
-    strlen(_fun(_type)) ? _type_str : "", \
+    strlen(_fun(_type)) && strcmp(_fun(_type), "invalid") ? _type_str : "", \
     _fun(_type)
 
         log_bench(__func__,

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -197,12 +197,18 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
                                         workspaceSizeInBytes,
                                         stream};
     if (get_logger_layer_mode() & rocblaslt_layer_mode_log_bench) {
+
+// To deal with some arguments may be invalid
+#define GEN_BENCH_ARG(_fun, _type_str, _type) \
+    strlen(_fun(_type)) ? _type_str : "", \
+    _fun(_type)
+
         log_bench(__func__,
-                  "--sizem",
+                  "-m",
                   m,
-                  "--sizen",
+                  "-n",
                   n,
-                  "--sizek",
+                  "-k",
                   k,
                   "--lda",
                   lda,
@@ -228,30 +234,29 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
                   *(float*)alpha,
                   "--beta",
                   *(float*)beta,
-                  "--a_type",
-                  hipblasltDatatype_to_bench_string(type_a),
-                  "--b_type",
-                  hipblasltDatatype_to_bench_string(type_b),
-                  "--c_type",
-                  hipblasltDatatype_to_bench_string(type_c),
-                  "--d_type",
-                  hipblasltDatatype_to_bench_string(type_d),
-                  "--compute_type",
-                  rocblaslt_compute_type_to_bench_string(compute_type),
-                  "--scale_type",
-                  hipblasltDatatype_to_bench_string(scale_type),
                   "--transA",
                   hipblasOperation_to_bench_string(opA),
                   "--transB",
                   hipblasOperation_to_bench_string(opB),
                   "--batch_count",
                   num_batches_a,
-                  "--bias_type",
-                  hipblasltDatatype_to_bench_string(bias_type),
-                  "--grouped_gemm",
-                  grouped_gemm,
-                  "--scaleAlpha_vector",
-                  scaleAlphaVec);
+                  grouped_gemm ? "--grouped_gemm" : "",
+                  scaleA ? "--scaleA" : "",
+                  scaleB ? "--scaleB" : "",
+                  scaleC ? "--scaleC" : "",
+                  scaleD ? "--scaleD" : "",
+                  scaleAlphaVec ? "--scaleAlpha_vector" : "",
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--a_type", type_a),
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--b_type", type_b),
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--c_type", type_c),
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--d_type", type_d),
+                  GEN_BENCH_ARG(rocblaslt_compute_type_to_bench_string, "--compute_type", compute_type),
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--scale_type", scale_type),
+                  GEN_BENCH_ARG(hipblasltDatatype_to_bench_string, "--bias_type", bias_type),
+                  rocblaslt_epilogue_to_bench_string(epilogue));
+
+#undef GEN_BENCH_ARG
+
     }
     return runContractionProblem(handle, algo, problem, gemmData);
 }

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -101,15 +101,16 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
         return isValid;
 
     // Internal assign
-    hipblasOperation_t opA           = matmul_descr->op_A;
-    hipblasOperation_t opB           = matmul_descr->op_B;
-    int                num_batches_a = matA->batch_count;
-    rocblaslt_epilogue epilogue      = matmul_descr->epilogue;
-    void*              scaleA        = matmul_descr->scaleA;
-    void*              scaleB        = matmul_descr->scaleB;
-    void*              scaleC        = matmul_descr->scaleC;
-    void*              scaleD        = matmul_descr->scaleD;
-    void*              scaleE        = matmul_descr->scaleE;
+    hipblasOperation_t  opA           = matmul_descr->op_A;
+    hipblasOperation_t  opB           = matmul_descr->op_B;
+    int                 num_batches_a = matA->batch_count;
+    rocblaslt_epilogue  epilogue      = matmul_descr->epilogue;
+    void*               scaleA        = matmul_descr->scaleA;
+    void*               scaleB        = matmul_descr->scaleB;
+    void*               scaleC        = matmul_descr->scaleC;
+    void*               scaleD        = matmul_descr->scaleD;
+    void*               scaleE        = matmul_descr->scaleE;
+    hipblasltDatatype_t scale_type    = matmul_descr->scale_type;
 
     // Others
     bool strided_batch = true;
@@ -195,54 +196,61 @@ rocblaslt_status rocblaslt_matmul_impl(const rocblaslt_handle       handle,
                                         workspace,
                                         workspaceSizeInBytes,
                                         stream};
-    if(get_logger_layer_mode() != rocblaslt_layer_mode_none)
-    {
-        log_trace(__func__,
-                  "transA",
-                  opA == HIPBLAS_OP_N ? "N" : "T",
-                  "transB",
-                  opB == HIPBLAS_OP_N ? "N" : "T",
-                  "batch_count",
-                  num_batches_a,
-                  "m",
+    if (get_logger_layer_mode() & rocblaslt_layer_mode_log_bench) {
+        log_bench(__func__,
+                  "--sizem",
                   m,
-                  "n",
+                  "--sizen",
                   n,
-                  "k",
+                  "--sizek",
                   k,
-                  "alpha",
-                  alpha,
-                  "type_a",
-                  type_a,
-                  "lda",
+                  "--lda",
                   lda,
-                  "batch_stride_a",
-                  batch_stride_a,
-                  "type_b",
-                  type_b,
-                  "ldb",
+                  "--ldb",
                   ldb,
-                  "batch_stride_b",
-                  batch_stride_b,
-                  "beta",
-                  beta,
-                  "type_c",
-                  type_c,
-                  "ldc",
+                  "--ldc",
                   ldc,
-                  "batch_stride_c",
-                  batch_stride_c,
-                  "type_d",
-                  type_d,
-                  "ldd",
+                  "--ldd",
                   ldd,
-                  "grouped_gemm",
+                  "--lde",
+                  lde,
+                  "--stride_a",
+                  batch_stride_a,
+                  "--stride_b",
+                  batch_stride_b,
+                  "--stride_c",
+                  batch_stride_c,
+                  "--stride_d",
+                  batch_stride_d,
+                  "--stride_e",
+                  batch_stride_e,
+                  "--alpha",
+                  *(float*)alpha,
+                  "--beta",
+                  *(float*)beta,
+                  "--a_type",
+                  hipblasltDatatype_to_bench_string(type_a),
+                  "--b_type",
+                  hipblasltDatatype_to_bench_string(type_b),
+                  "--c_type",
+                  hipblasltDatatype_to_bench_string(type_c),
+                  "--d_type",
+                  hipblasltDatatype_to_bench_string(type_d),
+                  "--compute_type",
+                  rocblaslt_compute_type_to_bench_string(compute_type),
+                  "--scale_type",
+                  hipblasltDatatype_to_bench_string(scale_type),
+                  "--transA",
+                  hipblasOperation_to_bench_string(opA),
+                  "--transB",
+                  hipblasOperation_to_bench_string(opB),
+                  "--batch_count",
+                  num_batches_a,
+                  "--bias_type",
+                  hipblasltDatatype_to_bench_string(bias_type),
+                  "--grouped_gemm",
                   grouped_gemm,
-                  "compute_type",
-                  compute_type,
-                  "bias",
-                  bias,
-                  "scaleAlphaVec",
+                  "--scaleAlpha_vector",
                   scaleAlphaVec);
     }
     return runContractionProblem(handle, algo, problem, gemmData);

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -103,7 +103,7 @@ const char* hipblasltDatatype_to_bench_string(hipblasltDatatype_t type)
     case HIPBLASLT_R_8F_E5M2:
         return "bf8_r";
     default:
-        return "Invalid";
+        return "";
     }
 }
 
@@ -141,7 +141,7 @@ const char* rocblaslt_compute_type_to_bench_string(rocblaslt_compute_type type)
     case rocblaslt_compute_f32_fast_f16:
         return "f32_f16_r";
     default:
-        return "Invalid";
+        return "";
     }
 }
 
@@ -227,7 +227,7 @@ const char* hipblasOperation_to_bench_string(hipblasOperation_t op)
     case HIPBLAS_OP_C:
         return "C";
     default:
-        return "Invalid";
+        return "";
     }
 }
 
@@ -284,6 +284,39 @@ const char* rocblaslt_epilogue_to_string(rocblaslt_epilogue epilogue)
         return "EPILOGUE_DGELU_BGRADB";
     default:
         return "Invalid epilogue";
+    }
+}
+
+const char* rocblaslt_epilogue_to_bench_string(rocblaslt_epilogue epilogue)
+{
+    switch(epilogue)
+    {
+    case ROCBLASLT_EPILOGUE_DEFAULT:
+        return "";
+    case ROCBLASLT_EPILOGUE_RELU:
+        return "--activation_type relu";
+    case ROCBLASLT_EPILOGUE_BIAS:
+        return "--bias_vector";
+    case ROCBLASLT_EPILOGUE_RELU_BIAS:
+        return "--activation_type relu --bias_vector";
+    case ROCBLASLT_EPILOGUE_GELU:
+        return "--activation_type gelu";
+    case ROCBLASLT_EPILOGUE_DGELU:
+        return "--activation_type gelu --gradient";
+    case ROCBLASLT_EPILOGUE_GELU_BIAS:
+        return "--activation_type gelu --bias_vector";
+    case ROCBLASLT_EPILOGUE_GELU_AUX:
+        return "--activation_type gelu --use_e";
+    case ROCBLASLT_EPILOGUE_GELU_AUX_BIAS:
+        return "--activation_type gelu --bias_vector --use_e";
+    case ROCBLASLT_EPILOGUE_DGELU_BGRAD:
+        return "--activation_type gelu --bias_vector --gradient";
+    case ROCBLASLT_EPILOGUE_BGRADA:
+        return "--bias_vector --gradient --bias_source a";
+    case ROCBLASLT_EPILOGUE_BGRADB:
+        return "--bias_vector --gradient --bias_source b";
+    default:
+        return "";
     }
 }
 

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -103,7 +103,7 @@ const char* hipblasltDatatype_to_bench_string(hipblasltDatatype_t type)
     case HIPBLASLT_R_8F_E5M2:
         return "bf8_r";
     default:
-        return "";
+        return "invalid";
     }
 }
 
@@ -141,7 +141,7 @@ const char* rocblaslt_compute_type_to_bench_string(rocblaslt_compute_type type)
     case rocblaslt_compute_f32_fast_f16:
         return "f32_f16_r";
     default:
-        return "";
+        return "invalid";
     }
 }
 
@@ -227,7 +227,7 @@ const char* hipblasOperation_to_bench_string(hipblasOperation_t op)
     case HIPBLAS_OP_C:
         return "C";
     default:
-        return "";
+        return "invalid";
     }
 }
 
@@ -316,7 +316,7 @@ const char* rocblaslt_epilogue_to_bench_string(rocblaslt_epilogue epilogue)
     case ROCBLASLT_EPILOGUE_BGRADB:
         return "--bias_vector --gradient --bias_source b";
     default:
-        return "";
+        return "invalid";
     }
 }
 

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -82,6 +82,31 @@ const char* hipblasltDatatype_to_string(hipblasltDatatype_t type)
     }
 }
 
+const char* hipblasltDatatype_to_bench_string(hipblasltDatatype_t type)
+{
+    switch(type)
+    {
+    case HIPBLASLT_R_32F:
+        return "f32_r";
+    case HIPBLASLT_R_64F:
+        return "f64_r";
+    case HIPBLASLT_R_16F:
+        return "f16_r";
+    case HIPBLASLT_R_16B:
+        return "bf16_r";
+    case HIPBLASLT_R_8I:
+        return "i8_r";
+    case HIPBLASLT_R_32I:
+        return "i32_r";
+    case HIPBLASLT_R_8F_E4M3:
+        return "f8_r";
+    case HIPBLASLT_R_8F_E5M2:
+        return "bf8_r";
+    default:
+        return "Invalid";
+    }
+}
+
 const char* rocblaslt_compute_type_to_string(rocblaslt_compute_type type)
 {
     switch(type)
@@ -96,6 +121,25 @@ const char* rocblaslt_compute_type_to_string(rocblaslt_compute_type type)
         return "COMPUTE_32I";
     case rocblaslt_compute_f32_fast_f16:
         return "COMPUTE_32F_16F";
+    default:
+        return "Invalid";
+    }
+}
+
+const char* rocblaslt_compute_type_to_bench_string(rocblaslt_compute_type type)
+{
+    switch(type)
+    {
+    case rocblaslt_compute_f32:
+        return "f32_r";
+    case rocblaslt_compute_f32_fast_xf32:
+        return "xf32_r";
+    case rocblaslt_compute_f64:
+        return "f64_r";
+    case rocblaslt_compute_i32:
+        return "i32_r";
+    case rocblaslt_compute_f32_fast_f16:
+        return "f32_f16_r";
     default:
         return "Invalid";
     }
@@ -156,6 +200,7 @@ const char* rocblaslt_matmul_desc_attributes_to_string(rocblaslt_matmul_desc_att
         return "Invalid";
     }
 }
+
 const char* hipblasOperation_to_string(hipblasOperation_t op)
 {
     switch(op)
@@ -166,6 +211,21 @@ const char* hipblasOperation_to_string(hipblasOperation_t op)
         return "OP_T";
     case HIPBLAS_OP_C:
         return "OP_C";
+    default:
+        return "Invalid";
+    }
+}
+
+const char* hipblasOperation_to_bench_string(hipblasOperation_t op)
+{
+    switch(op)
+    {
+    case HIPBLAS_OP_N:
+        return "N";
+    case HIPBLAS_OP_T:
+        return "T";
+    case HIPBLAS_OP_C:
+        return "C";
     default:
         return "Invalid";
     }
@@ -187,6 +247,8 @@ const char* rocblaslt_layer_mode2string(rocblaslt_layer_mode layer_mode)
         return "Info";
     case rocblaslt_layer_mode_log_api:
         return "Api";
+    case rocblaslt_layer_mode_log_bench:
+        return "Bench";
     default:
         return "Invalid";
     }


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-427775

To print out log which can be applied on hipblaslt-bench like this:

hipblaslt-bench -m 1024 -n 512 -k 1024 --lda 1024 --ldb 1024 --ldc 1024 --ldd 1024 --lde 1024 --stride_a 0 --stride_b 0 --stride_c 0 --stride_d 0 --stride_e 0 --alpha 1 --beta 1 --transA N --transB N --batch_count 1 --a_type f16_r --b_type f16_r --c_type f16_r --d_type f16_r --compute_type f32_r --scale_type f32_r

Enabled by export HIPBLASLT_LOG_MASK=32
