### PR TITLE
Amax codegen: odd-size-tail

### DIFF
--- a/clients/benchmarks/client_extop_amax.cpp
+++ b/clients/benchmarks/client_extop_amax.cpp
@@ -241,6 +241,9 @@ void compare(const char* title, const std::vector<T>& cpuOutput, const std::vect
     {
         T err  = abs(refOutput[i] - cpuOutput[i]);
         maxErr = max(maxErr, err);
+
+        std::cout << " refOut : " << float(refOutput[i]) << std::endl;
+        std::cout << " kernelOut : " << float(cpuOutput[i]) << std::endl;
     }
 
     std::cout << title << " max error : " << float(maxErr) << std::endl;


### PR DESCRIPTION
odd-size-tail = not multiple of load_size:
- [x] size 1~7
- [x] size less than 16384: 16377 ~ 16383
- [x] size bigger than a WS: 65537 ~ 65543
- [x] size cross a page 2MB (1048576 halfs): 1048569~1048575 / 1048577 ~ 10485483