### PR TITLE
Allow to get solution with null bias ptr

### DIFF
--- a/clients/gtest/auxiliary_gtest.cpp
+++ b/clients/gtest/auxiliary_gtest.cpp
@@ -110,8 +110,8 @@ namespace
                 testing_aux_matmul_alg_init_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_matmul_alg_init"))
                 testing_aux_matmul_alg_init(arg);
-            else if(!strcmp(arg.function, "aux_matmul_alg_set_attr_bad_arg"))
-                testing_aux_matmul_alg_set_attr_bad_arg(arg);
+            else if(!strcmp(arg.function, "aux_get_sol_with_null_biasaddr"))
+                testing_aux_get_sol_with_null_biasaddr(arg);
             else if(!strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg"))
                 testing_aux_matmul_alg_get_attr_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_matmul_plan_init_bad_arg"))
@@ -152,7 +152,7 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_set_get_attr")
                    || !strcmp(arg.function, "aux_matmul_alg_init_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_alg_init")
-                   || !strcmp(arg.function, "aux_matmul_alg_set_attr_bad_arg")
+                   || !strcmp(arg.function, "aux_get_sol_with_null_biasaddr")
                    || !strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init")

--- a/clients/gtest/auxiliary_gtest.yaml
+++ b/clients/gtest/auxiliary_gtest.yaml
@@ -22,82 +22,82 @@ Tests:
 - name: aux_mat_init_bad_arg
   category: pre_checkin
   function:
-    - aux_mat_init_bad_arg: *real_precisions
+    - aux_mat_init_bad_arg: *hpa_half_precision
 
 - name: aux_mat_destroy_bad_arg
   category: pre_checkin
   function:
-    - aux_mat_destroy_bad_arg: *real_precisions
+    - aux_mat_destroy_bad_arg: *hpa_half_precision
 
 - name: aux_mat_set_attr_bad_arg
   category: pre_checkin
   function:
-    - aux_mat_set_attr_bad_arg: *real_precisions
+    - aux_mat_set_attr_bad_arg: *hpa_half_precision
 
 - name: aux_mat_get_attr_bad_arg
   category: pre_checkin
   function:
-    - aux_mat_get_attr_bad_arg: *real_precisions
+    - aux_mat_get_attr_bad_arg: *hpa_half_precision
 
 - name: aux_mat_set_get_attr
   category: pre_checkin
   function:
-    - aux_mat_set_get_attr: *real_precisions
+    - aux_mat_set_get_attr: *hpa_half_precision
 
 - name: aux_matmul_init_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_init_bad_arg: *real_precisions
+    - aux_matmul_init_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_init
   category: pre_checkin
   function:
-    - aux_matmul_init: *real_precisions
+    - aux_matmul_init: *hpa_half_precision
 
 - name: aux_matmul_set_attr_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_set_attr_bad_arg: *real_precisions
+    - aux_matmul_set_attr_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_get_attr_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_get_attr_bad_arg: *real_precisions
+    - aux_matmul_get_attr_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_set_get_attr
   category: pre_checkin
   function:
-    - aux_matmul_set_get_attr: *real_precisions
+    - aux_matmul_set_get_attr: *hpa_half_precision
 
 - name: aux_matmul_alg_init_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_alg_init_bad_arg: *real_precisions
+    - aux_matmul_alg_init_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_alg_init
   category: pre_checkin
   function:
-    - aux_matmul_alg_init: *real_precisions
+    - aux_matmul_alg_init: *hpa_half_precision
 
-- name: aux_matmul_alg_set_attr_bad_arg
+- name: aux_get_sol_with_null_biasaddr
   category: pre_checkin
   function:
-    - aux_matmul_alg_set_attr_bad_arg: *real_precisions
+    - aux_get_sol_with_null_biasaddr: *hpa_half_precision
 
 - name: aux_matmul_alg_get_attr_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_alg_get_attr_bad_arg: *real_precisions
+    - aux_matmul_alg_get_attr_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_pref_init_bad_arg
   category: pre_checkin
   function:
-    - aux_matmul_pref_init_bad_arg: *real_precisions
+    - aux_matmul_pref_init_bad_arg: *hpa_half_precision
 
 - name: aux_matmul_pref_init
   category: pre_checkin
   function:
-    - aux_matmul_pref_init: *real_precisions
+    - aux_matmul_pref_init: *hpa_half_precision
 
 - name: aux_matmul_alg_null_matmul
   category: pre_checkin

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -300,7 +300,97 @@ void testing_aux_matmul_alg_init_bad_arg(const Arguments& arg) {}
 
 void testing_aux_matmul_alg_init(const Arguments& arg) {}
 
-void testing_aux_matmul_alg_set_attr_bad_arg(const Arguments& arg) {}
+void testing_aux_get_sol_with_null_biasaddr(const Arguments& arg)
+{
+    using InTypeA   = hipblasLtHalf;
+    using InTypeB   = hipblasLtHalf;
+    using OutType   = hipblasLtHalf;
+    using AlphaType = hipblasLtFloat;
+    using BetaType  = hipblasLtFloat;
+
+    hipStream_t        stream;
+    hipblasLtHandle_t  handle;
+    hipblasOperation_t trans_a = arg.transA == 'N' ? HIPBLAS_OP_N : HIPBLAS_OP_T;
+    hipblasOperation_t trans_b = arg.transB == 'N' ? HIPBLAS_OP_N : HIPBLAS_OP_T;
+    int64_t            m = arg.M[0];
+    int64_t            n = arg.N[0];
+    int64_t            k = arg.K[0];
+    int64_t            batch_count = 1;
+    float              alpha = arg.alpha;
+    float              beta = arg.beta;
+    void*              d_a;
+    void*              d_b;
+    void*              d_c;
+    void*              d_d;
+    void*              a;
+    void*              b;
+    void*              c;
+    void*              d;
+
+    CHECK_HIP_ERROR(hipStreamCreate(&stream));
+    CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
+    CHECK_HIP_ERROR(hipMalloc(&d_a, m * k * batch_count * sizeof(InTypeA)));
+    CHECK_HIP_ERROR(hipMalloc(&d_b, n * k * batch_count * sizeof(InTypeB)));
+    CHECK_HIP_ERROR(hipMalloc(&d_c, m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipMalloc(&d_d, m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipHostMalloc(&a, m * k * batch_count * sizeof(InTypeA)));
+    CHECK_HIP_ERROR(hipHostMalloc(&b, n * k * batch_count * sizeof(InTypeB)));
+    CHECK_HIP_ERROR(hipHostMalloc(&c, m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipHostMalloc(&d, m * n * batch_count * sizeof(OutType)));
+
+    CHECK_HIP_ERROR(hipMemcpyAsync(
+        d_a, a, m * k * batch_count * sizeof(InTypeA), hipMemcpyHostToDevice, stream));
+    CHECK_HIP_ERROR(hipMemcpyAsync(
+        d_b, b, n * k * batch_count * sizeof(InTypeB), hipMemcpyHostToDevice, stream));
+    CHECK_HIP_ERROR(hipMemcpyAsync(
+        d_c, c, m * n * batch_count * sizeof(OutType), hipMemcpyHostToDevice, stream));
+
+    hipblasLtMatrixLayout_t matA, matB, matC, matD;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, arg.a_type, m, k, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matB, arg.a_type, k, n, k));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matC, arg.a_type, m, n, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, arg.a_type, m, n, m));
+
+    hipblasLtMatmulDesc_t matmul;
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_BIAS;
+    CHECK_HIPBLASLT_ERROR(
+        hipblasLtMatmulDescCreate(&matmul, arg.compute_type, arg.scale_type));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue,sizeof(epilogue)));
+
+    hipblasLtMatmulPreference_t pref;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+    const int                        request_solutions = 1;
+    hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
+    int                              returnedAlgoCount = 0;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(handle,
+                                                          matmul,
+                                                          matA,
+                                                          matB,
+                                                          matC,
+                                                          matD,
+                                                          pref,
+                                                          request_solutions,
+                                                          heuristicResult,
+                                                          &returnedAlgoCount));
+
+    CHECK_SOLUTION_FOUND(returnedAlgoCount);
+
+    CHECK_HIP_ERROR(hipFree(a));
+    CHECK_HIP_ERROR(hipFree(b));
+    CHECK_HIP_ERROR(hipFree(c));
+    CHECK_HIP_ERROR(hipFree(d));
+    CHECK_HIP_ERROR(hipFree(d_a));
+    CHECK_HIP_ERROR(hipFree(d_b));
+    CHECK_HIP_ERROR(hipFree(d_c));
+    CHECK_HIP_ERROR(hipFree(d_d));
+    CHECK_HIPBLASLT_ERROR(hipblasLtDestroy(handle));
+    CHECK_HIP_ERROR(hipStreamDestroy(stream));
+}
 
 void testing_aux_matmul_alg_get_attr_bad_arg(const Arguments& arg) {}
 


### PR DESCRIPTION
For https://ontrack-internal.amd.com/browse/SWDEV-458510
Bias ptr is only necessary when launching gemm kernel.
This PR is used for aligning behavior with cublaslt.
