### PR TITLE
Added hipblaslt_ext::matmulIsTuned API

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable( sample_hipblaslt_gemm_get_all_algos_ext gemm_get_all_algos/sampl
 add_executable( sample_hipblaslt_gemm_get_algo_by_index_ext gemm_get_algo_by_index/sample_hipblaslt_gemm_get_algo_by_index_ext.cpp)
 add_executable( sample_hipblaslt_gemm_mix_precision_ext gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_ext.cpp)
 add_executable( sample_hipblaslt_gemm_mix_precision_with_amax_ext gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_amax_ext.cpp)
+add_executable( sample_hipblaslt_gemm_is_tuned_ext gemm_tuning/sample_hipblaslt_gemm_is_tuned_ext.cpp)
 add_executable( sample_hipblaslt_gemm_tuning_splitk_ext gemm_tuning/sample_hipblaslt_gemm_tuning_splitk_ext.cpp)
 add_executable( sample_hipblaslt_gemm_tuning_wgm_ext gemm_tuning/sample_hipblaslt_gemm_tuning_wgm_ext.cpp)
 add_executable( sample_hipblaslt_groupedgemm_ext groupedgemm/sample_hipblaslt_groupedgemm_ext.cpp)
@@ -51,6 +52,7 @@ set(samples sample_hipblaslt_gemm
             sample_hipblaslt_gemm_get_algo_by_index_ext
             sample_hipblaslt_gemm_mix_precision_ext
             sample_hipblaslt_gemm_mix_precision_with_amax_ext
+            sample_hipblaslt_gemm_is_tuned_ext
             sample_hipblaslt_gemm_tuning_splitk_ext
             sample_hipblaslt_gemm_tuning_wgm_ext
             sample_hipblaslt_groupedgemm_ext

--- a/clients/samples/gemm_tuning/sample_hipblaslt_gemm_is_tuned_ext.cpp
+++ b/clients/samples/gemm_tuning/sample_hipblaslt_gemm_is_tuned_ext.cpp
@@ -49,9 +49,9 @@ int main(int argc, char **argv)
     hipblasLtMatmulDescSetAttribute(matmulDesc, HIPBLASLT_MATMUL_DESC_TRANSA, &opA, sizeof(opA));
     hipblasLtPointerMode_t pMode = HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST;
     hipblasLtMatmulDescSetAttribute(matmulDesc, HIPBLASLT_MATMUL_DESC_POINTER_MODE, &pMode, sizeof(pMode));
-    const uint64_t m = std::atoll(argv[1]);
-    const uint64_t n = std::atoll(argv[2]);
-    const uint64_t k = std::atoll(argv[3]);
+    const uint64_t m = argc > 3 ? std::atoll(argv[1]): 128;
+    const uint64_t n = argc > 3 ? std::atoll(argv[2]): 128;
+    const uint64_t k = argc > 3 ? std::atoll(argv[3]): 128;
     hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, k, m, k);
     hipblasLtMatrixLayoutCreate(&matB, HIP_R_16F, k, n, k);
     hipblasLtMatrixLayoutCreate(&matC, HIP_R_16F, m, n, m);

--- a/clients/samples/gemm_tuning/sample_hipblaslt_gemm_is_tuned_ext.cpp
+++ b/clients/samples/gemm_tuning/sample_hipblaslt_gemm_is_tuned_ext.cpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <hip/hip_runtime.h>
+#include <hipblaslt/hipblaslt-ext.hpp>
+#include <iostream>
+
+void printResult(int tuned, uint64_t m, uint64_t n, uint64_t k) {
+    if (tuned == 1) {
+        std::cout << "[" << m << ", " << n << ", " << k << "] is tuned\n";
+    } else {
+        std::cout << "[" << m << ", " << n << ", " << k << "] is un-tuned\n";
+    }
+}
+
+int main(int argc, char **argv)
+{
+    hipblasLtHandle_t handle{};
+    hipblasLtCreate(&handle);
+    hipblasLtMatmulDesc_t matmulDesc{};
+    hipblasLtMatrixLayout_t matA{};
+    hipblasLtMatrixLayout_t matB{};
+    hipblasLtMatrixLayout_t matC{};
+    hipblasLtMatrixLayout_t matD{};
+    hipblasLtMatmulDescCreate(&matmulDesc, hipblasComputeType_t::HIPBLAS_COMPUTE_32F, HIP_R_32F);
+    hipblasOperation_t opA = HIPBLAS_OP_T;
+    hipblasLtMatmulDescSetAttribute(matmulDesc, HIPBLASLT_MATMUL_DESC_TRANSA, &opA, sizeof(opA));
+    hipblasLtPointerMode_t pMode = HIPBLASLT_POINTER_MODE_ALPHA_DEVICE_VECTOR_BETA_HOST;
+    hipblasLtMatmulDescSetAttribute(matmulDesc, HIPBLASLT_MATMUL_DESC_POINTER_MODE, &pMode, sizeof(pMode));
+    const uint64_t m = std::atoll(argv[1]);
+    const uint64_t n = std::atoll(argv[2]);
+    const uint64_t k = std::atoll(argv[3]);
+    hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, k, m, k);
+    hipblasLtMatrixLayoutCreate(&matB, HIP_R_16F, k, n, k);
+    hipblasLtMatrixLayoutCreate(&matC, HIP_R_16F, m, n, m);
+    hipblasLtMatrixLayoutCreate(&matD, HIP_R_16F, m, n, m);
+    auto tuned = hipblaslt_ext::matmulIsTuned(handle, matmulDesc, matA, matB, matC, matD);
+    printResult(tuned, m, n, k);
+    hipblasLtMatmulDescDestroy(matmulDesc);
+    hipblasLtMatrixLayoutDestroy(matA);
+    hipblasLtMatrixLayoutDestroy(matB);
+    hipblasLtMatrixLayoutDestroy(matC);
+    hipblasLtMatrixLayoutDestroy(matD);
+    hipblasLtDestroy(handle);
+    return 0;
+}

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -1011,4 +1011,12 @@ namespace hipblaslt_ext
      */
     HIPBLASLT_EXPORT
     hipblasStatus_t copyMatmul(hipblasLtMatmulDesc_t src, hipblasLtMatmulDesc_t dst);
