### PR TITLE
Add frequency monitor to hipBLASlt - bench

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,291 +1,157 @@
 # ########################################################################
-#Copyright(C) 2022 - 2024 Advanced Micro Devices, Inc.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
 #
-#Permission is hereby granted, free of charge, to any person obtaining a copy
-#of this software and associated documentation files(the "Software"), to deal
-#in the Software without restriction, including without limitation the rights
-#to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
-#copies of the Software, and to permit persons to whom the Software is
-#furnished to do so, subject to the following                       conditions:
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-#The above copyright notice and this permission notice shall be included in
-#all copies or substantial portions of the                               Software.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
-#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-#THE SOFTWARE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
 #
 # ########################################################################
 
-cmake_minimum_required(VERSION 3.25.2)
+cmake_minimum_required( VERSION 3.25.2 )
 
 #add_definitions(-D_HIPBLASLT_INTERNAL_BFLOAT16_)
 
-#This has to be initialized before the project() command appears
-#Set the default of CMAKE_BUILD_TYPE to be               release, \
-    unless user specifies with - D.MSVC_IDE does not use CMAKE_BUILD_TYPE
-    if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
-        set(CMAKE_BUILD_TYPE Release CACHE STRING
-            "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
-            endif()
+# This has to be initialized before the project() command appears
+# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
+if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
+endif()
 
-                project(hipblaslt - clients LANGUAGES CXX C)
+project( hipblaslt-clients LANGUAGES CXX C  )
 
-                    if(SKIP_LIBRARY)
-                        include_directories(${HIPBLASLT_LIBRARY_DIR} / include ${CMAKE_SOURCE_DIR}
-                                            / tensilelite) #For benchmark allocation function
-    else() include_directories(${CMAKE_BINARY_DIR} / include ${CMAKE_SOURCE_DIR}
-                               / tensilelite) endif()
 
-        set(THREADS_PREFER_PTHREAD_FLAG ON) find_package(Threads REQUIRED)
+if( SKIP_LIBRARY )
+  include_directories(${HIPBLASLT_LIBRARY_DIR}/include
+                      ${CMAKE_SOURCE_DIR}/tensilelite)  # For benchmark allocation function
+else()
+  include_directories(${CMAKE_BINARY_DIR}/include
+                      ${CMAKE_SOURCE_DIR}/tensilelite)
+endif()
 
-#if it fails to find OpenMP compile \
-    and link flags in strange configurations it can just use non - parallel reference computation
-#if there is no omp.h to find the client compilation will fail and this should be obvious, \
-    used to be                                                                    REQUIRED
-            find_package(OpenMP)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
 
-                if(TARGET OpenMP::OpenMP_CXX) set(COMMON_LINK_LIBS "OpenMP::OpenMP_CXX") list(
-                    APPEND COMMON_LINK_LIBS
-                    "-L${HIP_CLANG_ROOT}/lib;-Wl,-rpath=${HIP_CLANG_ROOT}/lib") endif()
+# if it fails to find OpenMP compile and link flags in strange configurations it can just use non-parallel reference computation
+# if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
+find_package(OpenMP)
 
-                    if(TARGET Threads::Threads) list(APPEND COMMON_LINK_LIBS
-                                                     "Threads::Threads") endif()
+if (TARGET OpenMP::OpenMP_CXX)
+  set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
+  list( APPEND COMMON_LINK_LIBS "-L${HIP_CLANG_ROOT}/lib;-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+endif()
 
-                        message(STATUS "CLIENT COMMON CXX_OPTIONS: ${COMMON_CXX_OPTIONS}") message(
-                            STATUS "CLIENT COMMON LINK: ${COMMON_LINK_LIBS}")
+if (TARGET Threads::Threads)
+  list( APPEND COMMON_LINK_LIBS "Threads::Threads")
+endif()
 
-                            list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} / cmake)
+message(STATUS "CLIENT COMMON CXX_OPTIONS: ${COMMON_CXX_OPTIONS}")
+message(STATUS "CLIENT COMMON LINK: ${COMMON_LINK_LIBS}")
 
-#include(build - options)
+list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
 
-#This option only works for make / nmake and the ninja generators, but no reason it shouldn't be on all the time
-#This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
-                                set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+#include( build-options )
 
-                                    if(NOT TARGET hipblaslt) find_package(
-                                        hipblaslt REQUIRED CONFIG PATHS ${ROCM_PATH} / hipblaslt
-                                        / opt / rocm / hipblaslt ${HIPBLASLT_LIBRARY_DIR}) endif()
+# This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
+# This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
+set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
-#Hip headers required of all clients; clients use hip to allocate device memory
-                                        list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} / opt / rocm) if(
-                                            NOT hip_FOUND) find_package(hip REQUIRED CONFIG PATHS ${
-                                            ROCM_PATH}) endif()
+if( NOT TARGET hipblaslt )
+  find_package( hipblaslt REQUIRED CONFIG PATHS ${ROCM_PATH}/hipblaslt /opt/rocm/hipblaslt ${HIPBLASLT_LIBRARY_DIR})
+endif( )
 
-                                            if(BUILD_CLIENTS_SAMPLES) add_subdirectory(
-                                                samples) endif()
+# Hip headers required of all clients; clients use hip to allocate device memory
+list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} /opt/rocm )
+if ( NOT hip_FOUND )
+  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} )
+endif( )
 
-                                                if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
-#Linking lapack library requires fortran flags
-                                                    find_package(cblas REQUIRED CONFIG) if(
-                                                        ${BLIS_FOUND}) set(BLAS_LIBRARY ${
-                                                        BLIS_LIB}) set(BLIS_CPP../ common
-                                                                       / blis_interface
-                                                                             .cpp) else() set(BLAS_LIBRARY
-                                                                                              "bla"
-                                                                                              "s") endif()
+if( BUILD_CLIENTS_SAMPLES )
+  add_subdirectory( samples )
+endif( )
 
-#Find the package ROCmSMI
-                                                        if(NOT WIN32) find_package(
-                                                            ROCmSMI
-                                                                REQUIRED) list(APPEND COMMON_LINK_LIBS
-                                                                                   rocm_smi) endif()
+if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
-#common source files used in subdirectories benchmarks and gtest thus../ common
-                                                            set(hipblaslt_test_bench_common..
-                                                                / common / singletons.cpp../ common
-                                                                / utility.cpp../ common
-                                                                / frequency_monitor.cpp../ common
-                                                                / cblas_interface.cpp../ common
-                                                                / argument_model.cpp../ common
-                                                                / hipblaslt_parse_data.cpp../ common
-                                                                / hipblaslt_arguments.cpp../ common
-                                                                / hipblaslt_random.cpp ${BLIS_CPP})
+  # Linking lapack library requires fortran flags
+  find_package( cblas REQUIRED CONFIG )
+  if(${BLIS_FOUND})
+    set( BLAS_LIBRARY ${BLIS_LIB} )
+    set( BLIS_CPP ../common/blis_interface.cpp )
+  else()
+    set( BLAS_LIBRARY "blas" )
+  endif()
 
