### PR TITLE
change API to hipblasltExtFastValueDevidedByAMaxWithRcp

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -99,7 +99,7 @@ add_executable( hipblaslt-bench-extop-layernorm client_extop_layernorm.cpp ../co
 add_executable( hipblaslt-bench-extop-matrixtransform client_extop_matrixtransform.cpp ../common/hipblaslt_random.cpp)
 add_executable( hipblaslt-bench-extop-softmax client_extop_softmax.cpp ../common/hipblaslt_random.cpp)
 add_executable( hipblaslt-bench-extop-amax client_extop_amax.cpp  ../common/hipblaslt_random.cpp)
-add_executable( hipblaslt-bench-extop-divided-by-amax client_extop_value_divided_by_amax.cpp  ../common/hipblaslt_random.cpp)
+add_executable( hipblaslt-bench-extop-divided-by-amax client_extop_value_divided_by_amax_with_rcp.cpp  ../common/hipblaslt_random.cpp)
 
 set(ext_bench_list_all hipblaslt-bench-groupedgemm-fixed-mk hipblaslt-bench-extop-layernorm hipblaslt-bench-extop-matrixtransform hipblaslt-bench-extop-softmax hipblaslt-bench-extop-amax hipblaslt-bench-extop-divided-by-amax)
 # Currently only build this for Ubuntu because other distro's llvm-dev version is not matching the rocm's version.

--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -114,9 +114,6 @@ void cblas_gemm(hipblasOperation_t     transA,
         A_Tc.initialize(sizeA);
         if constexpr(sizeof(TiA) > sizeof(TciACast))
         {
-            //hack for mixed mode only, scaleA/B is invisible to user, need to multiply the rcp
-            if constexpr(sizeof(TiB) == sizeof(TciBCast))
-              alpha /= scaleA;
             if(transA == HIPBLAS_OP_N)
             {
                 for(size_t i = 0; i < sizeA; i++)
@@ -155,8 +152,6 @@ void cblas_gemm(hipblasOperation_t     transA,
         A_Tc.initialize(sizeA);
         if constexpr(sizeof(TiA) > sizeof(TciACast))
         {
-            if constexpr(sizeof(TiB) == sizeof(TciBCast))
-              alpha /= scaleA;
             for(size_t i = 0; i < sizeA; i++)
             {
                 A_Tc[i] = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA));
@@ -182,8 +177,6 @@ void cblas_gemm(hipblasOperation_t     transA,
         B_Tc.initialize(sizeB);
         if constexpr(sizeof(TiB) > sizeof(TciBCast))
         {
-            if constexpr(sizeof(TiA) == sizeof(TciACast))
-              alpha /= scaleB;
             for(size_t i = 0; i < sizeB; i++)
             {
                 B_Tc[i] = static_cast<TcCast>(static_cast<TciBCast>(B[i] * scaleB));

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -42,6 +42,9 @@ add_executable( sample_hipblaslt_ext_op_layernorm ext_op/sample_hipblaslt_ext_op
 add_executable( sample_hipblaslt_ext_op_amax ext_op/sample_hipblaslt_ext_op_amax.cpp)
 add_executable( sample_hipblaslt_ext_op_amax_with_scale ext_op/sample_hipblaslt_ext_op_amax_with_scale.cpp)
 
+# TODO move to benchmark
+add_executable( sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext.cpp)
+
 set(samples sample_hipblaslt_gemm
             sample_hipblaslt_gemm_ext
             sample_hipblaslt_gemm_ext_bgradb
@@ -60,7 +63,8 @@ set(samples sample_hipblaslt_gemm
             sample_hipblaslt_groupedgemm_get_all_algos_ext
             sample_hipblaslt_ext_op_layernorm
             sample_hipblaslt_ext_op_amax
-            sample_hipblaslt_ext_op_amax_with_scale)
+            sample_hipblaslt_ext_op_amax_with_scale
+            sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext) # TODO:
 
 set( sample_list_all ${samples})
 

--- a/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext.cpp
+++ b/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext.cpp
@@ -1,0 +1,312 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#include <hip/hip_runtime.h>
+#include <hipblaslt/hipblaslt.h>
+#include <hipblaslt/hipblaslt-ext.hpp>
+#include <hipblaslt/hipblaslt-ext-op.h>
+#include <iostream>
+#include <iomanip>
+#include <random>
+
+#ifndef CHECK_HIP_ERROR
+#define CHECK_HIP_ERROR(error)                    \
+    if(error != hipSuccess)                       \
+    {                                             \
+        fprintf(stderr,                           \
+                "Hip error: '%s'(%d) at %s:%d\n", \
+                hipGetErrorString(error),         \
+                error,                            \
+                __FILE__,                         \
+                __LINE__);                        \
+        exit(EXIT_FAILURE);                       \
+    }
+#endif
+
+#ifndef CHECK_HIPBLASLT_ERROR
+#define CHECK_HIPBLASLT_ERROR(error)                                                      \
+    if(error != HIPBLAS_STATUS_SUCCESS)                                                   \
+    {                                                                                     \
+        fprintf(stderr, "hipBLASLt error(Err=%d) at %s:%d\n", error, __FILE__, __LINE__); \
+        fprintf(stderr, "\n");                                                            \
+        exit(EXIT_FAILURE);                                                               \
+    }
+#endif
+
+using hipblaslt_rng_t = std::mt19937;
+
+inline hipblaslt_rng_t get_seed()
+{
+    auto tid = std::this_thread::get_id();
+    return hipblaslt_rng_t(std::hash<std::thread::id>{}(tid));
+}
+
+thread_local hipblaslt_rng_t t_hipblaslt_rng = get_seed();
+
+template <typename T>
+void init_hpl(T* A, size_t size)
+{
+    for(size_t i = 0; i < size; i++)
+        A[i] = static_cast<T>(std::uniform_real_distribution<double>(-0.5, 0.5)(t_hipblaslt_rng));
+}
+
+template <typename Tci, typename Ti>
+float getValue(Ti value, float scale)
+{
+    if (sizeof(Tci) < sizeof(Ti))
+        return float(Tci(scale * float(value)));
+    else
+        return scale * float(value);
+}
+
+template <typename TypeA, typename TypeB, typename TypeCD, typename ComputeInputType, typename AlphaType, typename BetaType>
+int CpuGemmExtWithAmaxScaleAB(int64_t            M,
+                              int64_t            N,
+                              int64_t            K,
+                              int64_t            B,
+                              void*              a,
+                              void*              b,
+                              void*              c,
+                              void*              ref,
+                              AlphaType          alpha,
+                              BetaType           beta,
+                              float              scaleA,
+                              float              scaleB)
+{
+    const auto    batchStrideA = M * K;
+    const auto    batchStrideB = K * N;
+    const auto    batchStrideC = M * N;
+    const auto    batchStrideD = M * N;
+    const TypeA*  aPtr         = reinterpret_cast<const TypeA*>(a);
+    const TypeB*  bPtr         = reinterpret_cast<const TypeB*>(b);
+    const TypeCD* cPtr         = reinterpret_cast<const TypeCD*>(c);
+          TypeCD* refPtr       = reinterpret_cast<      TypeCD*>(ref);
+
+    for(int64_t b = 0; b < B; ++b)
+    {
+        for(int64_t i = 0; i < M; ++i)
+        {
+            for(int64_t j = 0; j < N; ++j)
+            {
+                float tmpRef = 0.0f;
+                for(int64_t k = 0; k < K; ++k)
+                {
+                    float valueA = getValue<ComputeInputType, TypeA>(aPtr[batchStrideA * b + M * k + i], scaleA);
+                    float valueB = getValue<ComputeInputType, TypeB>(bPtr[batchStrideB * b + K * j + k], scaleB);
+                    tmpRef += (valueA * valueB);
+                }
+
+                float valueC = float(cPtr[batchStrideC * b + j * M + i]);
+                refPtr[batchStrideD * b + j * M + i] = TypeCD(alpha * tmpRef + beta * valueC);
+            }
+        }
+    }
+
+    return 0;
+}
+
+template <typename TypeCD>
+int validate(int64_t m,
+             int64_t n,
+             int64_t batch_count,
+             void*   gpu,
+             void*   ref)
+{
+    const auto batchStrideD = m * n;
+    const TypeCD* gpuPtr = reinterpret_cast<const TypeCD*>(gpu);
+    const TypeCD* refPtr = reinterpret_cast<const TypeCD*>(ref);
+
+    std::cout << std::fixed;
+    std::cout << std::setprecision(6);
+
+    for(int64_t b = 0; b < batch_count; ++b)
+    {
+        for(int64_t i = 0; i < m; ++i)
+        {
+            for(int64_t j = 0; j < n; ++j)
+            {
+                const auto lhs = float(gpuPtr[batchStrideD * b + j * m + i]);
+                const auto rhs = float(refPtr[batchStrideD * b + j * m + i]);
+
+                if(std::abs(lhs - rhs) > 1e-5)
+                {
+                    std::cout << lhs << " vs " << rhs << '\n';
+                    return -1;
+                }
+            }
+        }
+    }
+
+    return 0;
+}
+
+template <typename InTypeA, typename InTypeB, typename OutType, typename ComputeInputType, typename AlphaType, typename BetaType>
+void GemmExtWithAmaxScaleAB(int64_t    m,
+                            int64_t    n,
+                            int64_t    k,
+                            int64_t    batch_count,
+                            AlphaType  alpha,
+                            BetaType   beta,
+                            float      cvtMax,
+                            int64_t    max_workspace_size)
+{
+    hipStream_t       stream;
+    hipblasLtHandle_t handle;
+    void *a, *b, *c, *d, *ref;
+    void *d_a, *d_b, *d_c, *d_d, *d_scaleA, *d_scaleB, *d_workspace, *d_sync; // device
+    float scaleA, scaleB;
+
+    // create stream and handle
+    CHECK_HIP_ERROR(hipStreamCreate(&stream));
+    CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
+
+    // create device memory
+    CHECK_HIP_ERROR(hipMalloc(&d_a, m * k * batch_count * sizeof(InTypeA)));
+    CHECK_HIP_ERROR(hipMalloc(&d_b, n * k * batch_count * sizeof(InTypeB)));
+    CHECK_HIP_ERROR(hipMalloc(&d_c, m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipMalloc(&d_d, m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipMalloc(&d_scaleA, sizeof(float)));
+    CHECK_HIP_ERROR(hipMalloc(&d_scaleB, sizeof(float)));
+    if(max_workspace_size > 0)
+        CHECK_HIP_ERROR(hipMalloc(&d_workspace, max_workspace_size));
+    CHECK_HIP_ERROR(hipMalloc(&d_sync, sizeof(int32_t)));
+
+    // create host memory
+    CHECK_HIP_ERROR(hipHostMalloc(&a,   m * k * batch_count * sizeof(InTypeA)));
+    CHECK_HIP_ERROR(hipHostMalloc(&b,   n * k * batch_count * sizeof(InTypeB)));
+    CHECK_HIP_ERROR(hipHostMalloc(&c,   m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipHostMalloc(&d,   m * n * batch_count * sizeof(OutType)));
+    CHECK_HIP_ERROR(hipHostMalloc(&ref, m * n * batch_count * sizeof(OutType)));
+
+    // initialize data
+    init_hpl<InTypeA>(reinterpret_cast<InTypeA*>(a), m * k * batch_count);
+    init_hpl<InTypeB>(reinterpret_cast<InTypeB*>(b), n * k * batch_count);
+    init_hpl<OutType>(reinterpret_cast<OutType*>(c), m * n * batch_count);
+
+    // copy data to device
+    CHECK_HIP_ERROR(hipMemset(d_sync, 0, sizeof(std::uint32_t)));
+    CHECK_HIP_ERROR(hipMemcpyAsync(d_a, a, m * k * batch_count * sizeof(InTypeA), hipMemcpyHostToDevice, stream));
+    CHECK_HIP_ERROR(hipMemcpyAsync(d_b, b, n * k * batch_count * sizeof(InTypeB), hipMemcpyHostToDevice, stream));
+    CHECK_HIP_ERROR(hipMemcpyAsync(d_c, c, m * n * batch_count * sizeof(OutType), hipMemcpyHostToDevice, stream));
+
+    // scale B is 240/AMax  and scaleA will be AMax/240
+    CHECK_HIPBLASLT_ERROR(hipblasltExtFastValueDividedByAMaxWithRcp(HIP_R_16F, HIP_R_32F, d_scaleB, d_scaleA, d_b, d_workspace, d_sync, n, k, cvtMax, stream));
+
+    // hipblaslt setProblem API
+    hipblaslt_ext::Gemm gemm(handle,
+                             HIPBLAS_OP_N,
+                             HIPBLAS_OP_N,
+                             HIP_R_8F_E4M3_FNUZ,
+                             HIP_R_16F,
+                             HIP_R_16F,
+                             HIP_R_16F,
+                             HIPBLAS_COMPUTE_32F);
+
+    hipblaslt_ext::GemmInputs inputs;
+    hipblaslt_ext::GemmEpilogue epilogue;
+    hipblaslt_ext::GemmPreference gemmPref;
+
+    inputs.a      = d_a;
+    inputs.b      = d_b;
+    inputs.c      = d_c;
+    inputs.d      = d_d;
+    inputs.alpha  = &alpha;
+    inputs.beta   = &beta;
+    inputs.scaleA = d_scaleA;
+    inputs.scaleB = d_scaleB;
+
+    gemmPref.setMaxWorkspaceBytes(max_workspace_size);
+
+    gemm.setProblem(m, n, k, batch_count, epilogue, inputs);
+
+    // hipblaslt algoGetHeuristic API
+    const int                                     request_solutions = 1;
+    std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
+    CHECK_HIPBLASLT_ERROR(gemm.algoGetHeuristic(request_solutions, gemmPref, heuristicResult));
+
+    if(!heuristicResult.empty())
+    {
+        // hipblaslt initialize, run and sync
+        CHECK_HIPBLASLT_ERROR(gemm.initialize(heuristicResult[0].algo, d_workspace));
+        CHECK_HIPBLASLT_ERROR(gemm.run(stream));
+
+        // get device data back to host
+        CHECK_HIP_ERROR(hipMemcpyAsync(&scaleA, d_scaleA, sizeof(float), hipMemcpyDeviceToHost, stream));
+        CHECK_HIP_ERROR(hipMemcpyAsync(&scaleB, d_scaleB, sizeof(float), hipMemcpyDeviceToHost, stream));
+        CHECK_HIP_ERROR(hipMemcpyAsync(d, d_d, m * n * batch_count * sizeof(OutType), hipMemcpyDeviceToHost, stream));
+
+        // sync to get result to host
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
+
+        // get ref result
+        CpuGemmExtWithAmaxScaleAB<InTypeA, InTypeB, OutType, ComputeInputType, AlphaType, BetaType>(m, n, k, batch_count, a, b, c, ref, alpha, beta, scaleA, scaleB);
+
+        if (validate<OutType>(m, n, batch_count, d, ref) == 0)
+            std::cout << "PASS" << std::endl;
+    }
+    else
+    {
+        std::cerr << "No valid solution found!" << std::endl;
+    }
+
+    CHECK_HIP_ERROR(hipFree(d_a));
+    CHECK_HIP_ERROR(hipFree(d_b));
+    CHECK_HIP_ERROR(hipFree(d_c));
+    CHECK_HIP_ERROR(hipFree(d_d));
+    CHECK_HIP_ERROR(hipFree(d_scaleA));
+    CHECK_HIP_ERROR(hipFree(d_scaleB));
+    CHECK_HIP_ERROR(hipFree(d_workspace));
+    CHECK_HIP_ERROR(hipFree(d_sync));
+
+    CHECK_HIP_ERROR(hipFree(a));
+    CHECK_HIP_ERROR(hipFree(b));
+    CHECK_HIP_ERROR(hipFree(c));
+    CHECK_HIP_ERROR(hipFree(d));
+    CHECK_HIP_ERROR(hipFree(ref));
+
+    return;
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 8)
+    {
+        std::cout << argv[0] << " [M] [N] [K] [B] [alpha] [beta] [cvtMax]" << std::endl;
+        return 0;
+    }
+
+    size_t m      = std::atoi(argv[1]);
+    size_t n      = std::atoi(argv[2]);
+    size_t k      = std::atoi(argv[3]);
+    size_t b      = std::atoi(argv[4]);
+    float  alpha  = std::atof(argv[5]);
+    float  beta   = std::atof(argv[6]);
+    float  cvtMax = std::atof(argv[7]);
+
+    GemmExtWithAmaxScaleAB<hipblaslt_f8_fnuz, hipblasLtHalf, hipblasLtHalf, hipblaslt_f8_fnuz, float, float>(m, n, k, b, alpha, beta, cvtMax, 32 * 1024 * 1024);
+
+    return 0;
+}
+

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -234,6 +234,9 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtFastAMax(const hipDataType datatype
  *  @param[out]
  *  output Amax tensor buffer. can't be nullptr.
  *
+ *  @param[out]
+ *  outputRCP Amax Rcp tensor buffer. (nullptr means don't wanna get this value)
+ *
  *  @param[in]
  *  input 2-D tensor buffer. can't be nullptr.
  *
@@ -260,16 +263,17 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtFastAMax(const hipDataType datatype
  *  \retval HIPBLAS_STATUS_INVALID_VALUE If \p m or n is 0, or input or output is nullptr.
  *  \retval HIPBLAS_STATUS_NOT_SUPPORTED If \p datatype is not (HIP_R_32F or HIP_R_16F).
  */
-HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtFastValueDevidedByAMax(const hipDataType datatype,
-                                                                    const hipDataType outDatatype,
-                                                                    void*             output,
-                                                                    const void*       input,
-                                                                    void*             workSpace,
-                                                                    void*             sync,
-                                                                    uint32_t          m,
-                                                                    uint32_t          n,
-                                                                    float             div,
-                                                                    hipStream_t       stream);
+HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtFastValueDividedByAMaxWithRcp(const hipDataType datatype,
+                                                                           const hipDataType outDatatype,
+                                                                           void*             output,
+                                                                           void*             outputRCP,
+                                                                           const void*       input,
+                                                                           void*             workSpace,
+                                                                           void*             sync,
+                                                                           uint32_t          m,
+                                                                           uint32_t          n,
+                                                                           float             div,
+                                                                           hipStream_t       stream);
 
 /*! \ingroup library_module
  *  \brief Perform absmax and scaling on given 2-D tensor. Generate one absmax value and scaled 2-D tensor output.

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -100,6 +100,7 @@ hipblasStatus_t hipblasltExtLayerNorm(hipDataType datatype,
 hipblasStatus_t hipblasltAMaxRun(const hipDataType datatype,
                                  const hipDataType outDatatype,
                                  void*             output,
+                                 void*             outputRCP,
                                  const void*       input,
                                  void*             workSpace,
                                  void*             sync,
@@ -133,7 +134,7 @@ hipblasStatus_t hipblasltExtAMax(const hipDataType datatype,
                                  hipStream_t       stream)
 {
     return hipblasltAMaxRun(
-        datatype, outDatatype, output, input, nullptr, nullptr, m, n, 0, 0, stream);
+        datatype, outDatatype, output, nullptr, input, nullptr, nullptr, m, n, 0, 0, stream);
 }
 
 hipblasStatus_t hipblasltExtFastAMax(const hipDataType datatype,
@@ -147,22 +148,23 @@ hipblasStatus_t hipblasltExtFastAMax(const hipDataType datatype,
                                      hipStream_t       stream)
 {
     return hipblasltAMaxRun(
-        datatype, outDatatype, output, input, workSpace, sync, m, n, 0, 0, stream);
+        datatype, outDatatype, output, nullptr, input, workSpace, sync, m, n, 0, 0, stream);
 }
 
-hipblasStatus_t hipblasltExtFastValueDevidedByAMax(const hipDataType datatype,
-                                                   const hipDataType outDatatype,
-                                                   void*             output,
-                                                   const void*       input,
-                                                   void*             workSpace,
-                                                   void*             sync,
-                                                   uint32_t          m,
-                                                   uint32_t          n,
-                                                   float             div,
-                                                   hipStream_t       stream)
+hipblasStatus_t hipblasltExtFastValueDividedByAMaxWithRcp(const hipDataType datatype,
+                                                          const hipDataType outDatatype,
+                                                          void*             output,
+                                                          void*             outputRCP,
+                                                          const void*       input,
+                                                          void*             workSpace,
+                                                          void*             sync,
+                                                          uint32_t          m,
+                                                          uint32_t          n,
+                                                          float             div,
+                                                          hipStream_t       stream)
 {
     return hipblasltAMaxRun(
-        datatype, outDatatype, output, input, workSpace, sync, m, n, 1, div, stream);
+        datatype, outDatatype, output, outputRCP, input, workSpace, sync, m, n, 1, div, stream);
 }
 
 hipblasStatus_t hipblasltExtAMaxWithScale(const hipDataType datatype,
@@ -490,6 +492,7 @@ hipblasStatus_t hipblasltLayerNormRun(hipDataType datatype,
 hipblasStatus_t hipblasltAMaxRun(const hipDataType datatype,
                                  const hipDataType outDatatype,
                                  void*             output,
+                                 void*             outputRCP,
                                  const void*       input,
                                  void*             workSpace,
                                  void*             sync,
@@ -559,8 +562,9 @@ hipblasStatus_t hipblasltAMaxRun(const hipDataType datatype,
     invocation.numWorkItems.z  = 1;
     invocation.sharedMemBytes  = 32 * sizeof(float);
     invocation.args            = Tensile::KernelArguments(false);
-    invocation.args.reserve(64, 9);
+    invocation.args.reserve(64, 10);
     invocation.args.append("output", output);
+    invocation.args.append("outputRCP", outputRCP);
     invocation.args.append("input", input);
     invocation.args.append("workSpace", workSpace);
     invocation.args.append("sync", sync);

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -302,7 +302,7 @@ namespace hipblaslt_ext
             {
                 if(isScaleAmaxDivisor)
                 {
-                    hipblasltExtFastValueDevidedByAMax(type, HIP_R_32F, scale, buf, workspace, sync, m, n, amaxDividend, stream);
+                    hipblasltExtFastValueDividedByAMaxWithRcp(type, HIP_R_32F, scale, nullptr, buf, workspace, sync, m, n, amaxDividend, stream);
                 }
                 else
                 {
@@ -329,7 +329,7 @@ namespace hipblaslt_ext
             {
                 if(isScaleAmaxDivisor)
                 {
-                    hipblasltExtFastValueDevidedByAMax(type, HIP_R_32F, scale, buf, workspace, sync, m, n, amaxDividend, stream);
+                    hipblasltExtFastValueDividedByAMaxWithRcp(type, HIP_R_32F, scale, nullptr, buf, workspace, sync, m, n, amaxDividend, stream);
                 }
                 else
                 {

--- a/library/src/amd_detail/hipblaslt.cpp
+++ b/library/src/amd_detail/hipblaslt.cpp
@@ -444,7 +444,7 @@ try
     {
         int* sync = ((int*)((rocblaslt_handle)handle)->Synchronizer);
         if(roc_matmul_desc->isScaleAmaxDivisorA)
-            hipblasltExtFastValueDevidedByAMax(tmp_matA->type, HIP_R_32F, roc_matmul_desc->scaleA, A, workspace, sync, tmp_matA->m, tmp_matA->n, roc_matmul_desc->amaxDividendA, stream);
+            hipblasltExtFastValueDividedByAMaxWithRcp(tmp_matA->type, HIP_R_32F, roc_matmul_desc->scaleA, nullptr, A, workspace, sync, tmp_matA->m, tmp_matA->n, roc_matmul_desc->amaxDividendA, stream);
         else
             hipblasltExtFastAMax(tmp_matA->type, HIP_R_32F, roc_matmul_desc->scaleA, A, workspace, ((rocblaslt_handle)handle)->Synchronizer, tmp_matA->m, tmp_matA->n, stream);
     }
@@ -465,7 +465,7 @@ try
     {
         int* sync = ((int*)((rocblaslt_handle)handle)->Synchronizer);
         if(roc_matmul_desc->isScaleAmaxDivisorB)
-            hipblasltExtFastValueDevidedByAMax(tmp_matB->type, HIP_R_32F, roc_matmul_desc->scaleB, B, workspace, sync, tmp_matB->m, tmp_matB->n, roc_matmul_desc->amaxDividendB, stream);
+            hipblasltExtFastValueDividedByAMaxWithRcp(tmp_matB->type, HIP_R_32F, roc_matmul_desc->scaleB, nullptr, B, workspace, sync, tmp_matB->m, tmp_matB->n, roc_matmul_desc->amaxDividendB, stream);
         else
             hipblasltExtFastAMax(tmp_matB->type, HIP_R_32F, roc_matmul_desc->scaleB, B, workspace, sync, tmp_matB->m, tmp_matB->n, stream);
     }

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -1409,29 +1409,6 @@ class KernelWriterAssembly(KernelWriter):
       elif waitForScaleAB:
         moduleWg.add(SWaitCnt(lgkmcnt=0, comment="wait for scaleA/B to load"))
 
-      # Calculate RCP and update Alpha
-      if kernel["ProblemType"]["UseScaleAB"]:
-        tmpVgpr = self.vgprPool.checkOut(1)
-        newAlphaVgpr = None
-        NeedUpdateAlpha = self.states.preloadScaleA or self.states.preloadScaleB
-        if NeedUpdateAlpha:
-          newAlphaVgpr = self.vgprPool.checkOut(1)
-          moduleWg.add(VMovB32(dst=vgpr(newAlphaVgpr), src=sgpr("Alpha")))
-        for preloadScale, name in zip([self.states.preloadScaleA, self.states.preloadScaleB], ['A','B']):
-          if preloadScale:
-            moduleWg.add(VMovB32(dst=vgpr(tmpVgpr), src=sgpr("Scale%s"%name)))
-            moduleWg.add(VRcpF32(dst=vgpr(tmpVgpr), src=vgpr(tmpVgpr), comment="Get 1/scaleB"))
-            if self.states.archCaps["TransOpWait"]:
-              moduleWg.add(SNop(waitState=0, comment="1 wait states"))
-            moduleWg.add(VMulF32(dst=vgpr(newAlphaVgpr), src0=vgpr(newAlphaVgpr), src1=vgpr(tmpVgpr)))
-            if self.states.archCaps["TransOpWait"]:
-              moduleWg.add(SNop(waitState=0, comment="1 wait states"))
-        if NeedUpdateAlpha:
-          moduleWg.add(VReadfirstlaneB32(dst=sgpr("Alpha"), src=vgpr(newAlphaVgpr), comment="Update Alpha"))
-        self.vgprPool.checkIn(tmpVgpr)
-        if newAlphaVgpr != None:
-          self.vgprPool.checkIn(newAlphaVgpr)
-
       labelMultiGemm = Label(label="MultiGemm", comment="")
       labelMultiGemmEnd = Label(label="MultiGemmEnd", comment="")
       module.add(moduleArgs)

--- a/tensilelite/Tensile/Source/client/source/Reference.cpp
+++ b/tensilelite/Tensile/Source/client/source/Reference.cpp
@@ -857,17 +857,12 @@ namespace Tensile
                         = GetValue<Accumulator>(problem.alphaType(), inputs.scaleA, 0, aConjugate);
                     Accumulator scaleB
                         = GetValue<Accumulator>(problem.alphaType(), inputs.scaleB, 0, aConjugate);
-                    //hack for mixed mode only, scaleA/B is invisible to user, need to multiply the rcp
                     if constexpr(sizeof(typename Inputs::AType)
-                                              > sizeof(typename Inputs::ComputeInputType))
-                        alpha /= scaleA;
-                    else
+                                              <= sizeof(typename Inputs::ComputeInputType))
                         alpha *= scaleA;
 
                     if constexpr(sizeof(typename Inputs::BType)
-                                              > sizeof(typename Inputs::ComputeInputType))
-                        alpha /= scaleB;
-                    else
+                                              <= sizeof(typename Inputs::ComputeInputType))
                         alpha *= scaleB;
                 }
 


### PR DESCRIPTION
hipblasltExtFastValueDevidedByAMaxWithRcp provides two outputs
1. value / AMax(buf)
2. AMax(buf) / value

samples:
client_extop_value_divided_by_amax.cpp
sample_hipblaslt_gemm_mix_precision_with_value_divided_amax_with_rcp_ext.cpp