+
+    HIPBLASLT_EXPORT
+    int matmulIsTuned(hipblasLtHandle_t       handle,
+                      hipblasLtMatmulDesc_t   matmulDesc,
+                      hipblasLtMatrixLayout_t Adesc,
+                      hipblasLtMatrixLayout_t Bdesc,
+                      hipblasLtMatrixLayout_t Cdesc,
+                      hipblasLtMatrixLayout_t Ddesc);
 } // End of namespace hipblasltext

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -753,4 +753,19 @@ namespace hipblaslt_ext
             rocblaslt_copy_matmul((rocblaslt_matmul_desc)src, (rocblaslt_matmul_desc)dst));
     }
 
+    int matmulIsTuned(hipblasLtHandle_t       handle,
+                      hipblasLtMatmulDesc_t   matmulDesc,
+                      hipblasLtMatrixLayout_t Adesc,
+                      hipblasLtMatrixLayout_t Bdesc,
+                      hipblasLtMatrixLayout_t Cdesc,
+                      hipblasLtMatrixLayout_t Ddesc)
+    {
+        return rocblaslt_matmul_is_tuned((rocblaslt_handle)handle,
+            (rocblaslt_matmul_desc)matmulDesc,
+            (rocblaslt_matrix_layout)Adesc,
+            (rocblaslt_matrix_layout)Bdesc,
+            (rocblaslt_matrix_layout)Cdesc,
+            (rocblaslt_matrix_layout)Ddesc);
+    }
+
 } // End of namespace hipblasltext

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
@@ -126,6 +126,13 @@ rocblaslt_status rocblaslt_matrix_transform(rocblaslt_handle                 han
                                             void*                   C,
                                             rocblaslt_matrix_layout Cdesc,
                                             hipStream_t             stream);
+ 
+int rocblaslt_matmul_is_tuned(rocblaslt_handle handle,
+                              rocblaslt_matmul_desc matmulDesc,
+                              rocblaslt_matrix_layout Adesc,
+                              rocblaslt_matrix_layout Bdesc,
+                              rocblaslt_matrix_layout Cdesc,
+                              rocblaslt_matrix_layout Ddesc);
 #ifdef __cplusplus
 }
 

--- a/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
@@ -42,6 +42,7 @@
 #include "handle.h"
 //#include "tuple_helper.hpp"
 #include "utility.hpp"
+#include <Tensile/Contractions.hpp>
 #include <Tensile/DataTypes.hpp>
 #include <atomic>
 
@@ -394,6 +395,12 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                                      rocblaslt_matmul_algo&        algo,
                                      const rocblaslt::RocTuning*   tuning,
                                      size_t&                       workspaceSizeInBytes);
