### PR TITLE
follow default bias type with cublaslt for F8/BF8 gemm

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
@@ -250,10 +250,14 @@ struct RocblasltContractionProblem
                 this->bias_type = HIP_R_32F;
             }
             else if((this->a_type == HIP_R_8F_E4M3_FNUZ || this->a_type == HIP_R_8F_E5M2_FNUZ)
-                    && (this->b_type == HIP_R_8F_E4M3_FNUZ || this->b_type == HIP_R_8F_E5M2_FNUZ)
-                    && (this->d_type == HIP_R_8F_E4M3_FNUZ || this->d_type == HIP_R_8F_E5M2_FNUZ))
+                    && (this->b_type == HIP_R_8F_E4M3_FNUZ || this->b_type == HIP_R_8F_E5M2_FNUZ))
             {
-                this->bias_type = HIP_R_32F;
+                if(this->d_type == HIP_R_32F || this->d_type == HIP_R_16BF)
+                    this->bias_type = HIP_R_16BF;
+                else if(this->d_type == HIP_R_16F)
+                    this->bias_type = HIP_R_16F;
+                else //more default cases once support C != D
+                    this->bias_type = HIP_R_16F;
             }
             else
             {


### PR DESCRIPTION
for SWDEV-443028.
TODO: need to add more cases once C type != D type are added.
Mix Mode F8 still follow output datatype.