### PR TITLE
Tensilelite icache flush

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -106,7 +106,7 @@ def generateCustomKernelSolutions(problemType, customKernels, internalSupportPar
     return solutions
 
 def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
-        biasTypeArgs, biasDimArgs, activationArgs, stepName, solutionSummationSizes):
+        biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, stepName, solutionSummationSizes):
     """Write all the files needed for a given benchmarking step"""
     if not globalParameters["MergeFiles"]:
         ensurePath(os.path.join(globalParameters["WorkingPath"], "Solutions"))
@@ -178,10 +178,10 @@ def writeBenchmarkFiles(stepBaseDir, solutions, problemSizes, \
                 idealSize = {"Exact": [idealM, idealN, idealK]}
                 idealSizes.append(idealSize)
         idealProblemSizes = ProblemSizes(problemType, idealSizes)
-        writeClientConfig(True, solutions, idealProblemSizes, biasTypeArgs, biasDimArgs, activationArgs, stepName, stepBaseDir, \
+        writeClientConfig(True, solutions, idealProblemSizes, biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, stepName, stepBaseDir, \
             newLibrary, codeObjectFiles, True)
     else:
-        writeClientConfig(True, solutions, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, stepName, stepBaseDir, \
+        writeClientConfig(True, solutions, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, stepName, stepBaseDir, \
             newLibrary, codeObjectFiles, False)
 
     if len(solutions) == 0:
@@ -227,8 +227,9 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
         print1("# Benchmark Step: {} - {} {:.3f}s".format(groupName, stepName, elapsedTime))
         print1("# Num Sizes: {}".format(benchmarkStep.problemSizes.totalProblemSizes))
         print1("# Bias Dim steps: {}".format(benchmarkStep.biasDimArgs.totalProblemSizes))
-        print1("# Activation steps: {}".format(benchmarkStep.biasTypeArgs.totalProblemSizes))
+        print1("# Bias Type steps: {}".format(benchmarkStep.biasTypeArgs.totalProblemSizes))
         print1("# Activation steps: {}".format(benchmarkStep.activationArgs.totalProblemSizes))
+        print1("# ICacheFlush steps: {}".format(len(benchmarkStep.icacheFlushArgs)))
         print1("# Fork Parameters:")
         for k, v in benchmarkStep.forkParams.items():
             print1("#     {}: {}".format(k, v))
@@ -302,7 +303,7 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
             prevCount = len(solutions)
             codeObjectFiles = writeBenchmarkFiles(stepBaseDir, solutions, \
                     benchmarkStep.problemSizes, benchmarkStep.biasTypeArgs, \
-                    benchmarkStep.biasDimArgs, benchmarkStep.activationArgs, shortName, [])
+                    benchmarkStep.biasDimArgs, benchmarkStep.activationArgs, benchmarkStep.icacheFlushArgs, shortName, [])
             # ^ this mutates solutions
 
             # write cache data

--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -124,6 +124,7 @@ def main( config ):
     #        - [Enum: none]
     #        - [Enum: gelu]
     #        - [Enum: relu]
+    icacheFlushArgs = [False,]
     if len(config) > 0:
       for lc in config[0:]:
         if "ActivationArgs" in lc:
@@ -131,6 +132,8 @@ def main( config ):
           break
         if "BiasDimArgs" in lc:
           biasDimEnums = lc["BiasDimArgs"]
+        if "ICacheFlush" in lc:
+          icacheFlushArgs = lc["ICacheFlush"]
     activationArgs = ActivationArgs(problemType, activationEnums) if problemType["ActivationType"] == 'all' else ""
     biasDimArgs = BiasDimArgs(problemType, biasDimEnums)
     clientParametersPaths.append(writeClientConfig(
@@ -140,6 +143,7 @@ def main( config ):
                                   biasTypeArgs=biasTypeArgs,
                                   biasDimArgs=biasDimArgs,
                                   activationArgs=activationArgs,
+                                  icacheFlushArgs=icacheFlushArgs,
                                   stepName=str(ProblemType(problemType)),
                                   stepBaseDir=globalParameters["WorkingPath"],
                                   newLibrary=newLibrary,

--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -512,7 +512,7 @@ def pruneModeName(mode):
     if mode == 5: return 'Prune0X0X'
     if mode == 6: return 'Prune00XX'
 
-def writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, libraryFile=None):
+def writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, libraryFile=None):
 
     with open(parametersFilePath, "w") as f:
         def param(key, value):
@@ -555,6 +555,11 @@ def writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs
         if biasDimArgs:
           for bdim in biasDimArgs.biasDims:
             param('bias-dim-args', bdim)
+
+        if icacheFlushArgs:
+          for opt in icacheFlushArgs:
+            param('icache-flush-args', opt)
+
         param('sparse',   problemType.sparse)
         param('high-precision-accumulate', problemType.highPrecisionAccumulate)
         param('strided-batched', problemType.stridedBatched)
@@ -631,7 +636,7 @@ def writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs
         param("rotating-buffer-size",     globalParameters["RotatingBufferSize"])
 
 
-def writeClientConfig(forBenchmark, solutions, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
+def writeClientConfig(forBenchmark, solutions, problemSizes, biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, stepName, stepBaseDir, newLibrary, codeObjectFiles, tileAwareSelection, configBase = "ClientParameters", libraryFile = None):
 
     if tileAwareSelection:
       filename = os.path.join(globalParameters["WorkingPath"], "%s_Granularity.ini"%configBase)
@@ -649,7 +654,7 @@ def writeClientConfig(forBenchmark, solutions, problemSizes, biasTypeArgs, biasD
 
     newSolution = next(iter(newLibrary.solutions.values()))
     sourceDir = os.path.join(stepBaseDir, "source")
-    writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, libraryFile)
+    writeClientConfigIni(problemSizes, biasTypeArgs, biasDimArgs, activationArgs, icacheFlushArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, libraryFile)
 
     return filename
 

--- a/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
+++ b/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
@@ -47,7 +47,7 @@ namespace Tensile
         public:
             using clock = std::chrono::steady_clock;
 
-            BenchmarkTimer(po::variables_map const& args, Hardware const& hardware);
+            BenchmarkTimer(po::variables_map const& args, Hardware const& hardware, float flushTimeUs);
 
             virtual bool needMoreBenchmarkRuns() const override;
             virtual void preBenchmarkRun() override;
@@ -86,6 +86,10 @@ namespace Tensile
 
             virtual void finalizeReport() override;
             virtual int  error() const override;
+            void setIFlushTimeUs(float timeUs)
+            {
+                m_flushTimeUs = timeUs;
+            }
 
         private:
             const int    m_numWarmups;
@@ -122,6 +126,7 @@ namespace Tensile
 
             double_millis m_timeInSolution;
             double_millis m_totalGPUTime;
+            float m_flushTimeUs;
         };
     } // namespace Client
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
+++ b/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
@@ -47,7 +47,9 @@ namespace Tensile
         public:
             using clock = std::chrono::steady_clock;
 
-            BenchmarkTimer(po::variables_map const& args, Hardware const& hardware, float flushTimeUs);
+            BenchmarkTimer(po::variables_map const& args,
+                           Hardware const&          hardware,
+                           float                    flushTimeUs);
 
             virtual bool needMoreBenchmarkRuns() const override;
             virtual void preBenchmarkRun() override;
@@ -86,7 +88,7 @@ namespace Tensile
 
             virtual void finalizeReport() override;
             virtual int  error() const override;
-            void setIFlushTimeUs(float timeUs)
+            void         setIFlushTimeUs(float timeUs)
             {
                 m_flushTimeUs = timeUs;
             }
@@ -126,7 +128,7 @@ namespace Tensile
 
             double_millis m_timeInSolution;
             double_millis m_totalGPUTime;
-            float m_flushTimeUs;
+            float         m_flushTimeUs;
         };
     } // namespace Client
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -90,6 +90,7 @@ namespace Tensile
             ActivationType                   m_activationType;
             std::vector<DataType>            m_biasTypeArgs;
             std::vector<int>                 m_biasDimArgs;
