### PR TITLE
Fix matrix transform edge handling

### DIFF
--- a/clients/gtest/matrix_transform_gtest.cpp
+++ b/clients/gtest/matrix_transform_gtest.cpp
@@ -385,7 +385,9 @@ namespace
     }
 }
 
-class MatrixTransformTest : public ::testing::TestWithParam<std::tuple<hipDataType,
+class MatrixTransformTest : public ::testing::TestWithParam<std::tuple<int64_t,
+                                                                       int64_t,
+                                                                       hipDataType,
                                                                        hipDataType,
                                                                        hipblasOperation_t,
                                                                        hipblasOperation_t,
@@ -397,16 +399,16 @@ class MatrixTransformTest : public ::testing::TestWithParam<std::tuple<hipDataTy
 
 TEST_P(MatrixTransformTest, Basic)
 {
-    int64_t                     m             = 1024;
-    int64_t                     n             = 1024;
+    int64_t                     m             = std::get<0>(GetParam());
+    int64_t                     n             = std::get<1>(GetParam());
     int32_t                     batchSize     = 1;
-    auto                        datatype      = std::get<0>(GetParam());
-    auto                        scaleDatatype = std::get<1>(GetParam());
-    auto                        opA           = std::get<2>(GetParam());
-    auto                        opB           = std::get<3>(GetParam());
-    auto                        orderA        = std::get<4>(GetParam());
-    auto                        orderB        = std::get<5>(GetParam());
-    auto                        orderC        = std::get<6>(GetParam());
+    auto                        datatype      = std::get<2>(GetParam());
+    auto                        scaleDatatype = std::get<3>(GetParam());
+    auto                        opA           = std::get<4>(GetParam());
+    auto                        opB           = std::get<5>(GetParam());
+    auto                        orderA        = std::get<6>(GetParam());
+    auto                        orderB        = std::get<7>(GetParam());
+    auto                        orderC        = std::get<8>(GetParam());
     float                       alpha         = 1;
     float                       beta          = 1;
     int64_t                     batchStride   = m * n;
@@ -1183,7 +1185,9 @@ TEST(MatrixTransformTest, ScalarsOnDevice)
 INSTANTIATE_TEST_SUITE_P(
     AllCombinations,
     MatrixTransformTest,
-    ::testing::Combine(::testing::ValuesIn({HIP_R_32F, HIP_R_16F, HIP_R_16BF, HIP_R_8I, HIP_R_32I}),
+    ::testing::Combine(::testing::ValuesIn({int64_t(1), int64_t(127), int64_t(1024)}),
+                       ::testing::ValuesIn({int64_t(1), int64_t(127), int64_t(1024)}),
+                       ::testing::ValuesIn({HIP_R_32F, HIP_R_16F, HIP_R_16BF, HIP_R_8I, HIP_R_32I}),
                        ::testing::ValuesIn({HIP_R_32F}),
                        ::testing::ValuesIn({HIPBLAS_OP_N, HIPBLAS_OP_T}),
                        ::testing::ValuesIn({HIPBLAS_OP_N, HIPBLAS_OP_T}),

--- a/library/src/amd_detail/rocblaslt/src/kernels/matrix_transform.hpp
+++ b/library/src/amd_detail/rocblaslt/src/kernels/matrix_transform.hpp
@@ -101,21 +101,21 @@ namespace amd_detail
               uint32_t NumThreadsM,
               uint32_t NumThreadsN,
               uint32_t VectorWidth>
-    __global__ void __launch_bounds__(256, 4) transform(DType*       c,
-                                                        const DType* a,
-                                                        const DType* b,
-                                                        ScaleType    alpha,
-                                                        const ScaleType*   alphaPtr,
-                                                        ScaleType    beta,
-                                                        const ScaleType*   betaPtr,
-                                                        uint32_t     numRows,
-                                                        uint32_t     numCols,
-                                                        uint32_t     ldA,
-                                                        uint32_t     ldB,
-                                                        uint32_t     ldC,
-                                                        uint32_t     batchStride,
-                                                        bool         transA,
-                                                        bool         transB)
+    __global__ void __launch_bounds__(256, 4) transform(DType*           c,
+                                                        const DType*     a,
+                                                        const DType*     b,
+                                                        ScaleType        alpha,
+                                                        const ScaleType* alphaPtr,
+                                                        ScaleType        beta,
+                                                        const ScaleType* betaPtr,
+                                                        uint32_t         numRows,
+                                                        uint32_t         numCols,
+                                                        uint32_t         ldA,
+                                                        uint32_t         ldB,
+                                                        uint32_t         ldC,
+                                                        uint32_t         batchStride,
+                                                        bool             transA,
+                                                        bool             transB)
     {
         constexpr auto TileM              = RowMajC ? NumThreadsM : NumThreadsM * VectorWidth;
         constexpr auto TileN              = RowMajC ? NumThreadsN * VectorWidth : NumThreadsN;
@@ -131,13 +131,13 @@ namespace amd_detail
         const auto tCol      = getThreadLocalColIdx<RowMajC, TileM, TileN, VectorWidth>(tId);
         const auto row       = blockRow + tRow;
         const auto col       = blockCol + tCol;
-        
-        if (alphaPtr)
+
+        if(alphaPtr)
         {
             alpha = *alphaPtr;
         }
 
-        if (betaPtr)
+        if(betaPtr)
         {
             beta = *betaPtr;
         }
@@ -146,13 +146,14 @@ namespace amd_detail
 
         if constexpr(VectorWidth == 1)
         {
-            if(row < numRows && col < numCols) {
-                const auto offsetA
-                    = (transA ? getOffset<RowMajA>(col, row, ldA) : getOffset<RowMajA>(row, col, ldA))
-                    + batchOffset;
-                const auto offsetB
-                    = (transB ? getOffset<RowMajB>(col, row, ldB) : getOffset<RowMajB>(row, col, ldB))
-                    + batchOffset;
+            if(row < numRows && col < numCols)
+            {
+                const auto offsetA = (transA ? getOffset<RowMajA>(col, row, ldA)
+                                             : getOffset<RowMajA>(row, col, ldA))
+                                     + batchOffset;
+                const auto offsetB = (transB ? getOffset<RowMajB>(col, row, ldB)
+                                             : getOffset<RowMajB>(row, col, ldB))
+                                     + batchOffset;
                 const ScaleType aData = a ? static_cast<ScaleType>(a[offsetA]) : 0;
                 const ScaleType bData = b ? static_cast<ScaleType>(b[offsetB]) : 0;
                 const DType     cData = static_cast<DType>(aData * alpha + bData * beta);
@@ -172,14 +173,18 @@ namespace amd_detail
             ScaleType  aData[VectorWidth] = {};
             ScaleType  bData[VectorWidth] = {};
 
-            if constexpr(RowMajC) {
-                if (row >= numRows) {
+            if constexpr(RowMajC)
+            {
+                if(row >= numRows)
+                {
                     return;
                 }
             }
 
-            if constexpr(!RowMajC) {
-                if (col >= numCols) {
+            if constexpr(!RowMajC)
+            {
+                if(col >= numCols)
+                {
                     return;
                 }
             }

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
@@ -41,6 +41,12 @@ namespace
         return &layout;
     }
 
+    template<typename T>
+    const T *dummyScalarPtr() {
+        static T scalar{};
+        return &scalar;
+    }
+
     template <typename DType,
               typename ScaleType,
               bool     RowMajA,
@@ -86,6 +92,14 @@ namespace
         }
         else
         {
+            if (!alphaPtr) {
+                alphaPtr = dummyScalarPtr<ScaleType>();
+            }
+
+            if (!betaPtr) {
+                betaPtr = dummyScalarPtr<ScaleType>();
+            }
+
             amd_detail::transform<DType,
                                   ScaleType,
                                   RowMajA,


### PR DESCRIPTION
## Brief ##
This PR fixes edge handling for `hipblasLtMatrixTransform` API.

## Tasks ##
 - Fixed incorrect edge handling for VW == 1 case
 - Added support to null scales
 - Amended unit test for matrix transform
    - allocate memory that aligned with page size for detection of out of bound access
    - simplify test cases for null A/B input.