### PR TITLE
Add allclose funtion to bench

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -827,7 +827,10 @@ try
         throw std::invalid_argument("Invalid value for --function");
 
     if(verify)
-        arg.norm_check = 1;
+    {
+        arg.norm_check     = 1;
+        arg.allclose_check = 1;
+    }
 
     switch(api_method)
     {

--- a/clients/common/hipblaslt_arguments.cpp
+++ b/clients/common/hipblaslt_arguments.cpp
@@ -100,14 +100,14 @@ void Arguments::init()
     solution_index         = -1;
     requested_solution_num = 1;
 
-    a_type       = HIP_R_16F;
-    b_type       = HIP_R_16F;
-    c_type       = HIP_R_16F;
-    d_type       = HIP_R_16F;
-    compute_type = HIPBLAS_COMPUTE_32F;
+    a_type              = HIP_R_16F;
+    b_type              = HIP_R_16F;
+    c_type              = HIP_R_16F;
+    d_type              = HIP_R_16F;
+    compute_type        = HIPBLAS_COMPUTE_32F;
     compute_input_typeA = HIPBLASLT_DATATYPE_INVALID;
     compute_input_typeB = HIPBLASLT_DATATYPE_INVALID;
-    scale_type   = HIP_R_32F;
+    scale_type          = HIP_R_32F;
 
     initialization = hipblaslt_initialization::hpl;
 
@@ -121,9 +121,10 @@ void Arguments::init()
     // bytes
     devices = 0;
 
-    norm_check = 0;
-    unit_check = 1;
-    timing     = 0;
+    norm_check     = 0;
+    allclose_check = 0;
+    unit_check     = 1;
+    timing         = 0;
 
     transA = '*';
     transB = '*';

--- a/clients/include/allclose.hpp
+++ b/clients/include/allclose.hpp
@@ -1,0 +1,298 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "allclose.hpp"
+#include "cblas.h"
+#include "hipblaslt_vector.hpp"
+#include "utility.hpp"
+#include <cstdio>
+#include <hipblaslt/hipblaslt.h>
+#include <limits>
+#include <memory>
+
+/* =====================================================================
+        allclose check: abs(A-B) <= atol + abs(rtol * B)
+    =================================================================== */
+
+/*!\file
+ * \brief compares two results (usually, CPU and GPU results); provides allclose check
+ */
+
+/* ============== Allclose Check for General Matrix ============= */
+/*! \brief compare the allclose error of two matrices hCPU & hGPU */
+
+template <typename T>
+bool allclose(size_t* N, T* a, T* b, double atol, double rtol, bool equal_nan = false)
+{
+    for(size_t i = 0; i < *N; i++)
+    {
+        //NaNs compare equal when equal_nan is true
+        if(equal_nan && (std::isnan(a[i]) && std::isnan(b[i])))
+            continue;
+        if(equal_nan && (std::isnan(a[i]) ^ std::isnan(b[i])))
+            return false;
+
+        double error     = std::abs(a[i] - b[i]);
+        double tolerance = atol + std::abs(rtol * b[i]);
+        if(!(error <= tolerance))
+            return false;
+    }
+    return true;
+}
+
+template <typename T,
+          std::enable_if_t<!(std::is_same<T, hipblaslt_f8_fnuz>{}
+                             || std::is_same<T, hipblaslt_bf8_fnuz>{}),
+                           int> = 0>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            T*      hCPU,
+                            T*      hGPU,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+    size_t              size = N * (size_t)lda;
+    host_vector<double> hCPU_double(size);
+    host_vector<double> hGPU_double(size);
+
+    for(int64_t i = 0; i < N; i++)
+    {
+        for(int64_t j = 0; j < M; j++)
+        {
+            size_t idx       = j + i * (size_t)lda;
+            hCPU_double[idx] = double(hCPU[idx]);
+            hGPU_double[idx] = double(hGPU[idx]);
+        }
+    }
+
+    std::vector<double> atols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> rtols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    for(auto& atol : atols)
+    {
+        for(auto& rtol : rtols)
+        {
+            if(allclose(&size, hCPU_double.data(), hGPU_double.data(), atol, rtol, false))
+            {
+                hipblaslt_atol = atol;
+                hipblaslt_rtol = rtol;
+                //early termination for accending rtols
+                break;
+            }
+        }
+        //early termination for accending atols
+        if(hipblaslt_atol != 1)
+            break;
+    }
+
+    if(hipblaslt_atol == 1)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+template <typename T,
+          std::enable_if_t<(std::is_same<T, hipblaslt_f8_fnuz>{}
+                            || std::is_same<T, hipblaslt_bf8_fnuz>{}),
+                           int> = 0>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            T*      hCPU,
+                            T*      hGPU,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+    size_t              size = N * (size_t)lda;
+    host_vector<double> hCPU_double(size);
+    host_vector<double> hGPU_double(size);
+
+    for(int64_t i = 0; i < N; i++)
+    {
+        for(int64_t j = 0; j < M; j++)
+        {
+            size_t idx       = j + i * (size_t)lda;
+            hCPU_double[idx] = double(float(hCPU[idx]));
+            hGPU_double[idx] = double(float(hGPU[idx]));
+        }
+    }
+
+    std::vector<double> atols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> rtols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    for(auto& atol : atols)
+    {
+        for(auto& rtol : rtols)
+        {
+            if(allclose(&size, hCPU_double.data(), hGPU_double.data(), atol, rtol, false))
+            {
+                hipblaslt_atol = atol;
+                hipblaslt_rtol = rtol;
+                //early termination for accending rtols
+                break;
+            }
+        }
+        //early termination for accending atols
+        if(hipblaslt_atol != 1)
+            break;
+    }
+
+    if(hipblaslt_atol == 1)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+// For BF16 and half, we convert the results to double first
+template <
+    typename T,
+    typename VEC,
+    std::enable_if_t<std::is_same<T, hipblasLtHalf>{} || std::is_same<T, hip_bfloat16>{}, int> = 0>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            VEC&&   hCPU,
+                            T*      hGPU,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+    size_t              size = N * (size_t)lda;
+    host_vector<double> hCPU_double(size);
+    host_vector<double> hGPU_double(size);
+
+    for(int64_t i = 0; i < N; i++)
+    {
+        for(int64_t j = 0; j < M; j++)
+        {
+            size_t idx       = j + i * (size_t)lda;
+            hCPU_double[idx] = hCPU[idx];
+            hGPU_double[idx] = hGPU[idx];
+        }
+    }
+
+    return allclose_check_general<double>(
+        allclose_type, M, N, lda, hCPU_double, hGPU_double, hipblaslt_atol, hipblaslt_rtol);
+}
+
+// For int8, we convert the results to int first
+template <typename T, typename VEC, std::enable_if_t<std::is_same<T, int8_t>{}, int> = 0>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            VEC&&   hCPU,
+                            T*      hGPU,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+    size_t           size = N * (size_t)lda;
+    host_vector<int> hCPU_int(size);
+    host_vector<int> hGPU_int(size);
+
+    for(int64_t i = 0; i < N; i++)
+    {
+        for(int64_t j = 0; j < M; j++)
+        {
+            size_t idx    = j + i * (size_t)lda;
+            hCPU_int[idx] = hCPU[idx];
+            hGPU_int[idx] = hGPU[idx];
+        }
+    }
+
+    return allclose_check_general<int>(
+        allclose_type, M, N, lda, hCPU_int, hGPU_int, hipblaslt_atol, hipblaslt_rtol);
+}
+
+/* ============== allclose check for strided_batched case ============= */
+template <typename T, template <typename> class VEC, typename T_hpa>
+bool allclose_check_general(char        allclose_type,
+                            int64_t     M,
+                            int64_t     N,
+                            int64_t     lda,
+                            int64_t     stride_a,
+                            VEC<T_hpa>& hCPU,
+                            T*          hGPU,
+                            int64_t     batch_count,
+                            double&     hipblaslt_atol,
+                            double&     hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+
+    for(size_t i = 0; i < batch_count; i++)
+    {
+        auto index = i * stride_a;
+        bool close = allclose_check_general(
+            allclose_type, M, N, lda, (T_hpa*)hCPU + index, hGPU + index, hipblaslt_atol, hipblaslt_rtol);
+        if(!close)
+            return false;
+    }
+
+    return true;
+}
+
+/* ============== allclose check for batched case ============= */
+template <typename T>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            T*      hCPU[],
+                            T*      hGPU[],
+                            int64_t batch_count,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
+{
+    if(M * N == 0)
+        return 0;
+
+    for(int64_t i = 0; i < batch_count; i++)
+    {
+        auto index = i;
+        bool close = allclose_check_general<T>(
+            allclose_type, M, N, lda, hCPU[index], hGPU[index], hipblaslt_atol, hipblaslt_rtol);
+        if(!close)
+            return false;
+    }
+
+    return true;
+}