+            std::vector<bool>                m_icacheFlushArgs;
             bool                             m_activationNoGuard;
             std::vector<ActivationType>      m_activationEnumArg;
             size_t                           m_maxWorkspaceSize = 0;

--- a/tensilelite/Tensile/Source/client/main.cpp
+++ b/tensilelite/Tensile/Source/client/main.cpp
@@ -67,23 +67,23 @@ namespace Tensile
         __global__ void flush_icache()
         {
             asm __volatile__("s_icache_inv \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t"
-                            "s_nop 0 \n\t" ::
-                                :);
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t"
+                             "s_nop 0 \n\t" ::
+                                 :);
         }
 
         uint32_t flush_grid_size()
@@ -96,39 +96,40 @@ namespace Tensile
 
         float estimate_flush_kernel_time(hipStream_t stream, bool useGPUTimer)
         {
-            const int flushIter = 100000;
-            hipEvent_t start, stop;
+            const int                                                   flushIter = 100000;
+            hipEvent_t                                                  start, stop;
             std::chrono::time_point<std::chrono::high_resolution_clock> begTime;
 
-            if (useGPUTimer)
+            if(useGPUTimer)
             {
                 HIP_CHECK_EXC(hipEventCreate(&start));
                 HIP_CHECK_EXC(hipEventCreate(&stop));
             }
 
             //warmup runs
-            for (int i = 0; i < flushIter; i++)
+            for(int i = 0; i < flushIter; i++)
             {
                 hipLaunchKernelGGL(flush_icache, flush_grid_size(), 64, 0, stream);
             }
 
-            if (useGPUTimer)
+            if(useGPUTimer)
             {
                 HIP_CHECK_EXC(hipEventRecord(start, stream));
-            } else
+            }
+            else
             {
                 HIP_CHECK_EXC(hipStreamSynchronize(stream));
                 begTime = std::chrono::high_resolution_clock::now();
             }
 