+
+std::vector<std::shared_ptr<Tensile::ContractionSolution>> getBestRawSolutions(RocblasltContractionProblem const& prob,
+                         rocblaslt_handle                   handle,
+                         std::shared_ptr<void>              gemmData,
+                         int                                requestedAlgoCount,
+                         size_t                             maxWorkSpaceBytes);
 
 /*******************************************************************************
  * getBestSolutions() calls finTopSolutions from Tensile and converts to       *

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2086,6 +2086,46 @@ inline auto getSolutions(
     return solutions;
 }
 
+std::vector<std::shared_ptr<Tensile::ContractionSolution>> getBestRawSolutions(RocblasltContractionProblem const& prob,
+                         rocblaslt_handle                   handle,
+                         std::shared_ptr<void>              gemmData,
+                         int                                requestedAlgoCount,
+                         size_t                             maxWorkSpaceBytes)
+{
+    std::shared_ptr<Tensile::MasterSolutionLibrary<Tensile::ContractionProblemGemm>> library;
+    std::shared_ptr<hipDeviceProp_t>                                                 deviceProp;
+    std::shared_ptr<Tensile::Hardware>                                               hardware;
+
+    static_cast<void>(get_library_and_adapter(&library, &deviceProp, handle->device));
+
+    hardware = Tensile::hip::GetDevice(*deviceProp);
+
+    std::shared_ptr<TensileDataGemm> data = std::static_pointer_cast<TensileDataGemm>(gemmData);
+    updateTensileProblem(false, prob, data->problem);
+
+    bool enableEpilogue = prob.epilogue == ROCBLASLT_EPILOGUE_DEFAULT ? false : true;
+
+    int  fallbackSize = 0;
+    auto solutions    = getSolutions(
+        prob, library, hardware, data->problem, enableEpilogue, requestedAlgoCount, fallbackSize);
+
+    // when there is no solution for xfloat32, fallback comput_type to fp32
+    if(solutions.size() == 0 && prob.compute_type == rocblaslt_compute_f32_fast_xf32)
+    {
+        log_api(__func__, "no solutions found, try to fallback");
+        data->problem.setF32XdlMathOp(Tensile::DataType::Float);
+        solutions = getSolutions(prob,
+                                 library,
+                                 hardware,
+                                 data->problem,
+                                 enableEpilogue,
+                                 requestedAlgoCount,
+                                 fallbackSize);
+    }
+
+    return solutions;
+}
+
 rocblaslt_status getBestSolutions(RocblasltContractionProblem const& prob,
                                   rocblaslt_handle                   handle,
                                   std::shared_ptr<void>              gemmData,

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -117,6 +117,14 @@ namespace Tensile
         using Inputs        = ContractionInputs;
         using GroupedInputs = ContractionGroupedInputs;
 
+ /**
+  * Indicate a solution is equally or estimatedly matched.
+  */
+        enum class MatchingTag {
+            Equal,
+            Estimated
+        };
+
         static std::string Type()
         {
             return "Contraction";
@@ -504,6 +512,7 @@ namespace Tensile
         int32_t               libraryLogicIndex = -1;
         std::map<int, double> ideals;
         LinearModel           linearModel;
+        MatchingTag           tag{MatchingTag::Estimated};
 
         uint32_t magicNumberAlg1(uint32_t x, uint32_t* magicShift) const;
         uint32_t magicNumberAlg2(uint32_t x, uint32_t* magicShift) const;

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ExactLogicLibrary.hpp
@@ -26,8 +26,10 @@
 
 #pragma once
 
+#include <type_traits>
 #include <Tensile/Debug.hpp>
 #include <Tensile/Predicates.hpp>
+#include <Tensile/ContractionProblemPredicates.hpp>
 #include <Tensile/SolutionLibrary.hpp>
 
 namespace Tensile
@@ -97,6 +99,10 @@ namespace Tensile
                 if(row.first(problem, hardware))
                 {
                     rv = row.second->findBestSolution(problem, hardware, fitness);
+
+                    if (rv && dynamic_cast<Predicates::Contraction::EqualityMatching *>(row.first.value.get()))
+                        rv->tag = MySolution::MatchingTag::Equal;
+
                     if(rv)
                         return rv;
                 }
@@ -163,6 +169,11 @@ namespace Tensile
                 {
                     solutions
                         = row.second->findTopSolutions(problem, hardware, numSolutions - rv.size());
+                    
+                    if (dynamic_cast<Predicates::Contraction::EqualityMatching *>(row.first.value.get()))
+                        for (auto &sol : solutions)
+                            sol->tag = MySolution::MatchingTag::Equal;
+
                     rv.insert(std::end(rv), std::begin(solutions), std::end(solutions));
                     if(rv.size() == numSolutions)
                         return rv;


### PR DESCRIPTION
## Brief ##
Added `hipblaslt_ext::matmulIsTuned` API, it can be used to check a given GEMM problem is exactly tuned or not.

## Implementation ##
 - added `rocblaslt_matmul_is_tuned` bridge function.
 - added `MatchingTag` in `ContractionSolution` struct.
 - in `ExactLogicLibrary`, set `MatchingTag` of matched solution to `Euqal` if the predicate is `Predicates::Contraction::EqualityMatching`.
 - `hipblaslt_ext::matmulIsTuned` returns `1` if tag of the best solution is `Equal` else `0`.
 - An example was also added.