### PR TITLE
Add Tensile_BUILD_ID for setting the specific build id kind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,7 +163,11 @@ else()
     option( Tensile_MERGE_FILES "Tensile to merge kernels and solutions files?" ON )
     option( Tensile_SHORT_FILENAMES "Tensile to use short file names? Use if compiler complains they're too long." OFF )
     option( Tensile_PRINT_DEBUG "Tensile to print runtime debug info?" OFF )
-
+  
+    if (NOT Tensile_BUILD_ID)
+      set(Tensile_BUILD_ID "sha1" CACHE STRING "Build ID Kind for Tensile" FORCE)
+    endif()
+    
     set( Tensile_TEST_LOCAL_PATH "" CACHE PATH "Use local Tensile directory instead of fetching a GitHub branch" )
 
     set_property( CACHE Tensile_LOGIC PROPERTY STRINGS aldebaran asm_full asm_lite asm_miopen hip_lite other )

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -274,6 +274,8 @@ globalParameters["UseUserArgs"] = False
 
 globalParameters["RotatingBufferSize"] = 0 # Size in MB
 
+globalParameters["BuildIdKind"] = "sha1"
+
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)
 

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -4631,7 +4631,7 @@ for codeObjectFileName in codeObjectFileNames:
 
   def getLinkCodeObjectArgs(self, objectFileNames, coFileName, *moreArgs):
     return getAsmLinkCodeObjectArgs(globalParameters['AssemblerPath'], \
-      objectFileNames, coFileName, *moreArgs)
+      objectFileNames, coFileName, globalParameters['BuildIdKind'], *moreArgs)
 
   def setTensileInstructions(self, ti):
     self.ti = ti

--- a/tensilelite/Tensile/Ops/gen_assembly.sh
+++ b/tensilelite/Tensile/Ops/gen_assembly.sh
@@ -26,6 +26,7 @@
 archStr=$1
 dst=$2
 venv=$3
+build_id_kind=$4
 
 rocm_path=/opt/rocm
 if ! [ -z ${ROCM_PATH+x} ]; then
@@ -72,7 +73,7 @@ for arch in "${archs[@]}"; do
         done
     fi
     wait
-    ${toolchain} -target amdgcn-amdhsa -Xlinker --build-id -o $dst/extop_$arch.co ${objs[@]}
+    ${toolchain} -target amdgcn-amdhsa -Xlinker --build-id=$build_id_kind -o $dst/extop_$arch.co ${objs[@]}
     python3 ./ExtOpCreateLibrary.py --src=$dst --co=$dst/extop_$arch.co --output=$dst --arch=$arch
 done
 

--- a/tensilelite/Tensile/Source/TensileCreateLibrary.cmake
+++ b/tensilelite/Tensile/Source/TensileCreateLibrary.cmake
@@ -39,7 +39,8 @@ function(TensileCreateLibraryCmake
     Tensile_LIBRARY_PRINT_DEBUG
     Tensile_CPU_THREADS
     Tensile_SEPARATE_ARCHITECTURES
-    Tensile_LAZY_LIBRARY_LOADING)
+    Tensile_LAZY_LIBRARY_LOADING,
+    Tensile_BUILD_ID)
 
 # make Tensile_PACKAGE_LIBRARY and optional parameter
 # to avoid breaking applications which us this
@@ -105,6 +106,10 @@ function(TensileCreateLibraryCmake
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--cxx-compiler=${Tensile_COMPILER}")
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--library-format=${Tensile_LIBRARY_FORMAT}")
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--jobs=${Tensile_CPU_THREADS}")
+
+  if(Tensile_BUILD_ID)
+    set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--build-id=${Tensile_BUILD_ID}")
+  endif()
 
   # TensileLibraryWriter positional arguments
   set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND}

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -244,7 +244,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
       hipFlags = ["--genco", "-D__HIP_HCC_COMPAT_MODE__=1"] #needs to be fixed when Maneesh's change is made available
 
       hipFlags += ['-I', outputPath]
-      hipFlags += ["-Xoffload-linker", "--build-id"]
+      hipFlags += ["-Xoffload-linker", "--build-id=%s"%globalParameters["BuildIdKind"]]
       hipFlags += ['-std=c++17']
       if globalParameters["SaveTemps"]:
         hipFlags += ['--save-temps']
@@ -1269,6 +1269,7 @@ def TensileCreateLibrary():
                          help="Generate solution-yaml matching table")
   argParser.add_argument("--asm-debug", dest="AsmDebug", action="store_true", default=False,
                          help="Keep debug information for built code objects")
+  argParser.add_argument("--build-id", dest="BuildIdKind", action="store", default="sha1")                         
 
   args = argParser.parse_args()
 
@@ -1310,6 +1311,7 @@ def TensileCreateLibrary():
   arguments["PrintLevel"] = args.PrintLevel
   arguments["PrintTiming"] = args.PrintTiming
   arguments["AsmDebug"] = args.AsmDebug
+  arguments["BuildIdKind"] = args.BuildIdKind
 
   for key, value in args.global_parameters:
     arguments[key] = value

--- a/tensilelite/Tensile/TensileInstructions/Utils.py
+++ b/tensilelite/Tensile/TensileInstructions/Utils.py
@@ -259,9 +259,9 @@ def getAsmCompileArgs(assemblerPath: str, codeObjectVersion: str, \
     return rv
 
 def getAsmLinkCodeObjectArgs(assemblerPath: str, objectFileNames: List[str], \
-    coFileName: str, *moreArgs):
+    coFileName: str, buildIdKind: str, *moreArgs):
     rv = [assemblerPath, '-target', 'amdgcn-amd-amdhsa']
-    rv += ["-Xlinker", "--build-id"]
+    rv += ["-Xlinker", "--build-id=%s"%(buildIdKind)]
     rv += moreArgs
     rv += ['-o', coFileName] + objectFileNames
     return rv

--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -201,6 +201,10 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--architecture=${archString}")
   endif()
 
+  if(Tensile_BUILD_ID)
+    set(Options ${Options} "--build-id=${Tensile_BUILD_ID}")
+  endif()
+
   if (WIN32)
     set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
   else()
@@ -274,7 +278,7 @@ function(TensileCreateExtOpLibraries OutputFolder ArchStr)
     COMMAND ${CMAKE_COMMAND} -E rm -rf ${build_tmp_dir}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${build_tmp_dir}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${OutputFolder}
-    COMMAND bash "${script}" "\"${Archs}\"" "${build_tmp_dir}" "${VIRTUALENV_HOME_DIR}"
+    COMMAND bash "${script}" "\"${Archs}\"" "${build_tmp_dir}" "${VIRTUALENV_HOME_DIR}" "${Tensile_BUILD_ID}"
     COMMAND ${CMAKE_COMMAND} -E copy ${ext_op_library_path} ${build_tmp_dir}/extop_*.co ${OutputFolder}
   )
 


### PR DESCRIPTION
Add Tensile_BUILD_ID for setting the specific build id kind, default is sha1
Used to fix the build-id to small issue on REHL. [SWDEV-447065](https://ontrack-internal.amd.com/browse/SWDEV-447065)