-            for (int i = 0; i < flushIter; i++)
+            for(int i = 0; i < flushIter; i++)
             {
                 hipLaunchKernelGGL(flush_icache, flush_grid_size(), 64, 0, stream);
             }
 
             float time{};
 
-            if (useGPUTimer)
+            if(useGPUTimer)
             {
                 HIP_CHECK_EXC(hipEventRecord(stop, stream));
                 HIP_CHECK_EXC(hipEventSynchronize(stop));
@@ -136,16 +137,19 @@ namespace Tensile
 
             HIP_CHECK_EXC(hipStreamSynchronize(stream));
 
-            if (useGPUTimer)
+            if(useGPUTimer)
             {
                 HIP_CHECK_EXC(hipEventElapsedTime(&time, start, stop));
                 HIP_CHECK_EXC(hipEventDestroy(start));
                 HIP_CHECK_EXC(hipEventDestroy(stop));
-            } else 
-            {
-                time = std::chrono::duration<float, std::milli>{std::chrono::high_resolution_clock::now() - begTime}.count();
             }
-            std::cout << "icache flush time: " << time / flushIter << " ms\n";
+            else
+            {
+                time = std::chrono::duration<float,
+                                             std::milli>{std::chrono::high_resolution_clock::now()
+                                                         - begTime}
+                           .count();
+            }
             return time / flushIter;
         }
 
@@ -464,7 +468,7 @@ namespace Tensile
 
         void parse_arg_bools(po::variables_map& args, std::string const& name)
         {
-            auto opts = args[name].as<std::vector<bool>>();
+            auto opts             = args[name].as<std::vector<bool>>();
             args.at(name).value() = boost::any(opts);
         }
 
@@ -610,13 +614,13 @@ int main(int argc, const char* argv[])
         numProblems = problems.size();
     int lastProblemIdx = firstProblemIdx + numProblems - 1;
 
-    int  firstSolutionIdx = args["solution-start-idx"].as<int>();
-    int  numSolutions     = args["num-solutions"].as<int>();
-    bool gpuTimer         = args["use-gpu-timer"].as<bool>();
-    bool runKernels       = !args["selection-only"].as<bool>();
-    bool exitOnError      = args["exit-on-error"].as<bool>();
-    bool groupedGemm      = args["grouped-gemm"].as<bool>();
-    const auto &icacheFlushArgs  = args["icache-flush-args"].as<std::vector<bool>>();
+    int         firstSolutionIdx = args["solution-start-idx"].as<int>();
+    int         numSolutions     = args["num-solutions"].as<int>();
+    bool        gpuTimer         = args["use-gpu-timer"].as<bool>();
+    bool        runKernels       = !args["selection-only"].as<bool>();
+    bool        exitOnError      = args["exit-on-error"].as<bool>();
+    bool        groupedGemm      = args["grouped-gemm"].as<bool>();
+    const auto& icacheFlushArgs  = args["icache-flush-args"].as<std::vector<bool>>();
 
     if(firstSolutionIdx < 0)
         firstSolutionIdx = library->solutions.begin()->first;
@@ -638,11 +642,12 @@ int main(int argc, const char* argv[])
     listeners.addListener(solutionIterator);
     listeners.addListener(std::make_shared<ProgressListener>(args));
     std::shared_ptr<BenchmarkTimer> benchmarkTimer;
