### PR TITLE
[Tensilelite] Reject the soluion when LBSPPA and LDSPAD is not 0, but the lds read/write address is inconsistence

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2799,8 +2799,8 @@ class Solution(collections.abc.Mapping):
           state["LdsPadA"] = 0
           if state["MatrixInstB"] == 1 and state["MatrixInstM"] == 16:
             state["LdsPadA"] = ((16 * state["VectorWidthA"] * state["ProblemType"]["DataType"].numBytes() + state["MacroTile0"] * state["ProblemType"]["DataType"].numBytes() * state["LocalReadVectorWidth"]) % 128) // state["ProblemType"]["DataType"].numBytes()
-          if state["GlobalReadVectorWidthA"] * state["ProblemType"]["DataTypeA"].numBytes() == 16 and state["LdsPadA"] == 0:
-            state["LdsPadA"] = 8 // state["ProblemType"]["DataTypeA"].numBytes()
+          if state["GlobalReadVectorWidthA"] * state["ProblemType"]["DataType"].numBytes() == 32 and state["LdsPadA"] == 0:
+            state["LdsPadA"] = 16 // state["ProblemType"]["DataType"].numBytes()
             if auto_LdsBlockSizePerPadA_for_mix:
               state["LdsBlockSizePerPadA"] = 128
 
@@ -2817,8 +2817,8 @@ class Solution(collections.abc.Mapping):
           state["LdsPadB"] = 0
           if state["MatrixInstB"] == 1 and state["MatrixInstM"] == 16:
             state["LdsPadB"] = ((16 * state["VectorWidthB"] * state["ProblemType"]["DataType"].numBytes() + state["MacroTile1"] * state["ProblemType"]["DataType"].numBytes() * state["LocalReadVectorWidth"]) % 128) // state["ProblemType"]["DataType"].numBytes()
-          if state["GlobalReadVectorWidthB"] * state["ProblemType"]["DataTypeB"].numBytes() == 16 and state["LdsPadB"] == 0:
-            state["LdsPadB"] = 8 // state["ProblemType"]["DataTypeB"].numBytes()
+          if state["GlobalReadVectorWidthB"] * state["ProblemType"]["DataType"].numBytes() == 32 and state["LdsPadB"] == 0:
+            state["LdsPadB"] = 16 // state["ProblemType"]["DataType"].numBytes()
             if auto_LdsBlockSizePerPadB_for_mix:
               state["LdsBlockSizePerPadB"] = 128
       else:

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2696,6 +2696,26 @@ class Solution(collections.abc.Mapping):
     if state["LdsBlockSizePerPadMetadata"] == -1:
       state["LdsBlockSizePerPadMetadata"] = state["LdsBlockSizePerPadA"]
 
+    if state["LdsBlockSizePerPadA"] != 0 :
+      for miwt in range(0, state["MIWaveTile"][0]):
+        if int(state["MacroTile0"] / state["LdsBlockSizePerPadA"]) + int((state["LSCA"] * miwt) / state["LdsBlockSizePerPadA"]) != int((state["MacroTile0"] +  (state["LSCA"] * miwt)) / state["LdsBlockSizePerPadA"]):
+          if auto_LdsBlockSizePerPadA_for_mix:
+            print("Padded address is inconisstent, set LdsBlockSizePerPadA=0.")
+            state["LdsBlockSizePerPadA"] = 0
+            break
+          else:
+            reject(state, "A's padded address is inconisstent")
+
+    if state["LdsBlockSizePerPadB"] != 0:
+      for miwt in range(0, state["MIWaveTile"][1]):
+        if int(state["MacroTile1"] / state["LdsBlockSizePerPadB"]) + int((state["LSCB"] * miwt) / state["LdsBlockSizePerPadB"]) != int((state["MacroTile1"] +  (state["LSCB"] * miwt)) / state["LdsBlockSizePerPadB"]):
+          if auto_LdsBlockSizePerPadB_for_mix:
+            print("Padded address is inconisstent, set LdsBlockSizePerPadB=0.")
+            state["LdsBlockSizePerPadB"] = 0
+            break
+          else:
+            reject(state, "B's padded address is inconisstent")
+
     if state["EnableMatrixInstruction"]:
       if state["LdsBlockSizePerPadA"]:
         if state["UnrollMajorLDSA"]:


### PR DESCRIPTION
Under some MT, that said MT=96x32x32, MIWT=3x1, FP16, LBSPPA=128, LdsPADA=4, LSCA=64
The LDS address will not same under these 2 formulas below, then causes the read/write address inconsistent.

1. int(MTA / LBSPPA ) + int( LSCA * [0 ~ MIWTA-1] / LBSPPA)
2.  int((MTA+ LSCA * [0 ~ MIWTA-1])  / LBSPPA) )