--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -62,10 +62,9 @@ public:
                   double                      gflops,
                   double                      gbytes,
                   double                      cpu_us,
-                  double                      norm1,
-                  double                      norm2,
-                  double                      norm3,
-                  double                      norm4)
+                  double                      norm,
+                  double                      atol,
+                  double                      rtol)
     {
         // requires enablement for frequency logging
         ArgumentModel_log_frequencies(name_line, val_line);
@@ -91,20 +90,20 @@ public:
         if(gflops != ArgumentLogging::NA_value)
         {
             name_line << ",hipblaslt-Gflops";
-            val_line << ", " << hipblaslt_gflops;
+            val_line << "," << hipblaslt_gflops;
         }
 
         if(gbytes != ArgumentLogging::NA_value)
         {
             // GB/s not usually reported for non-memory bound functions
             name_line << ",hipblaslt-GB/s";
-            val_line << ", " << hipblaslt_GBps;
+            val_line << "," << hipblaslt_GBps;
         }
 
         name_line << ",us";
-        val_line << ", " << gpu_us;
+        val_line << "," << gpu_us;
 
-        if(arg.unit_check || arg.norm_check)
+        if(arg.unit_check || arg.norm_check || arg.allclose_check)
         {
             if(cpu_us != ArgumentLogging::NA_value)
             {
@@ -120,25 +119,29 @@ public:
             }
             if(arg.norm_check)
             {
-                if(norm1 != ArgumentLogging::NA_value)
+                if(norm != ArgumentLogging::NA_value)
                 {
-                    name_line << ",norm_error_1";
-                    val_line << "," << norm1;
+                    name_line << ",norm_error";
+                    val_line << "," << norm;
                 }
-                if(norm2 != ArgumentLogging::NA_value)
+            }
+            if(arg.allclose_check)
+            {
+                if(atol != ArgumentLogging::NA_value)
                 {
-                    name_line << ",norm_error_2";
-                    val_line << "," << norm2;
+                    name_line << ",atol";
+                    if(atol == 1) // atol == init value
+                        val_line << "," << "failed";
+                    else
+                        val_line << "," << atol;
                 }
-                if(norm3 != ArgumentLogging::NA_value)
+                if(rtol != ArgumentLogging::NA_value)
                 {
-                    name_line << ",norm_error_3";
-                    val_line << "," << norm3;
-                }
-                if(norm4 != ArgumentLogging::NA_value)
-                {
-                    name_line << ",norm_error_4";
-                    val_line << "," << norm4;
+                    name_line << ",rtol";
+                    if(rtol == 1) // rtol == init value
+                        val_line << "," << "failed";
+                    else
+                        val_line << "," << rtol;
                 }
             }
         }
@@ -158,10 +161,9 @@ public:
                   double                      gflops,
                   double                      gpu_bytes = ArgumentLogging::NA_value,
                   double                      cpu_us    = ArgumentLogging::NA_value,
-                  double                      norm1     = ArgumentLogging::NA_value,
-                  double                      norm2     = ArgumentLogging::NA_value,
-                  double                      norm3     = ArgumentLogging::NA_value,
-                  double                      norm4     = ArgumentLogging::NA_value)
+                  double                      norm      = ArgumentLogging::NA_value,
+                  double                      atol      = ArgumentLogging::NA_value,
+                  double                      rtol      = ArgumentLogging::NA_value)
     {
         hipblaslt_internal_ostream name_list;
         hipblaslt_internal_ostream value_list;
@@ -206,10 +208,9 @@ public:
                      gflops,
                      gpu_bytes,
                      cpu_us,
-                     norm1,
-                     norm2,
-                     norm3,
-                     norm4);
+                     norm,
+                     atol,
+                     rtol);
 
         if(solution_index > -1)
         {

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -119,6 +119,7 @@ struct Arguments
     uint8_t devices;
 
     int8_t norm_check;
+    int8_t allclose_check;
     int8_t unit_check;
     int8_t timing;
 
@@ -219,6 +220,7 @@ struct Arguments
     OPER(streams) SEP                \
     OPER(devices) SEP                \
     OPER(norm_check) SEP             \
+    OPER(allclose_check) SEP         \
     OPER(unit_check) SEP             \
     OPER(timing) SEP                 \
     OPER(transA) SEP                 \

--- a/clients/include/hipblaslt_common.yaml
+++ b/clients/include/hipblaslt_common.yaml
@@ -245,6 +245,7 @@ Arguments:
   - streams: c_uint16
   - devices: c_uint8
   - norm_check: c_int8
+  - allclose_check: c_int8
   - unit_check: c_int8
   - timing: c_int8
   - transA: c_char
@@ -333,6 +334,7 @@ Defaults:
   devices: 0
   gpu_arch: ''
   norm_check: 0
+  allclose_check: 0
   unit_check: 1
   timing: 0
   iters: 10


### PR DESCRIPTION
1. Enable allclose by option "-v"
2. Allclose check follows the same flow of norm check
3. Remove unused codes, e.g., norm2, norm3, norm4
4. clang-format the codes