### PR TITLE
Optimize GSU Workgroup Assignment

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -742,6 +742,10 @@ validParameters = {
     #    to a different bank since all workgroups still start at same point.
     "StaggerUMapping":       [0,1,2,3,4],
 
+    # GSU Workgroup Coalesced Ordering
+    # False: {(wg0,wg1,wg2,wgn)|(wg0,wg1,wg2,wgn)|...|(wg0,wg1,wg2,wgn)}
+    # True:  {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
+    "GlobalSplitUCoalesced":        [False, True],
 
     # 0=don't use magic div (source only)
     # 1=magic div alg #1.  Slightly faster but limited range (if magic number is 2^32)
@@ -1089,6 +1093,7 @@ defaultBenchmarkCommonParameters = [
     {"MagicDivAlg":               [ 2 ] },
     {"GlobalSplitU":              [ 1 ] },
     {"GlobalSplitUAlgorithm":     [ "MultipleBuffer" ] },
+    {"GlobalSplitUCoalesced":     [ False ] },
     {"Use64bShadowLimit":         [ 1 ] },
     {"NumLoadsCoalescedA":        [ 1 ] },
     {"NumLoadsCoalescedB":        [ 1 ] },

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -188,6 +188,7 @@ class StateValues:
   unifiedVgprRegs: bool                  = False
   useAtomicAdd: bool                     = False
   serializedStore: bool                  = False
+  gsu_wg_coalesced: bool                 = False
 
   a: ABMatrixInfo                        = field(default_factory=ABMatrixInfo)
   b: ABMatrixInfo                        = field(default_factory=ABMatrixInfo)
@@ -1466,6 +1467,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     # increments
     def graIncrementsAB():
+      module.addComment1("global read addresses: increments a")
       for i in reversed(range(kernel["ProblemType"]["NumIndicesSummation"])):
         module.add(self.graIncrements(kernel, i, tensorParametersA))
       if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
@@ -3257,6 +3259,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
         vgprIdx = 0
         self.states.c.numVgprValu = 0
 
+    self.states.gsu_wg_coalesced = kernel["GlobalSplitUCoalesced"]
+    
     # TODO: alignment hack, figure out a better solution
     vgprIdx = ((vgprIdx+1)//2)*2
     # Avoid bank conflict between VgprA and VgprC

--- a/tensilelite/Tensile/TensileInstructions/Math.py
+++ b/tensilelite/Tensile/TensileInstructions/Math.py
@@ -362,9 +362,9 @@ def scalarUInt32DivideAndRemainder(qReg, dReg, divReg, rReg, tmpVgprRes: Registe
         module.add(VMovB32(dst=vgpr(tmpVgpr1), src=0, comment=rComment))
     SMovBX = SMovB64 if wavewidth == 64 else SMovB32
     module.add(SMovBX(dst=EXEC(), src=-1, comment=dComment))
-    module.add(VReadfirstlaneB32(dst=sgpr(qReg), src=vgpr(tmpVgpr0)))
+    module.add(VReadfirstlaneB32(dst=sgpr(qReg), src=vgpr(tmpVgpr0), comment="quotient"))
     if doRemainder:
-        module.add(VReadfirstlaneB32(dst=sgpr(rReg), src=vgpr(tmpVgpr1)))
+        module.add(VReadfirstlaneB32(dst=sgpr(rReg), src=vgpr(tmpVgpr1), comment="remainder"))
     return module
 
 ########################################

--- a/tensilelite/Tensile/Tests/common/gemm/gsuc.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gsuc.yaml
@@ -1,0 +1,91 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  MinimumRequiredVersion: 4.14.0
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 0
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+
+BenchmarkProblems:
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      UseBias: 1
+      Batched: True
+      Activation: True
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,  2, 2,  2, 2] #64x64
+          - [32, 32, 16, 1,  1,  1, 1,  2, 2] #64x64
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [64]
+        - LocalReadVectorWidth: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [-1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1,2,4]
+        - PreloadKernArgs: [1]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - GlobalSplitUCoalesced: [False,True]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [255, 255, 1, 255]
+          - Exact: [255, 255, 1, 256]
+          - Exact: [255, 255, 1, 257]
+          - Exact: [255, 256, 1, 255]
+          - Exact: [255, 256, 1, 256]
+          - Exact: [255, 256, 1, 257]
+          - Exact: [255, 257, 1, 255]
+          - Exact: [255, 257, 1, 256]
+          - Exact: [255, 257, 1, 257]
+
+          - Exact: [256, 255, 1, 255]
+          - Exact: [256, 255, 1, 256]
+          - Exact: [256, 255, 1, 257]
+          - Exact: [256, 256, 1, 255]
+          - Exact: [256, 256, 1, 256]
+          - Exact: [256, 256, 1, 257]
+          - Exact: [256, 257, 1, 255]
+          - Exact: [256, 257, 1, 256]
+          - Exact: [256, 257, 1, 257]
+
+          - Exact: [257, 255, 1, 255]
+          - Exact: [257, 255, 1, 256]
+          - Exact: [257, 255, 1, 257]
+          - Exact: [257, 256, 1, 255]
+          - Exact: [257, 256, 1, 256]
+          - Exact: [257, 256, 1, 257]
+          - Exact: [257, 257, 1, 255]
+          - Exact: [257, 257, 1, 256]
+          - Exact: [257, 257, 1, 257]
+        - BiasTypeArgs: ['h']
+        - ActivationArgs:
+          - [Enum: relu]

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_gsuc.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_gsuc.yaml
@@ -1,0 +1,92 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  KernelTime: True
+  NewClient: 2
+  BoundsCheck: False
+  # PrintSolutionRejectionReason: True
+  PrintWinnersOnly: True
+  ValidationMaxToPrint: 4      # maximum number of mismatches to print
+  ValidationPrintValids: False # print matches too
+  DataInitValueActivationArgs: [0.5, -1]
+  PruneSparseMode: 0
+  MinKForGSU: 1
+
+BenchmarkProblems:
+  #######################################
+  # NN - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: s
+      HighPrecisionAccumulate:  True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Sparse: 1
+      Batched: True
+      Activation: True
+      UseBias: 3
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,  1, 1,  2, 2] #32x32
+          - [16, 16, 16, 1,  1,  2, 2,  2, 2] #64x64
+          - [32, 32, 16, 1,  1,  1, 1,  1, 1] #32x32
+          - [32, 32, 16, 1,  1,  1, 1,  2, 2] #64x64
+        - AssertFree0ElementMultiple: [1,8]
+        - GlobalReadVectorWidthA: [4,8]
+        - VectorWidthA: [1,2,4]
+        - VectorWidthB: [1,2,4]
+        - DepthU: [32,64]
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - StaggerU: [0,4]
+        - ScheduleIterAlg: [3]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - PrefetchGlobalRead: [2]
+        - StoreRemapVectorWidth: [-1]
+        - GlobalSplitU: [1,2,4]
+        - GlobalSplitUAlgorithm: [MultipleBuffer]
+        - GlobalSplitUCoalesced: [False,True]
+        - 1LDSBuffer: [-1]
+        - DirectToVgprSparseMetadata: [0,1]
+        - WorkGroupMapping: [18]
+        - StoreVectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [256, 256, 1, 16] # classic format
+          - Exact: [256, 256, 1, 32] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 96] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [384, 384, 1, 16] # classic format
+          - Exact: [384, 384, 1, 32] # classic format
+          - Exact: [384, 384, 1, 64] # classic format
+          - Exact: [384, 384, 1, 96] # classic format
+          - Exact: [384, 384, 1, 128] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - BiasDimArgs: [0, 1]
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
1. Workgroup order changed from interleaved to coalesced assignment.
2. Used "GlobalSplitUCoalesced" to enable in GSU kernel.
3. Add test yaml for "GlobalSplitUCoalesced" (increase ~500s test time)