### PR TITLE
Add build-id for kernel builds

### DIFF
--- a/tensilelite/Tensile/Ops/gen_assembly.sh
+++ b/tensilelite/Tensile/Ops/gen_assembly.sh
@@ -63,7 +63,7 @@ for arch in "${archs[@]}"; do
         objs+=($o)
     done
     wait
-    ${toolchain} -target amdgcn-amdhsa -o $dst/extop_$arch.co ${objs[@]}
+    ${toolchain} -target amdgcn-amdhsa -Xlinker --build-id -o $dst/extop_$arch.co ${objs[@]}
     python3 ./ExtOpCreateLibrary.py --src=$dst --co=$dst/extop_$arch.co --output=$dst --arch=$arch
 done
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -244,6 +244,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       hipFlags = ["--genco", "-D__HIP_HCC_COMPAT_MODE__=1"] #needs to be fixed when Maneesh's change is made available
 
       hipFlags += ['-I', outputPath]
+      hipFlags += ["-Xoffload-linker", "--build-id"]
       hipFlags += ['-std=c++17']
       if globalParameters["SaveTemps"]:
         hipFlags += ['--save-temps']

--- a/tensilelite/Tensile/TensileInstructions/Utils.py
+++ b/tensilelite/Tensile/TensileInstructions/Utils.py
@@ -261,6 +261,7 @@ def getAsmCompileArgs(assemblerPath: str, codeObjectVersion: str, \
 def getAsmLinkCodeObjectArgs(assemblerPath: str, objectFileNames: List[str], \
     coFileName: str, *moreArgs):
     rv = [assemblerPath, '-target', 'amdgcn-amd-amdhsa']
+    rv += ["-Xlinker", "--build-id"]
     rv += moreArgs
     rv += ['-o', coFileName] + objectFileNames
     return rv


### PR DESCRIPTION
fix for [SWDEV-447065](https://ontrack-internal.amd.com/browse/SWDEV-447065)

build-id was missing when built with debug mode.