-                                                                if(BUILD_CLIENTS_BENCHMARKS) add_subdirectory(
-                                                                    benchmarks) endif()
+  # Find the package ROCmSMI
+  if(NOT WIN32)
+      find_package(ROCmSMI REQUIRED)
+      list( APPEND COMMON_LINK_LIBS rocm_smi )
+  endif()
+  
+  # common source files used in subdirectories benchmarks and gtest thus ../common
+  set( hipblaslt_test_bench_common
+      ../common/singletons.cpp
+      ../common/utility.cpp
+      ../common/frequency_monitor.cpp
+      ../common/cblas_interface.cpp
+      ../common/argument_model.cpp
+      ../common/hipblaslt_parse_data.cpp
+      ../common/hipblaslt_arguments.cpp
+      ../common/hipblaslt_random.cpp
+      ${BLIS_CPP}
+    )
 
-                                                                    if(BUILD_CLIENTS_TESTS) add_subdirectory(
-                                                                        gtest) endif()
+  if( BUILD_CLIENTS_BENCHMARKS )
+    add_subdirectory( benchmarks )
+  endif( )
 
-                                                                        endif()
+  if( BUILD_CLIENTS_TESTS )
+    add_subdirectory( gtest )
+  endif( )
 
-                                                                            set(HIPBLASLT_COMMON "$"
-                                                                                                 "{"
-                                                                                                 "P"
-                                                                                                 "R"
-                                                                                                 "O"
-                                                                                                 "J"
-                                                                                                 "E"
-                                                                                                 "C"
-                                                                                                 "T"
-                                                                                                 "_"
-                                                                                                 "B"
-                                                                                                 "I"
-                                                                                                 "N"
-                                                                                                 "A"
-                                                                                                 "R"
-                                                                                                 "Y"
-                                                                                                 "_"
-                                                                                                 "D"
-                                                                                                 "I"
-                                                                                                 "R"
-                                                                                                 "}"
-                                                                                                 "/"
-                                                                                                 "s"
-                                                                                                 "t"
-                                                                                                 "a"
-                                                                                                 "g"
-                                                                                                 "i"
-                                                                                                 "n"
-                                                                                                 "g"
-                                                                                                 "/"
-                                                                                                 "h"
-                                                                                                 "i"
-                                                                                                 "p"
-                                                                                                 "b"
-                                                                                                 "l"
-                                                                                                 "a"
-                                                                                                 "s"
-                                                                                                 "l"
-                                                                                                 "t"
-                                                                                                 "_"
-                                                                                                 "c"
-                                                                                                 "o"
-                                                                                                 "m"
-                                                                                                 "m"
-                                                                                                 "o"
-                                                                                                 "n"
-                                                                                                 "."
-                                                                                                 "y"
-                                                                                                 "a"
-                                                                                                 "m"
-                                                                                                 "l") add_custom_command(
-                                                                                OUTPUT
-                                                                                "${HIPBLASLT_"
-                                                                                "COMMON}" COMMAND ${
-                                                                                    CMAKE_COMMAND}
-                                                                                - E copy include
-                                                                                      / hipblaslt_common
-                                                                                            .yaml
-                                                                                        "${"
-                                                                                        "HIPBLASLT_"
-                                                                                        "COMMON"
-                                                                                        "}" DEPENDS
-                                                                                            include
-                                                                                      / hipblaslt_common
-                                                                                            .yaml
-                                                                                                WORKING_DIRECTORY
-                                                                                        "${CMAKE_"
-                                                                                        "CURRENT_"
-                                                                                        "SOURCE_"
-                                                                                        "DIR}")
+endif()
 
