### PR TITLE
gtest: Updated f8/b8 out test cases: some cases should use norm_check

### DIFF
--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -607,7 +607,7 @@ Tests:
   unit_check: 1
   gpu_arch: '94?'
 
-- name: matmul_real_1b_dst_f8
+- name: matmul_real_1b_dst_f8_SCDInt1
   category: pre_checkin
   function:
     matmul: *real_precisions_1b_dst_f8
@@ -619,14 +619,34 @@ Tests:
   beta: [ 0.0, 2.0 ]
   scaleA: [0, 1]
   scaleB: [0, 1]
-  scaleC: [0, 1]
-  scaleD: [0, 1]
+  scaleC: [0] # will use default value '1' 
+  scaleD: [0] # will use default value '1' 
   bias_vector: [0, 1]
   bias_type: f16_r
   unit_check: 1
   gpu_arch: '94?'
 
-- name: matmul_real_1b_dst_bf8
+- name: matmul_real_1b_dst_f8_SCDNotInt
+  category: pre_checkin
+  function:
+    matmul: *real_precisions_1b_dst_f8
+  M: [128, 129]
+  N: [128, 129]
+  K: [128, 129]
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [1] # will use random value from 0.0 to 1.0 
+  scaleD: [1] # will use random value from 0.0 to 1.0 
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 0
+  norm_check: 1
+  gpu_arch: '94?'
+
+- name: matmul_real_1b_dst_bf8_SCDInt1
   category: pre_checkin
   function:
     matmul: *real_precisions_1b_dst_bf8
@@ -638,11 +658,31 @@ Tests:
   beta: [ 0.0, 2.0 ]
   scaleA: [0, 1]
   scaleB: [0, 1]
-  scaleC: [0, 1]
-  scaleD: [0, 1]
-  bias_vector: [0, 1]
+  scaleC: [0] # will use default value '1' 
+  scaleD: [0] # will use default value '1' 
+  bias_vector: [0,1]
   bias_type: f16_r
   unit_check: 1
+  gpu_arch: '94?'
+
+- name: matmul_real_1b_dst_bf8_SCDNotInt
+  category: pre_checkin
+  function:
+    matmul: *real_precisions_1b_dst_bf8
+  M: [128, 129]
+  N: [128, 129]
+  K: [128, 129]
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [1] # will use random value from 0.0 to 1.0 
+  scaleD: [1] # will use random value from 0.0 to 1.0 
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 0
+  norm_check: 1
   gpu_arch: '94?'
 
 - name: matmul_fallback_equality_NN_batch16

--- a/clients/include/norm.hpp
+++ b/clients/include/norm.hpp
@@ -324,5 +324,9 @@ bool norm_check(double norm_error)
         return norm_error < 0.01;
     if(std::is_same<T, hipblasLtInt32>{})
         return norm_error < 0.0001;
+    if(std::is_same<T, hipblaslt_f8_fnuz>{})
+       return norm_error < 0.125;
+    if(std::is_same<T, hipblaslt_bf8_fnuz>{})
+        return norm_error < 0.25;    
     return false;
 }

--- a/clients/include/norm.hpp
+++ b/clients/include/norm.hpp
@@ -325,8 +325,8 @@ bool norm_check(double norm_error)
     if(std::is_same<T, hipblasLtInt32>{})
         return norm_error < 0.0001;
     if(std::is_same<T, hipblaslt_f8_fnuz>{})
-       return norm_error < 0.125;
+        return norm_error < 0.125;
     if(std::is_same<T, hipblaslt_bf8_fnuz>{})
-        return norm_error < 0.25;    
+        return norm_error < 0.25;
     return false;
 }

--- a/library/include/hipblaslt_float8.h
+++ b/library/include/hipblaslt_float8.h
@@ -76,7 +76,7 @@ struct HIPBLASLT_EXPORT hipblaslt_f8_fnuz
     // default constructor
     HIP_HOST_DEVICE hipblaslt_f8_fnuz() = default;
 
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     // device specific optimized F8 down-conversion code
 
     template <bool stochastic_rounding = false>
@@ -116,7 +116,7 @@ struct HIPBLASLT_EXPORT hipblaslt_f8_fnuz
 #endif // __gfx940__
 
     // constructor from float
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
 
     // NOTE: ON-DEVICE... always optimal bias
     explicit HIP_DEVICE hipblaslt_f8_fnuz(float                          v,
@@ -187,7 +187,7 @@ struct HIPBLASLT_EXPORT hipblaslt_f8_fnuz
     }
 
     // convert to float
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     // upcast using device specific intrinsic
     explicit inline HIP_DEVICE operator float() const
     {
@@ -258,7 +258,7 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8_fnuz
     // default constructor
     HIP_HOST_DEVICE hipblaslt_bf8_fnuz() = default;
 
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     // device specific optimized F8 down-conversion code
 
     template <bool stochastic_rounding = false>
@@ -298,7 +298,7 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8_fnuz
 #endif // __gfx940__
 
     // constructor from float
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
 
     // NOTE: ON-DEVICE... always optimal bias
     explicit HIP_DEVICE hipblaslt_bf8_fnuz(float                          v,
@@ -369,7 +369,7 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8_fnuz
     }
 
     // convert to float
-#if defined(__gfx940__)
+#if defined(__gfx940__) || defined(__gfx941__) || defined(__gfx942__)
     // upcast using device specific intrinsic
     explicit inline HIP_DEVICE operator float() const
     {


### PR DESCRIPTION
resolve: https://ontrack-internal.amd.com/browse/SWDEV-449221

The test failures are not only seen in that ticket but also can be seen "**occasionally**" in our CIs
The observations are: (for output type is F8 or B8)
1. **If ScaleC/D is false** (scaleC, D is 0/false), then the test initialization will use value **"1"**, (same in client code and tensile). In this case, using unit_check is good since all initializations are int.
2. **If ScaleC/D is true** when output type if F8/B8, then the initialization will use **random_small [0.0~1.0]** value with fraction. In this case, using unit check is not good since the tolerance of F8 (0.125) or B8 (0.25) can not be ignored. We should use norm_check instead.
3. Separated test cases into two different groups: 
   * One with ScaleCD=0 --> value would be 1 --> **unit_check** is good. 
   * And the other one with ScaleCD=1 --> value would be rand[0.0~0.1] --> **norm_check** is good. 