### PR TITLE
Update codeowners for docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
 * @jichangjichang @KKyang @aazz44ss @vin-huang @imcarsonliao @hcman2 @Serge45 @Jinp800125 @TonyYHsieh
+# Documentation files
+docs/* @ROCm/rocm-documentation @jichangjichang @KKyang @aazz44ss @vin-huang @imcarsonliao @hcman2 @Serge45 @Jinp800125 @TonyYHsieh
+*.md @ROCm/rocm-documentation @jichangjichang @KKyang @aazz44ss @vin-huang @imcarsonliao @hcman2 @Serge45 @Jinp800125 @TonyYHsieh
+*.rst @ROCm/rocm-documentation @jichangjichang @KKyang @aazz44ss @vin-huang @imcarsonliao @hcman2 @Serge45 @Jinp800125 @TonyYHsieh


### PR DESCRIPTION
Relates to https://github.com/ROCm/ROCm/issues/2833
Add documentation team as codeowners for documentation.
Goal is to make this group of code owners reviewers when merging documentation changes.