### PR TITLE
Enable static build and gprof support

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories( hipblaslt-bench
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}> # may be blank if not used
 )
 
-target_link_libraries( hipblaslt-bench PRIVATE ${BLAS_LIBRARY} roc::hipblaslt)
+target_link_libraries( hipblaslt-bench PRIVATE ${BLAS_LIBRARY} roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
 
 if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
@@ -139,7 +139,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 foreach( exe ${ext_bench_list_all} )
-  target_link_libraries( ${exe} PRIVATE roc::hipblaslt )
+  target_link_libraries( ${exe} PRIVATE roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
 
   set_target_properties( ${exe} PROPERTIES
     CXX_STANDARD 17

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories( hipblaslt-bench
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}> # may be blank if not used
 )
 
-target_link_libraries( hipblaslt-bench PRIVATE ${BLAS_LIBRARY} roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
+target_link_libraries( hipblaslt-bench PRIVATE ${BLAS_LIBRARY} roc::hipblaslt )
 
 if( CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   # GCC or hip-clang needs specific flags to turn on f16c intrinsics
@@ -139,7 +139,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 foreach( exe ${ext_bench_list_all} )
-  target_link_libraries( ${exe} PRIVATE roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
+  target_link_libraries( ${exe} PRIVATE roc::hipblaslt )
 
   set_target_properties( ${exe} PROPERTIES
     CXX_STANDARD 17

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories( hipblaslt-test
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
 )
 message("BLIS_INCLUDE_DIR=" ${BLIS_INCLUDE_DIR})
-target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipblaslt )
+target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
 
 if( NOT BUILD_CUDA )
   target_link_libraries( hipblaslt-test PRIVATE hip::host hip::device )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories( hipblaslt-test
     $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
 )
 message("BLIS_INCLUDE_DIR=" ${BLIS_INCLUDE_DIR})
-target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipblaslt ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
+target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipblaslt )
 
 if( NOT BUILD_CUDA )
   target_link_libraries( hipblaslt-test PRIVATE hip::host hip::device )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -96,7 +96,7 @@ foreach( exe ${sample_list_all} )
 endforeach( )
 
 foreach( exe ${sample_list_hip_device} )
-  target_link_libraries( ${exe} PRIVATE hip::device )
+  target_link_libraries( ${exe} PRIVATE hip::device ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
 endforeach( )
 
 foreach( exe ${sample_list_all} )

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -96,7 +96,7 @@ foreach( exe ${sample_list_all} )
 endforeach( )
 
 foreach( exe ${sample_list_hip_device} )
-  target_link_libraries( ${exe} PRIVATE hip::device ${CMAKE_CURRENT_SOURCE_DIR}/../../build/release/Tensile/lib/librocblaslt-tensile.a)
+  target_link_libraries( ${exe} PRIVATE hip::device )
 endforeach( )
 
 foreach( exe ${sample_list_all} )

--- a/install.sh
+++ b/install.sh
@@ -651,7 +651,7 @@ pushd .
 
   # library type
   if [[ "${build_static}" == true ]]; then
-    cmake_common_options="{cmake_common_options} -DBUILD_SHARED_LIBS=OFF"
+    cmake_common_options="${cmake_common_options} -DBUILD_SHARED_LIBS=OFF"
   fi
 
   # clients

--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,7 @@ function display_help()
   echo "    [--static] build static library"
   echo "    [--address-sanitizer] build with address sanitizer"
   echo "    [--codecoverage] build with code coverage profiling enabled"
+  echo "    [--gprof] enable profiling functionality with GNU gprof"
 }
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
@@ -368,6 +369,7 @@ tensile_version=
 build_tensile=true
 tensile_msgpack_backend=true
 update_cmake=true
+enable_gprof=false
 
 
 rocm_path=/opt/rocm
@@ -382,7 +384,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture: --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -483,6 +485,9 @@ while true; do
             shift ;;
         --cmake_install)
             update_cmake=true
+            shift ;;
+        --gprof)
+            enable_gprof=true
             shift ;;
         --) shift ; break ;;
         *)  echo "Unexpected command line parameter received: '${1}'; aborting";
@@ -713,6 +718,14 @@ pushd .
 
   if [[ "${build_release}" == false ]]; then
     tensile_opt="${tensile_opt} -DTensile_ASM_DEBUG=ON"
+  fi
+
+  if [[ "${enable_gprof}" == true ]]; then
+    if [[ "${build_static}" == false ]]; then
+      printf "'--gprof' can only be enabled for static build.\n"
+      exit 2
+    fi
+    cmake_common_options="${cmake_common_options} -DCMAKE_CXX_FLAGS=-pg -DCMAKE_C_FLAGS=-pg"
   fi
 
   echo $cmake_common_options

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -91,10 +91,18 @@ if( BUILD_WITH_TENSILE )
     target_compile_definitions( hipblaslt PRIVATE ${TensileHost_DEFINES} )
 
     get_target_property( TensileHost_LIBDIR TensileHost BINARY_DIR )
+    get_target_property( TensileHost_SOURCES TensileHost SOURCES )
+    get_target_property( TensileHost_SOURCE_DIR TensileHost SOURCE_DIR )
 
     message (STATUS "TensileHost_INCLUDES == ${TensileHost_INCLUDES}")
     message (STATUS "TensileHost_DEFINES == ${TensileHost_DEFINES}")
     message (STATUS "TensileHost_LIBDIR == ${TensileHost_LIBDIR}")
+    message (STATUS "TensileHost_SOURCE_DIR == ${TensileHost_SOURCE_DIR}")
+    message (STATUS "TensileHost_SOURCES == ${TensileHost_SOURCES}")
+    cmake_path(SET seperator NORMALIZE "/")
+    list(TRANSFORM TensileHost_SOURCES PREPEND "${TensileHost_SOURCE_DIR}${seperator}")
+    # add dependent sources from TensileHost for static build
+    target_sources(hipblaslt PRIVATE ${TensileHost_SOURCES})
 
     # recreate LLVM static dependencies
     if (${Tensile_LIBRARY_FORMAT} STREQUAL "yaml")
@@ -112,11 +120,6 @@ if( BUILD_WITH_TENSILE )
 
       target_link_libraries(hipblaslt PRIVATE LLVMObjectYAML )  # match tensile
     endif()
-
-    # to get TensileHost built first, not to link target
-    # as dependency chain can not be created
-    add_dependencies(hipblaslt TensileHost)
-
   endif()
 
   target_compile_definitions(hipblaslt PRIVATE ${TENSILE_DEFINES} )


### PR DESCRIPTION
## Brief ##
This PR enables static build and profiling with `gprof`.

## Implementation ##
 - For static build, simply added source files of TensileHost to hipBLASLt source list
 - For `gprof` support, added `--gprof` option to `install.sh`, and it can only be enabled with static build.

## Notes ##
For static build, client apps have to use `HIPBLASLT_TENSILE_LIBPATH` and `HIPBLASLT_EXT_OP_LIBRARY_PATH` to specify code object library paths of gemm and ext ops respectively.