-    float flushTimeMs{};
+    float                           flushTimeMs{};
 
     if(runKernels)
     {
-        bool hasIcacheFlush = std::any_of(begin(icacheFlushArgs), end(icacheFlushArgs), [](auto i){ return i;});
+        bool hasIcacheFlush
+            = std::any_of(begin(icacheFlushArgs), end(icacheFlushArgs), [](auto i) { return i; });
         flushTimeMs = hasIcacheFlush ? estimate_flush_kernel_time(stream, gpuTimer) : 0.f;
         listeners.addListener(std::make_shared<ReferenceValidator>(args, dataInit));
         benchmarkTimer = std::make_shared<BenchmarkTimer>(args, *hardware, flushTimeMs * 1000);
@@ -690,7 +695,8 @@ int main(int argc, const char* argv[])
     {
         listeners.preBenchmarkRun();
         const auto flushGridSize = flush_grid_size();
-        for (auto icacheFlush : icacheFlushArgs) {
+        for(auto icacheFlush : icacheFlushArgs)
+        {
             benchmarkTimer->setIFlushTimeUs(icacheFlush ? flushTimeMs * 1000 : 0.f);
 
             for(int problemIdx = firstProblemIdx; problemIdx <= lastProblemIdx; problemIdx++)
@@ -699,7 +705,7 @@ int main(int argc, const char* argv[])
 
                 reporters->report(ResultKey::ProblemIndex, problemIdx);
                 reporters->report(ResultKey::ProblemProgress,
-                                concatenate(problemIdx, "/", lastProblemIdx));
+                                  concatenate(problemIdx, "/", lastProblemIdx));
 
                 listeners.preProblem(problem);
                 auto inputs = dataInit->prepareGPUInputs(problem);
@@ -735,20 +741,21 @@ int main(int argc, const char* argv[])
                                 std::vector<std::vector<KernelInvocation>> kernels;
                                 for(size_t r = 0; r < inputArr.size(); r++)
                                 {
-                                    auto kernel = useUserArgs ? solution->solveTensileGPU((*problem),
-                                                                                        *inputArr[r],
-                                                                                        *hardware,
-                                                                                        &dUA,
-                                                                                        &dUAHost,
-                                                                                        nullptr,
-                                                                                        0,
-                                                                                        stream)
-                                                            : solution->solve((*problem),
-                                                                                *inputArr[r],
-                                                                                *hardware,
-                                                                                nullptr,
-                                                                                0,
-                                                                                stream);
+                                    auto kernel = useUserArgs
+                                                      ? solution->solveTensileGPU((*problem),
+                                                                                  *inputArr[r],
+                                                                                  *hardware,
+                                                                                  &dUA,
+                                                                                  &dUAHost,
+                                                                                  nullptr,
+                                                                                  0,
+                                                                                  stream)
+                                                      : solution->solve((*problem),
+                                                                        *inputArr[r],
+                                                                        *hardware,
+                                                                        nullptr,
+                                                                        0,
+                                                                        stream);
                                     kernels.push_back(kernel);
                                 }
 
@@ -794,9 +801,10 @@ int main(int argc, const char* argv[])
                                         HIP_CHECK_EXC(adapter.launchKernels(
                                             kernels[kIdx], stream, nullptr, nullptr));
 
-                                        if (icacheFlush)
+                                        if(icacheFlush)
                                         {
-                                            hipLaunchKernelGGL(flush_icache, flushGridSize, 64, 0, stream);
+                                            hipLaunchKernelGGL(
+                                                flush_icache, flushGridSize, 64, 0, stream);
                                         }
                                     }
 
@@ -816,7 +824,7 @@ int main(int argc, const char* argv[])
                         {
                             reporters->report(ResultKey::Validation, "INVALID");
                             reporters->log(LogLevel::Error,
-                                        concatenate("Exception occurred: ", err.what(), "\n"));
+                                           concatenate("Exception occurred: ", err.what(), "\n"));
                         }
                     }
 

--- a/tensilelite/Tensile/Source/client/main.cpp
+++ b/tensilelite/Tensile/Source/client/main.cpp
@@ -55,6 +55,7 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/program_options.hpp>
 
+#include <chrono>
 #include <cstddef>
 
 namespace po = boost::program_options;