-                                                                                set(HIPBLASLT_TEMPLATE "${PROJECT_BINARY_DIR}/staging/hipblaslt_template.yaml") add_custom_command(
-                                                                                    OUTPUT
-                                                                                    "${HIPBLASLT_"
-                                                                                    "TEMPLATE"
-                                                                                    "}" COMMAND
-                                                                                        ${CMAKE_COMMAND}
-                                                                                    - E copy include
-                                                                                          / hipblaslt_template
-                                                                                                .yaml
-                                                                                            "${"
-                                                                                            "HIPBLA"
-                                                                                            "SLT_"
-                                                                                            "TEMPLA"
-                                                                                            "TE"
-                                                                                            "}" DEPENDS
-                                                                                                include
-                                                                                          / hipblaslt_template
-                                                                                                .yaml
-                                                                                                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
-                                                                                    set(HIPBLASLT_GENTEST "${PROJECT_BINARY_DIR}/staging/hipblaslt_gentest.py") add_custom_command(
-                                                                                        OUTPUT
-                                                                                        "${"
-                                                                                        "HIPBLASLT_"
-                                                                                        "GENTEST"
-                                                                                        "}" COMMAND
-                                                                                            ${CMAKE_COMMAND}
-                                                                                        - E copy common
-                                                                                              / hipblaslt_gentest
-                                                                                                    .py
-                                                                                                "${"
-                                                                                                "HI"
-                                                                                                "PB"
-                                                                                                "LA"
-                                                                                                "SL"
-                                                                                                "T_"
-                                                                                                "GE"
-                                                                                                "NT"
-                                                                                                "ES"
-                                                                                                "T"
-                                                                                                "}" DEPENDS
-                                                                                                    common
-                                                                                              / hipblaslt_gentest
-                                                                                                    .py WORKING_DIRECTORY
-                                                                                                "${"
-                                                                                                "CM"
-                                                                                                "AK"
-                                                                                                "E_"
-                                                                                                "CU"
-                                                                                                "RR"
-                                                                                                "EN"
-                                                                                                "T_"
-                                                                                                "SO"
-                                                                                                "UR"
-                                                                                                "CE"
-                                                                                                "_D"
-                                                                                                "IR"
-                                                                                                "}")
+set( HIPBLASLT_COMMON "${PROJECT_BINARY_DIR}/staging/hipblaslt_common.yaml")
+add_custom_command( OUTPUT "${HIPBLASLT_COMMON}"
+                    COMMAND ${CMAKE_COMMAND} -E copy include/hipblaslt_common.yaml "${HIPBLASLT_COMMON}"
+                    DEPENDS include/hipblaslt_common.yaml
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 
-                                                                                        add_custom_target(
-                                                                                            hipblaslt
-                                                                                            - common
-                                                                                                DEPENDS
-                                                                                            "${"
-                                                                                            "HIPBLA"
-                                                                                            "SLT_"
-                                                                                            "COMMON"
-                                                                                            "}"
-                                                                                            "${"
-                                                                                            "HIPBLA"
-                                                                                            "SLT_"
-                                                                                            "TEMPLA"
-                                                                                            "TE}"
-                                                                                            "${"
-                                                                                            "HIPBLA"
-                                                                                            "SLT_"
-                                                                                            "GENTES"
-                                                                                            "T}")
+set( HIPBLASLT_TEMPLATE "${PROJECT_BINARY_DIR}/staging/hipblaslt_template.yaml")
+add_custom_command( OUTPUT "${HIPBLASLT_TEMPLATE}"
+                    COMMAND ${CMAKE_COMMAND} -E copy include/hipblaslt_template.yaml "${HIPBLASLT_TEMPLATE}"
+                    DEPENDS include/hipblaslt_template.yaml
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 
-                                                                                            rocm_install(
-                                                                                                FILES ${
-                                                                                                    HIPBLASLT_COMMON} ${
-                                                                                                    HIPBLASLT_TEMPLATE} DESTINATION
-                                                                                                "${"
-                                                                                                "CM"
-                                                                                                "AK"
-                                                                                                "E_"
-                                                                                                "IN"
-                                                                                                "ST"
-                                                                                                "AL"
-                                                                                                "L_"
-                                                                                                "BI"
-                                                                                                "ND"
-                                                                                                "IR"
-                                                                                                "}" COMPONENT
-                                                                                                    clients
-                                                                                                - common)
-                                                                                                rocm_install(
-                                                                                                    PROGRAMS
-                                                                                                        ${HIPBLASLT_GENTEST} DESTINATION
-                                                                                                    "${CMAKE_INSTALL_BINDIR}" COMPONENT
-                                                                                                        clients
-                                                                                                    - common)
+set( HIPBLASLT_GENTEST "${PROJECT_BINARY_DIR}/staging/hipblaslt_gentest.py")
+add_custom_command( OUTPUT "${HIPBLASLT_GENTEST}"
+                    COMMAND ${CMAKE_COMMAND} -E copy common/hipblaslt_gentest.py "${HIPBLASLT_GENTEST}"
+                    DEPENDS common/hipblaslt_gentest.py
+                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+
+add_custom_target( hipblaslt-common DEPENDS "${HIPBLASLT_COMMON}" "${HIPBLASLT_TEMPLATE}" "${HIPBLASLT_GENTEST}" )
+
+rocm_install(
+  FILES ${HIPBLASLT_COMMON} ${HIPBLASLT_TEMPLATE}
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  COMPONENT clients-common
+)
+rocm_install(
+  PROGRAMS ${HIPBLASLT_GENTEST}
+  DESTINATION "${CMAKE_INSTALL_BINDIR}"
+  COMPONENT clients-common
+)

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -1,150 +1,291 @@
 # ########################################################################
-# Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+#Copyright(C) 2022 - 2024 Advanced Micro Devices, Inc.
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+#Permission is hereby granted, free of charge, to any person obtaining a copy
+#of this software and associated documentation files(the "Software"), to deal
+#in the Software without restriction, including without limitation the rights
+#to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+#copies of the Software, and to permit persons to whom the Software is
+#furnished to do so, subject to the following                       conditions:
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+#The above copyright notice and this permission notice shall be included in
+#all copies or substantial portions of the                               Software.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+#AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#THE SOFTWARE.
 #
 # ########################################################################
 
-cmake_minimum_required( VERSION 3.25.2 )
+cmake_minimum_required(VERSION 3.25.2)
 
 #add_definitions(-D_HIPBLASLT_INTERNAL_BFLOAT16_)
 
-# This has to be initialized before the project() command appears
-# Set the default of CMAKE_BUILD_TYPE to be release, unless user specifies with -D.  MSVC_IDE does not use CMAKE_BUILD_TYPE
-if( NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
-endif()
+#This has to be initialized before the project() command appears
+#Set the default of CMAKE_BUILD_TYPE to be               release, \
+    unless user specifies with - D.MSVC_IDE does not use CMAKE_BUILD_TYPE
+    if(NOT DEFINED CMAKE_CONFIGURATION_TYPES AND NOT DEFINED CMAKE_BUILD_TYPE)
+        set(CMAKE_BUILD_TYPE Release CACHE STRING
+            "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel.")
+            endif()
 
-project( hipblaslt-clients LANGUAGES CXX C  )
+                project(hipblaslt - clients LANGUAGES CXX C)
 
+                    if(SKIP_LIBRARY)
+                        include_directories(${HIPBLASLT_LIBRARY_DIR} / include ${CMAKE_SOURCE_DIR}
+                                            / tensilelite) #For benchmark allocation function
+    else() include_directories(${CMAKE_BINARY_DIR} / include ${CMAKE_SOURCE_DIR}
+                               / tensilelite) endif()
 
-if( SKIP_LIBRARY )
-  include_directories(${HIPBLASLT_LIBRARY_DIR}/include
-                      ${CMAKE_SOURCE_DIR}/tensilelite)  # For benchmark allocation function
-else()
-  include_directories(${CMAKE_BINARY_DIR}/include
-                      ${CMAKE_SOURCE_DIR}/tensilelite)
-endif()
+        set(THREADS_PREFER_PTHREAD_FLAG ON) find_package(Threads REQUIRED)
 
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_package(Threads REQUIRED)
+#if it fails to find OpenMP compile \
+    and link flags in strange configurations it can just use non - parallel reference computation
+#if there is no omp.h to find the client compilation will fail and this should be obvious, \
+    used to be                                                                    REQUIRED
+            find_package(OpenMP)
 
-# if it fails to find OpenMP compile and link flags in strange configurations it can just use non-parallel reference computation
-# if there is no omp.h to find the client compilation will fail and this should be obvious, used to be REQUIRED
-find_package(OpenMP)
+                if(TARGET OpenMP::OpenMP_CXX) set(COMMON_LINK_LIBS "OpenMP::OpenMP_CXX") list(
+                    APPEND COMMON_LINK_LIBS
+                    "-L${HIP_CLANG_ROOT}/lib;-Wl,-rpath=${HIP_CLANG_ROOT}/lib") endif()
 
-if (TARGET OpenMP::OpenMP_CXX)
-  set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
-  list( APPEND COMMON_LINK_LIBS "-L${HIP_CLANG_ROOT}/lib;-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
-endif()
+                    if(TARGET Threads::Threads) list(APPEND COMMON_LINK_LIBS
+                                                     "Threads::Threads") endif()
 
-if (TARGET Threads::Threads)
-  list( APPEND COMMON_LINK_LIBS "Threads::Threads")
-endif()
+                        message(STATUS "CLIENT COMMON CXX_OPTIONS: ${COMMON_CXX_OPTIONS}") message(
+                            STATUS "CLIENT COMMON LINK: ${COMMON_LINK_LIBS}")
 
-message(STATUS "CLIENT COMMON CXX_OPTIONS: ${COMMON_CXX_OPTIONS}")
-message(STATUS "CLIENT COMMON LINK: ${COMMON_LINK_LIBS}")
+                            list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR} / cmake)
 
-list( APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake )
+#include(build - options)
 
-#include( build-options )
+#This option only works for make / nmake and the ninja generators, but no reason it shouldn't be on all the time
+#This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
+                                set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-# This option only works for make/nmake and the ninja generators, but no reason it shouldn't be on all the time
-# This tells cmake to create a compile_commands.json file that can be used with clang tooling or vim
-set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
+                                    if(NOT TARGET hipblaslt) find_package(
+                                        hipblaslt REQUIRED CONFIG PATHS ${ROCM_PATH} / hipblaslt
+                                        / opt / rocm / hipblaslt ${HIPBLASLT_LIBRARY_DIR}) endif()
 
-if( NOT TARGET hipblaslt )
-  find_package( hipblaslt REQUIRED CONFIG PATHS ${ROCM_PATH}/hipblaslt /opt/rocm/hipblaslt ${HIPBLASLT_LIBRARY_DIR})
-endif( )
+#Hip headers required of all clients; clients use hip to allocate device memory
+                                        list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} / opt / rocm) if(
+                                            NOT hip_FOUND) find_package(hip REQUIRED CONFIG PATHS ${
+                                            ROCM_PATH}) endif()
 
-# Hip headers required of all clients; clients use hip to allocate device memory
-list( APPEND CMAKE_PREFIX_PATH ${ROCM_PATH} /opt/rocm )
-if ( NOT hip_FOUND )
-  find_package( hip REQUIRED CONFIG PATHS ${ROCM_PATH} )
-endif( )
+                                            if(BUILD_CLIENTS_SAMPLES) add_subdirectory(
+                                                samples) endif()
 
+                                                if(BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
 
-if( BUILD_CLIENTS_SAMPLES )
-  add_subdirectory( samples )
-endif( )
+#Linking lapack library requires fortran flags
+                                                    find_package(cblas REQUIRED CONFIG) if(
+                                                        ${BLIS_FOUND}) set(BLAS_LIBRARY ${
+                                                        BLIS_LIB}) set(BLIS_CPP../ common
+                                                                       / blis_interface
+                                                                             .cpp) else() set(BLAS_LIBRARY
+                                                                                              "bla"
+                                                                                              "s") endif()
 
-if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
+#Find the package ROCmSMI
+                                                        if(NOT WIN32) find_package(
+                                                            ROCmSMI
+                                                                REQUIRED) list(APPEND COMMON_LINK_LIBS
+                                                                                   rocm_smi) endif()
 
-  # Linking lapack library requires fortran flags
-  find_package( cblas REQUIRED CONFIG )
-  if(${BLIS_FOUND})
-    set( BLAS_LIBRARY ${BLIS_LIB} )
-    set( BLIS_CPP ../common/blis_interface.cpp )
-  else()
-    set( BLAS_LIBRARY "blas" )
-  endif()
+#common source files used in subdirectories benchmarks and gtest thus../ common
+                                                            set(hipblaslt_test_bench_common..
+                                                                / common / singletons.cpp../ common
+                                                                / utility.cpp../ common
+                                                                / frequency_monitor.cpp../ common
+                                                                / cblas_interface.cpp../ common
+                                                                / argument_model.cpp../ common
+                                                                / hipblaslt_parse_data.cpp../ common
+                                                                / hipblaslt_arguments.cpp../ common
+                                                                / hipblaslt_random.cpp ${BLIS_CPP})
 
-  # common source files used in subdirectories benchmarks and gtest thus ../common
-  set( hipblaslt_test_bench_common
-      ../common/singletons.cpp
-      ../common/utility.cpp
-      ../common/cblas_interface.cpp
-      ../common/argument_model.cpp
-      ../common/hipblaslt_parse_data.cpp
-      ../common/hipblaslt_arguments.cpp
-      ../common/hipblaslt_random.cpp
-      ${BLIS_CPP}
-    )
+                                                                if(BUILD_CLIENTS_BENCHMARKS) add_subdirectory(
+                                                                    benchmarks) endif()
 
-  if( BUILD_CLIENTS_BENCHMARKS )
-    add_subdirectory( benchmarks )
-  endif( )
+                                                                    if(BUILD_CLIENTS_TESTS) add_subdirectory(
+                                                                        gtest) endif()
 
-  if( BUILD_CLIENTS_TESTS )
-    add_subdirectory( gtest )
-  endif( )
+                                                                        endif()
 
-endif()
+                                                                            set(HIPBLASLT_COMMON "$"
+                                                                                                 "{"
+                                                                                                 "P"
+                                                                                                 "R"
+                                                                                                 "O"
+                                                                                                 "J"
+                                                                                                 "E"
+                                                                                                 "C"
+                                                                                                 "T"
+                                                                                                 "_"
+                                                                                                 "B"
+                                                                                                 "I"
+                                                                                                 "N"
+                                                                                                 "A"
+                                                                                                 "R"
+                                                                                                 "Y"
+                                                                                                 "_"
+                                                                                                 "D"
+                                                                                                 "I"
+                                                                                                 "R"
+                                                                                                 "}"
+                                                                                                 "/"
+                                                                                                 "s"
+                                                                                                 "t"
+                                                                                                 "a"
+                                                                                                 "g"
+                                                                                                 "i"
+                                                                                                 "n"
+                                                                                                 "g"
+                                                                                                 "/"
+                                                                                                 "h"
+                                                                                                 "i"
+                                                                                                 "p"
+                                                                                                 "b"
+                                                                                                 "l"
+                                                                                                 "a"
+                                                                                                 "s"
+                                                                                                 "l"
+                                                                                                 "t"
+                                                                                                 "_"
+                                                                                                 "c"
+                                                                                                 "o"
+                                                                                                 "m"
+                                                                                                 "m"
+                                                                                                 "o"
+                                                                                                 "n"
+                                                                                                 "."
+                                                                                                 "y"
+                                                                                                 "a"
+                                                                                                 "m"
+                                                                                                 "l") add_custom_command(
+                                                                                OUTPUT
+                                                                                "${HIPBLASLT_"
+                                                                                "COMMON}" COMMAND ${
+                                                                                    CMAKE_COMMAND}
+                                                                                - E copy include
+                                                                                      / hipblaslt_common
+                                                                                            .yaml
+                                                                                        "${"
+                                                                                        "HIPBLASLT_"
+                                                                                        "COMMON"
+                                                                                        "}" DEPENDS
+                                                                                            include
+                                                                                      / hipblaslt_common
+                                                                                            .yaml
+                                                                                                WORKING_DIRECTORY
+                                                                                        "${CMAKE_"
+                                                                                        "CURRENT_"
+                                                                                        "SOURCE_"
+                                                                                        "DIR}")
 
+                                                                                set(HIPBLASLT_TEMPLATE "${PROJECT_BINARY_DIR}/staging/hipblaslt_template.yaml") add_custom_command(
+                                                                                    OUTPUT
+                                                                                    "${HIPBLASLT_"
+                                                                                    "TEMPLATE"
+                                                                                    "}" COMMAND
+                                                                                        ${CMAKE_COMMAND}
+                                                                                    - E copy include
+                                                                                          / hipblaslt_template
+                                                                                                .yaml
+                                                                                            "${"
+                                                                                            "HIPBLA"
+                                                                                            "SLT_"
+                                                                                            "TEMPLA"
+                                                                                            "TE"
+                                                                                            "}" DEPENDS
+                                                                                                include
+                                                                                          / hipblaslt_template
+                                                                                                .yaml
+                                                                                                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 
-set( HIPBLASLT_COMMON "${PROJECT_BINARY_DIR}/staging/hipblaslt_common.yaml")
-add_custom_command( OUTPUT "${HIPBLASLT_COMMON}"
-                    COMMAND ${CMAKE_COMMAND} -E copy include/hipblaslt_common.yaml "${HIPBLASLT_COMMON}"
-                    DEPENDS include/hipblaslt_common.yaml
-                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+                                                                                    set(HIPBLASLT_GENTEST "${PROJECT_BINARY_DIR}/staging/hipblaslt_gentest.py") add_custom_command(
+                                                                                        OUTPUT
+                                                                                        "${"
+                                                                                        "HIPBLASLT_"
+                                                                                        "GENTEST"
+                                                                                        "}" COMMAND
+                                                                                            ${CMAKE_COMMAND}
+                                                                                        - E copy common
+                                                                                              / hipblaslt_gentest
+                                                                                                    .py
+                                                                                                "${"
+                                                                                                "HI"
+                                                                                                "PB"
+                                                                                                "LA"
+                                                                                                "SL"
+                                                                                                "T_"
+                                                                                                "GE"
+                                                                                                "NT"
+                                                                                                "ES"
+                                                                                                "T"
+                                                                                                "}" DEPENDS
+                                                                                                    common
+                                                                                              / hipblaslt_gentest
+                                                                                                    .py WORKING_DIRECTORY
+                                                                                                "${"
+                                                                                                "CM"
+                                                                                                "AK"
+                                                                                                "E_"
+                                                                                                "CU"
+                                                                                                "RR"
+                                                                                                "EN"
+                                                                                                "T_"
+                                                                                                "SO"
+                                                                                                "UR"
+                                                                                                "CE"
+                                                                                                "_D"
+                                                                                                "IR"
+                                                                                                "}")
 
-set( HIPBLASLT_TEMPLATE "${PROJECT_BINARY_DIR}/staging/hipblaslt_template.yaml")
-add_custom_command( OUTPUT "${HIPBLASLT_TEMPLATE}"
-                    COMMAND ${CMAKE_COMMAND} -E copy include/hipblaslt_template.yaml "${HIPBLASLT_TEMPLATE}"
-                    DEPENDS include/hipblaslt_template.yaml
-                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
+                                                                                        add_custom_target(
+                                                                                            hipblaslt
+                                                                                            - common
+                                                                                                DEPENDS
+                                                                                            "${"
+                                                                                            "HIPBLA"
+                                                                                            "SLT_"
+                                                                                            "COMMON"
+                                                                                            "}"
+                                                                                            "${"
+                                                                                            "HIPBLA"
+                                                                                            "SLT_"
+                                                                                            "TEMPLA"
+                                                                                            "TE}"
+                                                                                            "${"
+                                                                                            "HIPBLA"
+                                                                                            "SLT_"
+                                                                                            "GENTES"
+                                                                                            "T}")
 
-set( HIPBLASLT_GENTEST "${PROJECT_BINARY_DIR}/staging/hipblaslt_gentest.py")
-add_custom_command( OUTPUT "${HIPBLASLT_GENTEST}"
-                    COMMAND ${CMAKE_COMMAND} -E copy common/hipblaslt_gentest.py "${HIPBLASLT_GENTEST}"
-                    DEPENDS common/hipblaslt_gentest.py
-                    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
-
-add_custom_target( hipblaslt-common DEPENDS "${HIPBLASLT_COMMON}" "${HIPBLASLT_TEMPLATE}" "${HIPBLASLT_GENTEST}" )
-
-rocm_install(
-  FILES ${HIPBLASLT_COMMON} ${HIPBLASLT_TEMPLATE}
-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  COMPONENT clients-common
-)
-rocm_install(
-  PROGRAMS ${HIPBLASLT_GENTEST}
-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
-  COMPONENT clients-common
-)
+                                                                                            rocm_install(
+                                                                                                FILES ${
+                                                                                                    HIPBLASLT_COMMON} ${
+                                                                                                    HIPBLASLT_TEMPLATE} DESTINATION
+                                                                                                "${"
+                                                                                                "CM"
+                                                                                                "AK"
+                                                                                                "E_"
+                                                                                                "IN"
+                                                                                                "ST"
+                                                                                                "AL"
+                                                                                                "L_"
+                                                                                                "BI"
+                                                                                                "ND"
+                                                                                                "IR"
+                                                                                                "}" COMPONENT
+                                                                                                    clients
+                                                                                                - common)
+                                                                                                rocm_install(
+                                                                                                    PROGRAMS
+                                                                                                        ${HIPBLASLT_GENTEST} DESTINATION
+                                                                                                    "${CMAKE_INSTALL_BINDIR}" COMPONENT
+                                                                                                        clients
+                                                                                                    - common)

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -41,6 +41,8 @@
 #include <string>
 #include <type_traits>
 
+#include "frequency_monitor.hpp"
+
 #include "testing_matmul.hpp"
 
 #include "type_dispatch.hpp"
@@ -75,12 +77,12 @@ void run_function(const func_map& map, const Arguments& arg, const std::string& 
 // Template to dispatch testing_matmul for performance tests
 // the test is marked invalid when (TiA, TiB, To, Tc) not in (H/H/S, B/B/S)
 template <typename TiA,
-          typename TiB = TiA,
-          typename To  = TiB,
-          typename Tc  = To,
+          typename TiB  = TiA,
+          typename To   = TiB,
+          typename Tc   = To,
           typename TciA = TiA,
           typename TciB = TiB,
-          typename     = void>
+          typename      = void>
 struct perf_matmul : hipblaslt_test_invalid
 {
 };
@@ -736,6 +738,9 @@ try
         throw std::invalid_argument("Invalid Device ID");
     set_device(device_id);
 
+    FrequencyMonitor& freq_monitor = getFrequencyMonitor();
+    freq_monitor.set_device_id(device_id);
+
     if(datafile)
         return hipblaslt_bench_datafile(filter, any_stride);
 
@@ -780,13 +785,19 @@ try
         throw std::invalid_argument("Invalid value for --compute_type " + compute_type);
 
     //The value HIPBLASLT_DATATYPE_INVALID indicates that the compute_input_typeA has no effect.
-    arg.compute_input_typeA = (compute_input_typeA != "") ? string_to_hip_datatype(compute_input_typeA) : HIPBLASLT_DATATYPE_INVALID;
+    arg.compute_input_typeA = (compute_input_typeA != "")
+                                  ? string_to_hip_datatype(compute_input_typeA)
+                                  : HIPBLASLT_DATATYPE_INVALID;
     if(arg.compute_input_typeA == HIPBLASLT_DATATYPE_INVALID && compute_input_typeA != "")
-        throw std::invalid_argument("Invalid value for --compute_input_typeA " + compute_input_typeA);
+        throw std::invalid_argument("Invalid value for --compute_input_typeA "
+                                    + compute_input_typeA);
 
-    arg.compute_input_typeB = (compute_input_typeB != "") ? string_to_hip_datatype(compute_input_typeB) : HIPBLASLT_DATATYPE_INVALID;
+    arg.compute_input_typeB = (compute_input_typeB != "")
+                                  ? string_to_hip_datatype(compute_input_typeB)
+                                  : HIPBLASLT_DATATYPE_INVALID;
     if(arg.compute_input_typeB == HIPBLASLT_DATATYPE_INVALID && compute_input_typeB != "")
-        throw std::invalid_argument("Invalid value for --compute_input_typeB " + compute_input_typeB);
+        throw std::invalid_argument("Invalid value for --compute_input_typeB "
+                                    + compute_input_typeB);
 
     if(string_to_hip_datatype(bias_type) == HIPBLASLT_DATATYPE_INVALID && bias_type != ""
        && bias_type != "default")
@@ -838,7 +849,9 @@ try
     }
 
     arg.norm_check_assert = false;
-    return run_bench_test(arg, filter, any_stride);
+    int status            = run_bench_test(arg, filter, any_stride);
+    freeFrequencyMonitor();
+    return status;
 }
 catch(const std::invalid_argument& exp)
 {

--- a/clients/common/argument_model.cpp
+++ b/clients/common/argument_model.cpp
@@ -25,6 +25,7 @@
  *******************************************************************************/
 
 #include "argument_model.hpp"
+#include "frequency_monitor.hpp"
 
 // this should have been a member variable but due to the complex variadic template this singleton allows global control
 
@@ -38,4 +39,43 @@ void ArgumentModel_set_log_function_name(bool f)
 bool ArgumentModel_get_log_function_name()
 {
     return log_function_name;
+}
+
+void ArgumentModel_log_frequencies(hipblaslt_internal_ostream& name_line,
+                                   hipblaslt_internal_ostream& val_line)
+{
+
+    FrequencyMonitor& frequency_monitor = getFrequencyMonitor();
+    if(!frequency_monitor.enabled())
+        return;
+    if(!frequency_monitor.detailedReport())
+    {
+        name_line << ",lowest-avg-freq";
+        val_line << "," << frequency_monitor.getLowestAverageSYSCLK();
+
+        name_line << ",lowest-median-freq";
+        val_line << "," << frequency_monitor.getLowestMedianSYSCLK();
+    }
+    else
+    {
+        auto allAvgSYSCLK = frequency_monitor.getAllAverageSYSCLK();
+        for(int i = 0; i < allAvgSYSCLK.size(); i++)
+        {
+            name_line << ",avg-freq_" << i;
+            val_line << "," << allAvgSYSCLK[i];
+        }
+
+        auto allMedianSYSCLK = frequency_monitor.getAllMedianSYSCLK();
+        for(int i = 0; i < allMedianSYSCLK.size(); i++)
+        {
+            name_line << ",median-freq_" << i;
+            val_line << "," << allMedianSYSCLK[i];
+        }
+    }
+
+    name_line << ",avg-MCLK";
+    val_line << "," << frequency_monitor.getAverageMEMCLK();
+
+    name_line << ",median-MCLK";
+    val_line << "," << frequency_monitor.getMedianMEMCLK();
 }

--- a/clients/common/frequency_monitor.cpp
+++ b/clients/common/frequency_monitor.cpp
@@ -1,0 +1,542 @@
+
+/* ************************************************************************
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "frequency_monitor.hpp"
+
+#include <atomic>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#ifndef _WIN32
+
+#include <hip/hip_runtime.h>
+#include <rocm_smi/rocm_smi.h>
+
+template <typename T>
+inline std::ostream& stream_write(std::ostream& stream, T&& val)
+{
+    return stream << std::forward<T>(val);
+}
+
+template <typename T, typename... Ts>
+inline std::ostream& stream_write(std::ostream& stream, T&& val, Ts&&... vals)
+{
+    return stream_write(stream << std::forward<T>(val), std::forward<Ts>(vals)...);
+}
+
+template <typename... Ts>
+inline std::string concatenate(Ts&&... vals)
+{
+    std::ostringstream msg;
+    stream_write(msg, std::forward<Ts>(vals)...);
+
+    return msg.str();
+}
+
+#define HIP_CHECK_EXC(expr)                                                                       \
+    do                                                                                            \
+    {                                                                                             \
+        hipError_t e = (expr);                                                                    \
+        if(e)                                                                                     \
+        {                                                                                         \
+            const char*        errName = hipGetErrorName(e);                                      \
+            const char*        errMsg  = hipGetErrorString(e);                                    \
+            std::ostringstream msg;                                                               \
+            msg << "Error " << e << "(" << errName << ") " << __FILE__ << ":" << __LINE__ << ": " \
+                << std::endl                                                                      \
+                << #expr << std::endl                                                             \
+                << errMsg << std::endl;                                                           \
+            throw std::runtime_error(msg.str());                                                  \
+        }                                                                                         \
+    } while(0)
+
+#define RSMI_CHECK_EXC(expr)                                                                      \
+    do                                                                                            \
+    {                                                                                             \
+        rsmi_status_t e = (expr);                                                                 \
+        if(e)                                                                                     \
+        {                                                                                         \
+            const char* errName = nullptr;                                                        \
+            rsmi_status_string(e, &errName);                                                      \
+            std::ostringstream msg;                                                               \
+            msg << "Error " << e << "(" << errName << ") " << __FILE__ << ":" << __LINE__ << ": " \
+                << std::endl                                                                      \
+                << #expr << std::endl;                                                            \
+            throw std::runtime_error(msg.str());                                                  \
+        }                                                                                         \
+    } while(0)
+
+#endif
+
+class FrequencyMonitorImp : public FrequencyMonitor
+{
+public:
+    const double cHzToMHz = 0.000001;
+    const double cMhzToHz = 1000000;
+
+    // deleting copy constructor
+    FrequencyMonitorImp(const FrequencyMonitorImp& obj) = delete;
+
+#ifndef _WIN32
+
+    bool enabled()
+    {
+        static const char* env1 = getenv("HIPBLASLT_BENCH_FREQ");
+        static const char* env2 = getenv("HIPBLASLT_BENCH_FREQ_ALL");
+        return env1 != nullptr || (env2 != nullptr && m_isMultiXCDSupported);
+    }
+
+    bool detailedReport()
+    {
+        static const char* env2 = getenv("HIPBLASLT_BENCH_FREQ_ALL");
+        return (env2 != nullptr && m_isMultiXCDSupported);
+    }
+
+    FrequencyMonitorImp()
+    {
+        initThread();
+    }
+
+    ~FrequencyMonitorImp()
+    {
+        m_stop = true;
+        m_exit = true;
+
+        m_cv.notify_all();
+        m_thread.join();
+    }
+
+    void set_device_id(int deviceId)
+    {
+        m_smiDeviceIndex = GetROCmSMIIndex(deviceId);
+
+        auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
+
+        if(status2 != RSMI_STATUS_SUCCESS)
+        {
+            m_XCDCount = 1;
+        }
+    }
+
+    void start()
+    {
+        if(!enabled())
+            return;
+
+        clearValues();
+        runBetweenEvents();
+    }
+
+    void stop()
+    {
+        if(!enabled())
+            return;
+
+        assertActive();
+        m_stop = true;
+        wait();
+    }
+
+    double averageValueMHz(double sum, std::vector<uint64_t>& data)
+    {
+        assertNotActive();
+        if(enabled() && data.empty())
+            return 0.0;
+
+        double averageFrequency = static_cast<double>(sum / data.size());
+        return averageFrequency * cHzToMHz;
+    }
+
+    double medianValueMHz(std::vector<uint64_t>& data)
+    {
+        assertNotActive();
+
+        double median = 0.0;
+        if(enabled() && data.empty())
+            return 0.0;
+
+        size_t num_datapoints = data.size();
+        if(num_datapoints)
+        {
+            std::sort(data.begin(), data.end());
+
+            median = static_cast<double>(data[(num_datapoints - 1) / 2]);
+            if(num_datapoints % 2 == 0)
+            {
+                median = static_cast<double>(median + data[(num_datapoints - 1) / 2 + 1]) / 2.0;
+            }
+        }
+        return median * cHzToMHz;
+    }
+
+    double getLowestAverageSYSCLK()
+    {
+        std::vector<double> allAvgSYSCLK = getAllAverageSYSCLK();
+        double              minAvgSYSCLK = allAvgSYSCLK[0];
+        for(int i = 1; i < m_XCDCount; i++)
+        {
+            if(allAvgSYSCLK[i] <= 0)
+                continue;
+            minAvgSYSCLK = min(minAvgSYSCLK, allAvgSYSCLK[i]);
+        }
+        return minAvgSYSCLK;
+    }
+
+    double getLowestMedianSYSCLK()
+    {
+        std::vector<double> allMedianSYSCLK = getAllMedianSYSCLK();
+        double              minMedianSYSCLK = allMedianSYSCLK[0];
+        for(int i = 1; i < m_XCDCount; i++)
+        {
+            if(allMedianSYSCLK[i] <= 0)
+                continue;
+            minMedianSYSCLK = min(minMedianSYSCLK, allMedianSYSCLK[i]);
+        }
+        return minMedianSYSCLK;
+    }
+
+    std::vector<double> getAllAverageSYSCLK()
+    {
+        std::vector<double> avgSYSCLK(m_XCDCount, 0.0);
+        for(int i = 0; i < m_XCDCount; i++)
+        {
+            avgSYSCLK[i] = averageValueMHz(m_SYSCLK_sum[i], m_SYSCLK_array[i]);
+        }
+        return avgSYSCLK;
+    }
+
+    std::vector<double> getAllMedianSYSCLK()
+    {
+        std::vector<double> medianSYSCLK(m_XCDCount, 0.0);
+        for(int i = 0; i < m_XCDCount; i++)
+        {
+            medianSYSCLK[i] = medianValueMHz(m_SYSCLK_array[i]);
+        }
+        return medianSYSCLK;
+    }
+
+    double getAverageMEMCLK()
+    {
+        return averageValueMHz(m_MEMCLK_sum, m_MEMCLK_array);
+    }
+
+    double getMedianMEMCLK()
+    {
+        return medianValueMHz(m_MEMCLK_array);
+    }
+
+private:
+    void initThread()
+    {
+        m_stop = false;
+        m_exit = false;
+
+        rsmi_version_t version;
+        auto           status1 = rsmi_version_get(&version);
+        m_isMultiXCDSupported  = false;
+        if(status1 == RSMI_STATUS_SUCCESS)
+        {
+            m_isMultiXCDSupported = (version.major >= 7);
+        }
+
+        m_thread = std::thread([=]() { this->runLoop(); });
+        return;
+    }
+
+    void runBetweenEvents()
+    {
+        assertNotActive();
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+
+            m_task   = std::move(Task([=]() { this->collect(); }));
+            m_future = m_task.get_future();
+
+            m_stop = false;
+            m_exit = false;
+        }
+        m_cv.notify_all();
+    }
+
+    void runLoop()
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        while(!m_exit)
+        {
+
+            while(!m_task.valid() && !m_exit)
+            {
+                m_cv.wait(lock);
+            }
+
+            if(m_exit)
+            {
+                return;
+            }
+
+            m_task();
+            m_task = std::move(Task());
+        }
+        return;
+    }
+
+    void collect()
+    {
+        rsmi_frequencies_t freq;
+        rsmi_gpu_metrics_t gpuMetrics;
+
+        do
+        {
+            if(m_isMultiXCDSupported)
+            {
+                // multi_XCD
+                auto status1 = rsmi_dev_gpu_metrics_info_get(m_smiDeviceIndex, &gpuMetrics);
+                if(status1 == RSMI_STATUS_SUCCESS)
+                {
+                    for(int i = 0; i < m_XCDCount; i++)
+                    {
+                        m_SYSCLK_sum[i] += gpuMetrics.current_gfxclks[i] * cMhzToHz;
+                        m_SYSCLK_array[i].push_back(gpuMetrics.current_gfxclks[i] * cMhzToHz);
+                    }
+                }
+            }
+            else
+            {
+                //XCD 0
+                auto status1
+                    = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, RSMI_CLK_TYPE_SYS, &freq);
+                if(status1 == RSMI_STATUS_SUCCESS)
+                {
+                    m_SYSCLK_sum[0] += freq.frequency[freq.current];
+                    m_SYSCLK_array[0].push_back(freq.frequency[freq.current]);
+                }
+            }
+
+            auto status2 = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, RSMI_CLK_TYPE_MEM, &freq);
+            if(status2 == RSMI_STATUS_SUCCESS)
+            {
+                m_MEMCLK_sum += freq.frequency[freq.current];
+                m_MEMCLK_array.push_back(freq.frequency[freq.current]);
+            }
+
+            // collect freq every 50ms regardless of success
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+        } while(!m_stop && !m_exit);
+    }
+
+    void assertActive()
+    {
+        if(!m_future.valid())
+            throw std::runtime_error("Monitor is not active.");
+    }
+
+    void assertNotActive()
+    {
+        if(m_future.valid())
+            throw std::runtime_error("Monitor is active.");
+    }
+
+    void clearValues()
+    {
+        m_SYSCLK_sum   = std::vector<uint64_t>(m_XCDCount, 0);
+        m_SYSCLK_array = std::vector<std::vector<uint64_t>>(m_XCDCount, std::vector<uint64_t>{});
+        m_MEMCLK_sum   = 0;
+        m_MEMCLK_array.clear();
+    }
+
+    void wait()
+    {
+        if(!m_future.valid())
+            return;
+
+        if(!m_stop)
+            throw std::runtime_error("Waiting for monitoring to stop with no end condition.");
+
+        m_future.wait();
+        m_future = std::move(std::future<void>());
+    }
+
+    void InitROCmSMI()
+    {
+        static rsmi_status_t status = rsmi_init(0);
+        RSMI_CHECK_EXC(status);
+    }
+
+    uint32_t GetROCmSMIIndex(int hipDeviceIndex)
+    {
+        InitROCmSMI();
+
+        hipDeviceProp_t props;
+
+        HIP_CHECK_EXC(hipGetDeviceProperties(&props, hipDeviceIndex));
+#if HIP_VERSION >= 50220730
+        int hip_version;
+        HIP_CHECK_EXC(hipRuntimeGetVersion(&hip_version));
+        if(hip_version >= 50220730)
+        {
+            HIP_CHECK_EXC(hipDeviceGetAttribute(&props.multiProcessorCount,
+                                                hipDeviceAttributePhysicalMultiProcessorCount,
+                                                hipDeviceIndex));
+        }
+#endif
+
+        uint64_t hipPCIID = 0;
+        // hipPCIID |= props.pciDeviceID & 0xFF;
+        // hipPCIID |= ((props.pciBusID & 0xFF) << 8);
+        // hipPCIID |= (props.pciDomainID) << 16;
+
+        hipPCIID |= (((uint64_t)props.pciDomainID & 0xffffffff) << 32);
+        hipPCIID |= ((props.pciBusID & 0xff) << 8);
+        hipPCIID |= ((props.pciDeviceID & 0x1f) << 3);
+
+        uint32_t smiCount = 0;
+
+        RSMI_CHECK_EXC(rsmi_num_monitor_devices(&smiCount));
+
+        std::ostringstream msg;
+        msg << "PCI IDs: [" << std::endl;
+
+        for(uint32_t smiIndex = 0; smiIndex < smiCount; smiIndex++)
+        {
+            uint64_t rsmiPCIID = 0;
+
+            RSMI_CHECK_EXC(rsmi_dev_pci_id_get(smiIndex, &rsmiPCIID));
+
+            msg << smiIndex << ": " << rsmiPCIID << std::endl;
+
+            if(hipPCIID == rsmiPCIID)
+                return smiIndex;
+        }
+
+        msg << "]" << std::endl;
+
+        throw std::runtime_error(concatenate("RSMI Can't find a device with PCI ID ",
+                                             hipPCIID,
+                                             "(",
+                                             props.pciDomainID,
+                                             "-",
+                                             props.pciBusID,
+                                             "-",
+                                             props.pciDeviceID,
+                                             ")\n",
+                                             msg.str()));
+    }
+
+    using Task = std::packaged_task<void(void)>;
+    Task                    m_task;
+    std::atomic<bool>       m_exit;
+    std::atomic<bool>       m_stop;
+    std::future<void>       m_future;
+    std::thread             m_thread;
+    std::condition_variable m_cv;
+    std::mutex              m_mutex;
+    uint32_t                m_smiDeviceIndex;
+    bool                    m_isMultiXCDSupported;
+    uint16_t                m_XCDCount;
+
+    std::vector<uint64_t>              m_SYSCLK_sum;
+    std::vector<std::vector<uint64_t>> m_SYSCLK_array;
+    uint64_t                           m_MEMCLK_sum;
+    std::vector<uint64_t>              m_MEMCLK_array;
+
+#else // WIN32
+
+    // not supporting windows for now
+
+public:
+    FrequencyMonitorImp() {}
+
+    ~FrequencyMonitorImp() {}
+
+    void set_device_id(int deviceId) {}
+
+    void start() {}
+
+    void stop() {}
+
+    bool enabled()
+    {
+        return false;
+    }
+
+    bool detailedReport()
+    {
+        return false;
+    }
+
+    double getLowestAverageSYSCLK()
+    {
+        return 0.0;
+    }
+
+    double getLowestMedianSYSCLK()
+    {
+        return 0.0;
+    }
+
+    std::vector<double> getAllAverageSYSCLK()
+    {
+        return std::vector<double>();
+    }
+
+    std::vector<double> getAllMedianSYSCLK()
+    {
+        return std::vector<double>();
+    }
+
+    double getAverageMEMCLK()
+    {
+        return 0.0;
+    }
+
+    double getMedianMEMCLK()
+    {
+        return 0.0;
+    }
+#endif
+};
+
+static FrequencyMonitorImp* g_FreqMonitorInstance{nullptr};
+
+FrequencyMonitor& getFrequencyMonitor()
+{
+    if(g_FreqMonitorInstance == nullptr)
+    {
+        g_FreqMonitorInstance = new FrequencyMonitorImp();
+    }
+    return *g_FreqMonitorInstance;
+}
+
+void freeFrequencyMonitor()
+{
+    if(g_FreqMonitorInstance != nullptr)
+    {
+        delete g_FreqMonitorInstance;
+        g_FreqMonitorInstance = nullptr;
+    }
+}

--- a/clients/common/frequency_monitor.cpp
+++ b/clients/common/frequency_monitor.cpp
@@ -118,8 +118,7 @@ public:
 
     FrequencyMonitorImp()
     {
-        if(enabled())
-            initThread();
+        initThread();
     }
 
     ~FrequencyMonitorImp()

--- a/clients/common/frequency_monitor.cpp
+++ b/clients/common/frequency_monitor.cpp
@@ -118,7 +118,8 @@ public:
 
     FrequencyMonitorImp()
     {
-        initThread();
+        if(enabled())
+            initThread();
     }
 
     ~FrequencyMonitorImp()

--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -36,6 +36,9 @@ namespace ArgumentLogging
 void ArgumentModel_set_log_function_name(bool f);
 bool ArgumentModel_get_log_function_name();
 
+void ArgumentModel_log_frequencies(hipblaslt_internal_ostream& name_line,
+                                   hipblaslt_internal_ostream& val_line);
+
 // ArgumentModel template has a variadic list of argument enums
 template <hipblaslt_argument... Args>
 class ArgumentModel
@@ -64,6 +67,9 @@ public:
                   double                      norm3,
                   double                      norm4)
     {
+        // requires enablement for frequency logging
+        ArgumentModel_log_frequencies(name_line, val_line);
+
         constexpr bool has_batch_count = has(e_batch_count);
         int64_t        batch_count     = has_batch_count ? arg.batch_count : 1;
         int64_t        hot_calls       = arg.iters < 1 ? 1 : arg.iters;

--- a/clients/include/frequency_monitor.hpp
+++ b/clients/include/frequency_monitor.hpp
@@ -1,0 +1,47 @@
+
+/* ************************************************************************
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+ * ies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+ * PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+ * CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ *
+ * ************************************************************************/
+#pragma once
+
+#include <vector>
+class FrequencyMonitor
+{
+public:
+    virtual bool enabled()        = 0;
+    virtual bool detailedReport() = 0;
+
+    virtual void set_device_id(int deviceId) = 0;
+
+    virtual void start() = 0;
+    virtual void stop()  = 0;
+
+    virtual double              getLowestAverageSYSCLK() = 0;
+    virtual double              getLowestMedianSYSCLK()  = 0;
+    virtual std::vector<double> getAllAverageSYSCLK()    = 0;
+    virtual std::vector<double> getAllMedianSYSCLK()     = 0;
+    virtual double              getAverageMEMCLK()       = 0;
+    virtual double              getMedianMEMCLK()        = 0;
+};
+
+FrequencyMonitor& getFrequencyMonitor();
+void              freeFrequencyMonitor();


### PR DESCRIPTION
This PR ports the frequency monitor present in rocBLAS to hipBLASlt that allows reporting frequency information while using hipBLASlt-bench. 

2 flags have been added to enable this feature - 

- ```HIPBLASLT_BENCH_FREQ=true``` to report minimum of the (average and median) XCD frequencies. 
- ```HIPBLASLT_BENCH_FREQ_ALL=true``` to report all of the (average and median) XCD frequencies.

Example usage 
- ```HIPBLASLT_BENCH_FREQ_ALL=true ./staging/hipblaslt-bench -f matmul -r s -m 4000 -n 4000 -k 4000 --lda 4000 --ldb 4000 --ldc 4000 --transA N --transB T -i 10000 -j 1000```
- ```HIPBLASLT_BENCH_FREQ=true ./staging/hipblaslt-bench -f matmul -r s -m 4000 -n 4000 -k 4000 --lda 4000 --ldb 4000 --ldc 4000 --transA N --transB T -i 10000 -j 1000```