### PR TITLE
[Gfx11xx] fix build break

### DIFF
--- a/tensilelite/Tensile/KernelWriterConversion.py
+++ b/tensilelite/Tensile/KernelWriterConversion.py
@@ -502,9 +502,12 @@ class KernelWriterConversion(KernelWriterBase):
         if globalParameters["AsmCaps"][archTuple]['v_pk_add_f32']:
           canPKF32Arch.append(arch)
       defineStr = []
-      defineStr = "#if defined(__%s__)"%getGfxName(canPKF32Arch[0])
-      for arch in canPKF32Arch[1:]:
-        defineStr += "|| defined(__%s__)"%getGfxName(arch)
+      if len(canPKF32Arch) > 0:
+        defineStr = "#if defined(__%s__)"%getGfxName(canPKF32Arch[0])
+        for arch in canPKF32Arch[1:]:
+          defineStr += "|| defined(__%s__)"%getGfxName(arch)
+      else:
+        defineStr = "#if 0"
       # PGR=2
       kStr += "  %s temp[NUM_GSU];" % loadTypeStr + self.endLine
       for gsuIdx in range(self.state["GlobalSplitU"]):

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3560,7 +3560,7 @@ class Solution(collections.abc.Mapping):
       hipccver = globalParameters['HipClangVersion'].split(".")
       hipccMaj = int(hipccver[0])
       hipccPatch = int(hipccver[2].split("-")[0])
-      if not (hipccMaj >= 6 and hipccPatch >= 32650):
+      if not (hipccMaj >= 6 and hipccPatch >= 32650 and (isa == (9, 0, 10) or isa == (9, 4))):
         #print("Force to Disable PreloadKernArgs since this hipcc version doesn't support",)
         state["PreloadKernArgs"] = 0
 


### PR DESCRIPTION
1. gfx11xx don't support preload_arg
2. build break when --architecture gfx11xx only
3. BB for ext ops with gfx11xx