@@ -63,6 +64,90 @@ namespace Tensile
 {
     namespace Client
     {
+        __global__ void flush_icache()
+        {
+            asm __volatile__("s_icache_inv \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t"
+                            "s_nop 0 \n\t" ::
+                                :);
+        }
+
+        uint32_t flush_grid_size()
+        {
+            hipDeviceProp_t deviceProps;
+            HIP_CHECK_EXC(hipGetDeviceProperties(&deviceProps, 0));
+            uint32_t numBlocks = deviceProps.multiProcessorCount * 60;
+            return numBlocks;
+        }
+
+        float estimate_flush_kernel_time(hipStream_t stream, bool useGPUTimer)
+        {
+            const int flushIter = 100000;
+            hipEvent_t start, stop;
+            std::chrono::time_point<std::chrono::high_resolution_clock> begTime;
+
+            if (useGPUTimer)
+            {
+                HIP_CHECK_EXC(hipEventCreate(&start));
+                HIP_CHECK_EXC(hipEventCreate(&stop));
+            }
+
+            //warmup runs
+            for (int i = 0; i < flushIter; i++)
+            {
+                hipLaunchKernelGGL(flush_icache, flush_grid_size(), 64, 0, stream);
+            }
+
+            if (useGPUTimer)
+            {
+                HIP_CHECK_EXC(hipEventRecord(start, stream));
+            } else
+            {
+                HIP_CHECK_EXC(hipStreamSynchronize(stream));
+                begTime = std::chrono::high_resolution_clock::now();
+            }
+
+            for (int i = 0; i < flushIter; i++)
+            {
+                hipLaunchKernelGGL(flush_icache, flush_grid_size(), 64, 0, stream);
+            }
+
+            float time{};
+
+            if (useGPUTimer)
+            {
+                HIP_CHECK_EXC(hipEventRecord(stop, stream));
+                HIP_CHECK_EXC(hipEventSynchronize(stop));
+            }
+
+            HIP_CHECK_EXC(hipStreamSynchronize(stream));
+
+            if (useGPUTimer)
+            {
+                HIP_CHECK_EXC(hipEventElapsedTime(&time, start, stop));
+                HIP_CHECK_EXC(hipEventDestroy(start));
+                HIP_CHECK_EXC(hipEventDestroy(stop));
+            } else 
+            {
+                time = std::chrono::duration<float, std::milli>{std::chrono::high_resolution_clock::now() - begTime}.count();
+            }
+            std::cout << "icache flush time: " << time / flushIter << " ms\n";
+            return time / flushIter;
+        }
 
         template <typename T>
         po::typed_value<T>* value_default(std::string const& desc)
@@ -254,6 +339,7 @@ namespace Tensile
                 ("use-scaleAlphaVec",         po::value<bool>()->default_value(false), "Use scaleAlphaVec.")
                 ("bias-type-args",            po::value<std::vector<DataType>>()->default_value(std::vector<DataType>(1, DataType::None), "[]"), "Bias data type args.")
                 ("bias-dim-args",             po::value<std::vector<int>>()->default_value(std::vector<int>(1, 0), "[]"), "Bias dimensions args.")
+                ("icache-flush-args",         po::value<std::vector<bool>>()->default_value(std::vector<bool>(1, false), "[]"), "ICache flush args.")
                 ("use-e",                     po::value<bool>()->default_value(false), "Use E.")
                 ("use-gradient",              po::value<bool>()->default_value(false), "Use gradient.")
                 ("use-user-args",             po::value<bool>()->default_value(false), "Use user argument structure as kernel input.")
@@ -376,6 +462,12 @@ namespace Tensile
             args.at(name).value() = v;
         }
 
+        void parse_arg_bools(po::variables_map& args, std::string const& name)
+        {
+            auto opts = args[name].as<std::vector<bool>>();
+            args.at(name).value() = boost::any(opts);
+        }
+
         void parse_arg_ints(po::variables_map& args, std::string const& name)
         {
             parse_arg_nums<size_t>(args, name);
@@ -463,6 +555,7 @@ namespace Tensile
             parse_activation_int(args, "activation-type");
             parse_activation_enum_args(args, "activation-enum-args");
             parse_arg_double(args, "activation-additional-args");
+            parse_arg_bools(args, "icache-flush-args");
             return args;
         }
 
@@ -523,6 +616,7 @@ int main(int argc, const char* argv[])
     bool runKernels       = !args["selection-only"].as<bool>();
     bool exitOnError      = args["exit-on-error"].as<bool>();
     bool groupedGemm      = args["grouped-gemm"].as<bool>();
+    const auto &icacheFlushArgs  = args["icache-flush-args"].as<std::vector<bool>>();
 
     if(firstSolutionIdx < 0)
         firstSolutionIdx = library->solutions.begin()->first;
@@ -543,10 +637,16 @@ int main(int argc, const char* argv[])
     listeners.addListener(dataInit);
     listeners.addListener(solutionIterator);
     listeners.addListener(std::make_shared<ProgressListener>(args));
+    std::shared_ptr<BenchmarkTimer> benchmarkTimer;
+    float flushTimeMs{};
+
     if(runKernels)
     {
+        bool hasIcacheFlush = std::any_of(begin(icacheFlushArgs), end(icacheFlushArgs), [](auto i){ return i;});
+        flushTimeMs = hasIcacheFlush ? estimate_flush_kernel_time(stream, gpuTimer) : 0.f;
         listeners.addListener(std::make_shared<ReferenceValidator>(args, dataInit));
-        listeners.addListener(std::make_shared<BenchmarkTimer>(args, *hardware));
+        benchmarkTimer = std::make_shared<BenchmarkTimer>(args, *hardware, flushTimeMs * 1000);
+        listeners.addListener(benchmarkTimer);
         listeners.addListener(std::make_shared<HardwareMonitorListener>(args));
     }
 
@@ -589,139 +689,148 @@ int main(int argc, const char* argv[])
     while(listeners.needMoreBenchmarkRuns())
     {
         listeners.preBenchmarkRun();
+        const auto flushGridSize = flush_grid_size();
+        for (auto icacheFlush : icacheFlushArgs) {
+            benchmarkTimer->setIFlushTimeUs(icacheFlush ? flushTimeMs * 1000 : 0.f);
 
-        for(int problemIdx = firstProblemIdx; problemIdx <= lastProblemIdx; problemIdx++)
-        {
-            auto problem = problems[problemIdx].get();
-
-            reporters->report(ResultKey::ProblemIndex, problemIdx);
-            reporters->report(ResultKey::ProblemProgress,
-                              concatenate(problemIdx, "/", lastProblemIdx));
-
-            listeners.preProblem(problem);
-            auto inputs = dataInit->prepareGPUInputs(problem);
-
-            size_t warmupInvocations    = listeners.numWarmupRuns();
-            size_t syncs                = listeners.numSyncs();
-            size_t enq                  = listeners.numEnqueuesPerSync();
-            size_t maxRotatingBufferNum = max(warmupInvocations, syncs * enq);
-
-            auto inputArr
-                = dataInit->prepareRotatingGPUOutput(maxRotatingBufferNum, problem, inputs);
-            bool resetInput = false;
-            while(solutionIterator->moreSolutionsInProblem())
+            for(int problemIdx = firstProblemIdx; problemIdx <= lastProblemIdx; problemIdx++)
             {
-                auto solution = solutionIterator->getSolution();
-                if(solution == nullptr)
-                    throw std::runtime_error("Could not find a solution");
+                auto problem = problems[problemIdx].get();
 
-                listeners.preSolution(*solution);
-                if(solutionIterator->runCurrentSolution() && runKernels)
+                reporters->report(ResultKey::ProblemIndex, problemIdx);
+                reporters->report(ResultKey::ProblemProgress,
+                                concatenate(problemIdx, "/", lastProblemIdx));
+
+                listeners.preProblem(problem);
+                auto inputs = dataInit->prepareGPUInputs(problem);
+
+                size_t warmupInvocations    = listeners.numWarmupRuns();
+                size_t syncs                = listeners.numSyncs();
+                size_t enq                  = listeners.numEnqueuesPerSync();
+                size_t maxRotatingBufferNum = max(warmupInvocations, syncs * enq);
+
+                auto inputArr
+                    = dataInit->prepareRotatingGPUOutput(maxRotatingBufferNum, problem, inputs);
+                bool resetInput = false;
+                while(solutionIterator->moreSolutionsInProblem())
                 {
-                    try
+                    auto solution = solutionIterator->getSolution();
+                    if(solution == nullptr)
+                        throw std::runtime_error("Could not find a solution");
+
+                    listeners.preSolution(*solution);
+                    if(solutionIterator->runCurrentSolution() && runKernels)
                     {
-                        while(listeners.needMoreRunsInSolution())
+                        try
                         {
-                            if(resetInput)
+                            while(listeners.needMoreRunsInSolution())
                             {
-                                auto inputs = dataInit->prepareGPUInputs(problem);
-                                inputArr[0] = inputs;
-                            }
-                            resetInput = true;
-
-                            std::vector<std::vector<KernelInvocation>> kernels;
-                            for(size_t r = 0; r < inputArr.size(); r++)
-                            {
-                                auto kernel = useUserArgs ? solution->solveTensileGPU((*problem),
-                                                                                      *inputArr[r],
-                                                                                      *hardware,
-                                                                                      &dUA,
-                                                                                      &dUAHost,
-                                                                                      nullptr,
-                                                                                      0,
-                                                                                      stream)
-                                                          : solution->solve((*problem),
-                                                                            *inputArr[r],
-                                                                            *hardware,
-                                                                            nullptr,
-                                                                            0,
-                                                                            stream);
-                                kernels.push_back(kernel);
-                            }
-
-                            size_t       warmupInvocations = listeners.numWarmupRuns();
-                            size_t       eventCount        = gpuTimer ? kernels[0].size() : 0;
-                            TimingEvents warmupStartEvents(warmupInvocations, eventCount);
-                            TimingEvents warmupStopEvents(warmupInvocations, eventCount);
-
-                            for(int i = 0; i < warmupInvocations; i++)
-                            {
-                                size_t kIdx = i % kernels.size();
-                                listeners.preWarmup();
-                                if(gpuTimer)
-                                    HIP_CHECK_EXC(adapter.launchKernels(kernels[kIdx],
-                                                                        stream,
-                                                                        warmupStartEvents[i],
-                                                                        warmupStopEvents[i]));
-                                else
-                                    HIP_CHECK_EXC(adapter.launchKernels(
-                                        kernels[kIdx], stream, nullptr, nullptr));
-                                listeners.postWarmup();
-                                // Do validation after first warmup
-                                if(i == 0)
-                                    listeners.validateWarmups(
-                                        inputs, warmupStartEvents, warmupStopEvents);
-                            }
-
-                            size_t syncs = listeners.numSyncs();
-                            size_t enq   = listeners.numEnqueuesPerSync();
-
-                            listeners.preSyncs();
-
-                            for(int i = 0; i < syncs; i++)
-                            {
-                                TimingEvents startEvents(enq, eventCount);
-                                TimingEvents stopEvents(enq, eventCount);
-
-                                listeners.preEnqueues(stream);
-
-                                for(int j = 0; j < enq; j++)
+                                if(resetInput)
                                 {
-                                    size_t kIdx = ((i * enq) + j) % kernels.size();
-                                    HIP_CHECK_EXC(adapter.launchKernels(
-                                        kernels[kIdx], stream, nullptr, nullptr));
+                                    auto inputs = dataInit->prepareGPUInputs(problem);
+                                    inputArr[0] = inputs;
+                                }
+                                resetInput = true;
+
+                                std::vector<std::vector<KernelInvocation>> kernels;
+                                for(size_t r = 0; r < inputArr.size(); r++)
+                                {
+                                    auto kernel = useUserArgs ? solution->solveTensileGPU((*problem),
+                                                                                        *inputArr[r],
+                                                                                        *hardware,
+                                                                                        &dUA,
+                                                                                        &dUAHost,
+                                                                                        nullptr,
+                                                                                        0,
+                                                                                        stream)
+                                                            : solution->solve((*problem),
+                                                                                *inputArr[r],
+                                                                                *hardware,
+                                                                                nullptr,
+                                                                                0,
+                                                                                stream);
+                                    kernels.push_back(kernel);
                                 }
 
-                                listeners.postEnqueues(startEvents, stopEvents, stream);
-                                listeners.validateEnqueues(inputs, startEvents, stopEvents);
-                            }
+                                size_t       warmupInvocations = listeners.numWarmupRuns();
+                                size_t       eventCount        = gpuTimer ? kernels[0].size() : 0;
+                                TimingEvents warmupStartEvents(warmupInvocations, eventCount);
+                                TimingEvents warmupStopEvents(warmupInvocations, eventCount);
 
-                            listeners.postSyncs();
+                                for(int i = 0; i < warmupInvocations; i++)
+                                {
+                                    size_t kIdx = i % kernels.size();
+                                    listeners.preWarmup();
+                                    if(gpuTimer)
+                                        HIP_CHECK_EXC(adapter.launchKernels(kernels[kIdx],
+                                                                            stream,
+                                                                            warmupStartEvents[i],
+                                                                            warmupStopEvents[i]));
+                                    else
+                                        HIP_CHECK_EXC(adapter.launchKernels(
+                                            kernels[kIdx], stream, nullptr, nullptr));
+                                    listeners.postWarmup();
+                                    // Do validation after first warmup
+                                    if(i == 0)
+                                        listeners.validateWarmups(
+                                            inputs, warmupStartEvents, warmupStopEvents);
+                                }
 
-                            if(useUserArgs)
-                            {
-                                solution->relaseDeviceUserArgs(dUA, dUAHost);
+                                size_t syncs = listeners.numSyncs();
+                                size_t enq   = listeners.numEnqueuesPerSync();
+
+                                listeners.preSyncs();
+
+                                for(int i = 0; i < syncs; i++)
+                                {
+                                    TimingEvents startEvents(enq, eventCount);
+                                    TimingEvents stopEvents(enq, eventCount);
+
+                                    listeners.preEnqueues(stream);
+
+                                    for(int j = 0; j < enq; j++)
+                                    {
+                                        size_t kIdx = ((i * enq) + j) % kernels.size();
+                                        HIP_CHECK_EXC(adapter.launchKernels(
+                                            kernels[kIdx], stream, nullptr, nullptr));
+
+                                        if (icacheFlush)
+                                        {
+                                            hipLaunchKernelGGL(flush_icache, flushGridSize, 64, 0, stream);
+                                        }
+                                    }
+
+                                    listeners.postEnqueues(startEvents, stopEvents, stream);
+                                    listeners.validateEnqueues(inputs, startEvents, stopEvents);
+                                }
+
+                                listeners.postSyncs();
+
+                                if(useUserArgs)
+                                {
+                                    solution->relaseDeviceUserArgs(dUA, dUAHost);
+                                }
                             }
                         }
+                        catch(std::runtime_error const& err)
+                        {
+                            reporters->report(ResultKey::Validation, "INVALID");
+                            reporters->log(LogLevel::Error,
+                                        concatenate("Exception occurred: ", err.what(), "\n"));
+                        }
                     }
-                    catch(std::runtime_error const& err)
+
+                    listeners.postSolution();
+
+                    if(exitOnError && listeners.error() > 0)
                     {
-                        reporters->report(ResultKey::Validation, "INVALID");
-                        reporters->log(LogLevel::Error,
-                                       concatenate("Exception occurred: ", err.what(), "\n"));
+                        // error range in shell is [0-255]
+                        return std::min(listeners.error(), 255);
                     }
                 }
 
-                listeners.postSolution();
-
-                if(exitOnError && listeners.error() > 0)
-                {
-                    // error range in shell is [0-255]
-                    return std::min(listeners.error(), 255);
-                }
+                listeners.postProblem();
             }
-
-            listeners.postProblem();
         }
 
         listeners.postBenchmarkRun();

--- a/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -41,7 +41,7 @@ namespace Tensile
     {
         static_assert(BenchmarkTimer::clock::is_steady, "Clock must be steady.");
 
-        BenchmarkTimer::BenchmarkTimer(po::variables_map const& args, Hardware const& hardware)
+        BenchmarkTimer::BenchmarkTimer(po::variables_map const& args, Hardware const& hardware, float flushTimeUs)
             : m_numWarmups(args["num-warmups"].as<int>())
             , m_syncAfterWarmups(args["sync-after-warmups"].as<bool>())
             , m_numBenchmarks(args["num-benchmarks"].as<int>())
@@ -55,6 +55,7 @@ namespace Tensile
             , m_sleepPercent(args["sleep-percent"].as<int>())
             , m_timeInSolution(0)
             , m_totalGPUTime(0)
+            , m_flushTimeUs(flushTimeUs)
         {
         }
 
@@ -115,7 +116,7 @@ namespace Tensile
         void BenchmarkTimer::postSolution()
         {
             double timePerEnqueue_us
-                = double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution;
+                = double_micros(m_timeInSolution).count() / m_numEnqueuesInSolution - m_flushTimeUs;
 
             ContractionSolution::ProjectedPerformance pp;
             double                                    flopCount = 0;

--- a/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
+++ b/tensilelite/Tensile/Source/client/source/BenchmarkTimer.cpp
@@ -41,7 +41,9 @@ namespace Tensile
     {
         static_assert(BenchmarkTimer::clock::is_steady, "Clock must be steady.");
 
-        BenchmarkTimer::BenchmarkTimer(po::variables_map const& args, Hardware const& hardware, float flushTimeUs)
+        BenchmarkTimer::BenchmarkTimer(po::variables_map const& args,
+                                       Hardware const&          hardware,
+                                       float                    flushTimeUs)
             : m_numWarmups(args["num-warmups"].as<int>())
             , m_syncAfterWarmups(args["sync-after-warmups"].as<bool>())
             , m_numBenchmarks(args["num-benchmarks"].as<int>())

--- a/tensilelite/Tensile/Tests/common/gemm/icache_flush.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/icache_flush.yaml
@@ -1,0 +1,96 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.14.0
+  NumElementsToValidate: 0
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+  MergeFiles: False
+  SyncsPerBenchmark: 1
+  NumBenchmarks : 1
+  NumWarmups: 1000
+  EnqueuesPerSync: 1000
+  RotatingBufferSize: 512
+  PrintSolutionRejectionReason: True
+  PrintWinnersOnly: True
+  CpuThreads: 1
+  DataInitTypeA: 12
+  DataInitTypeB: 13
+  SleepPercent: 0
+ 
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: F8
+      DataTypeA: F8
+      DataTypeB: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 0
+      UseBeta: True
+      SparseA: False
+      Activation: True
+      ActivationHPA: True
+      UseBias: 1
+      SupportUserArgs: True
+      BiasDataTypeList: ['s', 'h']
+      Batched: True
+      ActivationType:  all
+      UseScaleAB: True
+      UseScaleAlphaVec: True
+      ActivationFused: true
+
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1,   2, 1,  4,1 ] #128x16
+        - AssertFree0ElementMultiple: [8]
+        - AssertFree1ElementMultiple: [8]
+        - AssertSummationElementMultiple: [32]
+        - GlobalReadVectorWidthA: [-1] #
+        - GlobalReadVectorWidthB: [-1] #
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - NumElementsPerBatchStore: [0]
+        - DepthU: [128] #
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - WaveSeparateGlobalReadA: [2] #
+        - WaveSeparateGlobalReadB: [0] #
+        - WorkGroupMapping: [1]
+        - LocalReadVectorWidth: [-1]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - SourceSwap: [1]
+        - ActivationFuncCall: [true]
+        - 1LDSBuffer: [-1]
+        - StaggerU: [32]
+        - StaggerUStride: [256]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [2048, 16, 1, 16384]
+        - BiasTypeArgs: ['h']
+        - ActivationArgs:
+          - [Enum: none]
+        - ICacheFlush: [True]


### PR DESCRIPTION
## Brief ##
This PR ports icache flush mechanism in hipblaslt-bench to tensilelite.

## Implementation ##
 - Added `ICacheFlush` benchmark parameter to tuning YAML
 - Added `--icache-flush-args` to `tensile_client` app
 - Added icache flush kernel
 - Steps of icache flush involved tuning
    1. measure the performance of icache flush kernel, say `t`,
    2. interleave the solution kernel launch and icache flush kernel launch for each iteration, get it average elapsed time `T`,
    3. report `T - t` as final performance.

## Usage ##
For the tuning YAML, simply add `ICacheFlush: [True]` in benchmark/library client parameters, e.g.

```yaml
BenchmarkFinalParameters:
  - ProblemSizes:
    - Exact: [16384, 32, 1, 4096]
  - BiasTypeArgs: ['h']
  - ActivationArgs:
    - [Enum: none]
  - ICacheFlush: [True] ##for benchmark

LibraryClient:
  - ICacheFlush: [True] ##for library client
```