### PR TITLE
Add MAC F64 Instruction to Support gfx11/gfx12

### DIFF
--- a/clients/gtest/known_bugs.yaml
+++ b/clients/gtest/known_bugs.yaml
@@ -5,7 +5,6 @@
 #- { function: a_type: bf16_r, b_type: bf16_r, c_type: bf16_r, d_type: bf16_r, compute_type: f32_r, transA: N, transB: N, M: 512, N: 512, K: 512, lda: 512, ldb: 512, ldc: 512, ldd: 512, alpha: 5.0, alphai: 0.0, beta: 0.0, betai: 0.0, known_bug_platforms: gfx908 }
 
 Known bugs:
-- { function: matmul, a_type: f64_r, b_type: f64_r, c_type: f64_r, d_type: f64_r, compute_type: c_f64_r, scale_type: f64_r, known_bug_platforms: "gfx1100, gfx1101, gfx1102" }
 - { function: matmul, grouped_gemm: 1, known_bug_platforms: "gfx1100, gfx1101, gfx1102" }
 - { function: matmul, grouped_gemm: 2, known_bug_platforms: "gfx1100, gfx1101, gfx1102" }
 - { function: matmul, grouped_gemm: 5, known_bug_platforms: "gfx1100, gfx1101, gfx1102" }

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -2177,9 +2177,7 @@ void testing_matmul_with_bias(const Arguments& arg)
         static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
         //workaround before known_bug work
         if((gpu_arch_match(deviceProperties.gcnArchName, "11?") || gpu_arch_match(deviceProperties.gcnArchName, "12?"))
-           && (arg.gradient || arg.grouped_gemm
-               || arg.a_type == HIP_R_64F || arg.b_type == HIP_R_64F))
-		//arg.activation_type == gelu || arg.bias_source == a || arg.bias_source == b)
+           && (arg.gradient || arg.grouped_gemm)) 
         {
             hipblaslt_cerr << "No Solution Found!!" << std::endl;
             return;

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1200
+- gfx1200
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 64]
+    - [1, 1.15349]
+  - - [128, 64, 1, 32, 128, 128, 128, 64]
+    - [2, 2.30698]
+  - - [192, 64, 1, 32, 192, 192, 192, 64]
+    - [3, 3.45378]
+  - - [256, 64, 1, 32, 256, 256, 256, 64]
+    - [1, 4.61519]
+  - - [320, 64, 1, 32, 320, 320, 320, 64]
+    - [1, 5.7695]
+  - - [384, 64, 1, 32, 384, 384, 384, 64]
+    - [1, 6.93928]
+  - - [448, 64, 1, 32, 448, 448, 448, 64]
+    - [3, 8.07161]
+  - - [512, 64, 1, 32, 512, 512, 512, 64]
+    - [1, 9.23197]
+  - - [576, 64, 1, 32, 576, 576, 576, 64]
+    - [0, 26.473]
+  - - [640, 64, 1, 32, 640, 640, 640, 64]
+    - [3, 11.5263]
+  - - [704, 64, 1, 32, 704, 704, 704, 64]
+    - [3, 12.6861]
+  - - [768, 64, 1, 32, 768, 768, 768, 64]
+    - [3, 13.8206]
+  - - [832, 64, 1, 32, 832, 832, 832, 64]
+    - [1, 14.9244]
+  - - [896, 64, 1, 32, 896, 896, 896, 64]
+    - [2, 16.0613]
+  - - [960, 64, 1, 32, 960, 960, 960, 64]
+    - [3, 17.1941]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 64]
+    - [1, 156.972]
+  - - [64, 128, 1, 32, 64, 64, 64, 128]
+    - [2, 28.9982]
+  - - [128, 128, 1, 32, 128, 128, 128, 128]
+    - [3, 49.9322]
+  - - [192, 128, 1, 32, 192, 192, 192, 128]
+    - [3, 75.0412]
+  - - [256, 128, 1, 32, 256, 256, 256, 128]
+    - [3, 87.9678]
+  - - [320, 128, 1, 32, 320, 320, 320, 128]
+    - [0, 11.4678]
+  - - [384, 128, 1, 32, 384, 384, 384, 128]
+    - [2, 13.7349]
+  - - [448, 128, 1, 32, 448, 448, 448, 128]
+    - [0, 16.0824]
+  - - [512, 128, 1, 32, 512, 512, 512, 128]
+    - [0, 18.2957]
+  - - [576, 128, 1, 32, 576, 576, 576, 128]
+    - [3, 171.71]
+  - - [640, 128, 1, 32, 640, 640, 640, 128]
+    - [3, 41.8958]
+  - - [704, 128, 1, 32, 704, 704, 704, 128]
+    - [3, 184.137]
+  - - [768, 128, 1, 32, 768, 768, 768, 128]
+    - [2, 9.67241]
+  - - [832, 128, 1, 32, 832, 832, 832, 128]
+    - [2, 10.4909]
+  - - [896, 128, 1, 32, 896, 896, 896, 128]
+    - [3, 11.1885]
+  - - [960, 128, 1, 32, 960, 960, 960, 128]
+    - [1, 11.9394]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 128]
+    - [3, 221.452]
+  - - [64, 192, 1, 32, 64, 64, 64, 192]
+    - [3, 37.4474]
+  - - [128, 192, 1, 32, 128, 128, 128, 192]
+    - [2, 77.4047]
+  - - [192, 192, 1, 32, 192, 192, 192, 192]
+    - [3, 98.304]
+  - - [256, 192, 1, 32, 256, 256, 256, 192]
+    - [3, 5.21919]
+  - - [320, 192, 1, 32, 320, 320, 320, 192]
+    - [1, 6.03876]
+  - - [384, 192, 1, 32, 384, 384, 384, 192]
+    - [1, 7.71751]
+  - - [448, 192, 1, 32, 448, 448, 448, 192]
+    - [2, 9.04163]
+  - - [512, 192, 1, 32, 512, 512, 512, 192]
+    - [1, 10.2895]
+  - - [576, 192, 1, 32, 576, 576, 576, 192]
+    - [1, 11.56]
+  - - [640, 192, 1, 32, 640, 640, 640, 192]
+    - [2, 12.9306]
+  - - [704, 192, 1, 32, 704, 704, 704, 192]
+    - [3, 14.0882]
+  - - [768, 192, 1, 32, 768, 768, 768, 192]
+    - [1, 15.4489]
+  - - [832, 192, 1, 32, 832, 832, 832, 192]
+    - [1, 16.6423]
+  - - [896, 192, 1, 32, 896, 896, 896, 192]
+    - [1, 17.955]
+  - - [960, 192, 1, 32, 960, 960, 960, 192]
+    - [3, 19.4074]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 192]
+    - [2, 20.6185]
+  - - [64, 256, 1, 32, 64, 64, 64, 256]
+    - [3, 1.74497]
+  - - [128, 256, 1, 32, 128, 128, 128, 256]
+    - [3, 3.48907]
+  - - [192, 256, 1, 32, 192, 192, 192, 256]
+    - [2, 5.19085]
+  - - [256, 256, 1, 32, 256, 256, 256, 256]
+    - [1, 6.85968]
+  - - [320, 256, 1, 32, 320, 320, 320, 256]
+    - [1, 8.58146]
+  - - [384, 256, 1, 32, 384, 384, 384, 256]
+    - [2, 10.2789]
+  - - [448, 256, 1, 32, 448, 448, 448, 256]
+    - [1, 12.0221]
+  - - [512, 256, 1, 32, 512, 512, 512, 256]
+    - [2, 13.7992]
+  - - [576, 256, 1, 32, 576, 576, 576, 256]
+    - [2, 15.4454]
+  - - [640, 256, 1, 32, 640, 640, 640, 256]
+    - [2, 17.294]
+  - - [704, 256, 1, 32, 704, 704, 704, 256]
+    - [3, 243.546]
+  - - [768, 256, 1, 32, 768, 768, 768, 256]
+    - [1, 267.488]
+  - - [832, 256, 1, 32, 832, 832, 832, 256]
+    - [2, 22.3451]
+  - - [896, 256, 1, 32, 896, 896, 896, 256]
+    - [3, 23.9841]
+  - - [960, 256, 1, 32, 960, 960, 960, 256]
+    - [3, 25.715]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 256]
+    - [2, 22.0262]
+  - - [64, 320, 1, 32, 64, 64, 64, 320]
+    - [1, 2.18056]
+  - - [128, 320, 1, 32, 128, 128, 128, 320]
+    - [3, 4.34212]
+  - - [192, 320, 1, 32, 192, 192, 192, 320]
+    - [2, 6.47766]
+  - - [256, 320, 1, 32, 256, 256, 256, 320]
+    - [3, 8.64858]
+  - - [320, 320, 1, 32, 320, 320, 320, 320]
+    - [1, 10.7349]
+  - - [384, 320, 1, 32, 384, 384, 384, 320]
+    - [2, 12.5973]
+  - - [448, 320, 1, 32, 448, 448, 448, 320]
+    - [2, 15.1357]
+  - - [512, 320, 1, 32, 512, 512, 512, 320]
+    - [3, 252.547]
+  - - [576, 320, 1, 32, 576, 576, 576, 320]
+    - [1, 248.661]
+  - - [640, 320, 1, 32, 640, 640, 640, 320]
+    - [1, 21.5383]
+  - - [704, 320, 1, 32, 704, 704, 704, 320]
+    - [2, 23.9253]
+  - - [768, 320, 1, 32, 768, 768, 768, 320]
+    - [1, 25.7457]
+  - - [832, 320, 1, 32, 832, 832, 832, 320]
+    - [3, 28.0186]
+  - - [896, 320, 1, 32, 896, 896, 896, 320]
+    - [1, 29.7589]
+  - - [960, 320, 1, 32, 960, 960, 960, 320]
+    - [3, 31.8639]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 320]
+    - [3, 33.5333]
+  - - [64, 384, 1, 32, 64, 64, 64, 384]
+    - [3, 2.61959]
+  - - [128, 384, 1, 32, 128, 128, 128, 384]
+    - [2, 5.19532]
+  - - [192, 384, 1, 32, 192, 192, 192, 384]
+    - [1, 7.73864]
+  - - [256, 384, 1, 32, 256, 256, 256, 384]
+    - [2, 10.3442]
+  - - [320, 384, 1, 32, 320, 320, 320, 384]
+    - [3, 13.0091]
+  - - [384, 384, 1, 32, 384, 384, 384, 384]
+    - [2, 15.506]
+  - - [448, 384, 1, 32, 448, 448, 448, 384]
+    - [3, 18.2215]
+  - - [512, 384, 1, 32, 512, 512, 512, 384]
+    - [3, 20.7071]
+  - - [576, 384, 1, 32, 576, 576, 576, 384]
+    - [2, 23.2403]
+  - - [640, 384, 1, 32, 640, 640, 640, 384]
+    - [1, 25.7196]
+  - - [704, 384, 1, 32, 704, 704, 704, 384]
+    - [3, 28.3867]
+  - - [768, 384, 1, 32, 768, 768, 768, 384]
+    - [3, 30.7539]
+  - - [832, 384, 1, 32, 832, 832, 832, 384]
+    - [3, 32.7878]
+  - - [896, 384, 1, 32, 896, 896, 896, 384]
+    - [2, 35.4019]
+  - - [960, 384, 1, 32, 960, 960, 960, 384]
+    - [1, 317.618]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 384]
+    - [3, 39.8052]
+  - - [64, 448, 1, 32, 64, 64, 64, 448]
+    - [3, 3.04604]
+  - - [128, 448, 1, 32, 128, 128, 128, 448]
+    - [1, 6.00949]
+  - - [192, 448, 1, 32, 192, 192, 192, 448]
+    - [3, 9.07966]
+  - - [256, 448, 1, 32, 256, 256, 256, 448]
+    - [1, 11.9952]
+  - - [320, 448, 1, 32, 320, 320, 320, 448]
+    - [2, 15.0959]
+  - - [384, 448, 1, 32, 384, 384, 384, 448]
+    - [3, 18.0005]
+  - - [448, 448, 1, 32, 448, 448, 448, 448]
+    - [3, 21.2546]
+  - - [512, 448, 1, 32, 512, 512, 512, 448]
+    - [2, 23.9822]
+  - - [576, 448, 1, 32, 576, 576, 576, 448]
+    - [2, 27.2094]
+  - - [640, 448, 1, 32, 640, 640, 640, 448]
+    - [2, 30.0287]
+  - - [704, 448, 1, 32, 704, 704, 704, 448]
+    - [1, 307.512]
+  - - [768, 448, 1, 32, 768, 768, 768, 448]
+    - [3, 29.7306]
+  - - [832, 448, 1, 32, 832, 832, 832, 448]
+    - [0, 34.5814]
+  - - [896, 448, 1, 32, 896, 896, 896, 448]
+    - [2, 40.7985]
+  - - [960, 448, 1, 32, 960, 960, 960, 448]
+    - [2, 39.8658]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 448]
+    - [2, 42.8819]
+  - - [64, 512, 1, 32, 64, 64, 64, 512]
+    - [1, 3.44874]
+  - - [128, 512, 1, 32, 128, 128, 128, 512]
+    - [2, 6.86934]
+  - - [192, 512, 1, 32, 192, 192, 192, 512]
+    - [3, 10.369]
+  - - [256, 512, 1, 32, 256, 256, 256, 512]
+    - [1, 13.5592]
+  - - [320, 512, 1, 32, 320, 320, 320, 512]
+    - [3, 17.1914]
+  - - [384, 512, 1, 32, 384, 384, 384, 512]
+    - [2, 20.7593]
+  - - [448, 512, 1, 32, 448, 448, 448, 512]
+    - [2, 24.1348]
+  - - [512, 512, 1, 32, 512, 512, 512, 512]
+    - [2, 27.674]
+  - - [576, 512, 1, 32, 576, 576, 576, 512]
+    - [3, 27.5609]
+  - - [640, 512, 1, 32, 640, 640, 640, 512]
+    - [1, 30.388]
+  - - [704, 512, 1, 32, 704, 704, 704, 512]
+    - [3, 36.7949]
+  - - [768, 512, 1, 32, 768, 768, 768, 512]
+    - [3, 39.2313]
+  - - [832, 512, 1, 32, 832, 832, 832, 512]
+    - [2, 39.7191]
+  - - [896, 512, 1, 32, 896, 896, 896, 512]
+    - [1, 332.877]
+  - - [960, 512, 1, 32, 960, 960, 960, 512]
+    - [1, 316.344]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 512]
+    - [0, 48.3693]
+  - - [64, 576, 1, 32, 64, 64, 64, 576]
+    - [3, 3.86628]
+  - - [128, 576, 1, 32, 128, 128, 128, 576]
+    - [3, 169.246]
+  - - [192, 576, 1, 32, 192, 192, 192, 576]
+    - [1, 11.5076]
+  - - [256, 576, 1, 32, 256, 256, 256, 576]
+    - [3, 240.984]
+  - - [320, 576, 1, 32, 320, 320, 320, 576]
+    - [1, 19.296]
+  - - [384, 576, 1, 32, 384, 384, 384, 576]
+    - [2, 23.1318]
+  - - [448, 576, 1, 32, 448, 448, 448, 576]
+    - [1, 26.9123]
+  - - [512, 576, 1, 32, 512, 512, 512, 576]
+    - [2, 30.8021]
+  - - [576, 576, 1, 32, 576, 576, 576, 576]
+    - [2, 272.506]
+  - - [640, 576, 1, 32, 640, 640, 640, 576]
+    - [3, 122.23]
+  - - [704, 576, 1, 32, 704, 704, 704, 576]
+    - [2, 41.1188]
+  - - [768, 576, 1, 32, 768, 768, 768, 576]
+    - [2, 39.9551]
+  - - [832, 576, 1, 32, 832, 832, 832, 576]
+    - [3, 47.4793]
+  - - [896, 576, 1, 32, 896, 896, 896, 576]
+    - [1, 46.8264]
+  - - [960, 576, 1, 32, 960, 960, 960, 576]
+    - [3, 52.0216]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 576]
+    - [0, 53.3314]
+  - - [64, 640, 1, 32, 64, 64, 64, 640]
+    - [2, 4.331]
+  - - [128, 640, 1, 32, 128, 128, 128, 640]
+    - [1, 8.52829]
+  - - [192, 640, 1, 32, 192, 192, 192, 640]
+    - [2, 12.8344]
+  - - [256, 640, 1, 32, 256, 256, 256, 640]
+    - [2, 17.1025]
+  - - [320, 640, 1, 32, 320, 320, 320, 640]
+    - [3, 21.6428]
+  - - [384, 640, 1, 32, 384, 384, 384, 640]
+    - [3, 25.6713]
+  - - [448, 640, 1, 32, 448, 448, 448, 640]
+    - [3, 29.9567]
+  - - [512, 640, 1, 32, 512, 512, 512, 640]
+    - [1, 33.6966]
+  - - [576, 640, 1, 32, 576, 576, 576, 640]
+    - [3, 34.7046]
+  - - [640, 640, 1, 32, 640, 640, 640, 640]
+    - [3, 38.7075]
+  - - [704, 640, 1, 32, 704, 704, 704, 640]
+    - [2, 41.7002]
+  - - [768, 640, 1, 32, 768, 768, 768, 640]
+    - [3, 268.407]
+  - - [832, 640, 1, 32, 832, 832, 832, 640]
+    - [0, 47.4228]
+  - - [896, 640, 1, 32, 896, 896, 896, 640]
+    - [3, 53.5508]
+  - - [960, 640, 1, 32, 960, 960, 960, 640]
+    - [3, 57.2031]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 640]
+    - [3, 61.6009]
+  - - [64, 704, 1, 32, 64, 64, 64, 704]
+    - [3, 4.74723]
+  - - [128, 704, 1, 32, 128, 128, 128, 704]
+    - [2, 9.33162]
+  - - [192, 704, 1, 32, 192, 192, 192, 704]
+    - [3, 14.165]
+  - - [256, 704, 1, 32, 256, 256, 256, 704]
+    - [3, 18.904]
+  - - [320, 704, 1, 32, 320, 320, 320, 704]
+    - [2, 23.5144]
+  - - [384, 704, 1, 32, 384, 384, 384, 704]
+    - [3, 249.301]
+  - - [448, 704, 1, 32, 448, 448, 448, 704]
+    - [1, 304.727]
+  - - [512, 704, 1, 32, 512, 512, 512, 704]
+    - [2, 33.8328]
+  - - [576, 704, 1, 32, 576, 576, 576, 704]
+    - [3, 37.3401]
+  - - [640, 704, 1, 32, 640, 640, 640, 704]
+    - [2, 41.8036]
+  - - [704, 704, 1, 32, 704, 704, 704, 704]
+    - [1, 45.7716]
+  - - [768, 704, 1, 32, 768, 768, 768, 704]
+    - [2, 50.4436]
+  - - [832, 704, 1, 32, 832, 832, 832, 704]
+    - [3, 53.7131]
+  - - [896, 704, 1, 32, 896, 896, 896, 704]
+    - [1, 56.0678]
+  - - [960, 704, 1, 32, 960, 960, 960, 704]
+    - [2, 307.985]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 704]
+    - [2, 67.1612]
+  - - [64, 768, 1, 32, 64, 64, 64, 768]
+    - [3, 5.19884]
+  - - [128, 768, 1, 32, 128, 128, 128, 768]
+    - [2, 10.2936]
+  - - [192, 768, 1, 32, 192, 192, 192, 768]
+    - [2, 15.3667]
+  - - [256, 768, 1, 32, 256, 256, 256, 768]
+    - [3, 20.6856]
+  - - [320, 768, 1, 32, 320, 320, 320, 768]
+    - [2, 25.3605]
+  - - [384, 768, 1, 32, 384, 384, 384, 768]
+    - [3, 30.9622]
+  - - [448, 768, 1, 32, 448, 448, 448, 768]
+    - [2, 35.5596]
+  - - [512, 768, 1, 32, 512, 512, 512, 768]
+    - [3, 253.685]
+  - - [576, 768, 1, 32, 576, 576, 576, 768]
+    - [1, 319.252]
+  - - [640, 768, 1, 32, 640, 640, 640, 768]
+    - [1, 241.292]
+  - - [704, 768, 1, 32, 704, 704, 704, 768]
+    - [1, 300.788]
+  - - [768, 768, 1, 32, 768, 768, 768, 768]
+    - [1, 313.942]
+  - - [832, 768, 1, 32, 832, 832, 832, 768]
+    - [2, 307.385]
+  - - [896, 768, 1, 32, 896, 896, 896, 768]
+    - [3, 304.819]
+  - - [960, 768, 1, 32, 960, 960, 960, 768]
+    - [1, 353.821]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 768]
+    - [1, 358.792]
+  - - [64, 832, 1, 32, 64, 64, 64, 832]
+    - [3, 87.2025]
+  - - [128, 832, 1, 32, 128, 128, 128, 832]
+    - [3, 61.0068]
+  - - [192, 832, 1, 32, 192, 192, 192, 832]
+    - [2, 88.1567]
+  - - [256, 832, 1, 32, 256, 256, 256, 832]
+    - [3, 121.006]
+  - - [320, 832, 1, 32, 320, 320, 320, 832]
+    - [3, 145.996]
+  - - [384, 832, 1, 32, 384, 384, 384, 832]
+    - [1, 159.358]
+  - - [448, 832, 1, 32, 448, 448, 448, 832]
+    - [2, 196.644]
+  - - [512, 832, 1, 32, 512, 512, 512, 832]
+    - [3, 39.8819]
+  - - [576, 832, 1, 32, 576, 576, 576, 832]
+    - [0, 44.024]
+  - - [640, 832, 1, 32, 640, 640, 640, 832]
+    - [3, 49.7875]
+  - - [704, 832, 1, 32, 704, 704, 704, 832]
+    - [2, 54.7966]
+  - - [768, 832, 1, 32, 768, 768, 768, 832]
+    - [3, 59.57]
+  - - [832, 832, 1, 32, 832, 832, 832, 832]
+    - [2, 64.4347]
+  - - [896, 832, 1, 32, 896, 896, 896, 832]
+    - [3, 62.0957]
+  - - [960, 832, 1, 32, 960, 960, 960, 832]
+    - [3, 73.2347]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 832]
+    - [1, 76.9799]
+  - - [64, 896, 1, 32, 64, 64, 64, 896]
+    - [1, 6.00575]
+  - - [128, 896, 1, 32, 128, 128, 128, 896]
+    - [2, 11.8982]
+  - - [192, 896, 1, 32, 192, 192, 192, 896]
+    - [3, 17.0944]
+  - - [256, 896, 1, 32, 256, 256, 256, 896]
+    - [2, 146.566]
+  - - [320, 896, 1, 32, 320, 320, 320, 896]
+    - [2, 170.017]
+  - - [384, 896, 1, 32, 384, 384, 384, 896]
+    - [1, 316.017]
+  - - [448, 896, 1, 32, 448, 448, 448, 896]
+    - [2, 221.179]
+  - - [512, 896, 1, 32, 512, 512, 512, 896]
+    - [3, 277.503]
+  - - [576, 896, 1, 32, 576, 576, 576, 896]
+    - [1, 306.855]
+  - - [640, 896, 1, 32, 640, 640, 640, 896]
+    - [1, 345.316]
+  - - [704, 896, 1, 32, 704, 704, 704, 896]
+    - [1, 354.619]
+  - - [768, 896, 1, 32, 768, 768, 768, 896]
+    - [2, 307.715]
+  - - [832, 896, 1, 32, 832, 832, 832, 896]
+    - [3, 314.626]
+  - - [896, 896, 1, 32, 896, 896, 896, 896]
+    - [3, 321.929]
+  - - [960, 896, 1, 32, 960, 960, 960, 896]
+    - [3, 308.716]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 896]
+    - [2, 320.174]
+  - - [64, 960, 1, 32, 64, 64, 64, 960]
+    - [2, 65.8874]
+  - - [128, 960, 1, 32, 128, 128, 128, 960]
+    - [1, 78.462]
+  - - [192, 960, 1, 32, 192, 192, 192, 960]
+    - [2, 113.755]
+  - - [256, 960, 1, 32, 256, 256, 256, 960]
+    - [1, 152.986]
+  - - [320, 960, 1, 32, 320, 320, 320, 960]
+    - [3, 189.192]
+  - - [384, 960, 1, 32, 384, 384, 384, 960]
+    - [2, 228.769]
+  - - [448, 960, 1, 32, 448, 448, 448, 960]
+    - [3, 286.598]
+  - - [512, 960, 1, 32, 512, 512, 512, 960]
+    - [2, 278.088]
+  - - [576, 960, 1, 32, 576, 576, 576, 960]
+    - [1, 321.953]
+  - - [640, 960, 1, 32, 640, 640, 640, 960]
+    - [2, 304.064]
+  - - [704, 960, 1, 32, 704, 704, 704, 960]
+    - [2, 311.268]
+  - - [768, 960, 1, 32, 768, 768, 768, 960]
+    - [2, 312.572]
+  - - [832, 960, 1, 32, 832, 832, 832, 960]
+    - [3, 296.232]
+  - - [896, 960, 1, 32, 896, 896, 896, 960]
+    - [2, 319.019]
+  - - [960, 960, 1, 32, 960, 960, 960, 960]
+    - [3, 320.415]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 960]
+    - [3, 85.4244]
+  - - [64, 1024, 1, 32, 64, 64, 64, 1024]
+    - [1, 6.77317]
+  - - [128, 1024, 1, 32, 128, 128, 128, 1024]
+    - [2, 13.688]
+  - - [192, 1024, 1, 32, 192, 192, 192, 1024]
+    - [2, 20.3846]
+  - - [256, 1024, 1, 32, 256, 256, 256, 1024]
+    - [2, 27.202]
+  - - [320, 1024, 1, 32, 320, 320, 320, 1024]
+    - [2, 33.9201]
+  - - [384, 1024, 1, 32, 384, 384, 384, 1024]
+    - [3, 39.4082]
+  - - [448, 1024, 1, 32, 448, 448, 448, 1024]
+    - [1, 36.7013]
+  - - [512, 1024, 1, 32, 512, 512, 512, 1024]
+    - [2, 292.896]
+  - - [576, 1024, 1, 32, 576, 576, 576, 1024]
+    - [2, 55.0864]
+  - - [640, 1024, 1, 32, 640, 640, 640, 1024]
+    - [2, 61.8052]
+  - - [704, 1024, 1, 32, 704, 704, 704, 1024]
+    - [2, 66.8208]
+  - - [768, 1024, 1, 32, 768, 768, 768, 1024]
+    - [1, 71.9595]
+  - - [832, 1024, 1, 32, 832, 832, 832, 1024]
+    - [2, 76.7081]
+  - - [896, 1024, 1, 32, 896, 896, 896, 1024]
+    - [2, 81.1912]
+  - - [960, 1024, 1, 32, 960, 960, 960, 1024]
+    - [1, 88.5319]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 1024]
+    - [2, 90.0024]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1200
+- gfx1200
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 32]
+    - [2, 1.15233]
+  - - [128, 64, 1, 32, 128, 128, 128, 32]
+    - [2, 2.30557]
+  - - [192, 64, 1, 32, 192, 192, 192, 32]
+    - [2, 3.45926]
+  - - [256, 64, 1, 32, 256, 256, 256, 32]
+    - [2, 4.61702]
+  - - [320, 64, 1, 32, 320, 320, 320, 32]
+    - [2, 5.75784]
+  - - [384, 64, 1, 32, 384, 384, 384, 32]
+    - [3, 73.7741]
+  - - [448, 64, 1, 32, 448, 448, 448, 32]
+    - [2, 86.557]
+  - - [512, 64, 1, 32, 512, 512, 512, 32]
+    - [2, 97.4513]
+  - - [576, 64, 1, 32, 576, 576, 576, 32]
+    - [2, 107.241]
+  - - [640, 64, 1, 32, 640, 640, 640, 32]
+    - [0, 11.4934]
+  - - [704, 64, 1, 32, 704, 704, 704, 32]
+    - [3, 12.5832]
+  - - [768, 64, 1, 32, 768, 768, 768, 32]
+    - [1, 129.56]
+  - - [832, 64, 1, 32, 832, 832, 832, 32]
+    - [0, 14.8445]
+  - - [896, 64, 1, 32, 896, 896, 896, 32]
+    - [2, 16.0774]
+  - - [960, 64, 1, 32, 960, 960, 960, 32]
+    - [3, 17.2047]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 18.3397]
+  - - [64, 128, 1, 32, 64, 64, 64, 32]
+    - [2, 2.29779]
+  - - [128, 128, 1, 32, 128, 128, 128, 32]
+    - [1, 49.1827]
+  - - [192, 128, 1, 32, 192, 192, 192, 32]
+    - [2, 6.90061]
+  - - [256, 128, 1, 32, 256, 256, 256, 32]
+    - [3, 9.25727]
+  - - [320, 128, 1, 32, 320, 320, 320, 32]
+    - [1, 11.4929]
+  - - [384, 128, 1, 32, 384, 384, 384, 32]
+    - [3, 13.7801]
+  - - [448, 128, 1, 32, 448, 448, 448, 32]
+    - [2, 16.0311]
+  - - [512, 128, 1, 32, 512, 512, 512, 32]
+    - [0, 18.3654]
+  - - [576, 128, 1, 32, 576, 576, 576, 32]
+    - [1, 20.671]
+  - - [640, 128, 1, 32, 640, 640, 640, 32]
+    - [3, 22.9547]
+  - - [704, 128, 1, 32, 704, 704, 704, 32]
+    - [2, 25.2049]
+  - - [768, 128, 1, 32, 768, 768, 768, 32]
+    - [3, 191.34]
+  - - [832, 128, 1, 32, 832, 832, 832, 32]
+    - [1, 194.291]
+  - - [896, 128, 1, 32, 896, 896, 896, 32]
+    - [3, 32.0944]
+  - - [960, 128, 1, 32, 960, 960, 960, 32]
+    - [1, 34.426]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 36.7083]
+  - - [64, 192, 1, 32, 64, 64, 64, 32]
+    - [0, 3.43462]
+  - - [128, 192, 1, 32, 128, 128, 128, 32]
+    - [0, 6.89094]
+  - - [192, 192, 1, 32, 192, 192, 192, 32]
+    - [3, 10.3477]
+  - - [256, 192, 1, 32, 256, 256, 256, 32]
+    - [0, 13.7716]
+  - - [320, 192, 1, 32, 320, 320, 320, 32]
+    - [1, 17.2334]
+  - - [384, 192, 1, 32, 384, 384, 384, 32]
+    - [1, 20.7037]
+  - - [448, 192, 1, 32, 448, 448, 448, 32]
+    - [1, 176.217]
+  - - [512, 192, 1, 32, 512, 512, 512, 32]
+    - [2, 27.5457]
+  - - [576, 192, 1, 32, 576, 576, 576, 32]
+    - [2, 30.9428]
+  - - [640, 192, 1, 32, 640, 640, 640, 32]
+    - [1, 34.4411]
+  - - [704, 192, 1, 32, 704, 704, 704, 32]
+    - [1, 37.5628]
+  - - [768, 192, 1, 32, 768, 768, 768, 32]
+    - [3, 41.3149]
+  - - [832, 192, 1, 32, 832, 832, 832, 32]
+    - [1, 44.7695]
+  - - [896, 192, 1, 32, 896, 896, 896, 32]
+    - [1, 48.1164]
+  - - [960, 192, 1, 32, 960, 960, 960, 32]
+    - [3, 51.5691]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 55.0576]
+  - - [64, 256, 1, 32, 64, 64, 64, 32]
+    - [3, 4.62759]
+  - - [128, 256, 1, 32, 128, 128, 128, 32]
+    - [1, 9.19316]
+  - - [192, 256, 1, 32, 192, 192, 192, 32]
+    - [3, 13.7734]
+  - - [256, 256, 1, 32, 256, 256, 256, 32]
+    - [0, 18.3645]
+  - - [320, 256, 1, 32, 320, 320, 320, 32]
+    - [1, 22.9336]
+  - - [384, 256, 1, 32, 384, 384, 384, 32]
+    - [1, 27.5204]
+  - - [448, 256, 1, 32, 448, 448, 448, 32]
+    - [3, 32.1352]
+  - - [512, 256, 1, 32, 512, 512, 512, 32]
+    - [0, 36.7067]
+  - - [576, 256, 1, 32, 576, 576, 576, 32]
+    - [0, 41.2282]
+  - - [640, 256, 1, 32, 640, 640, 640, 32]
+    - [2, 45.845]
+  - - [704, 256, 1, 32, 704, 704, 704, 32]
+    - [3, 50.4231]
+  - - [768, 256, 1, 32, 768, 768, 768, 32]
+    - [2, 54.9251]
+  - - [832, 256, 1, 32, 832, 832, 832, 32]
+    - [3, 59.4115]
+  - - [896, 256, 1, 32, 896, 896, 896, 32]
+    - [2, 64.1858]
+  - - [960, 256, 1, 32, 960, 960, 960, 32]
+    - [2, 254.016]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 32]
+    - [0, 254.969]
+  - - [64, 320, 1, 32, 64, 64, 64, 32]
+    - [3, 7.61467]
+  - - [128, 320, 1, 32, 128, 128, 128, 32]
+    - [2, 14.2299]
+  - - [192, 320, 1, 32, 192, 192, 192, 32]
+    - [3, 128.163]
+  - - [256, 320, 1, 32, 256, 256, 256, 32]
+    - [3, 56.1577]
+  - - [320, 320, 1, 32, 320, 320, 320, 32]
+    - [2, 77.3195]
+  - - [384, 320, 1, 32, 384, 384, 384, 32]
+    - [2, 94.9098]
+  - - [448, 320, 1, 32, 448, 448, 448, 32]
+    - [2, 106.13]
+  - - [512, 320, 1, 32, 512, 512, 512, 32]
+    - [1, 114.111]
+  - - [576, 320, 1, 32, 576, 576, 576, 32]
+    - [2, 136.423]
+  - - [640, 320, 1, 32, 640, 640, 640, 32]
+    - [1, 145.136]
+  - - [704, 320, 1, 32, 704, 704, 704, 32]
+    - [3, 178.043]
+  - - [768, 320, 1, 32, 768, 768, 768, 32]
+    - [3, 187.805]
+  - - [832, 320, 1, 32, 832, 832, 832, 32]
+    - [2, 201.408]
+  - - [896, 320, 1, 32, 896, 896, 896, 32]
+    - [2, 215.225]
+  - - [960, 320, 1, 32, 960, 960, 960, 32]
+    - [2, 234.057]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 208.317]
+  - - [64, 384, 1, 32, 64, 64, 64, 32]
+    - [3, 9.21145]
+  - - [128, 384, 1, 32, 128, 128, 128, 32]
+    - [1, 17.025]
+  - - [192, 384, 1, 32, 192, 192, 192, 32]
+    - [1, 7.75723]
+  - - [256, 384, 1, 32, 256, 256, 256, 32]
+    - [2, 10.3896]
+  - - [320, 384, 1, 32, 320, 320, 320, 32]
+    - [1, 223.666]
+  - - [384, 384, 1, 32, 384, 384, 384, 32]
+    - [2, 15.4626]
+  - - [448, 384, 1, 32, 448, 448, 448, 32]
+    - [2, 18.1659]
+  - - [512, 384, 1, 32, 512, 512, 512, 32]
+    - [2, 20.8546]
+  - - [576, 384, 1, 32, 576, 576, 576, 32]
+    - [1, 23.0688]
+  - - [640, 384, 1, 32, 640, 640, 640, 32]
+    - [3, 25.9462]
+  - - [704, 384, 1, 32, 704, 704, 704, 32]
+    - [3, 28.3835]
+  - - [768, 384, 1, 32, 768, 768, 768, 32]
+    - [2, 27.8558]
+  - - [832, 384, 1, 32, 832, 832, 832, 32]
+    - [3, 32.9007]
+  - - [896, 384, 1, 32, 896, 896, 896, 32]
+    - [1, 36.1089]
+  - - [960, 384, 1, 32, 960, 960, 960, 32]
+    - [1, 33.7818]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 36.0871]
+  - - [64, 448, 1, 32, 64, 64, 64, 32]
+    - [1, 3.07978]
+  - - [128, 448, 1, 32, 128, 128, 128, 32]
+    - [2, 136.533]
+  - - [192, 448, 1, 32, 192, 192, 192, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 256, 32]
+    - [1, 207.34]
+  - - [320, 448, 1, 32, 320, 320, 320, 32]
+    - [1, 234.296]
+  - - [384, 448, 1, 32, 384, 384, 384, 32]
+    - [3, 18.1899]
+  - - [448, 448, 1, 32, 448, 448, 448, 32]
+    - [2, 21.0968]
+  - - [512, 448, 1, 32, 512, 512, 512, 32]
+    - [3, 24.1189]
+  - - [576, 448, 1, 32, 576, 576, 576, 32]
+    - [3, 24.1095]
+  - - [640, 448, 1, 32, 640, 640, 640, 32]
+    - [2, 269.221]
+  - - [704, 448, 1, 32, 704, 704, 704, 32]
+    - [3, 204.303]
+  - - [768, 448, 1, 32, 768, 768, 768, 32]
+    - [3, 228.899]
+  - - [832, 448, 1, 32, 832, 832, 832, 32]
+    - [2, 248.18]
+  - - [896, 448, 1, 32, 896, 896, 896, 32]
+    - [3, 267.157]
+  - - [960, 448, 1, 32, 960, 960, 960, 32]
+    - [3, 278.144]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 291.966]
+  - - [64, 512, 1, 32, 64, 64, 64, 32]
+    - [3, 10.8942]
+  - - [128, 512, 1, 32, 128, 128, 128, 32]
+    - [2, 55.8645]
+  - - [192, 512, 1, 32, 192, 192, 192, 32]
+    - [2, 65.906]
+  - - [256, 512, 1, 32, 256, 256, 256, 32]
+    - [2, 86.2139]
+  - - [320, 512, 1, 32, 320, 320, 320, 32]
+    - [2, 106.66]
+  - - [384, 512, 1, 32, 384, 384, 384, 32]
+    - [1, 124.202]
+  - - [448, 512, 1, 32, 448, 448, 448, 32]
+    - [1, 139.478]
+  - - [512, 512, 1, 32, 512, 512, 512, 32]
+    - [3, 177.031]
+  - - [576, 512, 1, 32, 576, 576, 576, 32]
+    - [3, 194.86]
+  - - [640, 512, 1, 32, 640, 640, 640, 32]
+    - [3, 205.36]
+  - - [704, 512, 1, 32, 704, 704, 704, 32]
+    - [3, 266.013]
+  - - [768, 512, 1, 32, 768, 768, 768, 32]
+    - [3, 36.8442]
+  - - [832, 512, 1, 32, 832, 832, 832, 32]
+    - [2, 40.0112]
+  - - [896, 512, 1, 32, 896, 896, 896, 32]
+    - [3, 45.583]
+  - - [960, 512, 1, 32, 960, 960, 960, 32]
+    - [2, 45.1471]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 632.613]
+  - - [64, 576, 1, 32, 64, 64, 64, 32]
+    - [2, 12.9474]
+  - - [128, 576, 1, 32, 128, 128, 128, 32]
+    - [2, 50.4554]
+  - - [192, 576, 1, 32, 192, 192, 192, 32]
+    - [2, 84.8362]
+  - - [256, 576, 1, 32, 256, 256, 256, 32]
+    - [2, 111.643]
+  - - [320, 576, 1, 32, 320, 320, 320, 32]
+    - [1, 130.896]
+  - - [384, 576, 1, 32, 384, 384, 384, 32]
+    - [3, 61.5439]
+  - - [448, 576, 1, 32, 448, 448, 448, 32]
+    - [1, 71.8731]
+  - - [512, 576, 1, 32, 512, 512, 512, 32]
+    - [2, 81.845]
+  - - [576, 576, 1, 32, 576, 576, 576, 32]
+    - [3, 93.0358]
+  - - [640, 576, 1, 32, 640, 640, 640, 32]
+    - [1, 103.328]
+  - - [704, 576, 1, 32, 704, 704, 704, 32]
+    - [3, 113.566]
+  - - [768, 576, 1, 32, 768, 768, 768, 32]
+    - [2, 123.809]
+  - - [832, 576, 1, 32, 832, 832, 832, 32]
+    - [2, 135.286]
+  - - [896, 576, 1, 32, 896, 896, 896, 32]
+    - [0, 144.16]
+  - - [960, 576, 1, 32, 960, 960, 960, 32]
+    - [0, 154.289]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 55.2663]
+  - - [64, 640, 1, 32, 64, 64, 64, 32]
+    - [3, 4.32657]
+  - - [128, 640, 1, 32, 128, 128, 128, 32]
+    - [3, 8.54722]
+  - - [192, 640, 1, 32, 192, 192, 192, 32]
+    - [3, 210.501]
+  - - [256, 640, 1, 32, 256, 256, 256, 32]
+    - [1, 248.478]
+  - - [320, 640, 1, 32, 320, 320, 320, 32]
+    - [1, 20.9872]
+  - - [384, 640, 1, 32, 384, 384, 384, 32]
+    - [3, 25.903]
+  - - [448, 640, 1, 32, 448, 448, 448, 32]
+    - [1, 26.54]
+  - - [512, 640, 1, 32, 512, 512, 512, 32]
+    - [3, 33.82]
+  - - [576, 640, 1, 32, 576, 576, 576, 32]
+    - [1, 37.43]
+  - - [640, 640, 1, 32, 640, 640, 640, 32]
+    - [3, 34.0321]
+  - - [704, 640, 1, 32, 704, 704, 704, 32]
+    - [2, 45.0431]
+  - - [768, 640, 1, 32, 768, 768, 768, 32]
+    - [3, 45.9295]
+  - - [832, 640, 1, 32, 832, 832, 832, 32]
+    - [3, 276.88]
+  - - [896, 640, 1, 32, 896, 896, 896, 32]
+    - [2, 53.7209]
+  - - [960, 640, 1, 32, 960, 960, 960, 32]
+    - [2, 57.1025]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 59.7382]
+  - - [64, 704, 1, 32, 64, 64, 64, 32]
+    - [3, 4.74053]
+  - - [128, 704, 1, 32, 128, 128, 128, 32]
+    - [2, 9.37091]
+  - - [192, 704, 1, 32, 192, 192, 192, 32]
+    - [2, 14.1319]
+  - - [256, 704, 1, 32, 256, 256, 256, 32]
+    - [2, 19.5838]
+  - - [320, 704, 1, 32, 320, 320, 320, 32]
+    - [3, 23.6964]
+  - - [384, 704, 1, 32, 384, 384, 384, 32]
+    - [3, 27.7649]
+  - - [448, 704, 1, 32, 448, 448, 448, 32]
+    - [2, 32.7588]
+  - - [512, 704, 1, 32, 512, 512, 512, 32]
+    - [2, 33.4895]
+  - - [576, 704, 1, 32, 576, 576, 576, 32]
+    - [2, 37.6538]
+  - - [640, 704, 1, 32, 640, 640, 640, 32]
+    - [0, 36.5703]
+  - - [704, 704, 1, 32, 704, 704, 704, 32]
+    - [3, 46.5967]
+  - - [768, 704, 1, 32, 768, 768, 768, 32]
+    - [1, 49.955]
+  - - [832, 704, 1, 32, 832, 832, 832, 32]
+    - [2, 54.7614]
+  - - [896, 704, 1, 32, 896, 896, 896, 32]
+    - [2, 58.6893]
+  - - [960, 704, 1, 32, 960, 960, 960, 32]
+    - [1, 53.1547]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 66.2851]
+  - - [64, 768, 1, 32, 64, 64, 64, 32]
+    - [3, 5.20244]
+  - - [128, 768, 1, 32, 128, 128, 128, 32]
+    - [2, 10.3143]
+  - - [192, 768, 1, 32, 192, 192, 192, 32]
+    - [3, 15.5431]
+  - - [256, 768, 1, 32, 256, 256, 256, 32]
+    - [3, 20.7303]
+  - - [320, 768, 1, 32, 320, 320, 320, 32]
+    - [3, 25.6257]
+  - - [384, 768, 1, 32, 384, 384, 384, 32]
+    - [3, 30.8031]
+  - - [448, 768, 1, 32, 448, 448, 448, 32]
+    - [2, 32.4291]
+  - - [512, 768, 1, 32, 512, 512, 512, 32]
+    - [3, 39.7506]
+  - - [576, 768, 1, 32, 576, 576, 576, 32]
+    - [2, 41.4418]
+  - - [640, 768, 1, 32, 640, 640, 640, 32]
+    - [2, 295.426]
+  - - [704, 768, 1, 32, 704, 704, 704, 32]
+    - [2, 50.5342]
+  - - [768, 768, 1, 32, 768, 768, 768, 32]
+    - [2, 54.939]
+  - - [832, 768, 1, 32, 832, 832, 832, 32]
+    - [3, 58.1719]
+  - - [896, 768, 1, 32, 896, 896, 896, 32]
+    - [1, 63.765]
+  - - [960, 768, 1, 32, 960, 960, 960, 32]
+    - [2, 68.1401]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 70.5119]
+  - - [64, 832, 1, 32, 64, 64, 64, 32]
+    - [2, 131.274]
+  - - [128, 832, 1, 32, 128, 128, 128, 32]
+    - [1, 193.19]
+  - - [192, 832, 1, 32, 192, 192, 192, 32]
+    - [1, 242.72]
+  - - [256, 832, 1, 32, 256, 256, 256, 32]
+    - [1, 269.392]
+  - - [320, 832, 1, 32, 320, 320, 320, 32]
+    - [0, 72.9044]
+  - - [384, 832, 1, 32, 384, 384, 384, 32]
+    - [2, 29.7413]
+  - - [448, 832, 1, 32, 448, 448, 448, 32]
+    - [2, 37.9717]
+  - - [512, 832, 1, 32, 512, 512, 512, 32]
+    - [3, 42.7618]
+  - - [576, 832, 1, 32, 576, 576, 576, 32]
+    - [1, 36.6624]
+  - - [640, 832, 1, 32, 640, 640, 640, 32]
+    - [3, 49.675]
+  - - [704, 832, 1, 32, 704, 704, 704, 32]
+    - [2, 56.5567]
+  - - [768, 832, 1, 32, 768, 768, 768, 32]
+    - [3, 59.3651]
+  - - [832, 832, 1, 32, 832, 832, 832, 32]
+    - [3, 64.4816]
+  - - [896, 832, 1, 32, 896, 896, 896, 32]
+    - [2, 68.9171]
+  - - [960, 832, 1, 32, 960, 960, 960, 32]
+    - [1, 63.7849]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 79.2627]
+  - - [64, 896, 1, 32, 64, 64, 64, 32]
+    - [2, 6.0592]
+  - - [128, 896, 1, 32, 128, 128, 128, 32]
+    - [3, 12.0502]
+  - - [192, 896, 1, 32, 192, 192, 192, 32]
+    - [3, 249.774]
+  - - [256, 896, 1, 32, 256, 256, 256, 32]
+    - [2, 23.7929]
+  - - [320, 896, 1, 32, 320, 320, 320, 32]
+    - [2, 83.3031]
+  - - [384, 896, 1, 32, 384, 384, 384, 32]
+    - [3, 34.9013]
+  - - [448, 896, 1, 32, 448, 448, 448, 32]
+    - [1, 35.9602]
+  - - [512, 896, 1, 32, 512, 512, 512, 32]
+    - [1, 42.0896]
+  - - [576, 896, 1, 32, 576, 576, 576, 32]
+    - [3, 48.2746]
+  - - [640, 896, 1, 32, 640, 640, 640, 32]
+    - [1, 53.1706]
+  - - [704, 896, 1, 32, 704, 704, 704, 32]
+    - [2, 59.3754]
+  - - [768, 896, 1, 32, 768, 768, 768, 32]
+    - [3, 63.9902]
+  - - [832, 896, 1, 32, 832, 832, 832, 32]
+    - [0, 67.4584]
+  - - [896, 896, 1, 32, 896, 896, 896, 32]
+    - [2, 72.8681]
+  - - [960, 896, 1, 32, 960, 960, 960, 32]
+    - [1, 79.6003]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 82.539]
+  - - [64, 960, 1, 32, 64, 64, 64, 32]
+    - [1, 6.40329]
+  - - [128, 960, 1, 32, 128, 128, 128, 32]
+    - [2, 12.9321]
+  - - [192, 960, 1, 32, 192, 192, 192, 32]
+    - [2, 19.3689]
+  - - [256, 960, 1, 32, 256, 256, 256, 32]
+    - [1, 25.2785]
+  - - [320, 960, 1, 32, 320, 320, 320, 32]
+    - [1, 31.4692]
+  - - [384, 960, 1, 32, 384, 384, 384, 32]
+    - [2, 34.3398]
+  - - [448, 960, 1, 32, 448, 448, 448, 32]
+    - [2, 40.19]
+  - - [512, 960, 1, 32, 512, 512, 512, 32]
+    - [3, 45.686]
+  - - [576, 960, 1, 32, 576, 576, 576, 32]
+    - [3, 51.5217]
+  - - [640, 960, 1, 32, 640, 640, 640, 32]
+    - [2, 57.8128]
+  - - [704, 960, 1, 32, 704, 704, 704, 32]
+    - [0, 61.3229]
+  - - [768, 960, 1, 32, 768, 768, 768, 32]
+    - [0, 65.2042]
+  - - [832, 960, 1, 32, 832, 832, 832, 32]
+    - [2, 72.6756]
+  - - [896, 960, 1, 32, 896, 896, 896, 32]
+    - [1, 79.4669]
+  - - [960, 960, 1, 32, 960, 960, 960, 32]
+    - [2, 78.536]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 85.7013]
+  - - [64, 1024, 1, 32, 64, 64, 64, 32]
+    - [3, 6.90076]
+  - - [128, 1024, 1, 32, 128, 128, 128, 32]
+    - [3, 13.7965]
+  - - [192, 1024, 1, 32, 192, 192, 192, 32]
+    - [3, 20.4795]
+  - - [256, 1024, 1, 32, 256, 256, 256, 32]
+    - [3, 27.4706]
+  - - [320, 1024, 1, 32, 320, 320, 320, 32]
+    - [0, 29.5718]
+  - - [384, 1024, 1, 32, 384, 384, 384, 32]
+    - [2, 40.0721]
+  - - [448, 1024, 1, 32, 448, 448, 448, 32]
+    - [2, 42.8763]
+  - - [512, 1024, 1, 32, 512, 512, 512, 32]
+    - [3, 48.9415]
+  - - [576, 1024, 1, 32, 576, 576, 576, 32]
+    - [0, 53.6033]
+  - - [640, 1024, 1, 32, 640, 640, 640, 32]
+    - [1, 59.8688]
+  - - [704, 1024, 1, 32, 704, 704, 704, 32]
+    - [0, 64.5626]
+  - - [768, 1024, 1, 32, 768, 768, 768, 32]
+    - [2, 61.8968]
+  - - [832, 1024, 1, 32, 832, 832, 832, 32]
+    - [1, 78.4519]
+  - - [896, 1024, 1, 32, 896, 896, 896, 32]
+    - [2, 69.6129]
+  - - [960, 1024, 1, 32, 960, 960, 960, 32]
+    - [3, 85.3746]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 90.2469]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1200
+- gfx1200
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 64]
+    - [1, 1.15726]
+  - - [128, 64, 1, 32, 128, 128, 32, 64]
+    - [3, 2.31821]
+  - - [192, 64, 1, 32, 192, 192, 32, 64]
+    - [2, 3.47424]
+  - - [256, 64, 1, 32, 256, 256, 32, 64]
+    - [2, 4.63209]
+  - - [320, 64, 1, 32, 320, 320, 32, 64]
+    - [2, 5.79552]
+  - - [384, 64, 1, 32, 384, 384, 32, 64]
+    - [3, 6.95431]
+  - - [448, 64, 1, 32, 448, 448, 32, 64]
+    - [3, 76.2046]
+  - - [512, 64, 1, 32, 512, 512, 32, 64]
+    - [1, 9.2716]
+  - - [576, 64, 1, 32, 576, 576, 32, 64]
+    - [0, 102.578]
+  - - [640, 64, 1, 32, 640, 640, 32, 64]
+    - [3, 11.5757]
+  - - [704, 64, 1, 32, 704, 704, 32, 64]
+    - [2, 12.7349]
+  - - [768, 64, 1, 32, 768, 768, 32, 64]
+    - [2, 13.8773]
+  - - [832, 64, 1, 32, 832, 832, 32, 64]
+    - [2, 14.9677]
+  - - [896, 64, 1, 32, 896, 896, 32, 64]
+    - [0, 16.1127]
+  - - [960, 64, 1, 32, 960, 960, 32, 64]
+    - [3, 17.2894]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 64]
+    - [2, 18.451]
+  - - [64, 128, 1, 32, 64, 64, 32, 128]
+    - [3, 24.1385]
+  - - [128, 128, 1, 32, 128, 128, 32, 128]
+    - [0, 55.8942]
+  - - [192, 128, 1, 32, 192, 192, 32, 128]
+    - [2, 77.5536]
+  - - [256, 128, 1, 32, 256, 256, 32, 128]
+    - [3, 3.71372]
+  - - [320, 128, 1, 32, 320, 320, 32, 128]
+    - [3, 4.61828]
+  - - [384, 128, 1, 32, 384, 384, 32, 128]
+    - [1, 5.23804]
+  - - [448, 128, 1, 32, 448, 448, 32, 128]
+    - [3, 6.42685]
+  - - [512, 128, 1, 32, 512, 512, 32, 128]
+    - [1, 6.90462]
+  - - [576, 128, 1, 32, 576, 576, 32, 128]
+    - [3, 7.89334]
+  - - [640, 128, 1, 32, 640, 640, 32, 128]
+    - [2, 8.75149]
+  - - [704, 128, 1, 32, 704, 704, 32, 128]
+    - [3, 9.61092]
+  - - [768, 128, 1, 32, 768, 768, 32, 128]
+    - [3, 10.4859]
+  - - [832, 128, 1, 32, 832, 832, 32, 128]
+    - [1, 11.2858]
+  - - [896, 128, 1, 32, 896, 896, 32, 128]
+    - [1, 213.125]
+  - - [960, 128, 1, 32, 960, 960, 32, 128]
+    - [2, 13.1457]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 128]
+    - [2, 14.0183]
+  - - [64, 192, 1, 32, 64, 64, 32, 192]
+    - [3, 1.32088]
+  - - [128, 192, 1, 32, 128, 128, 32, 192]
+    - [2, 2.64208]
+  - - [192, 192, 1, 32, 192, 192, 32, 192]
+    - [2, 3.91608]
+  - - [256, 192, 1, 32, 256, 256, 32, 192]
+    - [3, 5.28406]
+  - - [320, 192, 1, 32, 320, 320, 32, 192]
+    - [2, 6.54701]
+  - - [384, 192, 1, 32, 384, 384, 32, 192]
+    - [1, 7.81296]
+  - - [448, 192, 1, 32, 448, 448, 32, 192]
+    - [2, 9.13691]
+  - - [512, 192, 1, 32, 512, 512, 32, 192]
+    - [1, 10.4083]
+  - - [576, 192, 1, 32, 576, 576, 32, 192]
+    - [2, 11.7711]
+  - - [640, 192, 1, 32, 640, 640, 32, 192]
+    - [3, 13.14]
+  - - [704, 192, 1, 32, 704, 704, 32, 192]
+    - [1, 14.2987]
+  - - [768, 192, 1, 32, 768, 768, 32, 192]
+    - [2, 15.7448]
+  - - [832, 192, 1, 32, 832, 832, 32, 192]
+    - [2, 17.0191]
+  - - [896, 192, 1, 32, 896, 896, 32, 192]
+    - [2, 18.3705]
+  - - [960, 192, 1, 32, 960, 960, 32, 192]
+    - [1, 19.4195]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 192]
+    - [3, 20.9334]
+  - - [64, 256, 1, 32, 64, 64, 32, 256]
+    - [2, 1.73956]
+  - - [128, 256, 1, 32, 128, 128, 32, 256]
+    - [1, 3.50886]
+  - - [192, 256, 1, 32, 192, 192, 32, 256]
+    - [3, 5.30402]
+  - - [256, 256, 1, 32, 256, 256, 32, 256]
+    - [3, 7.03596]
+  - - [320, 256, 1, 32, 320, 320, 32, 256]
+    - [3, 8.79437]
+  - - [384, 256, 1, 32, 384, 384, 32, 256]
+    - [2, 10.3936]
+  - - [448, 256, 1, 32, 448, 448, 32, 256]
+    - [2, 12.1206]
+  - - [512, 256, 1, 32, 512, 512, 32, 256]
+    - [3, 14.0427]
+  - - [576, 256, 1, 32, 576, 576, 32, 256]
+    - [3, 15.7864]
+  - - [640, 256, 1, 32, 640, 640, 32, 256]
+    - [3, 17.4744]
+  - - [704, 256, 1, 32, 704, 704, 32, 256]
+    - [1, 247.513]
+  - - [768, 256, 1, 32, 768, 768, 32, 256]
+    - [2, 20.6236]
+  - - [832, 256, 1, 32, 832, 832, 32, 256]
+    - [3, 22.6944]
+  - - [896, 256, 1, 32, 896, 896, 32, 256]
+    - [3, 24.3493]
+  - - [960, 256, 1, 32, 960, 960, 32, 256]
+    - [2, 25.8264]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 256]
+    - [1, 24.3747]
+  - - [64, 320, 1, 32, 64, 64, 32, 320]
+    - [2, 1.92099]
+  - - [128, 320, 1, 32, 128, 128, 32, 320]
+    - [2, 112.993]
+  - - [192, 320, 1, 32, 192, 192, 32, 320]
+    - [2, 15.7677]
+  - - [256, 320, 1, 32, 256, 256, 32, 320]
+    - [2, 170.445]
+  - - [320, 320, 1, 32, 320, 320, 32, 320]
+    - [2, 10.8445]
+  - - [384, 320, 1, 32, 384, 384, 32, 320]
+    - [1, 12.7485]
+  - - [448, 320, 1, 32, 448, 448, 32, 320]
+    - [1, 15.127]
+  - - [512, 320, 1, 32, 512, 512, 32, 320]
+    - [2, 17.4663]
+  - - [576, 320, 1, 32, 576, 576, 32, 320]
+    - [2, 14.4937]
+  - - [640, 320, 1, 32, 640, 640, 32, 320]
+    - [3, 21.761]
+  - - [704, 320, 1, 32, 704, 704, 32, 320]
+    - [3, 24.1234]
+  - - [768, 320, 1, 32, 768, 768, 32, 320]
+    - [1, 26.199]
+  - - [832, 320, 1, 32, 832, 832, 32, 320]
+    - [2, 28.1632]
+  - - [896, 320, 1, 32, 896, 896, 32, 320]
+    - [2, 30.1531]
+  - - [960, 320, 1, 32, 960, 960, 32, 320]
+    - [3, 31.8247]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 320]
+    - [2, 34.0556]
+  - - [64, 384, 1, 32, 64, 64, 32, 384]
+    - [3, 2.66269]
+  - - [128, 384, 1, 32, 128, 128, 32, 384]
+    - [1, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 384]
+    - [3, 7.91506]
+  - - [256, 384, 1, 32, 256, 256, 32, 384]
+    - [2, 10.4834]
+  - - [320, 384, 1, 32, 320, 320, 32, 384]
+    - [3, 13.1668]
+  - - [384, 384, 1, 32, 384, 384, 32, 384]
+    - [2, 15.7136]
+  - - [448, 384, 1, 32, 448, 448, 32, 384]
+    - [3, 18.5612]
+  - - [512, 384, 1, 32, 512, 512, 32, 384]
+    - [3, 21.012]
+  - - [576, 384, 1, 32, 576, 576, 32, 384]
+    - [2, 23.57]
+  - - [640, 384, 1, 32, 640, 640, 32, 384]
+    - [1, 26.1267]
+  - - [704, 384, 1, 32, 704, 704, 32, 384]
+    - [2, 25.9286]
+  - - [768, 384, 1, 32, 768, 768, 32, 384]
+    - [3, 30.459]
+  - - [832, 384, 1, 32, 832, 832, 32, 384]
+    - [3, 32.9458]
+  - - [896, 384, 1, 32, 896, 896, 32, 384]
+    - [2, 35.4332]
+  - - [960, 384, 1, 32, 960, 960, 32, 384]
+    - [1, 321.255]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 384]
+    - [3, 35.291]
+  - - [64, 448, 1, 32, 64, 64, 32, 448]
+    - [1, 3.08144]
+  - - [128, 448, 1, 32, 128, 128, 32, 448]
+    - [1, 6.12932]
+  - - [192, 448, 1, 32, 192, 192, 32, 448]
+    - [1, 9.12646]
+  - - [256, 448, 1, 32, 256, 256, 32, 448]
+    - [2, 12.2539]
+  - - [320, 448, 1, 32, 320, 320, 32, 448]
+    - [2, 15.2543]
+  - - [384, 448, 1, 32, 384, 384, 32, 448]
+    - [2, 18.3503]
+  - - [448, 448, 1, 32, 448, 448, 32, 448]
+    - [2, 21.3375]
+  - - [512, 448, 1, 32, 512, 512, 32, 448]
+    - [2, 250.342]
+  - - [576, 448, 1, 32, 576, 576, 32, 448]
+    - [3, 27.1378]
+  - - [640, 448, 1, 32, 640, 640, 32, 448]
+    - [3, 29.9288]
+  - - [704, 448, 1, 32, 704, 704, 32, 448]
+    - [3, 30.1579]
+  - - [768, 448, 1, 32, 768, 768, 32, 448]
+    - [2, 31.8502]
+  - - [832, 448, 1, 32, 832, 832, 32, 448]
+    - [3, 35.3894]
+  - - [896, 448, 1, 32, 896, 896, 32, 448]
+    - [1, 37.6614]
+  - - [960, 448, 1, 32, 960, 960, 32, 448]
+    - [2, 41.1963]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 448]
+    - [2, 44.0087]
+  - - [64, 512, 1, 32, 64, 64, 32, 512]
+    - [1, 3.52295]
+  - - [128, 512, 1, 32, 128, 128, 32, 512]
+    - [1, 6.94911]
+  - - [192, 512, 1, 32, 192, 192, 32, 512]
+    - [3, 10.5167]
+  - - [256, 512, 1, 32, 256, 256, 32, 512]
+    - [2, 14.0604]
+  - - [320, 512, 1, 32, 320, 320, 32, 512]
+    - [2, 17.2647]
+  - - [384, 512, 1, 32, 384, 384, 32, 512]
+    - [3, 18.5058]
+  - - [448, 512, 1, 32, 448, 448, 32, 512]
+    - [2, 24.1574]
+  - - [512, 512, 1, 32, 512, 512, 32, 512]
+    - [3, 23.8816]
+  - - [576, 512, 1, 32, 576, 576, 32, 512]
+    - [1, 30.8791]
+  - - [640, 512, 1, 32, 640, 640, 32, 512]
+    - [1, 30.8095]
+  - - [704, 512, 1, 32, 704, 704, 32, 512]
+    - [1, 31.2565]
+  - - [768, 512, 1, 32, 768, 768, 32, 512]
+    - [3, 37.0819]
+  - - [832, 512, 1, 32, 832, 832, 32, 512]
+    - [0, 38.4813]
+  - - [896, 512, 1, 32, 896, 896, 32, 512]
+    - [3, 272.76]
+  - - [960, 512, 1, 32, 960, 960, 32, 512]
+    - [2, 285.143]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 512]
+    - [2, 300.344]
+  - - [64, 576, 1, 32, 64, 64, 32, 576]
+    - [1, 3.94252]
+  - - [128, 576, 1, 32, 128, 128, 32, 576]
+    - [2, 7.85877]
+  - - [192, 576, 1, 32, 192, 192, 32, 576]
+    - [1, 11.7529]
+  - - [256, 576, 1, 32, 256, 256, 32, 576]
+    - [2, 15.6784]
+  - - [320, 576, 1, 32, 320, 320, 32, 576]
+    - [2, 19.6958]
+  - - [384, 576, 1, 32, 384, 384, 32, 576]
+    - [3, 23.6192]
+  - - [448, 576, 1, 32, 448, 448, 32, 576]
+    - [2, 27.2277]
+  - - [512, 576, 1, 32, 512, 512, 32, 576]
+    - [1, 303.057]
+  - - [576, 576, 1, 32, 576, 576, 32, 576]
+    - [2, 56.6076]
+  - - [640, 576, 1, 32, 640, 640, 32, 576]
+    - [3, 37.3097]
+  - - [704, 576, 1, 32, 704, 704, 32, 576]
+    - [3, 40.4755]
+  - - [768, 576, 1, 32, 768, 768, 32, 576]
+    - [3, 42.0593]
+  - - [832, 576, 1, 32, 832, 832, 32, 576]
+    - [3, 45.7279]
+  - - [896, 576, 1, 32, 896, 896, 32, 576]
+    - [1, 48.5906]
+  - - [960, 576, 1, 32, 960, 960, 32, 576]
+    - [2, 52.451]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 576]
+    - [1, 52.4547]
+  - - [64, 640, 1, 32, 64, 64, 32, 640]
+    - [2, 4.36809]
+  - - [128, 640, 1, 32, 128, 128, 32, 640]
+    - [1, 8.54343]
+  - - [192, 640, 1, 32, 192, 192, 32, 640]
+    - [2, 13.0236]
+  - - [256, 640, 1, 32, 256, 256, 32, 640]
+    - [3, 17.4794]
+  - - [320, 640, 1, 32, 320, 320, 32, 640]
+    - [2, 21.473]
+  - - [384, 640, 1, 32, 384, 384, 32, 640]
+    - [1, 25.7238]
+  - - [448, 640, 1, 32, 448, 448, 32, 640]
+    - [1, 28.8571]
+  - - [512, 640, 1, 32, 512, 512, 32, 640]
+    - [3, 31.1338]
+  - - [576, 640, 1, 32, 576, 576, 32, 640]
+    - [3, 37.6695]
+  - - [640, 640, 1, 32, 640, 640, 32, 640]
+    - [3, 41.3063]
+  - - [704, 640, 1, 32, 704, 704, 32, 640]
+    - [2, 282.038]
+  - - [768, 640, 1, 32, 768, 768, 32, 640]
+    - [1, 44.3651]
+  - - [832, 640, 1, 32, 832, 832, 32, 640]
+    - [1, 339.561]
+  - - [896, 640, 1, 32, 896, 896, 32, 640]
+    - [1, 342.221]
+  - - [960, 640, 1, 32, 960, 960, 32, 640]
+    - [2, 54.8507]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 640]
+    - [1, 60.763]
+  - - [64, 704, 1, 32, 64, 64, 32, 704]
+    - [2, 4.83657]
+  - - [128, 704, 1, 32, 128, 128, 32, 704]
+    - [2, 9.51187]
+  - - [192, 704, 1, 32, 192, 192, 32, 704]
+    - [3, 14.5053]
+  - - [256, 704, 1, 32, 256, 256, 32, 704]
+    - [1, 19.0363]
+  - - [320, 704, 1, 32, 320, 320, 32, 704]
+    - [1, 267.593]
+  - - [384, 704, 1, 32, 384, 384, 32, 704]
+    - [2, 28.4469]
+  - - [448, 704, 1, 32, 448, 448, 32, 704]
+    - [2, 32.8767]
+  - - [512, 704, 1, 32, 512, 512, 32, 704]
+    - [1, 32.7986]
+  - - [576, 704, 1, 32, 576, 576, 32, 704]
+    - [1, 319.605]
+  - - [640, 704, 1, 32, 640, 640, 32, 704]
+    - [3, 44.8045]
+  - - [704, 704, 1, 32, 704, 704, 32, 704]
+    - [3, 46.3515]
+  - - [768, 704, 1, 32, 768, 768, 32, 704]
+    - [1, 50.2597]
+  - - [832, 704, 1, 32, 832, 832, 32, 704]
+    - [2, 54.9452]
+  - - [896, 704, 1, 32, 896, 896, 32, 704]
+    - [1, 58.9238]
+  - - [960, 704, 1, 32, 960, 960, 32, 704]
+    - [3, 57.3889]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 704]
+    - [1, 67.3308]
+  - - [64, 768, 1, 32, 64, 64, 32, 768]
+    - [2, 5.13066]
+  - - [128, 768, 1, 32, 128, 128, 32, 768]
+    - [3, 10.4063]
+  - - [192, 768, 1, 32, 192, 192, 32, 768]
+    - [3, 15.5295]
+  - - [256, 768, 1, 32, 256, 256, 32, 768]
+    - [2, 235.635]
+  - - [320, 768, 1, 32, 320, 320, 32, 768]
+    - [3, 25.7752]
+  - - [384, 768, 1, 32, 384, 384, 32, 768]
+    - [2, 27.6193]
+  - - [448, 768, 1, 32, 448, 448, 32, 768]
+    - [2, 35.5029]
+  - - [512, 768, 1, 32, 512, 512, 32, 768]
+    - [0, 283.396]
+  - - [576, 768, 1, 32, 576, 576, 32, 768]
+    - [3, 41.5159]
+  - - [640, 768, 1, 32, 640, 640, 32, 768]
+    - [1, 318.394]
+  - - [704, 768, 1, 32, 704, 704, 32, 768]
+    - [1, 151.018]
+  - - [768, 768, 1, 32, 768, 768, 32, 768]
+    - [2, 54.769]
+  - - [832, 768, 1, 32, 832, 832, 32, 768]
+    - [3, 59.8533]
+  - - [896, 768, 1, 32, 896, 896, 32, 768]
+    - [3, 64.697]
+  - - [960, 768, 1, 32, 960, 960, 32, 768]
+    - [3, 272.639]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 768]
+    - [0, 158.739]
+  - - [64, 832, 1, 32, 64, 64, 32, 832]
+    - [3, 5.6198]
+  - - [128, 832, 1, 32, 128, 128, 32, 832]
+    - [3, 11.2135]
+  - - [192, 832, 1, 32, 192, 192, 32, 832]
+    - [1, 12.6673]
+  - - [256, 832, 1, 32, 256, 256, 32, 832]
+    - [2, 21.8459]
+  - - [320, 832, 1, 32, 320, 320, 32, 832]
+    - [2, 27.6993]
+  - - [384, 832, 1, 32, 384, 384, 32, 832]
+    - [2, 33.2084]
+  - - [448, 832, 1, 32, 448, 448, 32, 832]
+    - [1, 34.47]
+  - - [512, 832, 1, 32, 512, 512, 32, 832]
+    - [3, 38.4699]
+  - - [576, 832, 1, 32, 576, 576, 32, 832]
+    - [3, 44.7355]
+  - - [640, 832, 1, 32, 640, 640, 32, 832]
+    - [2, 49.7729]
+  - - [704, 832, 1, 32, 704, 704, 32, 832]
+    - [0, 51.9778]
+  - - [768, 832, 1, 32, 768, 768, 32, 832]
+    - [2, 60.0476]
+  - - [832, 832, 1, 32, 832, 832, 32, 832]
+    - [3, 61.0171]
+  - - [896, 832, 1, 32, 896, 896, 32, 832]
+    - [3, 68.7008]
+  - - [960, 832, 1, 32, 960, 960, 32, 832]
+    - [1, 73.7301]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 832]
+    - [2, 76.7188]
+  - - [64, 896, 1, 32, 64, 64, 32, 896]
+    - [3, 6.0638]
+  - - [128, 896, 1, 32, 128, 128, 32, 896]
+    - [1, 11.8097]
+  - - [192, 896, 1, 32, 192, 192, 32, 896]
+    - [1, 260.408]
+  - - [256, 896, 1, 32, 256, 256, 32, 896]
+    - [1, 112.061]
+  - - [320, 896, 1, 32, 320, 320, 32, 896]
+    - [1, 21.646]
+  - - [384, 896, 1, 32, 384, 384, 32, 896]
+    - [3, 35.1622]
+  - - [448, 896, 1, 32, 448, 448, 32, 896]
+    - [2, 40.6641]
+  - - [512, 896, 1, 32, 512, 512, 32, 896]
+    - [2, 42.9101]
+  - - [576, 896, 1, 32, 576, 576, 32, 896]
+    - [0, 43.0245]
+  - - [640, 896, 1, 32, 640, 640, 32, 896]
+    - [3, 79.8571]
+  - - [704, 896, 1, 32, 704, 704, 32, 896]
+    - [1, 49.3707]
+  - - [768, 896, 1, 32, 768, 768, 32, 896]
+    - [3, 63.6994]
+  - - [832, 896, 1, 32, 832, 832, 32, 896]
+    - [2, 61.6821]
+  - - [896, 896, 1, 32, 896, 896, 32, 896]
+    - [2, 72.8566]
+  - - [960, 896, 1, 32, 960, 960, 32, 896]
+    - [1, 354.886]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 896]
+    - [0, 317.886]
+  - - [64, 960, 1, 32, 64, 64, 32, 960]
+    - [1, 53.3971]
+  - - [128, 960, 1, 32, 128, 128, 32, 960]
+    - [3, 90.4142]
+  - - [192, 960, 1, 32, 192, 192, 32, 960]
+    - [2, 122.611]
+  - - [256, 960, 1, 32, 256, 256, 32, 960]
+    - [3, 183.744]
+  - - [320, 960, 1, 32, 320, 320, 32, 960]
+    - [3, 223.215]
+  - - [384, 960, 1, 32, 384, 384, 32, 960]
+    - [3, 254.894]
+  - - [448, 960, 1, 32, 448, 448, 32, 960]
+    - [1, 281.213]
+  - - [512, 960, 1, 32, 512, 512, 32, 960]
+    - [1, 112.761]
+  - - [576, 960, 1, 32, 576, 576, 32, 960]
+    - [3, 48.9911]
+  - - [640, 960, 1, 32, 640, 640, 32, 960]
+    - [3, 55.7371]
+  - - [704, 960, 1, 32, 704, 704, 32, 960]
+    - [2, 63.3231]
+  - - [768, 960, 1, 32, 768, 768, 32, 960]
+    - [3, 68.2938]
+  - - [832, 960, 1, 32, 832, 832, 32, 960]
+    - [2, 72.4314]
+  - - [896, 960, 1, 32, 896, 896, 32, 960]
+    - [1, 77.3032]
+  - - [960, 960, 1, 32, 960, 960, 32, 960]
+    - [1, 81.6484]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 960]
+    - [1, 88.853]
+  - - [64, 1024, 1, 32, 64, 64, 32, 1024]
+    - [1, 6.85587]
+  - - [128, 1024, 1, 32, 128, 128, 32, 1024]
+    - [2, 13.7617]
+  - - [192, 1024, 1, 32, 192, 192, 32, 1024]
+    - [3, 20.7908]
+  - - [256, 1024, 1, 32, 256, 256, 32, 1024]
+    - [2, 264.621]
+  - - [320, 1024, 1, 32, 320, 320, 32, 1024]
+    - [0, 110.725]
+  - - [384, 1024, 1, 32, 384, 384, 32, 1024]
+    - [1, 34.0459]
+  - - [448, 1024, 1, 32, 448, 448, 32, 1024]
+    - [1, 329.589]
+  - - [512, 1024, 1, 32, 512, 512, 32, 1024]
+    - [1, 49.0545]
+  - - [576, 1024, 1, 32, 576, 576, 32, 1024]
+    - [3, 51.7861]
+  - - [640, 1024, 1, 32, 640, 640, 32, 1024]
+    - [3, 60.799]
+  - - [704, 1024, 1, 32, 704, 704, 32, 1024]
+    - [3, 66.7098]
+  - - [768, 1024, 1, 32, 768, 768, 32, 1024]
+    - [1, 73.2018]
+  - - [832, 1024, 1, 32, 832, 832, 32, 1024]
+    - [0, 76.422]
+  - - [896, 1024, 1, 32, 896, 896, 32, 1024]
+    - [1, 83.9504]
+  - - [960, 1024, 1, 32, 960, 960, 32, 1024]
+    - [1, 88.6428]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 1024]
+    - [0, 89.8096]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1200/Equality/gfx1200_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1200
+- gfx1200
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 32]
+    - [1, 1.15885]
+  - - [128, 64, 1, 32, 128, 128, 32, 32]
+    - [3, 2.32324]
+  - - [192, 64, 1, 32, 192, 192, 32, 32]
+    - [2, 3.48116]
+  - - [256, 64, 1, 32, 256, 256, 32, 32]
+    - [2, 4.67611]
+  - - [320, 64, 1, 32, 320, 320, 32, 32]
+    - [3, 5.79706]
+  - - [384, 64, 1, 32, 384, 384, 32, 32]
+    - [3, 72.9529]
+  - - [448, 64, 1, 32, 448, 448, 32, 32]
+    - [2, 8.11405]
+  - - [512, 64, 1, 32, 512, 512, 32, 32]
+    - [3, 85.8082]
+  - - [576, 64, 1, 32, 576, 576, 32, 32]
+    - [3, 10.4384]
+  - - [640, 64, 1, 32, 640, 640, 32, 32]
+    - [1, 11.5436]
+  - - [704, 64, 1, 32, 704, 704, 32, 32]
+    - [3, 117.41]
+  - - [768, 64, 1, 32, 768, 768, 32, 32]
+    - [0, 13.8645]
+  - - [832, 64, 1, 32, 832, 832, 32, 32]
+    - [3, 14.9874]
+  - - [896, 64, 1, 32, 896, 896, 32, 32]
+    - [3, 16.1559]
+  - - [960, 64, 1, 32, 960, 960, 32, 32]
+    - [0, 17.3001]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 32]
+    - [2, 18.4299]
+  - - [64, 128, 1, 32, 64, 64, 32, 32]
+    - [2, 2.31268]
+  - - [128, 128, 1, 32, 128, 128, 32, 32]
+    - [3, 47.0636]
+  - - [192, 128, 1, 32, 192, 192, 32, 32]
+    - [2, 75.4733]
+  - - [256, 128, 1, 32, 256, 256, 32, 32]
+    - [2, 93.9542]
+  - - [320, 128, 1, 32, 320, 320, 32, 32]
+    - [2, 109.227]
+  - - [384, 128, 1, 32, 384, 384, 32, 32]
+    - [1, 13.8266]
+  - - [448, 128, 1, 32, 448, 448, 32, 32]
+    - [3, 124.83]
+  - - [512, 128, 1, 32, 512, 512, 32, 32]
+    - [3, 18.2917]
+  - - [576, 128, 1, 32, 576, 576, 32, 32]
+    - [0, 20.7346]
+  - - [640, 128, 1, 32, 640, 640, 32, 32]
+    - [1, 23.0505]
+  - - [704, 128, 1, 32, 704, 704, 32, 32]
+    - [2, 25.3635]
+  - - [768, 128, 1, 32, 768, 768, 32, 32]
+    - [1, 27.6814]
+  - - [832, 128, 1, 32, 832, 832, 32, 32]
+    - [1, 29.9696]
+  - - [896, 128, 1, 32, 896, 896, 32, 32]
+    - [2, 32.2652]
+  - - [960, 128, 1, 32, 960, 960, 32, 32]
+    - [2, 34.5972]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 32]
+    - [2, 36.8745]
+  - - [64, 192, 1, 32, 64, 64, 32, 32]
+    - [0, 3.46628]
+  - - [128, 192, 1, 32, 128, 128, 32, 32]
+    - [3, 6.93591]
+  - - [192, 192, 1, 32, 192, 192, 32, 32]
+    - [3, 10.3805]
+  - - [256, 192, 1, 32, 256, 256, 32, 32]
+    - [2, 13.8505]
+  - - [320, 192, 1, 32, 320, 320, 32, 32]
+    - [3, 17.316]
+  - - [384, 192, 1, 32, 384, 384, 32, 32]
+    - [1, 7.68846]
+  - - [448, 192, 1, 32, 448, 448, 32, 32]
+    - [3, 9.14738]
+  - - [512, 192, 1, 32, 512, 512, 32, 32]
+    - [2, 10.3843]
+  - - [576, 192, 1, 32, 576, 576, 32, 32]
+    - [1, 11.6535]
+  - - [640, 192, 1, 32, 640, 640, 32, 32]
+    - [2, 12.944]
+  - - [704, 192, 1, 32, 704, 704, 32, 32]
+    - [2, 14.3917]
+  - - [768, 192, 1, 32, 768, 768, 32, 32]
+    - [2, 15.7115]
+  - - [832, 192, 1, 32, 832, 832, 32, 32]
+    - [2, 220.337]
+  - - [896, 192, 1, 32, 896, 896, 32, 32]
+    - [2, 18.3103]
+  - - [960, 192, 1, 32, 960, 960, 32, 32]
+    - [1, 19.5163]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 32]
+    - [3, 137.893]
+  - - [64, 256, 1, 32, 64, 64, 32, 32]
+    - [3, 5.97204]
+  - - [128, 256, 1, 32, 128, 128, 32, 32]
+    - [2, 3.49203]
+  - - [192, 256, 1, 32, 192, 192, 32, 32]
+    - [2, 5.33651]
+  - - [256, 256, 1, 32, 256, 256, 32, 32]
+    - [3, 6.97152]
+  - - [320, 256, 1, 32, 320, 320, 32, 32]
+    - [2, 8.71078]
+  - - [384, 256, 1, 32, 384, 384, 32, 32]
+    - [3, 10.4597]
+  - - [448, 256, 1, 32, 448, 448, 32, 32]
+    - [1, 203.663]
+  - - [512, 256, 1, 32, 512, 512, 32, 32]
+    - [2, 13.9188]
+  - - [576, 256, 1, 32, 576, 576, 32, 32]
+    - [2, 29.9022]
+  - - [640, 256, 1, 32, 640, 640, 32, 32]
+    - [2, 17.1125]
+  - - [704, 256, 1, 32, 704, 704, 32, 32]
+    - [2, 19.0225]
+  - - [768, 256, 1, 32, 768, 768, 32, 32]
+    - [3, 20.817]
+  - - [832, 256, 1, 32, 832, 832, 32, 32]
+    - [3, 22.6918]
+  - - [896, 256, 1, 32, 896, 896, 32, 32]
+    - [3, 24.2741]
+  - - [960, 256, 1, 32, 960, 960, 32, 32]
+    - [3, 20.772]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 32]
+    - [3, 237.638]
+  - - [64, 320, 1, 32, 64, 64, 32, 32]
+    - [2, 62.7739]
+  - - [128, 320, 1, 32, 128, 128, 32, 32]
+    - [2, 4.32093]
+  - - [192, 320, 1, 32, 192, 192, 32, 32]
+    - [1, 6.51134]
+  - - [256, 320, 1, 32, 256, 256, 32, 32]
+    - [3, 8.74086]
+  - - [320, 320, 1, 32, 320, 320, 32, 32]
+    - [2, 10.8937]
+  - - [384, 320, 1, 32, 384, 384, 32, 32]
+    - [2, 12.66]
+  - - [448, 320, 1, 32, 448, 448, 32, 32]
+    - [2, 15.2365]
+  - - [512, 320, 1, 32, 512, 512, 32, 32]
+    - [2, 17.4799]
+  - - [576, 320, 1, 32, 576, 576, 32, 32]
+    - [2, 19.514]
+  - - [640, 320, 1, 32, 640, 640, 32, 32]
+    - [2, 21.8103]
+  - - [704, 320, 1, 32, 704, 704, 32, 32]
+    - [1, 23.6307]
+  - - [768, 320, 1, 32, 768, 768, 32, 32]
+    - [1, 25.6416]
+  - - [832, 320, 1, 32, 832, 832, 32, 32]
+    - [3, 28.0408]
+  - - [896, 320, 1, 32, 896, 896, 32, 32]
+    - [1, 29.8762]
+  - - [960, 320, 1, 32, 960, 960, 32, 32]
+    - [1, 32.2111]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 32]
+    - [3, 31.1564]
+  - - [64, 384, 1, 32, 64, 64, 32, 32]
+    - [1, 2.61567]
+  - - [128, 384, 1, 32, 128, 128, 32, 32]
+    - [3, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 32]
+    - [2, 7.81608]
+  - - [256, 384, 1, 32, 256, 256, 32, 32]
+    - [1, 10.3665]
+  - - [320, 384, 1, 32, 320, 320, 32, 32]
+    - [2, 13.0853]
+  - - [384, 384, 1, 32, 384, 384, 32, 32]
+    - [2, 15.5012]
+  - - [448, 384, 1, 32, 448, 448, 32, 32]
+    - [2, 18.2013]
+  - - [512, 384, 1, 32, 512, 512, 32, 32]
+    - [3, 21.0359]
+  - - [576, 384, 1, 32, 576, 576, 32, 32]
+    - [2, 23.2003]
+  - - [640, 384, 1, 32, 640, 640, 32, 32]
+    - [3, 233.224]
+  - - [704, 384, 1, 32, 704, 704, 32, 32]
+    - [2, 28.4422]
+  - - [768, 384, 1, 32, 768, 768, 32, 32]
+    - [2, 30.8141]
+  - - [832, 384, 1, 32, 832, 832, 32, 32]
+    - [3, 32.5949]
+  - - [896, 384, 1, 32, 896, 896, 32, 32]
+    - [3, 34.7521]
+  - - [960, 384, 1, 32, 960, 960, 32, 32]
+    - [3, 33.5664]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 32]
+    - [3, 37.4289]
+  - - [64, 448, 1, 32, 64, 64, 32, 32]
+    - [1, 3.0641]
+  - - [128, 448, 1, 32, 128, 128, 32, 32]
+    - [2, 6.09522]
+  - - [192, 448, 1, 32, 192, 192, 32, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 32, 32]
+    - [2, 11.7963]
+  - - [320, 448, 1, 32, 320, 320, 32, 32]
+    - [2, 15.1838]
+  - - [384, 448, 1, 32, 384, 384, 32, 32]
+    - [3, 18.3064]
+  - - [448, 448, 1, 32, 448, 448, 32, 32]
+    - [3, 21.3841]
+  - - [512, 448, 1, 32, 512, 512, 32, 32]
+    - [3, 18.3367]
+  - - [576, 448, 1, 32, 576, 576, 32, 32]
+    - [3, 27.083]
+  - - [640, 448, 1, 32, 640, 640, 32, 32]
+    - [3, 26.9496]
+  - - [704, 448, 1, 32, 704, 704, 32, 32]
+    - [1, 32.8944]
+  - - [768, 448, 1, 32, 768, 768, 32, 32]
+    - [3, 35.0341]
+  - - [832, 448, 1, 32, 832, 832, 32, 32]
+    - [2, 26.0992]
+  - - [896, 448, 1, 32, 896, 896, 32, 32]
+    - [1, 41.1343]
+  - - [960, 448, 1, 32, 960, 960, 32, 32]
+    - [3, 40.0223]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 32]
+    - [3, 38.111]
+  - - [64, 512, 1, 32, 64, 64, 32, 32]
+    - [2, 3.53227]
+  - - [128, 512, 1, 32, 128, 128, 32, 32]
+    - [1, 6.93958]
+  - - [192, 512, 1, 32, 192, 192, 32, 32]
+    - [3, 10.4611]
+  - - [256, 512, 1, 32, 256, 256, 32, 32]
+    - [1, 13.7945]
+  - - [320, 512, 1, 32, 320, 320, 32, 32]
+    - [2, 17.3286]
+  - - [384, 512, 1, 32, 384, 384, 32, 32]
+    - [2, 20.6608]
+  - - [448, 512, 1, 32, 448, 448, 32, 32]
+    - [2, 24.2853]
+  - - [512, 512, 1, 32, 512, 512, 32, 32]
+    - [1, 27.4679]
+  - - [576, 512, 1, 32, 576, 576, 32, 32]
+    - [0, 17.8717]
+  - - [640, 512, 1, 32, 640, 640, 32, 32]
+    - [2, 270.667]
+  - - [704, 512, 1, 32, 704, 704, 32, 32]
+    - [2, 36.9238]
+  - - [768, 512, 1, 32, 768, 768, 32, 32]
+    - [3, 39.3362]
+  - - [832, 512, 1, 32, 832, 832, 32, 32]
+    - [3, 40.6126]
+  - - [896, 512, 1, 32, 896, 896, 32, 32]
+    - [3, 37.5678]
+  - - [960, 512, 1, 32, 960, 960, 32, 32]
+    - [2, 46.6799]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 32]
+    - [1, 49.4521]
+  - - [64, 576, 1, 32, 64, 64, 32, 32]
+    - [3, 4.16165]
+  - - [128, 576, 1, 32, 128, 128, 32, 32]
+    - [1, 165.211]
+  - - [192, 576, 1, 32, 192, 192, 32, 32]
+    - [1, 11.6914]
+  - - [256, 576, 1, 32, 256, 256, 32, 32]
+    - [2, 15.6145]
+  - - [320, 576, 1, 32, 320, 320, 32, 32]
+    - [3, 19.5201]
+  - - [384, 576, 1, 32, 384, 384, 32, 32]
+    - [2, 23.3173]
+  - - [448, 576, 1, 32, 448, 448, 32, 32]
+    - [2, 26.4926]
+  - - [512, 576, 1, 32, 512, 512, 32, 32]
+    - [2, 30.8559]
+  - - [576, 576, 1, 32, 576, 576, 32, 32]
+    - [1, 25.7695]
+  - - [640, 576, 1, 32, 640, 640, 32, 32]
+    - [1, 38.4963]
+  - - [704, 576, 1, 32, 704, 704, 32, 32]
+    - [1, 38.0312]
+  - - [768, 576, 1, 32, 768, 768, 32, 32]
+    - [1, 45.0796]
+  - - [832, 576, 1, 32, 832, 832, 32, 32]
+    - [2, 47.4484]
+  - - [896, 576, 1, 32, 896, 896, 32, 32]
+    - [2, 48.7268]
+  - - [960, 576, 1, 32, 960, 960, 32, 32]
+    - [2, 49.2269]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 32]
+    - [2, 55.1113]
+  - - [64, 640, 1, 32, 64, 64, 32, 32]
+    - [1, 4.31759]
+  - - [128, 640, 1, 32, 128, 128, 32, 32]
+    - [3, 8.77126]
+  - - [192, 640, 1, 32, 192, 192, 32, 32]
+    - [2, 13.0281]
+  - - [256, 640, 1, 32, 256, 256, 32, 32]
+    - [3, 17.3725]
+  - - [320, 640, 1, 32, 320, 320, 32, 32]
+    - [2, 21.5674]
+  - - [384, 640, 1, 32, 384, 384, 32, 32]
+    - [2, 25.8732]
+  - - [448, 640, 1, 32, 448, 448, 32, 32]
+    - [3, 233.34]
+  - - [512, 640, 1, 32, 512, 512, 32, 32]
+    - [1, 29.7957]
+  - - [576, 640, 1, 32, 576, 576, 32, 32]
+    - [2, 37.6816]
+  - - [640, 640, 1, 32, 640, 640, 32, 32]
+    - [3, 39.1071]
+  - - [704, 640, 1, 32, 704, 704, 32, 32]
+    - [3, 44.6269]
+  - - [768, 640, 1, 32, 768, 768, 32, 32]
+    - [0, 45.3769]
+  - - [832, 640, 1, 32, 832, 832, 32, 32]
+    - [1, 50.2744]
+  - - [896, 640, 1, 32, 896, 896, 32, 32]
+    - [0, 53.1083]
+  - - [960, 640, 1, 32, 960, 960, 32, 32]
+    - [3, 55.344]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 32]
+    - [1, 61.5259]
+  - - [64, 704, 1, 32, 64, 64, 32, 32]
+    - [1, 4.78203]
+  - - [128, 704, 1, 32, 128, 128, 32, 32]
+    - [1, 9.11814]
+  - - [192, 704, 1, 32, 192, 192, 32, 32]
+    - [3, 14.38]
+  - - [256, 704, 1, 32, 256, 256, 32, 32]
+    - [3, 19.1484]
+  - - [320, 704, 1, 32, 320, 320, 32, 32]
+    - [2, 23.4029]
+  - - [384, 704, 1, 32, 384, 384, 32, 32]
+    - [1, 28.2559]
+  - - [448, 704, 1, 32, 448, 448, 32, 32]
+    - [3, 22.4257]
+  - - [512, 704, 1, 32, 512, 512, 32, 32]
+    - [3, 36.3124]
+  - - [576, 704, 1, 32, 576, 576, 32, 32]
+    - [0, 37.5889]
+  - - [640, 704, 1, 32, 640, 640, 32, 32]
+    - [3, 42.7372]
+  - - [704, 704, 1, 32, 704, 704, 32, 32]
+    - [2, 46.9011]
+  - - [768, 704, 1, 32, 768, 768, 32, 32]
+    - [2, 50.9832]
+  - - [832, 704, 1, 32, 832, 832, 32, 32]
+    - [2, 54.8969]
+  - - [896, 704, 1, 32, 896, 896, 32, 32]
+    - [1, 49.5075]
+  - - [960, 704, 1, 32, 960, 960, 32, 32]
+    - [2, 63.639]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 32]
+    - [2, 66.0261]
+  - - [64, 768, 1, 32, 64, 64, 32, 32]
+    - [1, 5.19274]
+  - - [128, 768, 1, 32, 128, 128, 32, 32]
+    - [2, 10.3992]
+  - - [192, 768, 1, 32, 192, 192, 32, 32]
+    - [3, 223.418]
+  - - [256, 768, 1, 32, 256, 256, 32, 32]
+    - [1, 266.136]
+  - - [320, 768, 1, 32, 320, 320, 32, 32]
+    - [3, 231.986]
+  - - [384, 768, 1, 32, 384, 384, 32, 32]
+    - [3, 30.6112]
+  - - [448, 768, 1, 32, 448, 448, 32, 32]
+    - [2, 31.5821]
+  - - [512, 768, 1, 32, 512, 512, 32, 32]
+    - [1, 40.6042]
+  - - [576, 768, 1, 32, 576, 576, 32, 32]
+    - [3, 41.8486]
+  - - [640, 768, 1, 32, 640, 640, 32, 32]
+    - [1, 41.7104]
+  - - [704, 768, 1, 32, 704, 704, 32, 32]
+    - [3, 275.064]
+  - - [768, 768, 1, 32, 768, 768, 32, 32]
+    - [1, 55.7396]
+  - - [832, 768, 1, 32, 832, 832, 32, 32]
+    - [3, 51.1568]
+  - - [896, 768, 1, 32, 896, 896, 32, 32]
+    - [1, 61.4199]
+  - - [960, 768, 1, 32, 960, 960, 32, 32]
+    - [3, 67.4196]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 32]
+    - [1, 73.2776]
+  - - [64, 832, 1, 32, 64, 64, 32, 32]
+    - [1, 5.63096]
+  - - [128, 832, 1, 32, 128, 128, 32, 32]
+    - [1, 11.1455]
+  - - [192, 832, 1, 32, 192, 192, 32, 32]
+    - [3, 16.7104]
+  - - [256, 832, 1, 32, 256, 256, 32, 32]
+    - [1, 22.388]
+  - - [320, 832, 1, 32, 320, 320, 32, 32]
+    - [0, 24.4102]
+  - - [384, 832, 1, 32, 384, 384, 32, 32]
+    - [1, 29.782]
+  - - [448, 832, 1, 32, 448, 448, 32, 32]
+    - [0, 31.3102]
+  - - [512, 832, 1, 32, 512, 512, 32, 32]
+    - [1, 39.0439]
+  - - [576, 832, 1, 32, 576, 576, 32, 32]
+    - [3, 44.3718]
+  - - [640, 832, 1, 32, 640, 640, 32, 32]
+    - [3, 48.3954]
+  - - [704, 832, 1, 32, 704, 704, 32, 32]
+    - [3, 45.2543]
+  - - [768, 832, 1, 32, 768, 768, 32, 32]
+    - [1, 56.8015]
+  - - [832, 832, 1, 32, 832, 832, 32, 32]
+    - [1, 54.7432]
+  - - [896, 832, 1, 32, 896, 896, 32, 32]
+    - [3, 58.3343]
+  - - [960, 832, 1, 32, 960, 960, 32, 32]
+    - [3, 71.7503]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 32]
+    - [1, 79.1776]
+  - - [64, 896, 1, 32, 64, 64, 32, 32]
+    - [1, 6.06912]
+  - - [128, 896, 1, 32, 128, 128, 32, 32]
+    - [2, 12.1569]
+  - - [192, 896, 1, 32, 192, 192, 32, 32]
+    - [2, 18.2019]
+  - - [256, 896, 1, 32, 256, 256, 32, 32]
+    - [2, 245.482]
+  - - [320, 896, 1, 32, 320, 320, 32, 32]
+    - [1, 29.0058]
+  - - [384, 896, 1, 32, 384, 384, 32, 32]
+    - [2, 35.5104]
+  - - [448, 896, 1, 32, 448, 448, 32, 32]
+    - [3, 28.1229]
+  - - [512, 896, 1, 32, 512, 512, 32, 32]
+    - [0, 42.3518]
+  - - [576, 896, 1, 32, 576, 576, 32, 32]
+    - [2, 48.9644]
+  - - [640, 896, 1, 32, 640, 640, 32, 32]
+    - [2, 45.7064]
+  - - [704, 896, 1, 32, 704, 704, 32, 32]
+    - [1, 59.4734]
+  - - [768, 896, 1, 32, 768, 768, 32, 32]
+    - [3, 51.5563]
+  - - [832, 896, 1, 32, 832, 832, 32, 32]
+    - [1, 70.0206]
+  - - [896, 896, 1, 32, 896, 896, 32, 32]
+    - [2, 72.8327]
+  - - [960, 896, 1, 32, 960, 960, 32, 32]
+    - [3, 75.7387]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 32]
+    - [3, 316.72]
+  - - [64, 960, 1, 32, 64, 64, 32, 32]
+    - [3, 47.761]
+  - - [128, 960, 1, 32, 128, 128, 32, 32]
+    - [3, 73.8913]
+  - - [192, 960, 1, 32, 192, 192, 32, 32]
+    - [2, 19.4311]
+  - - [256, 960, 1, 32, 256, 256, 32, 32]
+    - [2, 24.6167]
+  - - [320, 960, 1, 32, 320, 320, 32, 32]
+    - [2, 32.1022]
+  - - [384, 960, 1, 32, 384, 384, 32, 32]
+    - [3, 37.3233]
+  - - [448, 960, 1, 32, 448, 448, 32, 32]
+    - [0, 39.6573]
+  - - [512, 960, 1, 32, 512, 512, 32, 32]
+    - [1, 317.879]
+  - - [576, 960, 1, 32, 576, 576, 32, 32]
+    - [2, 47.8887]
+  - - [640, 960, 1, 32, 640, 640, 32, 32]
+    - [3, 45.7758]
+  - - [704, 960, 1, 32, 704, 704, 32, 32]
+    - [0, 62.4041]
+  - - [768, 960, 1, 32, 768, 768, 32, 32]
+    - [1, 69.5882]
+  - - [832, 960, 1, 32, 832, 832, 32, 32]
+    - [2, 72.5228]
+  - - [896, 960, 1, 32, 896, 896, 32, 32]
+    - [2, 77.1612]
+  - - [960, 960, 1, 32, 960, 960, 32, 32]
+    - [1, 84.0368]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 32]
+    - [3, 84.7878]
+  - - [64, 1024, 1, 32, 64, 64, 32, 32]
+    - [2, 6.94924]
+  - - [128, 1024, 1, 32, 128, 128, 32, 32]
+    - [1, 13.864]
+  - - [192, 1024, 1, 32, 192, 192, 32, 32]
+    - [3, 20.9498]
+  - - [256, 1024, 1, 32, 256, 256, 32, 32]
+    - [3, 27.3377]
+  - - [320, 1024, 1, 32, 320, 320, 32, 32]
+    - [1, 30.6626]
+  - - [384, 1024, 1, 32, 384, 384, 32, 32]
+    - [3, 37.2913]
+  - - [448, 1024, 1, 32, 448, 448, 32, 32]
+    - [3, 43.6989]
+  - - [512, 1024, 1, 32, 512, 512, 32, 32]
+    - [1, 49.0983]
+  - - [576, 1024, 1, 32, 576, 576, 32, 32]
+    - [2, 55.7223]
+  - - [640, 1024, 1, 32, 640, 640, 32, 32]
+    - [1, 61.4772]
+  - - [704, 1024, 1, 32, 704, 704, 32, 32]
+    - [1, 65.5096]
+  - - [768, 1024, 1, 32, 768, 768, 32, 32]
+    - [2, 71.6308]
+  - - [832, 1024, 1, 32, 832, 832, 32, 32]
+    - [3, 76.1074]
+  - - [896, 1024, 1, 32, 896, 896, 32, 32]
+    - [1, 83.761]
+  - - [960, 1024, 1, 32, 960, 960, 32, 32]
+    - [0, 85.4755]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 32]
+    - [0, 519.579]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1201
+- gfx1201
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 64]
+    - [1, 1.15349]
+  - - [128, 64, 1, 32, 128, 128, 128, 64]
+    - [2, 2.30698]
+  - - [192, 64, 1, 32, 192, 192, 192, 64]
+    - [3, 3.45378]
+  - - [256, 64, 1, 32, 256, 256, 256, 64]
+    - [1, 4.61519]
+  - - [320, 64, 1, 32, 320, 320, 320, 64]
+    - [1, 5.7695]
+  - - [384, 64, 1, 32, 384, 384, 384, 64]
+    - [1, 6.93928]
+  - - [448, 64, 1, 32, 448, 448, 448, 64]
+    - [3, 8.07161]
+  - - [512, 64, 1, 32, 512, 512, 512, 64]
+    - [1, 9.23197]
+  - - [576, 64, 1, 32, 576, 576, 576, 64]
+    - [0, 26.473]
+  - - [640, 64, 1, 32, 640, 640, 640, 64]
+    - [3, 11.5263]
+  - - [704, 64, 1, 32, 704, 704, 704, 64]
+    - [3, 12.6861]
+  - - [768, 64, 1, 32, 768, 768, 768, 64]
+    - [3, 13.8206]
+  - - [832, 64, 1, 32, 832, 832, 832, 64]
+    - [1, 14.9244]
+  - - [896, 64, 1, 32, 896, 896, 896, 64]
+    - [2, 16.0613]
+  - - [960, 64, 1, 32, 960, 960, 960, 64]
+    - [3, 17.1941]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 64]
+    - [1, 156.972]
+  - - [64, 128, 1, 32, 64, 64, 64, 128]
+    - [2, 28.9982]
+  - - [128, 128, 1, 32, 128, 128, 128, 128]
+    - [3, 49.9322]
+  - - [192, 128, 1, 32, 192, 192, 192, 128]
+    - [3, 75.0412]
+  - - [256, 128, 1, 32, 256, 256, 256, 128]
+    - [3, 87.9678]
+  - - [320, 128, 1, 32, 320, 320, 320, 128]
+    - [0, 11.4678]
+  - - [384, 128, 1, 32, 384, 384, 384, 128]
+    - [2, 13.7349]
+  - - [448, 128, 1, 32, 448, 448, 448, 128]
+    - [0, 16.0824]
+  - - [512, 128, 1, 32, 512, 512, 512, 128]
+    - [0, 18.2957]
+  - - [576, 128, 1, 32, 576, 576, 576, 128]
+    - [3, 171.71]
+  - - [640, 128, 1, 32, 640, 640, 640, 128]
+    - [3, 41.8958]
+  - - [704, 128, 1, 32, 704, 704, 704, 128]
+    - [3, 184.137]
+  - - [768, 128, 1, 32, 768, 768, 768, 128]
+    - [2, 9.67241]
+  - - [832, 128, 1, 32, 832, 832, 832, 128]
+    - [2, 10.4909]
+  - - [896, 128, 1, 32, 896, 896, 896, 128]
+    - [3, 11.1885]
+  - - [960, 128, 1, 32, 960, 960, 960, 128]
+    - [1, 11.9394]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 128]
+    - [3, 221.452]
+  - - [64, 192, 1, 32, 64, 64, 64, 192]
+    - [3, 37.4474]
+  - - [128, 192, 1, 32, 128, 128, 128, 192]
+    - [2, 77.4047]
+  - - [192, 192, 1, 32, 192, 192, 192, 192]
+    - [3, 98.304]
+  - - [256, 192, 1, 32, 256, 256, 256, 192]
+    - [3, 5.21919]
+  - - [320, 192, 1, 32, 320, 320, 320, 192]
+    - [1, 6.03876]
+  - - [384, 192, 1, 32, 384, 384, 384, 192]
+    - [1, 7.71751]
+  - - [448, 192, 1, 32, 448, 448, 448, 192]
+    - [2, 9.04163]
+  - - [512, 192, 1, 32, 512, 512, 512, 192]
+    - [1, 10.2895]
+  - - [576, 192, 1, 32, 576, 576, 576, 192]
+    - [1, 11.56]
+  - - [640, 192, 1, 32, 640, 640, 640, 192]
+    - [2, 12.9306]
+  - - [704, 192, 1, 32, 704, 704, 704, 192]
+    - [3, 14.0882]
+  - - [768, 192, 1, 32, 768, 768, 768, 192]
+    - [1, 15.4489]
+  - - [832, 192, 1, 32, 832, 832, 832, 192]
+    - [1, 16.6423]
+  - - [896, 192, 1, 32, 896, 896, 896, 192]
+    - [1, 17.955]
+  - - [960, 192, 1, 32, 960, 960, 960, 192]
+    - [3, 19.4074]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 192]
+    - [2, 20.6185]
+  - - [64, 256, 1, 32, 64, 64, 64, 256]
+    - [3, 1.74497]
+  - - [128, 256, 1, 32, 128, 128, 128, 256]
+    - [3, 3.48907]
+  - - [192, 256, 1, 32, 192, 192, 192, 256]
+    - [2, 5.19085]
+  - - [256, 256, 1, 32, 256, 256, 256, 256]
+    - [1, 6.85968]
+  - - [320, 256, 1, 32, 320, 320, 320, 256]
+    - [1, 8.58146]
+  - - [384, 256, 1, 32, 384, 384, 384, 256]
+    - [2, 10.2789]
+  - - [448, 256, 1, 32, 448, 448, 448, 256]
+    - [1, 12.0221]
+  - - [512, 256, 1, 32, 512, 512, 512, 256]
+    - [2, 13.7992]
+  - - [576, 256, 1, 32, 576, 576, 576, 256]
+    - [2, 15.4454]
+  - - [640, 256, 1, 32, 640, 640, 640, 256]
+    - [2, 17.294]
+  - - [704, 256, 1, 32, 704, 704, 704, 256]
+    - [3, 243.546]
+  - - [768, 256, 1, 32, 768, 768, 768, 256]
+    - [1, 267.488]
+  - - [832, 256, 1, 32, 832, 832, 832, 256]
+    - [2, 22.3451]
+  - - [896, 256, 1, 32, 896, 896, 896, 256]
+    - [3, 23.9841]
+  - - [960, 256, 1, 32, 960, 960, 960, 256]
+    - [3, 25.715]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 256]
+    - [2, 22.0262]
+  - - [64, 320, 1, 32, 64, 64, 64, 320]
+    - [1, 2.18056]
+  - - [128, 320, 1, 32, 128, 128, 128, 320]
+    - [3, 4.34212]
+  - - [192, 320, 1, 32, 192, 192, 192, 320]
+    - [2, 6.47766]
+  - - [256, 320, 1, 32, 256, 256, 256, 320]
+    - [3, 8.64858]
+  - - [320, 320, 1, 32, 320, 320, 320, 320]
+    - [1, 10.7349]
+  - - [384, 320, 1, 32, 384, 384, 384, 320]
+    - [2, 12.5973]
+  - - [448, 320, 1, 32, 448, 448, 448, 320]
+    - [2, 15.1357]
+  - - [512, 320, 1, 32, 512, 512, 512, 320]
+    - [3, 252.547]
+  - - [576, 320, 1, 32, 576, 576, 576, 320]
+    - [1, 248.661]
+  - - [640, 320, 1, 32, 640, 640, 640, 320]
+    - [1, 21.5383]
+  - - [704, 320, 1, 32, 704, 704, 704, 320]
+    - [2, 23.9253]
+  - - [768, 320, 1, 32, 768, 768, 768, 320]
+    - [1, 25.7457]
+  - - [832, 320, 1, 32, 832, 832, 832, 320]
+    - [3, 28.0186]
+  - - [896, 320, 1, 32, 896, 896, 896, 320]
+    - [1, 29.7589]
+  - - [960, 320, 1, 32, 960, 960, 960, 320]
+    - [3, 31.8639]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 320]
+    - [3, 33.5333]
+  - - [64, 384, 1, 32, 64, 64, 64, 384]
+    - [3, 2.61959]
+  - - [128, 384, 1, 32, 128, 128, 128, 384]
+    - [2, 5.19532]
+  - - [192, 384, 1, 32, 192, 192, 192, 384]
+    - [1, 7.73864]
+  - - [256, 384, 1, 32, 256, 256, 256, 384]
+    - [2, 10.3442]
+  - - [320, 384, 1, 32, 320, 320, 320, 384]
+    - [3, 13.0091]
+  - - [384, 384, 1, 32, 384, 384, 384, 384]
+    - [2, 15.506]
+  - - [448, 384, 1, 32, 448, 448, 448, 384]
+    - [3, 18.2215]
+  - - [512, 384, 1, 32, 512, 512, 512, 384]
+    - [3, 20.7071]
+  - - [576, 384, 1, 32, 576, 576, 576, 384]
+    - [2, 23.2403]
+  - - [640, 384, 1, 32, 640, 640, 640, 384]
+    - [1, 25.7196]
+  - - [704, 384, 1, 32, 704, 704, 704, 384]
+    - [3, 28.3867]
+  - - [768, 384, 1, 32, 768, 768, 768, 384]
+    - [3, 30.7539]
+  - - [832, 384, 1, 32, 832, 832, 832, 384]
+    - [3, 32.7878]
+  - - [896, 384, 1, 32, 896, 896, 896, 384]
+    - [2, 35.4019]
+  - - [960, 384, 1, 32, 960, 960, 960, 384]
+    - [1, 317.618]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 384]
+    - [3, 39.8052]
+  - - [64, 448, 1, 32, 64, 64, 64, 448]
+    - [3, 3.04604]
+  - - [128, 448, 1, 32, 128, 128, 128, 448]
+    - [1, 6.00949]
+  - - [192, 448, 1, 32, 192, 192, 192, 448]
+    - [3, 9.07966]
+  - - [256, 448, 1, 32, 256, 256, 256, 448]
+    - [1, 11.9952]
+  - - [320, 448, 1, 32, 320, 320, 320, 448]
+    - [2, 15.0959]
+  - - [384, 448, 1, 32, 384, 384, 384, 448]
+    - [3, 18.0005]
+  - - [448, 448, 1, 32, 448, 448, 448, 448]
+    - [3, 21.2546]
+  - - [512, 448, 1, 32, 512, 512, 512, 448]
+    - [2, 23.9822]
+  - - [576, 448, 1, 32, 576, 576, 576, 448]
+    - [2, 27.2094]
+  - - [640, 448, 1, 32, 640, 640, 640, 448]
+    - [2, 30.0287]
+  - - [704, 448, 1, 32, 704, 704, 704, 448]
+    - [1, 307.512]
+  - - [768, 448, 1, 32, 768, 768, 768, 448]
+    - [3, 29.7306]
+  - - [832, 448, 1, 32, 832, 832, 832, 448]
+    - [0, 34.5814]
+  - - [896, 448, 1, 32, 896, 896, 896, 448]
+    - [2, 40.7985]
+  - - [960, 448, 1, 32, 960, 960, 960, 448]
+    - [2, 39.8658]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 448]
+    - [2, 42.8819]
+  - - [64, 512, 1, 32, 64, 64, 64, 512]
+    - [1, 3.44874]
+  - - [128, 512, 1, 32, 128, 128, 128, 512]
+    - [2, 6.86934]
+  - - [192, 512, 1, 32, 192, 192, 192, 512]
+    - [3, 10.369]
+  - - [256, 512, 1, 32, 256, 256, 256, 512]
+    - [1, 13.5592]
+  - - [320, 512, 1, 32, 320, 320, 320, 512]
+    - [3, 17.1914]
+  - - [384, 512, 1, 32, 384, 384, 384, 512]
+    - [2, 20.7593]
+  - - [448, 512, 1, 32, 448, 448, 448, 512]
+    - [2, 24.1348]
+  - - [512, 512, 1, 32, 512, 512, 512, 512]
+    - [2, 27.674]
+  - - [576, 512, 1, 32, 576, 576, 576, 512]
+    - [3, 27.5609]
+  - - [640, 512, 1, 32, 640, 640, 640, 512]
+    - [1, 30.388]
+  - - [704, 512, 1, 32, 704, 704, 704, 512]
+    - [3, 36.7949]
+  - - [768, 512, 1, 32, 768, 768, 768, 512]
+    - [3, 39.2313]
+  - - [832, 512, 1, 32, 832, 832, 832, 512]
+    - [2, 39.7191]
+  - - [896, 512, 1, 32, 896, 896, 896, 512]
+    - [1, 332.877]
+  - - [960, 512, 1, 32, 960, 960, 960, 512]
+    - [1, 316.344]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 512]
+    - [0, 48.3693]
+  - - [64, 576, 1, 32, 64, 64, 64, 576]
+    - [3, 3.86628]
+  - - [128, 576, 1, 32, 128, 128, 128, 576]
+    - [3, 169.246]
+  - - [192, 576, 1, 32, 192, 192, 192, 576]
+    - [1, 11.5076]
+  - - [256, 576, 1, 32, 256, 256, 256, 576]
+    - [3, 240.984]
+  - - [320, 576, 1, 32, 320, 320, 320, 576]
+    - [1, 19.296]
+  - - [384, 576, 1, 32, 384, 384, 384, 576]
+    - [2, 23.1318]
+  - - [448, 576, 1, 32, 448, 448, 448, 576]
+    - [1, 26.9123]
+  - - [512, 576, 1, 32, 512, 512, 512, 576]
+    - [2, 30.8021]
+  - - [576, 576, 1, 32, 576, 576, 576, 576]
+    - [2, 272.506]
+  - - [640, 576, 1, 32, 640, 640, 640, 576]
+    - [3, 122.23]
+  - - [704, 576, 1, 32, 704, 704, 704, 576]
+    - [2, 41.1188]
+  - - [768, 576, 1, 32, 768, 768, 768, 576]
+    - [2, 39.9551]
+  - - [832, 576, 1, 32, 832, 832, 832, 576]
+    - [3, 47.4793]
+  - - [896, 576, 1, 32, 896, 896, 896, 576]
+    - [1, 46.8264]
+  - - [960, 576, 1, 32, 960, 960, 960, 576]
+    - [3, 52.0216]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 576]
+    - [0, 53.3314]
+  - - [64, 640, 1, 32, 64, 64, 64, 640]
+    - [2, 4.331]
+  - - [128, 640, 1, 32, 128, 128, 128, 640]
+    - [1, 8.52829]
+  - - [192, 640, 1, 32, 192, 192, 192, 640]
+    - [2, 12.8344]
+  - - [256, 640, 1, 32, 256, 256, 256, 640]
+    - [2, 17.1025]
+  - - [320, 640, 1, 32, 320, 320, 320, 640]
+    - [3, 21.6428]
+  - - [384, 640, 1, 32, 384, 384, 384, 640]
+    - [3, 25.6713]
+  - - [448, 640, 1, 32, 448, 448, 448, 640]
+    - [3, 29.9567]
+  - - [512, 640, 1, 32, 512, 512, 512, 640]
+    - [1, 33.6966]
+  - - [576, 640, 1, 32, 576, 576, 576, 640]
+    - [3, 34.7046]
+  - - [640, 640, 1, 32, 640, 640, 640, 640]
+    - [3, 38.7075]
+  - - [704, 640, 1, 32, 704, 704, 704, 640]
+    - [2, 41.7002]
+  - - [768, 640, 1, 32, 768, 768, 768, 640]
+    - [3, 268.407]
+  - - [832, 640, 1, 32, 832, 832, 832, 640]
+    - [0, 47.4228]
+  - - [896, 640, 1, 32, 896, 896, 896, 640]
+    - [3, 53.5508]
+  - - [960, 640, 1, 32, 960, 960, 960, 640]
+    - [3, 57.2031]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 640]
+    - [3, 61.6009]
+  - - [64, 704, 1, 32, 64, 64, 64, 704]
+    - [3, 4.74723]
+  - - [128, 704, 1, 32, 128, 128, 128, 704]
+    - [2, 9.33162]
+  - - [192, 704, 1, 32, 192, 192, 192, 704]
+    - [3, 14.165]
+  - - [256, 704, 1, 32, 256, 256, 256, 704]
+    - [3, 18.904]
+  - - [320, 704, 1, 32, 320, 320, 320, 704]
+    - [2, 23.5144]
+  - - [384, 704, 1, 32, 384, 384, 384, 704]
+    - [3, 249.301]
+  - - [448, 704, 1, 32, 448, 448, 448, 704]
+    - [1, 304.727]
+  - - [512, 704, 1, 32, 512, 512, 512, 704]
+    - [2, 33.8328]
+  - - [576, 704, 1, 32, 576, 576, 576, 704]
+    - [3, 37.3401]
+  - - [640, 704, 1, 32, 640, 640, 640, 704]
+    - [2, 41.8036]
+  - - [704, 704, 1, 32, 704, 704, 704, 704]
+    - [1, 45.7716]
+  - - [768, 704, 1, 32, 768, 768, 768, 704]
+    - [2, 50.4436]
+  - - [832, 704, 1, 32, 832, 832, 832, 704]
+    - [3, 53.7131]
+  - - [896, 704, 1, 32, 896, 896, 896, 704]
+    - [1, 56.0678]
+  - - [960, 704, 1, 32, 960, 960, 960, 704]
+    - [2, 307.985]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 704]
+    - [2, 67.1612]
+  - - [64, 768, 1, 32, 64, 64, 64, 768]
+    - [3, 5.19884]
+  - - [128, 768, 1, 32, 128, 128, 128, 768]
+    - [2, 10.2936]
+  - - [192, 768, 1, 32, 192, 192, 192, 768]
+    - [2, 15.3667]
+  - - [256, 768, 1, 32, 256, 256, 256, 768]
+    - [3, 20.6856]
+  - - [320, 768, 1, 32, 320, 320, 320, 768]
+    - [2, 25.3605]
+  - - [384, 768, 1, 32, 384, 384, 384, 768]
+    - [3, 30.9622]
+  - - [448, 768, 1, 32, 448, 448, 448, 768]
+    - [2, 35.5596]
+  - - [512, 768, 1, 32, 512, 512, 512, 768]
+    - [3, 253.685]
+  - - [576, 768, 1, 32, 576, 576, 576, 768]
+    - [1, 319.252]
+  - - [640, 768, 1, 32, 640, 640, 640, 768]
+    - [1, 241.292]
+  - - [704, 768, 1, 32, 704, 704, 704, 768]
+    - [1, 300.788]
+  - - [768, 768, 1, 32, 768, 768, 768, 768]
+    - [1, 313.942]
+  - - [832, 768, 1, 32, 832, 832, 832, 768]
+    - [2, 307.385]
+  - - [896, 768, 1, 32, 896, 896, 896, 768]
+    - [3, 304.819]
+  - - [960, 768, 1, 32, 960, 960, 960, 768]
+    - [1, 353.821]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 768]
+    - [1, 358.792]
+  - - [64, 832, 1, 32, 64, 64, 64, 832]
+    - [3, 87.2025]
+  - - [128, 832, 1, 32, 128, 128, 128, 832]
+    - [3, 61.0068]
+  - - [192, 832, 1, 32, 192, 192, 192, 832]
+    - [2, 88.1567]
+  - - [256, 832, 1, 32, 256, 256, 256, 832]
+    - [3, 121.006]
+  - - [320, 832, 1, 32, 320, 320, 320, 832]
+    - [3, 145.996]
+  - - [384, 832, 1, 32, 384, 384, 384, 832]
+    - [1, 159.358]
+  - - [448, 832, 1, 32, 448, 448, 448, 832]
+    - [2, 196.644]
+  - - [512, 832, 1, 32, 512, 512, 512, 832]
+    - [3, 39.8819]
+  - - [576, 832, 1, 32, 576, 576, 576, 832]
+    - [0, 44.024]
+  - - [640, 832, 1, 32, 640, 640, 640, 832]
+    - [3, 49.7875]
+  - - [704, 832, 1, 32, 704, 704, 704, 832]
+    - [2, 54.7966]
+  - - [768, 832, 1, 32, 768, 768, 768, 832]
+    - [3, 59.57]
+  - - [832, 832, 1, 32, 832, 832, 832, 832]
+    - [2, 64.4347]
+  - - [896, 832, 1, 32, 896, 896, 896, 832]
+    - [3, 62.0957]
+  - - [960, 832, 1, 32, 960, 960, 960, 832]
+    - [3, 73.2347]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 832]
+    - [1, 76.9799]
+  - - [64, 896, 1, 32, 64, 64, 64, 896]
+    - [1, 6.00575]
+  - - [128, 896, 1, 32, 128, 128, 128, 896]
+    - [2, 11.8982]
+  - - [192, 896, 1, 32, 192, 192, 192, 896]
+    - [3, 17.0944]
+  - - [256, 896, 1, 32, 256, 256, 256, 896]
+    - [2, 146.566]
+  - - [320, 896, 1, 32, 320, 320, 320, 896]
+    - [2, 170.017]
+  - - [384, 896, 1, 32, 384, 384, 384, 896]
+    - [1, 316.017]
+  - - [448, 896, 1, 32, 448, 448, 448, 896]
+    - [2, 221.179]
+  - - [512, 896, 1, 32, 512, 512, 512, 896]
+    - [3, 277.503]
+  - - [576, 896, 1, 32, 576, 576, 576, 896]
+    - [1, 306.855]
+  - - [640, 896, 1, 32, 640, 640, 640, 896]
+    - [1, 345.316]
+  - - [704, 896, 1, 32, 704, 704, 704, 896]
+    - [1, 354.619]
+  - - [768, 896, 1, 32, 768, 768, 768, 896]
+    - [2, 307.715]
+  - - [832, 896, 1, 32, 832, 832, 832, 896]
+    - [3, 314.626]
+  - - [896, 896, 1, 32, 896, 896, 896, 896]
+    - [3, 321.929]
+  - - [960, 896, 1, 32, 960, 960, 960, 896]
+    - [3, 308.716]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 896]
+    - [2, 320.174]
+  - - [64, 960, 1, 32, 64, 64, 64, 960]
+    - [2, 65.8874]
+  - - [128, 960, 1, 32, 128, 128, 128, 960]
+    - [1, 78.462]
+  - - [192, 960, 1, 32, 192, 192, 192, 960]
+    - [2, 113.755]
+  - - [256, 960, 1, 32, 256, 256, 256, 960]
+    - [1, 152.986]
+  - - [320, 960, 1, 32, 320, 320, 320, 960]
+    - [3, 189.192]
+  - - [384, 960, 1, 32, 384, 384, 384, 960]
+    - [2, 228.769]
+  - - [448, 960, 1, 32, 448, 448, 448, 960]
+    - [3, 286.598]
+  - - [512, 960, 1, 32, 512, 512, 512, 960]
+    - [2, 278.088]
+  - - [576, 960, 1, 32, 576, 576, 576, 960]
+    - [1, 321.953]
+  - - [640, 960, 1, 32, 640, 640, 640, 960]
+    - [2, 304.064]
+  - - [704, 960, 1, 32, 704, 704, 704, 960]
+    - [2, 311.268]
+  - - [768, 960, 1, 32, 768, 768, 768, 960]
+    - [2, 312.572]
+  - - [832, 960, 1, 32, 832, 832, 832, 960]
+    - [3, 296.232]
+  - - [896, 960, 1, 32, 896, 896, 896, 960]
+    - [2, 319.019]
+  - - [960, 960, 1, 32, 960, 960, 960, 960]
+    - [3, 320.415]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 960]
+    - [3, 85.4244]
+  - - [64, 1024, 1, 32, 64, 64, 64, 1024]
+    - [1, 6.77317]
+  - - [128, 1024, 1, 32, 128, 128, 128, 1024]
+    - [2, 13.688]
+  - - [192, 1024, 1, 32, 192, 192, 192, 1024]
+    - [2, 20.3846]
+  - - [256, 1024, 1, 32, 256, 256, 256, 1024]
+    - [2, 27.202]
+  - - [320, 1024, 1, 32, 320, 320, 320, 1024]
+    - [2, 33.9201]
+  - - [384, 1024, 1, 32, 384, 384, 384, 1024]
+    - [3, 39.4082]
+  - - [448, 1024, 1, 32, 448, 448, 448, 1024]
+    - [1, 36.7013]
+  - - [512, 1024, 1, 32, 512, 512, 512, 1024]
+    - [2, 292.896]
+  - - [576, 1024, 1, 32, 576, 576, 576, 1024]
+    - [2, 55.0864]
+  - - [640, 1024, 1, 32, 640, 640, 640, 1024]
+    - [2, 61.8052]
+  - - [704, 1024, 1, 32, 704, 704, 704, 1024]
+    - [2, 66.8208]
+  - - [768, 1024, 1, 32, 768, 768, 768, 1024]
+    - [1, 71.9595]
+  - - [832, 1024, 1, 32, 832, 832, 832, 1024]
+    - [2, 76.7081]
+  - - [896, 1024, 1, 32, 896, 896, 896, 1024]
+    - [2, 81.1912]
+  - - [960, 1024, 1, 32, 960, 960, 960, 1024]
+    - [1, 88.5319]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 1024]
+    - [2, 90.0024]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1201
+- gfx1201
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 32]
+    - [2, 1.15233]
+  - - [128, 64, 1, 32, 128, 128, 128, 32]
+    - [2, 2.30557]
+  - - [192, 64, 1, 32, 192, 192, 192, 32]
+    - [2, 3.45926]
+  - - [256, 64, 1, 32, 256, 256, 256, 32]
+    - [2, 4.61702]
+  - - [320, 64, 1, 32, 320, 320, 320, 32]
+    - [2, 5.75784]
+  - - [384, 64, 1, 32, 384, 384, 384, 32]
+    - [3, 73.7741]
+  - - [448, 64, 1, 32, 448, 448, 448, 32]
+    - [2, 86.557]
+  - - [512, 64, 1, 32, 512, 512, 512, 32]
+    - [2, 97.4513]
+  - - [576, 64, 1, 32, 576, 576, 576, 32]
+    - [2, 107.241]
+  - - [640, 64, 1, 32, 640, 640, 640, 32]
+    - [0, 11.4934]
+  - - [704, 64, 1, 32, 704, 704, 704, 32]
+    - [3, 12.5832]
+  - - [768, 64, 1, 32, 768, 768, 768, 32]
+    - [1, 129.56]
+  - - [832, 64, 1, 32, 832, 832, 832, 32]
+    - [0, 14.8445]
+  - - [896, 64, 1, 32, 896, 896, 896, 32]
+    - [2, 16.0774]
+  - - [960, 64, 1, 32, 960, 960, 960, 32]
+    - [3, 17.2047]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 18.3397]
+  - - [64, 128, 1, 32, 64, 64, 64, 32]
+    - [2, 2.29779]
+  - - [128, 128, 1, 32, 128, 128, 128, 32]
+    - [1, 49.1827]
+  - - [192, 128, 1, 32, 192, 192, 192, 32]
+    - [2, 6.90061]
+  - - [256, 128, 1, 32, 256, 256, 256, 32]
+    - [3, 9.25727]
+  - - [320, 128, 1, 32, 320, 320, 320, 32]
+    - [1, 11.4929]
+  - - [384, 128, 1, 32, 384, 384, 384, 32]
+    - [3, 13.7801]
+  - - [448, 128, 1, 32, 448, 448, 448, 32]
+    - [2, 16.0311]
+  - - [512, 128, 1, 32, 512, 512, 512, 32]
+    - [0, 18.3654]
+  - - [576, 128, 1, 32, 576, 576, 576, 32]
+    - [1, 20.671]
+  - - [640, 128, 1, 32, 640, 640, 640, 32]
+    - [3, 22.9547]
+  - - [704, 128, 1, 32, 704, 704, 704, 32]
+    - [2, 25.2049]
+  - - [768, 128, 1, 32, 768, 768, 768, 32]
+    - [3, 191.34]
+  - - [832, 128, 1, 32, 832, 832, 832, 32]
+    - [1, 194.291]
+  - - [896, 128, 1, 32, 896, 896, 896, 32]
+    - [3, 32.0944]
+  - - [960, 128, 1, 32, 960, 960, 960, 32]
+    - [1, 34.426]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 36.7083]
+  - - [64, 192, 1, 32, 64, 64, 64, 32]
+    - [0, 3.43462]
+  - - [128, 192, 1, 32, 128, 128, 128, 32]
+    - [0, 6.89094]
+  - - [192, 192, 1, 32, 192, 192, 192, 32]
+    - [3, 10.3477]
+  - - [256, 192, 1, 32, 256, 256, 256, 32]
+    - [0, 13.7716]
+  - - [320, 192, 1, 32, 320, 320, 320, 32]
+    - [1, 17.2334]
+  - - [384, 192, 1, 32, 384, 384, 384, 32]
+    - [1, 20.7037]
+  - - [448, 192, 1, 32, 448, 448, 448, 32]
+    - [1, 176.217]
+  - - [512, 192, 1, 32, 512, 512, 512, 32]
+    - [2, 27.5457]
+  - - [576, 192, 1, 32, 576, 576, 576, 32]
+    - [2, 30.9428]
+  - - [640, 192, 1, 32, 640, 640, 640, 32]
+    - [1, 34.4411]
+  - - [704, 192, 1, 32, 704, 704, 704, 32]
+    - [1, 37.5628]
+  - - [768, 192, 1, 32, 768, 768, 768, 32]
+    - [3, 41.3149]
+  - - [832, 192, 1, 32, 832, 832, 832, 32]
+    - [1, 44.7695]
+  - - [896, 192, 1, 32, 896, 896, 896, 32]
+    - [1, 48.1164]
+  - - [960, 192, 1, 32, 960, 960, 960, 32]
+    - [3, 51.5691]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 55.0576]
+  - - [64, 256, 1, 32, 64, 64, 64, 32]
+    - [3, 4.62759]
+  - - [128, 256, 1, 32, 128, 128, 128, 32]
+    - [1, 9.19316]
+  - - [192, 256, 1, 32, 192, 192, 192, 32]
+    - [3, 13.7734]
+  - - [256, 256, 1, 32, 256, 256, 256, 32]
+    - [0, 18.3645]
+  - - [320, 256, 1, 32, 320, 320, 320, 32]
+    - [1, 22.9336]
+  - - [384, 256, 1, 32, 384, 384, 384, 32]
+    - [1, 27.5204]
+  - - [448, 256, 1, 32, 448, 448, 448, 32]
+    - [3, 32.1352]
+  - - [512, 256, 1, 32, 512, 512, 512, 32]
+    - [0, 36.7067]
+  - - [576, 256, 1, 32, 576, 576, 576, 32]
+    - [0, 41.2282]
+  - - [640, 256, 1, 32, 640, 640, 640, 32]
+    - [2, 45.845]
+  - - [704, 256, 1, 32, 704, 704, 704, 32]
+    - [3, 50.4231]
+  - - [768, 256, 1, 32, 768, 768, 768, 32]
+    - [2, 54.9251]
+  - - [832, 256, 1, 32, 832, 832, 832, 32]
+    - [3, 59.4115]
+  - - [896, 256, 1, 32, 896, 896, 896, 32]
+    - [2, 64.1858]
+  - - [960, 256, 1, 32, 960, 960, 960, 32]
+    - [2, 254.016]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 32]
+    - [0, 254.969]
+  - - [64, 320, 1, 32, 64, 64, 64, 32]
+    - [3, 7.61467]
+  - - [128, 320, 1, 32, 128, 128, 128, 32]
+    - [2, 14.2299]
+  - - [192, 320, 1, 32, 192, 192, 192, 32]
+    - [3, 128.163]
+  - - [256, 320, 1, 32, 256, 256, 256, 32]
+    - [3, 56.1577]
+  - - [320, 320, 1, 32, 320, 320, 320, 32]
+    - [2, 77.3195]
+  - - [384, 320, 1, 32, 384, 384, 384, 32]
+    - [2, 94.9098]
+  - - [448, 320, 1, 32, 448, 448, 448, 32]
+    - [2, 106.13]
+  - - [512, 320, 1, 32, 512, 512, 512, 32]
+    - [1, 114.111]
+  - - [576, 320, 1, 32, 576, 576, 576, 32]
+    - [2, 136.423]
+  - - [640, 320, 1, 32, 640, 640, 640, 32]
+    - [1, 145.136]
+  - - [704, 320, 1, 32, 704, 704, 704, 32]
+    - [3, 178.043]
+  - - [768, 320, 1, 32, 768, 768, 768, 32]
+    - [3, 187.805]
+  - - [832, 320, 1, 32, 832, 832, 832, 32]
+    - [2, 201.408]
+  - - [896, 320, 1, 32, 896, 896, 896, 32]
+    - [2, 215.225]
+  - - [960, 320, 1, 32, 960, 960, 960, 32]
+    - [2, 234.057]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 208.317]
+  - - [64, 384, 1, 32, 64, 64, 64, 32]
+    - [3, 9.21145]
+  - - [128, 384, 1, 32, 128, 128, 128, 32]
+    - [1, 17.025]
+  - - [192, 384, 1, 32, 192, 192, 192, 32]
+    - [1, 7.75723]
+  - - [256, 384, 1, 32, 256, 256, 256, 32]
+    - [2, 10.3896]
+  - - [320, 384, 1, 32, 320, 320, 320, 32]
+    - [1, 223.666]
+  - - [384, 384, 1, 32, 384, 384, 384, 32]
+    - [2, 15.4626]
+  - - [448, 384, 1, 32, 448, 448, 448, 32]
+    - [2, 18.1659]
+  - - [512, 384, 1, 32, 512, 512, 512, 32]
+    - [2, 20.8546]
+  - - [576, 384, 1, 32, 576, 576, 576, 32]
+    - [1, 23.0688]
+  - - [640, 384, 1, 32, 640, 640, 640, 32]
+    - [3, 25.9462]
+  - - [704, 384, 1, 32, 704, 704, 704, 32]
+    - [3, 28.3835]
+  - - [768, 384, 1, 32, 768, 768, 768, 32]
+    - [2, 27.8558]
+  - - [832, 384, 1, 32, 832, 832, 832, 32]
+    - [3, 32.9007]
+  - - [896, 384, 1, 32, 896, 896, 896, 32]
+    - [1, 36.1089]
+  - - [960, 384, 1, 32, 960, 960, 960, 32]
+    - [1, 33.7818]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 36.0871]
+  - - [64, 448, 1, 32, 64, 64, 64, 32]
+    - [1, 3.07978]
+  - - [128, 448, 1, 32, 128, 128, 128, 32]
+    - [2, 136.533]
+  - - [192, 448, 1, 32, 192, 192, 192, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 256, 32]
+    - [1, 207.34]
+  - - [320, 448, 1, 32, 320, 320, 320, 32]
+    - [1, 234.296]
+  - - [384, 448, 1, 32, 384, 384, 384, 32]
+    - [3, 18.1899]
+  - - [448, 448, 1, 32, 448, 448, 448, 32]
+    - [2, 21.0968]
+  - - [512, 448, 1, 32, 512, 512, 512, 32]
+    - [3, 24.1189]
+  - - [576, 448, 1, 32, 576, 576, 576, 32]
+    - [3, 24.1095]
+  - - [640, 448, 1, 32, 640, 640, 640, 32]
+    - [2, 269.221]
+  - - [704, 448, 1, 32, 704, 704, 704, 32]
+    - [3, 204.303]
+  - - [768, 448, 1, 32, 768, 768, 768, 32]
+    - [3, 228.899]
+  - - [832, 448, 1, 32, 832, 832, 832, 32]
+    - [2, 248.18]
+  - - [896, 448, 1, 32, 896, 896, 896, 32]
+    - [3, 267.157]
+  - - [960, 448, 1, 32, 960, 960, 960, 32]
+    - [3, 278.144]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 291.966]
+  - - [64, 512, 1, 32, 64, 64, 64, 32]
+    - [3, 10.8942]
+  - - [128, 512, 1, 32, 128, 128, 128, 32]
+    - [2, 55.8645]
+  - - [192, 512, 1, 32, 192, 192, 192, 32]
+    - [2, 65.906]
+  - - [256, 512, 1, 32, 256, 256, 256, 32]
+    - [2, 86.2139]
+  - - [320, 512, 1, 32, 320, 320, 320, 32]
+    - [2, 106.66]
+  - - [384, 512, 1, 32, 384, 384, 384, 32]
+    - [1, 124.202]
+  - - [448, 512, 1, 32, 448, 448, 448, 32]
+    - [1, 139.478]
+  - - [512, 512, 1, 32, 512, 512, 512, 32]
+    - [3, 177.031]
+  - - [576, 512, 1, 32, 576, 576, 576, 32]
+    - [3, 194.86]
+  - - [640, 512, 1, 32, 640, 640, 640, 32]
+    - [3, 205.36]
+  - - [704, 512, 1, 32, 704, 704, 704, 32]
+    - [3, 266.013]
+  - - [768, 512, 1, 32, 768, 768, 768, 32]
+    - [3, 36.8442]
+  - - [832, 512, 1, 32, 832, 832, 832, 32]
+    - [2, 40.0112]
+  - - [896, 512, 1, 32, 896, 896, 896, 32]
+    - [3, 45.583]
+  - - [960, 512, 1, 32, 960, 960, 960, 32]
+    - [2, 45.1471]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 632.613]
+  - - [64, 576, 1, 32, 64, 64, 64, 32]
+    - [2, 12.9474]
+  - - [128, 576, 1, 32, 128, 128, 128, 32]
+    - [2, 50.4554]
+  - - [192, 576, 1, 32, 192, 192, 192, 32]
+    - [2, 84.8362]
+  - - [256, 576, 1, 32, 256, 256, 256, 32]
+    - [2, 111.643]
+  - - [320, 576, 1, 32, 320, 320, 320, 32]
+    - [1, 130.896]
+  - - [384, 576, 1, 32, 384, 384, 384, 32]
+    - [3, 61.5439]
+  - - [448, 576, 1, 32, 448, 448, 448, 32]
+    - [1, 71.8731]
+  - - [512, 576, 1, 32, 512, 512, 512, 32]
+    - [2, 81.845]
+  - - [576, 576, 1, 32, 576, 576, 576, 32]
+    - [3, 93.0358]
+  - - [640, 576, 1, 32, 640, 640, 640, 32]
+    - [1, 103.328]
+  - - [704, 576, 1, 32, 704, 704, 704, 32]
+    - [3, 113.566]
+  - - [768, 576, 1, 32, 768, 768, 768, 32]
+    - [2, 123.809]
+  - - [832, 576, 1, 32, 832, 832, 832, 32]
+    - [2, 135.286]
+  - - [896, 576, 1, 32, 896, 896, 896, 32]
+    - [0, 144.16]
+  - - [960, 576, 1, 32, 960, 960, 960, 32]
+    - [0, 154.289]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 55.2663]
+  - - [64, 640, 1, 32, 64, 64, 64, 32]
+    - [3, 4.32657]
+  - - [128, 640, 1, 32, 128, 128, 128, 32]
+    - [3, 8.54722]
+  - - [192, 640, 1, 32, 192, 192, 192, 32]
+    - [3, 210.501]
+  - - [256, 640, 1, 32, 256, 256, 256, 32]
+    - [1, 248.478]
+  - - [320, 640, 1, 32, 320, 320, 320, 32]
+    - [1, 20.9872]
+  - - [384, 640, 1, 32, 384, 384, 384, 32]
+    - [3, 25.903]
+  - - [448, 640, 1, 32, 448, 448, 448, 32]
+    - [1, 26.54]
+  - - [512, 640, 1, 32, 512, 512, 512, 32]
+    - [3, 33.82]
+  - - [576, 640, 1, 32, 576, 576, 576, 32]
+    - [1, 37.43]
+  - - [640, 640, 1, 32, 640, 640, 640, 32]
+    - [3, 34.0321]
+  - - [704, 640, 1, 32, 704, 704, 704, 32]
+    - [2, 45.0431]
+  - - [768, 640, 1, 32, 768, 768, 768, 32]
+    - [3, 45.9295]
+  - - [832, 640, 1, 32, 832, 832, 832, 32]
+    - [3, 276.88]
+  - - [896, 640, 1, 32, 896, 896, 896, 32]
+    - [2, 53.7209]
+  - - [960, 640, 1, 32, 960, 960, 960, 32]
+    - [2, 57.1025]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 59.7382]
+  - - [64, 704, 1, 32, 64, 64, 64, 32]
+    - [3, 4.74053]
+  - - [128, 704, 1, 32, 128, 128, 128, 32]
+    - [2, 9.37091]
+  - - [192, 704, 1, 32, 192, 192, 192, 32]
+    - [2, 14.1319]
+  - - [256, 704, 1, 32, 256, 256, 256, 32]
+    - [2, 19.5838]
+  - - [320, 704, 1, 32, 320, 320, 320, 32]
+    - [3, 23.6964]
+  - - [384, 704, 1, 32, 384, 384, 384, 32]
+    - [3, 27.7649]
+  - - [448, 704, 1, 32, 448, 448, 448, 32]
+    - [2, 32.7588]
+  - - [512, 704, 1, 32, 512, 512, 512, 32]
+    - [2, 33.4895]
+  - - [576, 704, 1, 32, 576, 576, 576, 32]
+    - [2, 37.6538]
+  - - [640, 704, 1, 32, 640, 640, 640, 32]
+    - [0, 36.5703]
+  - - [704, 704, 1, 32, 704, 704, 704, 32]
+    - [3, 46.5967]
+  - - [768, 704, 1, 32, 768, 768, 768, 32]
+    - [1, 49.955]
+  - - [832, 704, 1, 32, 832, 832, 832, 32]
+    - [2, 54.7614]
+  - - [896, 704, 1, 32, 896, 896, 896, 32]
+    - [2, 58.6893]
+  - - [960, 704, 1, 32, 960, 960, 960, 32]
+    - [1, 53.1547]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 66.2851]
+  - - [64, 768, 1, 32, 64, 64, 64, 32]
+    - [3, 5.20244]
+  - - [128, 768, 1, 32, 128, 128, 128, 32]
+    - [2, 10.3143]
+  - - [192, 768, 1, 32, 192, 192, 192, 32]
+    - [3, 15.5431]
+  - - [256, 768, 1, 32, 256, 256, 256, 32]
+    - [3, 20.7303]
+  - - [320, 768, 1, 32, 320, 320, 320, 32]
+    - [3, 25.6257]
+  - - [384, 768, 1, 32, 384, 384, 384, 32]
+    - [3, 30.8031]
+  - - [448, 768, 1, 32, 448, 448, 448, 32]
+    - [2, 32.4291]
+  - - [512, 768, 1, 32, 512, 512, 512, 32]
+    - [3, 39.7506]
+  - - [576, 768, 1, 32, 576, 576, 576, 32]
+    - [2, 41.4418]
+  - - [640, 768, 1, 32, 640, 640, 640, 32]
+    - [2, 295.426]
+  - - [704, 768, 1, 32, 704, 704, 704, 32]
+    - [2, 50.5342]
+  - - [768, 768, 1, 32, 768, 768, 768, 32]
+    - [2, 54.939]
+  - - [832, 768, 1, 32, 832, 832, 832, 32]
+    - [3, 58.1719]
+  - - [896, 768, 1, 32, 896, 896, 896, 32]
+    - [1, 63.765]
+  - - [960, 768, 1, 32, 960, 960, 960, 32]
+    - [2, 68.1401]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 70.5119]
+  - - [64, 832, 1, 32, 64, 64, 64, 32]
+    - [2, 131.274]
+  - - [128, 832, 1, 32, 128, 128, 128, 32]
+    - [1, 193.19]
+  - - [192, 832, 1, 32, 192, 192, 192, 32]
+    - [1, 242.72]
+  - - [256, 832, 1, 32, 256, 256, 256, 32]
+    - [1, 269.392]
+  - - [320, 832, 1, 32, 320, 320, 320, 32]
+    - [0, 72.9044]
+  - - [384, 832, 1, 32, 384, 384, 384, 32]
+    - [2, 29.7413]
+  - - [448, 832, 1, 32, 448, 448, 448, 32]
+    - [2, 37.9717]
+  - - [512, 832, 1, 32, 512, 512, 512, 32]
+    - [3, 42.7618]
+  - - [576, 832, 1, 32, 576, 576, 576, 32]
+    - [1, 36.6624]
+  - - [640, 832, 1, 32, 640, 640, 640, 32]
+    - [3, 49.675]
+  - - [704, 832, 1, 32, 704, 704, 704, 32]
+    - [2, 56.5567]
+  - - [768, 832, 1, 32, 768, 768, 768, 32]
+    - [3, 59.3651]
+  - - [832, 832, 1, 32, 832, 832, 832, 32]
+    - [3, 64.4816]
+  - - [896, 832, 1, 32, 896, 896, 896, 32]
+    - [2, 68.9171]
+  - - [960, 832, 1, 32, 960, 960, 960, 32]
+    - [1, 63.7849]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 79.2627]
+  - - [64, 896, 1, 32, 64, 64, 64, 32]
+    - [2, 6.0592]
+  - - [128, 896, 1, 32, 128, 128, 128, 32]
+    - [3, 12.0502]
+  - - [192, 896, 1, 32, 192, 192, 192, 32]
+    - [3, 249.774]
+  - - [256, 896, 1, 32, 256, 256, 256, 32]
+    - [2, 23.7929]
+  - - [320, 896, 1, 32, 320, 320, 320, 32]
+    - [2, 83.3031]
+  - - [384, 896, 1, 32, 384, 384, 384, 32]
+    - [3, 34.9013]
+  - - [448, 896, 1, 32, 448, 448, 448, 32]
+    - [1, 35.9602]
+  - - [512, 896, 1, 32, 512, 512, 512, 32]
+    - [1, 42.0896]
+  - - [576, 896, 1, 32, 576, 576, 576, 32]
+    - [3, 48.2746]
+  - - [640, 896, 1, 32, 640, 640, 640, 32]
+    - [1, 53.1706]
+  - - [704, 896, 1, 32, 704, 704, 704, 32]
+    - [2, 59.3754]
+  - - [768, 896, 1, 32, 768, 768, 768, 32]
+    - [3, 63.9902]
+  - - [832, 896, 1, 32, 832, 832, 832, 32]
+    - [0, 67.4584]
+  - - [896, 896, 1, 32, 896, 896, 896, 32]
+    - [2, 72.8681]
+  - - [960, 896, 1, 32, 960, 960, 960, 32]
+    - [1, 79.6003]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 82.539]
+  - - [64, 960, 1, 32, 64, 64, 64, 32]
+    - [1, 6.40329]
+  - - [128, 960, 1, 32, 128, 128, 128, 32]
+    - [2, 12.9321]
+  - - [192, 960, 1, 32, 192, 192, 192, 32]
+    - [2, 19.3689]
+  - - [256, 960, 1, 32, 256, 256, 256, 32]
+    - [1, 25.2785]
+  - - [320, 960, 1, 32, 320, 320, 320, 32]
+    - [1, 31.4692]
+  - - [384, 960, 1, 32, 384, 384, 384, 32]
+    - [2, 34.3398]
+  - - [448, 960, 1, 32, 448, 448, 448, 32]
+    - [2, 40.19]
+  - - [512, 960, 1, 32, 512, 512, 512, 32]
+    - [3, 45.686]
+  - - [576, 960, 1, 32, 576, 576, 576, 32]
+    - [3, 51.5217]
+  - - [640, 960, 1, 32, 640, 640, 640, 32]
+    - [2, 57.8128]
+  - - [704, 960, 1, 32, 704, 704, 704, 32]
+    - [0, 61.3229]
+  - - [768, 960, 1, 32, 768, 768, 768, 32]
+    - [0, 65.2042]
+  - - [832, 960, 1, 32, 832, 832, 832, 32]
+    - [2, 72.6756]
+  - - [896, 960, 1, 32, 896, 896, 896, 32]
+    - [1, 79.4669]
+  - - [960, 960, 1, 32, 960, 960, 960, 32]
+    - [2, 78.536]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 85.7013]
+  - - [64, 1024, 1, 32, 64, 64, 64, 32]
+    - [3, 6.90076]
+  - - [128, 1024, 1, 32, 128, 128, 128, 32]
+    - [3, 13.7965]
+  - - [192, 1024, 1, 32, 192, 192, 192, 32]
+    - [3, 20.4795]
+  - - [256, 1024, 1, 32, 256, 256, 256, 32]
+    - [3, 27.4706]
+  - - [320, 1024, 1, 32, 320, 320, 320, 32]
+    - [0, 29.5718]
+  - - [384, 1024, 1, 32, 384, 384, 384, 32]
+    - [2, 40.0721]
+  - - [448, 1024, 1, 32, 448, 448, 448, 32]
+    - [2, 42.8763]
+  - - [512, 1024, 1, 32, 512, 512, 512, 32]
+    - [3, 48.9415]
+  - - [576, 1024, 1, 32, 576, 576, 576, 32]
+    - [0, 53.6033]
+  - - [640, 1024, 1, 32, 640, 640, 640, 32]
+    - [1, 59.8688]
+  - - [704, 1024, 1, 32, 704, 704, 704, 32]
+    - [0, 64.5626]
+  - - [768, 1024, 1, 32, 768, 768, 768, 32]
+    - [2, 61.8968]
+  - - [832, 1024, 1, 32, 832, 832, 832, 32]
+    - [1, 78.4519]
+  - - [896, 1024, 1, 32, 896, 896, 896, 32]
+    - [2, 69.6129]
+  - - [960, 1024, 1, 32, 960, 960, 960, 32]
+    - [3, 85.3746]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 90.2469]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1201
+- gfx1201
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 64]
+    - [1, 1.15726]
+  - - [128, 64, 1, 32, 128, 128, 32, 64]
+    - [3, 2.31821]
+  - - [192, 64, 1, 32, 192, 192, 32, 64]
+    - [2, 3.47424]
+  - - [256, 64, 1, 32, 256, 256, 32, 64]
+    - [2, 4.63209]
+  - - [320, 64, 1, 32, 320, 320, 32, 64]
+    - [2, 5.79552]
+  - - [384, 64, 1, 32, 384, 384, 32, 64]
+    - [3, 6.95431]
+  - - [448, 64, 1, 32, 448, 448, 32, 64]
+    - [3, 76.2046]
+  - - [512, 64, 1, 32, 512, 512, 32, 64]
+    - [1, 9.2716]
+  - - [576, 64, 1, 32, 576, 576, 32, 64]
+    - [0, 102.578]
+  - - [640, 64, 1, 32, 640, 640, 32, 64]
+    - [3, 11.5757]
+  - - [704, 64, 1, 32, 704, 704, 32, 64]
+    - [2, 12.7349]
+  - - [768, 64, 1, 32, 768, 768, 32, 64]
+    - [2, 13.8773]
+  - - [832, 64, 1, 32, 832, 832, 32, 64]
+    - [2, 14.9677]
+  - - [896, 64, 1, 32, 896, 896, 32, 64]
+    - [0, 16.1127]
+  - - [960, 64, 1, 32, 960, 960, 32, 64]
+    - [3, 17.2894]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 64]
+    - [2, 18.451]
+  - - [64, 128, 1, 32, 64, 64, 32, 128]
+    - [3, 24.1385]
+  - - [128, 128, 1, 32, 128, 128, 32, 128]
+    - [0, 55.8942]
+  - - [192, 128, 1, 32, 192, 192, 32, 128]
+    - [2, 77.5536]
+  - - [256, 128, 1, 32, 256, 256, 32, 128]
+    - [3, 3.71372]
+  - - [320, 128, 1, 32, 320, 320, 32, 128]
+    - [3, 4.61828]
+  - - [384, 128, 1, 32, 384, 384, 32, 128]
+    - [1, 5.23804]
+  - - [448, 128, 1, 32, 448, 448, 32, 128]
+    - [3, 6.42685]
+  - - [512, 128, 1, 32, 512, 512, 32, 128]
+    - [1, 6.90462]
+  - - [576, 128, 1, 32, 576, 576, 32, 128]
+    - [3, 7.89334]
+  - - [640, 128, 1, 32, 640, 640, 32, 128]
+    - [2, 8.75149]
+  - - [704, 128, 1, 32, 704, 704, 32, 128]
+    - [3, 9.61092]
+  - - [768, 128, 1, 32, 768, 768, 32, 128]
+    - [3, 10.4859]
+  - - [832, 128, 1, 32, 832, 832, 32, 128]
+    - [1, 11.2858]
+  - - [896, 128, 1, 32, 896, 896, 32, 128]
+    - [1, 213.125]
+  - - [960, 128, 1, 32, 960, 960, 32, 128]
+    - [2, 13.1457]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 128]
+    - [2, 14.0183]
+  - - [64, 192, 1, 32, 64, 64, 32, 192]
+    - [3, 1.32088]
+  - - [128, 192, 1, 32, 128, 128, 32, 192]
+    - [2, 2.64208]
+  - - [192, 192, 1, 32, 192, 192, 32, 192]
+    - [2, 3.91608]
+  - - [256, 192, 1, 32, 256, 256, 32, 192]
+    - [3, 5.28406]
+  - - [320, 192, 1, 32, 320, 320, 32, 192]
+    - [2, 6.54701]
+  - - [384, 192, 1, 32, 384, 384, 32, 192]
+    - [1, 7.81296]
+  - - [448, 192, 1, 32, 448, 448, 32, 192]
+    - [2, 9.13691]
+  - - [512, 192, 1, 32, 512, 512, 32, 192]
+    - [1, 10.4083]
+  - - [576, 192, 1, 32, 576, 576, 32, 192]
+    - [2, 11.7711]
+  - - [640, 192, 1, 32, 640, 640, 32, 192]
+    - [3, 13.14]
+  - - [704, 192, 1, 32, 704, 704, 32, 192]
+    - [1, 14.2987]
+  - - [768, 192, 1, 32, 768, 768, 32, 192]
+    - [2, 15.7448]
+  - - [832, 192, 1, 32, 832, 832, 32, 192]
+    - [2, 17.0191]
+  - - [896, 192, 1, 32, 896, 896, 32, 192]
+    - [2, 18.3705]
+  - - [960, 192, 1, 32, 960, 960, 32, 192]
+    - [1, 19.4195]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 192]
+    - [3, 20.9334]
+  - - [64, 256, 1, 32, 64, 64, 32, 256]
+    - [2, 1.73956]
+  - - [128, 256, 1, 32, 128, 128, 32, 256]
+    - [1, 3.50886]
+  - - [192, 256, 1, 32, 192, 192, 32, 256]
+    - [3, 5.30402]
+  - - [256, 256, 1, 32, 256, 256, 32, 256]
+    - [3, 7.03596]
+  - - [320, 256, 1, 32, 320, 320, 32, 256]
+    - [3, 8.79437]
+  - - [384, 256, 1, 32, 384, 384, 32, 256]
+    - [2, 10.3936]
+  - - [448, 256, 1, 32, 448, 448, 32, 256]
+    - [2, 12.1206]
+  - - [512, 256, 1, 32, 512, 512, 32, 256]
+    - [3, 14.0427]
+  - - [576, 256, 1, 32, 576, 576, 32, 256]
+    - [3, 15.7864]
+  - - [640, 256, 1, 32, 640, 640, 32, 256]
+    - [3, 17.4744]
+  - - [704, 256, 1, 32, 704, 704, 32, 256]
+    - [1, 247.513]
+  - - [768, 256, 1, 32, 768, 768, 32, 256]
+    - [2, 20.6236]
+  - - [832, 256, 1, 32, 832, 832, 32, 256]
+    - [3, 22.6944]
+  - - [896, 256, 1, 32, 896, 896, 32, 256]
+    - [3, 24.3493]
+  - - [960, 256, 1, 32, 960, 960, 32, 256]
+    - [2, 25.8264]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 256]
+    - [1, 24.3747]
+  - - [64, 320, 1, 32, 64, 64, 32, 320]
+    - [2, 1.92099]
+  - - [128, 320, 1, 32, 128, 128, 32, 320]
+    - [2, 112.993]
+  - - [192, 320, 1, 32, 192, 192, 32, 320]
+    - [2, 15.7677]
+  - - [256, 320, 1, 32, 256, 256, 32, 320]
+    - [2, 170.445]
+  - - [320, 320, 1, 32, 320, 320, 32, 320]
+    - [2, 10.8445]
+  - - [384, 320, 1, 32, 384, 384, 32, 320]
+    - [1, 12.7485]
+  - - [448, 320, 1, 32, 448, 448, 32, 320]
+    - [1, 15.127]
+  - - [512, 320, 1, 32, 512, 512, 32, 320]
+    - [2, 17.4663]
+  - - [576, 320, 1, 32, 576, 576, 32, 320]
+    - [2, 14.4937]
+  - - [640, 320, 1, 32, 640, 640, 32, 320]
+    - [3, 21.761]
+  - - [704, 320, 1, 32, 704, 704, 32, 320]
+    - [3, 24.1234]
+  - - [768, 320, 1, 32, 768, 768, 32, 320]
+    - [1, 26.199]
+  - - [832, 320, 1, 32, 832, 832, 32, 320]
+    - [2, 28.1632]
+  - - [896, 320, 1, 32, 896, 896, 32, 320]
+    - [2, 30.1531]
+  - - [960, 320, 1, 32, 960, 960, 32, 320]
+    - [3, 31.8247]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 320]
+    - [2, 34.0556]
+  - - [64, 384, 1, 32, 64, 64, 32, 384]
+    - [3, 2.66269]
+  - - [128, 384, 1, 32, 128, 128, 32, 384]
+    - [1, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 384]
+    - [3, 7.91506]
+  - - [256, 384, 1, 32, 256, 256, 32, 384]
+    - [2, 10.4834]
+  - - [320, 384, 1, 32, 320, 320, 32, 384]
+    - [3, 13.1668]
+  - - [384, 384, 1, 32, 384, 384, 32, 384]
+    - [2, 15.7136]
+  - - [448, 384, 1, 32, 448, 448, 32, 384]
+    - [3, 18.5612]
+  - - [512, 384, 1, 32, 512, 512, 32, 384]
+    - [3, 21.012]
+  - - [576, 384, 1, 32, 576, 576, 32, 384]
+    - [2, 23.57]
+  - - [640, 384, 1, 32, 640, 640, 32, 384]
+    - [1, 26.1267]
+  - - [704, 384, 1, 32, 704, 704, 32, 384]
+    - [2, 25.9286]
+  - - [768, 384, 1, 32, 768, 768, 32, 384]
+    - [3, 30.459]
+  - - [832, 384, 1, 32, 832, 832, 32, 384]
+    - [3, 32.9458]
+  - - [896, 384, 1, 32, 896, 896, 32, 384]
+    - [2, 35.4332]
+  - - [960, 384, 1, 32, 960, 960, 32, 384]
+    - [1, 321.255]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 384]
+    - [3, 35.291]
+  - - [64, 448, 1, 32, 64, 64, 32, 448]
+    - [1, 3.08144]
+  - - [128, 448, 1, 32, 128, 128, 32, 448]
+    - [1, 6.12932]
+  - - [192, 448, 1, 32, 192, 192, 32, 448]
+    - [1, 9.12646]
+  - - [256, 448, 1, 32, 256, 256, 32, 448]
+    - [2, 12.2539]
+  - - [320, 448, 1, 32, 320, 320, 32, 448]
+    - [2, 15.2543]
+  - - [384, 448, 1, 32, 384, 384, 32, 448]
+    - [2, 18.3503]
+  - - [448, 448, 1, 32, 448, 448, 32, 448]
+    - [2, 21.3375]
+  - - [512, 448, 1, 32, 512, 512, 32, 448]
+    - [2, 250.342]
+  - - [576, 448, 1, 32, 576, 576, 32, 448]
+    - [3, 27.1378]
+  - - [640, 448, 1, 32, 640, 640, 32, 448]
+    - [3, 29.9288]
+  - - [704, 448, 1, 32, 704, 704, 32, 448]
+    - [3, 30.1579]
+  - - [768, 448, 1, 32, 768, 768, 32, 448]
+    - [2, 31.8502]
+  - - [832, 448, 1, 32, 832, 832, 32, 448]
+    - [3, 35.3894]
+  - - [896, 448, 1, 32, 896, 896, 32, 448]
+    - [1, 37.6614]
+  - - [960, 448, 1, 32, 960, 960, 32, 448]
+    - [2, 41.1963]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 448]
+    - [2, 44.0087]
+  - - [64, 512, 1, 32, 64, 64, 32, 512]
+    - [1, 3.52295]
+  - - [128, 512, 1, 32, 128, 128, 32, 512]
+    - [1, 6.94911]
+  - - [192, 512, 1, 32, 192, 192, 32, 512]
+    - [3, 10.5167]
+  - - [256, 512, 1, 32, 256, 256, 32, 512]
+    - [2, 14.0604]
+  - - [320, 512, 1, 32, 320, 320, 32, 512]
+    - [2, 17.2647]
+  - - [384, 512, 1, 32, 384, 384, 32, 512]
+    - [3, 18.5058]
+  - - [448, 512, 1, 32, 448, 448, 32, 512]
+    - [2, 24.1574]
+  - - [512, 512, 1, 32, 512, 512, 32, 512]
+    - [3, 23.8816]
+  - - [576, 512, 1, 32, 576, 576, 32, 512]
+    - [1, 30.8791]
+  - - [640, 512, 1, 32, 640, 640, 32, 512]
+    - [1, 30.8095]
+  - - [704, 512, 1, 32, 704, 704, 32, 512]
+    - [1, 31.2565]
+  - - [768, 512, 1, 32, 768, 768, 32, 512]
+    - [3, 37.0819]
+  - - [832, 512, 1, 32, 832, 832, 32, 512]
+    - [0, 38.4813]
+  - - [896, 512, 1, 32, 896, 896, 32, 512]
+    - [3, 272.76]
+  - - [960, 512, 1, 32, 960, 960, 32, 512]
+    - [2, 285.143]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 512]
+    - [2, 300.344]
+  - - [64, 576, 1, 32, 64, 64, 32, 576]
+    - [1, 3.94252]
+  - - [128, 576, 1, 32, 128, 128, 32, 576]
+    - [2, 7.85877]
+  - - [192, 576, 1, 32, 192, 192, 32, 576]
+    - [1, 11.7529]
+  - - [256, 576, 1, 32, 256, 256, 32, 576]
+    - [2, 15.6784]
+  - - [320, 576, 1, 32, 320, 320, 32, 576]
+    - [2, 19.6958]
+  - - [384, 576, 1, 32, 384, 384, 32, 576]
+    - [3, 23.6192]
+  - - [448, 576, 1, 32, 448, 448, 32, 576]
+    - [2, 27.2277]
+  - - [512, 576, 1, 32, 512, 512, 32, 576]
+    - [1, 303.057]
+  - - [576, 576, 1, 32, 576, 576, 32, 576]
+    - [2, 56.6076]
+  - - [640, 576, 1, 32, 640, 640, 32, 576]
+    - [3, 37.3097]
+  - - [704, 576, 1, 32, 704, 704, 32, 576]
+    - [3, 40.4755]
+  - - [768, 576, 1, 32, 768, 768, 32, 576]
+    - [3, 42.0593]
+  - - [832, 576, 1, 32, 832, 832, 32, 576]
+    - [3, 45.7279]
+  - - [896, 576, 1, 32, 896, 896, 32, 576]
+    - [1, 48.5906]
+  - - [960, 576, 1, 32, 960, 960, 32, 576]
+    - [2, 52.451]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 576]
+    - [1, 52.4547]
+  - - [64, 640, 1, 32, 64, 64, 32, 640]
+    - [2, 4.36809]
+  - - [128, 640, 1, 32, 128, 128, 32, 640]
+    - [1, 8.54343]
+  - - [192, 640, 1, 32, 192, 192, 32, 640]
+    - [2, 13.0236]
+  - - [256, 640, 1, 32, 256, 256, 32, 640]
+    - [3, 17.4794]
+  - - [320, 640, 1, 32, 320, 320, 32, 640]
+    - [2, 21.473]
+  - - [384, 640, 1, 32, 384, 384, 32, 640]
+    - [1, 25.7238]
+  - - [448, 640, 1, 32, 448, 448, 32, 640]
+    - [1, 28.8571]
+  - - [512, 640, 1, 32, 512, 512, 32, 640]
+    - [3, 31.1338]
+  - - [576, 640, 1, 32, 576, 576, 32, 640]
+    - [3, 37.6695]
+  - - [640, 640, 1, 32, 640, 640, 32, 640]
+    - [3, 41.3063]
+  - - [704, 640, 1, 32, 704, 704, 32, 640]
+    - [2, 282.038]
+  - - [768, 640, 1, 32, 768, 768, 32, 640]
+    - [1, 44.3651]
+  - - [832, 640, 1, 32, 832, 832, 32, 640]
+    - [1, 339.561]
+  - - [896, 640, 1, 32, 896, 896, 32, 640]
+    - [1, 342.221]
+  - - [960, 640, 1, 32, 960, 960, 32, 640]
+    - [2, 54.8507]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 640]
+    - [1, 60.763]
+  - - [64, 704, 1, 32, 64, 64, 32, 704]
+    - [2, 4.83657]
+  - - [128, 704, 1, 32, 128, 128, 32, 704]
+    - [2, 9.51187]
+  - - [192, 704, 1, 32, 192, 192, 32, 704]
+    - [3, 14.5053]
+  - - [256, 704, 1, 32, 256, 256, 32, 704]
+    - [1, 19.0363]
+  - - [320, 704, 1, 32, 320, 320, 32, 704]
+    - [1, 267.593]
+  - - [384, 704, 1, 32, 384, 384, 32, 704]
+    - [2, 28.4469]
+  - - [448, 704, 1, 32, 448, 448, 32, 704]
+    - [2, 32.8767]
+  - - [512, 704, 1, 32, 512, 512, 32, 704]
+    - [1, 32.7986]
+  - - [576, 704, 1, 32, 576, 576, 32, 704]
+    - [1, 319.605]
+  - - [640, 704, 1, 32, 640, 640, 32, 704]
+    - [3, 44.8045]
+  - - [704, 704, 1, 32, 704, 704, 32, 704]
+    - [3, 46.3515]
+  - - [768, 704, 1, 32, 768, 768, 32, 704]
+    - [1, 50.2597]
+  - - [832, 704, 1, 32, 832, 832, 32, 704]
+    - [2, 54.9452]
+  - - [896, 704, 1, 32, 896, 896, 32, 704]
+    - [1, 58.9238]
+  - - [960, 704, 1, 32, 960, 960, 32, 704]
+    - [3, 57.3889]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 704]
+    - [1, 67.3308]
+  - - [64, 768, 1, 32, 64, 64, 32, 768]
+    - [2, 5.13066]
+  - - [128, 768, 1, 32, 128, 128, 32, 768]
+    - [3, 10.4063]
+  - - [192, 768, 1, 32, 192, 192, 32, 768]
+    - [3, 15.5295]
+  - - [256, 768, 1, 32, 256, 256, 32, 768]
+    - [2, 235.635]
+  - - [320, 768, 1, 32, 320, 320, 32, 768]
+    - [3, 25.7752]
+  - - [384, 768, 1, 32, 384, 384, 32, 768]
+    - [2, 27.6193]
+  - - [448, 768, 1, 32, 448, 448, 32, 768]
+    - [2, 35.5029]
+  - - [512, 768, 1, 32, 512, 512, 32, 768]
+    - [0, 283.396]
+  - - [576, 768, 1, 32, 576, 576, 32, 768]
+    - [3, 41.5159]
+  - - [640, 768, 1, 32, 640, 640, 32, 768]
+    - [1, 318.394]
+  - - [704, 768, 1, 32, 704, 704, 32, 768]
+    - [1, 151.018]
+  - - [768, 768, 1, 32, 768, 768, 32, 768]
+    - [2, 54.769]
+  - - [832, 768, 1, 32, 832, 832, 32, 768]
+    - [3, 59.8533]
+  - - [896, 768, 1, 32, 896, 896, 32, 768]
+    - [3, 64.697]
+  - - [960, 768, 1, 32, 960, 960, 32, 768]
+    - [3, 272.639]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 768]
+    - [0, 158.739]
+  - - [64, 832, 1, 32, 64, 64, 32, 832]
+    - [3, 5.6198]
+  - - [128, 832, 1, 32, 128, 128, 32, 832]
+    - [3, 11.2135]
+  - - [192, 832, 1, 32, 192, 192, 32, 832]
+    - [1, 12.6673]
+  - - [256, 832, 1, 32, 256, 256, 32, 832]
+    - [2, 21.8459]
+  - - [320, 832, 1, 32, 320, 320, 32, 832]
+    - [2, 27.6993]
+  - - [384, 832, 1, 32, 384, 384, 32, 832]
+    - [2, 33.2084]
+  - - [448, 832, 1, 32, 448, 448, 32, 832]
+    - [1, 34.47]
+  - - [512, 832, 1, 32, 512, 512, 32, 832]
+    - [3, 38.4699]
+  - - [576, 832, 1, 32, 576, 576, 32, 832]
+    - [3, 44.7355]
+  - - [640, 832, 1, 32, 640, 640, 32, 832]
+    - [2, 49.7729]
+  - - [704, 832, 1, 32, 704, 704, 32, 832]
+    - [0, 51.9778]
+  - - [768, 832, 1, 32, 768, 768, 32, 832]
+    - [2, 60.0476]
+  - - [832, 832, 1, 32, 832, 832, 32, 832]
+    - [3, 61.0171]
+  - - [896, 832, 1, 32, 896, 896, 32, 832]
+    - [3, 68.7008]
+  - - [960, 832, 1, 32, 960, 960, 32, 832]
+    - [1, 73.7301]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 832]
+    - [2, 76.7188]
+  - - [64, 896, 1, 32, 64, 64, 32, 896]
+    - [3, 6.0638]
+  - - [128, 896, 1, 32, 128, 128, 32, 896]
+    - [1, 11.8097]
+  - - [192, 896, 1, 32, 192, 192, 32, 896]
+    - [1, 260.408]
+  - - [256, 896, 1, 32, 256, 256, 32, 896]
+    - [1, 112.061]
+  - - [320, 896, 1, 32, 320, 320, 32, 896]
+    - [1, 21.646]
+  - - [384, 896, 1, 32, 384, 384, 32, 896]
+    - [3, 35.1622]
+  - - [448, 896, 1, 32, 448, 448, 32, 896]
+    - [2, 40.6641]
+  - - [512, 896, 1, 32, 512, 512, 32, 896]
+    - [2, 42.9101]
+  - - [576, 896, 1, 32, 576, 576, 32, 896]
+    - [0, 43.0245]
+  - - [640, 896, 1, 32, 640, 640, 32, 896]
+    - [3, 79.8571]
+  - - [704, 896, 1, 32, 704, 704, 32, 896]
+    - [1, 49.3707]
+  - - [768, 896, 1, 32, 768, 768, 32, 896]
+    - [3, 63.6994]
+  - - [832, 896, 1, 32, 832, 832, 32, 896]
+    - [2, 61.6821]
+  - - [896, 896, 1, 32, 896, 896, 32, 896]
+    - [2, 72.8566]
+  - - [960, 896, 1, 32, 960, 960, 32, 896]
+    - [1, 354.886]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 896]
+    - [0, 317.886]
+  - - [64, 960, 1, 32, 64, 64, 32, 960]
+    - [1, 53.3971]
+  - - [128, 960, 1, 32, 128, 128, 32, 960]
+    - [3, 90.4142]
+  - - [192, 960, 1, 32, 192, 192, 32, 960]
+    - [2, 122.611]
+  - - [256, 960, 1, 32, 256, 256, 32, 960]
+    - [3, 183.744]
+  - - [320, 960, 1, 32, 320, 320, 32, 960]
+    - [3, 223.215]
+  - - [384, 960, 1, 32, 384, 384, 32, 960]
+    - [3, 254.894]
+  - - [448, 960, 1, 32, 448, 448, 32, 960]
+    - [1, 281.213]
+  - - [512, 960, 1, 32, 512, 512, 32, 960]
+    - [1, 112.761]
+  - - [576, 960, 1, 32, 576, 576, 32, 960]
+    - [3, 48.9911]
+  - - [640, 960, 1, 32, 640, 640, 32, 960]
+    - [3, 55.7371]
+  - - [704, 960, 1, 32, 704, 704, 32, 960]
+    - [2, 63.3231]
+  - - [768, 960, 1, 32, 768, 768, 32, 960]
+    - [3, 68.2938]
+  - - [832, 960, 1, 32, 832, 832, 32, 960]
+    - [2, 72.4314]
+  - - [896, 960, 1, 32, 896, 896, 32, 960]
+    - [1, 77.3032]
+  - - [960, 960, 1, 32, 960, 960, 32, 960]
+    - [1, 81.6484]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 960]
+    - [1, 88.853]
+  - - [64, 1024, 1, 32, 64, 64, 32, 1024]
+    - [1, 6.85587]
+  - - [128, 1024, 1, 32, 128, 128, 32, 1024]
+    - [2, 13.7617]
+  - - [192, 1024, 1, 32, 192, 192, 32, 1024]
+    - [3, 20.7908]
+  - - [256, 1024, 1, 32, 256, 256, 32, 1024]
+    - [2, 264.621]
+  - - [320, 1024, 1, 32, 320, 320, 32, 1024]
+    - [0, 110.725]
+  - - [384, 1024, 1, 32, 384, 384, 32, 1024]
+    - [1, 34.0459]
+  - - [448, 1024, 1, 32, 448, 448, 32, 1024]
+    - [1, 329.589]
+  - - [512, 1024, 1, 32, 512, 512, 32, 1024]
+    - [1, 49.0545]
+  - - [576, 1024, 1, 32, 576, 576, 32, 1024]
+    - [3, 51.7861]
+  - - [640, 1024, 1, 32, 640, 640, 32, 1024]
+    - [3, 60.799]
+  - - [704, 1024, 1, 32, 704, 704, 32, 1024]
+    - [3, 66.7098]
+  - - [768, 1024, 1, 32, 768, 768, 32, 1024]
+    - [1, 73.2018]
+  - - [832, 1024, 1, 32, 832, 832, 32, 1024]
+    - [0, 76.422]
+  - - [896, 1024, 1, 32, 896, 896, 32, 1024]
+    - [1, 83.9504]
+  - - [960, 1024, 1, 32, 960, 960, 32, 1024]
+    - [1, 88.6428]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 1024]
+    - [0, 89.8096]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/gfx1201/Equality/gfx1201_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- gfx1201
+- gfx1201
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [12, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 32]
+    - [1, 1.15885]
+  - - [128, 64, 1, 32, 128, 128, 32, 32]
+    - [3, 2.32324]
+  - - [192, 64, 1, 32, 192, 192, 32, 32]
+    - [2, 3.48116]
+  - - [256, 64, 1, 32, 256, 256, 32, 32]
+    - [2, 4.67611]
+  - - [320, 64, 1, 32, 320, 320, 32, 32]
+    - [3, 5.79706]
+  - - [384, 64, 1, 32, 384, 384, 32, 32]
+    - [3, 72.9529]
+  - - [448, 64, 1, 32, 448, 448, 32, 32]
+    - [2, 8.11405]
+  - - [512, 64, 1, 32, 512, 512, 32, 32]
+    - [3, 85.8082]
+  - - [576, 64, 1, 32, 576, 576, 32, 32]
+    - [3, 10.4384]
+  - - [640, 64, 1, 32, 640, 640, 32, 32]
+    - [1, 11.5436]
+  - - [704, 64, 1, 32, 704, 704, 32, 32]
+    - [3, 117.41]
+  - - [768, 64, 1, 32, 768, 768, 32, 32]
+    - [0, 13.8645]
+  - - [832, 64, 1, 32, 832, 832, 32, 32]
+    - [3, 14.9874]
+  - - [896, 64, 1, 32, 896, 896, 32, 32]
+    - [3, 16.1559]
+  - - [960, 64, 1, 32, 960, 960, 32, 32]
+    - [0, 17.3001]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 32]
+    - [2, 18.4299]
+  - - [64, 128, 1, 32, 64, 64, 32, 32]
+    - [2, 2.31268]
+  - - [128, 128, 1, 32, 128, 128, 32, 32]
+    - [3, 47.0636]
+  - - [192, 128, 1, 32, 192, 192, 32, 32]
+    - [2, 75.4733]
+  - - [256, 128, 1, 32, 256, 256, 32, 32]
+    - [2, 93.9542]
+  - - [320, 128, 1, 32, 320, 320, 32, 32]
+    - [2, 109.227]
+  - - [384, 128, 1, 32, 384, 384, 32, 32]
+    - [1, 13.8266]
+  - - [448, 128, 1, 32, 448, 448, 32, 32]
+    - [3, 124.83]
+  - - [512, 128, 1, 32, 512, 512, 32, 32]
+    - [3, 18.2917]
+  - - [576, 128, 1, 32, 576, 576, 32, 32]
+    - [0, 20.7346]
+  - - [640, 128, 1, 32, 640, 640, 32, 32]
+    - [1, 23.0505]
+  - - [704, 128, 1, 32, 704, 704, 32, 32]
+    - [2, 25.3635]
+  - - [768, 128, 1, 32, 768, 768, 32, 32]
+    - [1, 27.6814]
+  - - [832, 128, 1, 32, 832, 832, 32, 32]
+    - [1, 29.9696]
+  - - [896, 128, 1, 32, 896, 896, 32, 32]
+    - [2, 32.2652]
+  - - [960, 128, 1, 32, 960, 960, 32, 32]
+    - [2, 34.5972]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 32]
+    - [2, 36.8745]
+  - - [64, 192, 1, 32, 64, 64, 32, 32]
+    - [0, 3.46628]
+  - - [128, 192, 1, 32, 128, 128, 32, 32]
+    - [3, 6.93591]
+  - - [192, 192, 1, 32, 192, 192, 32, 32]
+    - [3, 10.3805]
+  - - [256, 192, 1, 32, 256, 256, 32, 32]
+    - [2, 13.8505]
+  - - [320, 192, 1, 32, 320, 320, 32, 32]
+    - [3, 17.316]
+  - - [384, 192, 1, 32, 384, 384, 32, 32]
+    - [1, 7.68846]
+  - - [448, 192, 1, 32, 448, 448, 32, 32]
+    - [3, 9.14738]
+  - - [512, 192, 1, 32, 512, 512, 32, 32]
+    - [2, 10.3843]
+  - - [576, 192, 1, 32, 576, 576, 32, 32]
+    - [1, 11.6535]
+  - - [640, 192, 1, 32, 640, 640, 32, 32]
+    - [2, 12.944]
+  - - [704, 192, 1, 32, 704, 704, 32, 32]
+    - [2, 14.3917]
+  - - [768, 192, 1, 32, 768, 768, 32, 32]
+    - [2, 15.7115]
+  - - [832, 192, 1, 32, 832, 832, 32, 32]
+    - [2, 220.337]
+  - - [896, 192, 1, 32, 896, 896, 32, 32]
+    - [2, 18.3103]
+  - - [960, 192, 1, 32, 960, 960, 32, 32]
+    - [1, 19.5163]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 32]
+    - [3, 137.893]
+  - - [64, 256, 1, 32, 64, 64, 32, 32]
+    - [3, 5.97204]
+  - - [128, 256, 1, 32, 128, 128, 32, 32]
+    - [2, 3.49203]
+  - - [192, 256, 1, 32, 192, 192, 32, 32]
+    - [2, 5.33651]
+  - - [256, 256, 1, 32, 256, 256, 32, 32]
+    - [3, 6.97152]
+  - - [320, 256, 1, 32, 320, 320, 32, 32]
+    - [2, 8.71078]
+  - - [384, 256, 1, 32, 384, 384, 32, 32]
+    - [3, 10.4597]
+  - - [448, 256, 1, 32, 448, 448, 32, 32]
+    - [1, 203.663]
+  - - [512, 256, 1, 32, 512, 512, 32, 32]
+    - [2, 13.9188]
+  - - [576, 256, 1, 32, 576, 576, 32, 32]
+    - [2, 29.9022]
+  - - [640, 256, 1, 32, 640, 640, 32, 32]
+    - [2, 17.1125]
+  - - [704, 256, 1, 32, 704, 704, 32, 32]
+    - [2, 19.0225]
+  - - [768, 256, 1, 32, 768, 768, 32, 32]
+    - [3, 20.817]
+  - - [832, 256, 1, 32, 832, 832, 32, 32]
+    - [3, 22.6918]
+  - - [896, 256, 1, 32, 896, 896, 32, 32]
+    - [3, 24.2741]
+  - - [960, 256, 1, 32, 960, 960, 32, 32]
+    - [3, 20.772]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 32]
+    - [3, 237.638]
+  - - [64, 320, 1, 32, 64, 64, 32, 32]
+    - [2, 62.7739]
+  - - [128, 320, 1, 32, 128, 128, 32, 32]
+    - [2, 4.32093]
+  - - [192, 320, 1, 32, 192, 192, 32, 32]
+    - [1, 6.51134]
+  - - [256, 320, 1, 32, 256, 256, 32, 32]
+    - [3, 8.74086]
+  - - [320, 320, 1, 32, 320, 320, 32, 32]
+    - [2, 10.8937]
+  - - [384, 320, 1, 32, 384, 384, 32, 32]
+    - [2, 12.66]
+  - - [448, 320, 1, 32, 448, 448, 32, 32]
+    - [2, 15.2365]
+  - - [512, 320, 1, 32, 512, 512, 32, 32]
+    - [2, 17.4799]
+  - - [576, 320, 1, 32, 576, 576, 32, 32]
+    - [2, 19.514]
+  - - [640, 320, 1, 32, 640, 640, 32, 32]
+    - [2, 21.8103]
+  - - [704, 320, 1, 32, 704, 704, 32, 32]
+    - [1, 23.6307]
+  - - [768, 320, 1, 32, 768, 768, 32, 32]
+    - [1, 25.6416]
+  - - [832, 320, 1, 32, 832, 832, 32, 32]
+    - [3, 28.0408]
+  - - [896, 320, 1, 32, 896, 896, 32, 32]
+    - [1, 29.8762]
+  - - [960, 320, 1, 32, 960, 960, 32, 32]
+    - [1, 32.2111]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 32]
+    - [3, 31.1564]
+  - - [64, 384, 1, 32, 64, 64, 32, 32]
+    - [1, 2.61567]
+  - - [128, 384, 1, 32, 128, 128, 32, 32]
+    - [3, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 32]
+    - [2, 7.81608]
+  - - [256, 384, 1, 32, 256, 256, 32, 32]
+    - [1, 10.3665]
+  - - [320, 384, 1, 32, 320, 320, 32, 32]
+    - [2, 13.0853]
+  - - [384, 384, 1, 32, 384, 384, 32, 32]
+    - [2, 15.5012]
+  - - [448, 384, 1, 32, 448, 448, 32, 32]
+    - [2, 18.2013]
+  - - [512, 384, 1, 32, 512, 512, 32, 32]
+    - [3, 21.0359]
+  - - [576, 384, 1, 32, 576, 576, 32, 32]
+    - [2, 23.2003]
+  - - [640, 384, 1, 32, 640, 640, 32, 32]
+    - [3, 233.224]
+  - - [704, 384, 1, 32, 704, 704, 32, 32]
+    - [2, 28.4422]
+  - - [768, 384, 1, 32, 768, 768, 32, 32]
+    - [2, 30.8141]
+  - - [832, 384, 1, 32, 832, 832, 32, 32]
+    - [3, 32.5949]
+  - - [896, 384, 1, 32, 896, 896, 32, 32]
+    - [3, 34.7521]
+  - - [960, 384, 1, 32, 960, 960, 32, 32]
+    - [3, 33.5664]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 32]
+    - [3, 37.4289]
+  - - [64, 448, 1, 32, 64, 64, 32, 32]
+    - [1, 3.0641]
+  - - [128, 448, 1, 32, 128, 128, 32, 32]
+    - [2, 6.09522]
+  - - [192, 448, 1, 32, 192, 192, 32, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 32, 32]
+    - [2, 11.7963]
+  - - [320, 448, 1, 32, 320, 320, 32, 32]
+    - [2, 15.1838]
+  - - [384, 448, 1, 32, 384, 384, 32, 32]
+    - [3, 18.3064]
+  - - [448, 448, 1, 32, 448, 448, 32, 32]
+    - [3, 21.3841]
+  - - [512, 448, 1, 32, 512, 512, 32, 32]
+    - [3, 18.3367]
+  - - [576, 448, 1, 32, 576, 576, 32, 32]
+    - [3, 27.083]
+  - - [640, 448, 1, 32, 640, 640, 32, 32]
+    - [3, 26.9496]
+  - - [704, 448, 1, 32, 704, 704, 32, 32]
+    - [1, 32.8944]
+  - - [768, 448, 1, 32, 768, 768, 32, 32]
+    - [3, 35.0341]
+  - - [832, 448, 1, 32, 832, 832, 32, 32]
+    - [2, 26.0992]
+  - - [896, 448, 1, 32, 896, 896, 32, 32]
+    - [1, 41.1343]
+  - - [960, 448, 1, 32, 960, 960, 32, 32]
+    - [3, 40.0223]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 32]
+    - [3, 38.111]
+  - - [64, 512, 1, 32, 64, 64, 32, 32]
+    - [2, 3.53227]
+  - - [128, 512, 1, 32, 128, 128, 32, 32]
+    - [1, 6.93958]
+  - - [192, 512, 1, 32, 192, 192, 32, 32]
+    - [3, 10.4611]
+  - - [256, 512, 1, 32, 256, 256, 32, 32]
+    - [1, 13.7945]
+  - - [320, 512, 1, 32, 320, 320, 32, 32]
+    - [2, 17.3286]
+  - - [384, 512, 1, 32, 384, 384, 32, 32]
+    - [2, 20.6608]
+  - - [448, 512, 1, 32, 448, 448, 32, 32]
+    - [2, 24.2853]
+  - - [512, 512, 1, 32, 512, 512, 32, 32]
+    - [1, 27.4679]
+  - - [576, 512, 1, 32, 576, 576, 32, 32]
+    - [0, 17.8717]
+  - - [640, 512, 1, 32, 640, 640, 32, 32]
+    - [2, 270.667]
+  - - [704, 512, 1, 32, 704, 704, 32, 32]
+    - [2, 36.9238]
+  - - [768, 512, 1, 32, 768, 768, 32, 32]
+    - [3, 39.3362]
+  - - [832, 512, 1, 32, 832, 832, 32, 32]
+    - [3, 40.6126]
+  - - [896, 512, 1, 32, 896, 896, 32, 32]
+    - [3, 37.5678]
+  - - [960, 512, 1, 32, 960, 960, 32, 32]
+    - [2, 46.6799]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 32]
+    - [1, 49.4521]
+  - - [64, 576, 1, 32, 64, 64, 32, 32]
+    - [3, 4.16165]
+  - - [128, 576, 1, 32, 128, 128, 32, 32]
+    - [1, 165.211]
+  - - [192, 576, 1, 32, 192, 192, 32, 32]
+    - [1, 11.6914]
+  - - [256, 576, 1, 32, 256, 256, 32, 32]
+    - [2, 15.6145]
+  - - [320, 576, 1, 32, 320, 320, 32, 32]
+    - [3, 19.5201]
+  - - [384, 576, 1, 32, 384, 384, 32, 32]
+    - [2, 23.3173]
+  - - [448, 576, 1, 32, 448, 448, 32, 32]
+    - [2, 26.4926]
+  - - [512, 576, 1, 32, 512, 512, 32, 32]
+    - [2, 30.8559]
+  - - [576, 576, 1, 32, 576, 576, 32, 32]
+    - [1, 25.7695]
+  - - [640, 576, 1, 32, 640, 640, 32, 32]
+    - [1, 38.4963]
+  - - [704, 576, 1, 32, 704, 704, 32, 32]
+    - [1, 38.0312]
+  - - [768, 576, 1, 32, 768, 768, 32, 32]
+    - [1, 45.0796]
+  - - [832, 576, 1, 32, 832, 832, 32, 32]
+    - [2, 47.4484]
+  - - [896, 576, 1, 32, 896, 896, 32, 32]
+    - [2, 48.7268]
+  - - [960, 576, 1, 32, 960, 960, 32, 32]
+    - [2, 49.2269]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 32]
+    - [2, 55.1113]
+  - - [64, 640, 1, 32, 64, 64, 32, 32]
+    - [1, 4.31759]
+  - - [128, 640, 1, 32, 128, 128, 32, 32]
+    - [3, 8.77126]
+  - - [192, 640, 1, 32, 192, 192, 32, 32]
+    - [2, 13.0281]
+  - - [256, 640, 1, 32, 256, 256, 32, 32]
+    - [3, 17.3725]
+  - - [320, 640, 1, 32, 320, 320, 32, 32]
+    - [2, 21.5674]
+  - - [384, 640, 1, 32, 384, 384, 32, 32]
+    - [2, 25.8732]
+  - - [448, 640, 1, 32, 448, 448, 32, 32]
+    - [3, 233.34]
+  - - [512, 640, 1, 32, 512, 512, 32, 32]
+    - [1, 29.7957]
+  - - [576, 640, 1, 32, 576, 576, 32, 32]
+    - [2, 37.6816]
+  - - [640, 640, 1, 32, 640, 640, 32, 32]
+    - [3, 39.1071]
+  - - [704, 640, 1, 32, 704, 704, 32, 32]
+    - [3, 44.6269]
+  - - [768, 640, 1, 32, 768, 768, 32, 32]
+    - [0, 45.3769]
+  - - [832, 640, 1, 32, 832, 832, 32, 32]
+    - [1, 50.2744]
+  - - [896, 640, 1, 32, 896, 896, 32, 32]
+    - [0, 53.1083]
+  - - [960, 640, 1, 32, 960, 960, 32, 32]
+    - [3, 55.344]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 32]
+    - [1, 61.5259]
+  - - [64, 704, 1, 32, 64, 64, 32, 32]
+    - [1, 4.78203]
+  - - [128, 704, 1, 32, 128, 128, 32, 32]
+    - [1, 9.11814]
+  - - [192, 704, 1, 32, 192, 192, 32, 32]
+    - [3, 14.38]
+  - - [256, 704, 1, 32, 256, 256, 32, 32]
+    - [3, 19.1484]
+  - - [320, 704, 1, 32, 320, 320, 32, 32]
+    - [2, 23.4029]
+  - - [384, 704, 1, 32, 384, 384, 32, 32]
+    - [1, 28.2559]
+  - - [448, 704, 1, 32, 448, 448, 32, 32]
+    - [3, 22.4257]
+  - - [512, 704, 1, 32, 512, 512, 32, 32]
+    - [3, 36.3124]
+  - - [576, 704, 1, 32, 576, 576, 32, 32]
+    - [0, 37.5889]
+  - - [640, 704, 1, 32, 640, 640, 32, 32]
+    - [3, 42.7372]
+  - - [704, 704, 1, 32, 704, 704, 32, 32]
+    - [2, 46.9011]
+  - - [768, 704, 1, 32, 768, 768, 32, 32]
+    - [2, 50.9832]
+  - - [832, 704, 1, 32, 832, 832, 32, 32]
+    - [2, 54.8969]
+  - - [896, 704, 1, 32, 896, 896, 32, 32]
+    - [1, 49.5075]
+  - - [960, 704, 1, 32, 960, 960, 32, 32]
+    - [2, 63.639]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 32]
+    - [2, 66.0261]
+  - - [64, 768, 1, 32, 64, 64, 32, 32]
+    - [1, 5.19274]
+  - - [128, 768, 1, 32, 128, 128, 32, 32]
+    - [2, 10.3992]
+  - - [192, 768, 1, 32, 192, 192, 32, 32]
+    - [3, 223.418]
+  - - [256, 768, 1, 32, 256, 256, 32, 32]
+    - [1, 266.136]
+  - - [320, 768, 1, 32, 320, 320, 32, 32]
+    - [3, 231.986]
+  - - [384, 768, 1, 32, 384, 384, 32, 32]
+    - [3, 30.6112]
+  - - [448, 768, 1, 32, 448, 448, 32, 32]
+    - [2, 31.5821]
+  - - [512, 768, 1, 32, 512, 512, 32, 32]
+    - [1, 40.6042]
+  - - [576, 768, 1, 32, 576, 576, 32, 32]
+    - [3, 41.8486]
+  - - [640, 768, 1, 32, 640, 640, 32, 32]
+    - [1, 41.7104]
+  - - [704, 768, 1, 32, 704, 704, 32, 32]
+    - [3, 275.064]
+  - - [768, 768, 1, 32, 768, 768, 32, 32]
+    - [1, 55.7396]
+  - - [832, 768, 1, 32, 832, 832, 32, 32]
+    - [3, 51.1568]
+  - - [896, 768, 1, 32, 896, 896, 32, 32]
+    - [1, 61.4199]
+  - - [960, 768, 1, 32, 960, 960, 32, 32]
+    - [3, 67.4196]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 32]
+    - [1, 73.2776]
+  - - [64, 832, 1, 32, 64, 64, 32, 32]
+    - [1, 5.63096]
+  - - [128, 832, 1, 32, 128, 128, 32, 32]
+    - [1, 11.1455]
+  - - [192, 832, 1, 32, 192, 192, 32, 32]
+    - [3, 16.7104]
+  - - [256, 832, 1, 32, 256, 256, 32, 32]
+    - [1, 22.388]
+  - - [320, 832, 1, 32, 320, 320, 32, 32]
+    - [0, 24.4102]
+  - - [384, 832, 1, 32, 384, 384, 32, 32]
+    - [1, 29.782]
+  - - [448, 832, 1, 32, 448, 448, 32, 32]
+    - [0, 31.3102]
+  - - [512, 832, 1, 32, 512, 512, 32, 32]
+    - [1, 39.0439]
+  - - [576, 832, 1, 32, 576, 576, 32, 32]
+    - [3, 44.3718]
+  - - [640, 832, 1, 32, 640, 640, 32, 32]
+    - [3, 48.3954]
+  - - [704, 832, 1, 32, 704, 704, 32, 32]
+    - [3, 45.2543]
+  - - [768, 832, 1, 32, 768, 768, 32, 32]
+    - [1, 56.8015]
+  - - [832, 832, 1, 32, 832, 832, 32, 32]
+    - [1, 54.7432]
+  - - [896, 832, 1, 32, 896, 896, 32, 32]
+    - [3, 58.3343]
+  - - [960, 832, 1, 32, 960, 960, 32, 32]
+    - [3, 71.7503]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 32]
+    - [1, 79.1776]
+  - - [64, 896, 1, 32, 64, 64, 32, 32]
+    - [1, 6.06912]
+  - - [128, 896, 1, 32, 128, 128, 32, 32]
+    - [2, 12.1569]
+  - - [192, 896, 1, 32, 192, 192, 32, 32]
+    - [2, 18.2019]
+  - - [256, 896, 1, 32, 256, 256, 32, 32]
+    - [2, 245.482]
+  - - [320, 896, 1, 32, 320, 320, 32, 32]
+    - [1, 29.0058]
+  - - [384, 896, 1, 32, 384, 384, 32, 32]
+    - [2, 35.5104]
+  - - [448, 896, 1, 32, 448, 448, 32, 32]
+    - [3, 28.1229]
+  - - [512, 896, 1, 32, 512, 512, 32, 32]
+    - [0, 42.3518]
+  - - [576, 896, 1, 32, 576, 576, 32, 32]
+    - [2, 48.9644]
+  - - [640, 896, 1, 32, 640, 640, 32, 32]
+    - [2, 45.7064]
+  - - [704, 896, 1, 32, 704, 704, 32, 32]
+    - [1, 59.4734]
+  - - [768, 896, 1, 32, 768, 768, 32, 32]
+    - [3, 51.5563]
+  - - [832, 896, 1, 32, 832, 832, 32, 32]
+    - [1, 70.0206]
+  - - [896, 896, 1, 32, 896, 896, 32, 32]
+    - [2, 72.8327]
+  - - [960, 896, 1, 32, 960, 960, 32, 32]
+    - [3, 75.7387]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 32]
+    - [3, 316.72]
+  - - [64, 960, 1, 32, 64, 64, 32, 32]
+    - [3, 47.761]
+  - - [128, 960, 1, 32, 128, 128, 32, 32]
+    - [3, 73.8913]
+  - - [192, 960, 1, 32, 192, 192, 32, 32]
+    - [2, 19.4311]
+  - - [256, 960, 1, 32, 256, 256, 32, 32]
+    - [2, 24.6167]
+  - - [320, 960, 1, 32, 320, 320, 32, 32]
+    - [2, 32.1022]
+  - - [384, 960, 1, 32, 384, 384, 32, 32]
+    - [3, 37.3233]
+  - - [448, 960, 1, 32, 448, 448, 32, 32]
+    - [0, 39.6573]
+  - - [512, 960, 1, 32, 512, 512, 32, 32]
+    - [1, 317.879]
+  - - [576, 960, 1, 32, 576, 576, 32, 32]
+    - [2, 47.8887]
+  - - [640, 960, 1, 32, 640, 640, 32, 32]
+    - [3, 45.7758]
+  - - [704, 960, 1, 32, 704, 704, 32, 32]
+    - [0, 62.4041]
+  - - [768, 960, 1, 32, 768, 768, 32, 32]
+    - [1, 69.5882]
+  - - [832, 960, 1, 32, 832, 832, 32, 32]
+    - [2, 72.5228]
+  - - [896, 960, 1, 32, 896, 896, 32, 32]
+    - [2, 77.1612]
+  - - [960, 960, 1, 32, 960, 960, 32, 32]
+    - [1, 84.0368]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 32]
+    - [3, 84.7878]
+  - - [64, 1024, 1, 32, 64, 64, 32, 32]
+    - [2, 6.94924]
+  - - [128, 1024, 1, 32, 128, 128, 32, 32]
+    - [1, 13.864]
+  - - [192, 1024, 1, 32, 192, 192, 32, 32]
+    - [3, 20.9498]
+  - - [256, 1024, 1, 32, 256, 256, 32, 32]
+    - [3, 27.3377]
+  - - [320, 1024, 1, 32, 320, 320, 32, 32]
+    - [1, 30.6626]
+  - - [384, 1024, 1, 32, 384, 384, 32, 32]
+    - [3, 37.2913]
+  - - [448, 1024, 1, 32, 448, 448, 32, 32]
+    - [3, 43.6989]
+  - - [512, 1024, 1, 32, 512, 512, 32, 32]
+    - [1, 49.0983]
+  - - [576, 1024, 1, 32, 576, 576, 32, 32]
+    - [2, 55.7223]
+  - - [640, 1024, 1, 32, 640, 640, 32, 32]
+    - [1, 61.4772]
+  - - [704, 1024, 1, 32, 704, 704, 32, 32]
+    - [1, 65.5096]
+  - - [768, 1024, 1, 32, 768, 768, 32, 32]
+    - [2, 71.6308]
+  - - [832, 1024, 1, 32, 832, 832, 32, 32]
+    - [3, 76.1074]
+  - - [896, 1024, 1, 32, 896, 896, 32, 32]
+    - [1, 83.761]
+  - - [960, 1024, 1, 32, 960, 960, 32, 32]
+    - [0, 85.4755]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 32]
+    - [0, 519.579]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi31
+- gfx1100
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 64]
+    - [1, 1.15349]
+  - - [128, 64, 1, 32, 128, 128, 128, 64]
+    - [2, 2.30698]
+  - - [192, 64, 1, 32, 192, 192, 192, 64]
+    - [3, 3.45378]
+  - - [256, 64, 1, 32, 256, 256, 256, 64]
+    - [1, 4.61519]
+  - - [320, 64, 1, 32, 320, 320, 320, 64]
+    - [1, 5.7695]
+  - - [384, 64, 1, 32, 384, 384, 384, 64]
+    - [1, 6.93928]
+  - - [448, 64, 1, 32, 448, 448, 448, 64]
+    - [3, 8.07161]
+  - - [512, 64, 1, 32, 512, 512, 512, 64]
+    - [1, 9.23197]
+  - - [576, 64, 1, 32, 576, 576, 576, 64]
+    - [0, 26.473]
+  - - [640, 64, 1, 32, 640, 640, 640, 64]
+    - [3, 11.5263]
+  - - [704, 64, 1, 32, 704, 704, 704, 64]
+    - [3, 12.6861]
+  - - [768, 64, 1, 32, 768, 768, 768, 64]
+    - [3, 13.8206]
+  - - [832, 64, 1, 32, 832, 832, 832, 64]
+    - [1, 14.9244]
+  - - [896, 64, 1, 32, 896, 896, 896, 64]
+    - [2, 16.0613]
+  - - [960, 64, 1, 32, 960, 960, 960, 64]
+    - [3, 17.1941]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 64]
+    - [1, 156.972]
+  - - [64, 128, 1, 32, 64, 64, 64, 128]
+    - [2, 28.9982]
+  - - [128, 128, 1, 32, 128, 128, 128, 128]
+    - [3, 49.9322]
+  - - [192, 128, 1, 32, 192, 192, 192, 128]
+    - [3, 75.0412]
+  - - [256, 128, 1, 32, 256, 256, 256, 128]
+    - [3, 87.9678]
+  - - [320, 128, 1, 32, 320, 320, 320, 128]
+    - [0, 11.4678]
+  - - [384, 128, 1, 32, 384, 384, 384, 128]
+    - [2, 13.7349]
+  - - [448, 128, 1, 32, 448, 448, 448, 128]
+    - [0, 16.0824]
+  - - [512, 128, 1, 32, 512, 512, 512, 128]
+    - [0, 18.2957]
+  - - [576, 128, 1, 32, 576, 576, 576, 128]
+    - [3, 171.71]
+  - - [640, 128, 1, 32, 640, 640, 640, 128]
+    - [3, 41.8958]
+  - - [704, 128, 1, 32, 704, 704, 704, 128]
+    - [3, 184.137]
+  - - [768, 128, 1, 32, 768, 768, 768, 128]
+    - [2, 9.67241]
+  - - [832, 128, 1, 32, 832, 832, 832, 128]
+    - [2, 10.4909]
+  - - [896, 128, 1, 32, 896, 896, 896, 128]
+    - [3, 11.1885]
+  - - [960, 128, 1, 32, 960, 960, 960, 128]
+    - [1, 11.9394]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 128]
+    - [3, 221.452]
+  - - [64, 192, 1, 32, 64, 64, 64, 192]
+    - [3, 37.4474]
+  - - [128, 192, 1, 32, 128, 128, 128, 192]
+    - [2, 77.4047]
+  - - [192, 192, 1, 32, 192, 192, 192, 192]
+    - [3, 98.304]
+  - - [256, 192, 1, 32, 256, 256, 256, 192]
+    - [3, 5.21919]
+  - - [320, 192, 1, 32, 320, 320, 320, 192]
+    - [1, 6.03876]
+  - - [384, 192, 1, 32, 384, 384, 384, 192]
+    - [1, 7.71751]
+  - - [448, 192, 1, 32, 448, 448, 448, 192]
+    - [2, 9.04163]
+  - - [512, 192, 1, 32, 512, 512, 512, 192]
+    - [1, 10.2895]
+  - - [576, 192, 1, 32, 576, 576, 576, 192]
+    - [1, 11.56]
+  - - [640, 192, 1, 32, 640, 640, 640, 192]
+    - [2, 12.9306]
+  - - [704, 192, 1, 32, 704, 704, 704, 192]
+    - [3, 14.0882]
+  - - [768, 192, 1, 32, 768, 768, 768, 192]
+    - [1, 15.4489]
+  - - [832, 192, 1, 32, 832, 832, 832, 192]
+    - [1, 16.6423]
+  - - [896, 192, 1, 32, 896, 896, 896, 192]
+    - [1, 17.955]
+  - - [960, 192, 1, 32, 960, 960, 960, 192]
+    - [3, 19.4074]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 192]
+    - [2, 20.6185]
+  - - [64, 256, 1, 32, 64, 64, 64, 256]
+    - [3, 1.74497]
+  - - [128, 256, 1, 32, 128, 128, 128, 256]
+    - [3, 3.48907]
+  - - [192, 256, 1, 32, 192, 192, 192, 256]
+    - [2, 5.19085]
+  - - [256, 256, 1, 32, 256, 256, 256, 256]
+    - [1, 6.85968]
+  - - [320, 256, 1, 32, 320, 320, 320, 256]
+    - [1, 8.58146]
+  - - [384, 256, 1, 32, 384, 384, 384, 256]
+    - [2, 10.2789]
+  - - [448, 256, 1, 32, 448, 448, 448, 256]
+    - [1, 12.0221]
+  - - [512, 256, 1, 32, 512, 512, 512, 256]
+    - [2, 13.7992]
+  - - [576, 256, 1, 32, 576, 576, 576, 256]
+    - [2, 15.4454]
+  - - [640, 256, 1, 32, 640, 640, 640, 256]
+    - [2, 17.294]
+  - - [704, 256, 1, 32, 704, 704, 704, 256]
+    - [3, 243.546]
+  - - [768, 256, 1, 32, 768, 768, 768, 256]
+    - [1, 267.488]
+  - - [832, 256, 1, 32, 832, 832, 832, 256]
+    - [2, 22.3451]
+  - - [896, 256, 1, 32, 896, 896, 896, 256]
+    - [3, 23.9841]
+  - - [960, 256, 1, 32, 960, 960, 960, 256]
+    - [3, 25.715]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 256]
+    - [2, 22.0262]
+  - - [64, 320, 1, 32, 64, 64, 64, 320]
+    - [1, 2.18056]
+  - - [128, 320, 1, 32, 128, 128, 128, 320]
+    - [3, 4.34212]
+  - - [192, 320, 1, 32, 192, 192, 192, 320]
+    - [2, 6.47766]
+  - - [256, 320, 1, 32, 256, 256, 256, 320]
+    - [3, 8.64858]
+  - - [320, 320, 1, 32, 320, 320, 320, 320]
+    - [1, 10.7349]
+  - - [384, 320, 1, 32, 384, 384, 384, 320]
+    - [2, 12.5973]
+  - - [448, 320, 1, 32, 448, 448, 448, 320]
+    - [2, 15.1357]
+  - - [512, 320, 1, 32, 512, 512, 512, 320]
+    - [3, 252.547]
+  - - [576, 320, 1, 32, 576, 576, 576, 320]
+    - [1, 248.661]
+  - - [640, 320, 1, 32, 640, 640, 640, 320]
+    - [1, 21.5383]
+  - - [704, 320, 1, 32, 704, 704, 704, 320]
+    - [2, 23.9253]
+  - - [768, 320, 1, 32, 768, 768, 768, 320]
+    - [1, 25.7457]
+  - - [832, 320, 1, 32, 832, 832, 832, 320]
+    - [3, 28.0186]
+  - - [896, 320, 1, 32, 896, 896, 896, 320]
+    - [1, 29.7589]
+  - - [960, 320, 1, 32, 960, 960, 960, 320]
+    - [3, 31.8639]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 320]
+    - [3, 33.5333]
+  - - [64, 384, 1, 32, 64, 64, 64, 384]
+    - [3, 2.61959]
+  - - [128, 384, 1, 32, 128, 128, 128, 384]
+    - [2, 5.19532]
+  - - [192, 384, 1, 32, 192, 192, 192, 384]
+    - [1, 7.73864]
+  - - [256, 384, 1, 32, 256, 256, 256, 384]
+    - [2, 10.3442]
+  - - [320, 384, 1, 32, 320, 320, 320, 384]
+    - [3, 13.0091]
+  - - [384, 384, 1, 32, 384, 384, 384, 384]
+    - [2, 15.506]
+  - - [448, 384, 1, 32, 448, 448, 448, 384]
+    - [3, 18.2215]
+  - - [512, 384, 1, 32, 512, 512, 512, 384]
+    - [3, 20.7071]
+  - - [576, 384, 1, 32, 576, 576, 576, 384]
+    - [2, 23.2403]
+  - - [640, 384, 1, 32, 640, 640, 640, 384]
+    - [1, 25.7196]
+  - - [704, 384, 1, 32, 704, 704, 704, 384]
+    - [3, 28.3867]
+  - - [768, 384, 1, 32, 768, 768, 768, 384]
+    - [3, 30.7539]
+  - - [832, 384, 1, 32, 832, 832, 832, 384]
+    - [3, 32.7878]
+  - - [896, 384, 1, 32, 896, 896, 896, 384]
+    - [2, 35.4019]
+  - - [960, 384, 1, 32, 960, 960, 960, 384]
+    - [1, 317.618]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 384]
+    - [3, 39.8052]
+  - - [64, 448, 1, 32, 64, 64, 64, 448]
+    - [3, 3.04604]
+  - - [128, 448, 1, 32, 128, 128, 128, 448]
+    - [1, 6.00949]
+  - - [192, 448, 1, 32, 192, 192, 192, 448]
+    - [3, 9.07966]
+  - - [256, 448, 1, 32, 256, 256, 256, 448]
+    - [1, 11.9952]
+  - - [320, 448, 1, 32, 320, 320, 320, 448]
+    - [2, 15.0959]
+  - - [384, 448, 1, 32, 384, 384, 384, 448]
+    - [3, 18.0005]
+  - - [448, 448, 1, 32, 448, 448, 448, 448]
+    - [3, 21.2546]
+  - - [512, 448, 1, 32, 512, 512, 512, 448]
+    - [2, 23.9822]
+  - - [576, 448, 1, 32, 576, 576, 576, 448]
+    - [2, 27.2094]
+  - - [640, 448, 1, 32, 640, 640, 640, 448]
+    - [2, 30.0287]
+  - - [704, 448, 1, 32, 704, 704, 704, 448]
+    - [1, 307.512]
+  - - [768, 448, 1, 32, 768, 768, 768, 448]
+    - [3, 29.7306]
+  - - [832, 448, 1, 32, 832, 832, 832, 448]
+    - [0, 34.5814]
+  - - [896, 448, 1, 32, 896, 896, 896, 448]
+    - [2, 40.7985]
+  - - [960, 448, 1, 32, 960, 960, 960, 448]
+    - [2, 39.8658]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 448]
+    - [2, 42.8819]
+  - - [64, 512, 1, 32, 64, 64, 64, 512]
+    - [1, 3.44874]
+  - - [128, 512, 1, 32, 128, 128, 128, 512]
+    - [2, 6.86934]
+  - - [192, 512, 1, 32, 192, 192, 192, 512]
+    - [3, 10.369]
+  - - [256, 512, 1, 32, 256, 256, 256, 512]
+    - [1, 13.5592]
+  - - [320, 512, 1, 32, 320, 320, 320, 512]
+    - [3, 17.1914]
+  - - [384, 512, 1, 32, 384, 384, 384, 512]
+    - [2, 20.7593]
+  - - [448, 512, 1, 32, 448, 448, 448, 512]
+    - [2, 24.1348]
+  - - [512, 512, 1, 32, 512, 512, 512, 512]
+    - [2, 27.674]
+  - - [576, 512, 1, 32, 576, 576, 576, 512]
+    - [3, 27.5609]
+  - - [640, 512, 1, 32, 640, 640, 640, 512]
+    - [1, 30.388]
+  - - [704, 512, 1, 32, 704, 704, 704, 512]
+    - [3, 36.7949]
+  - - [768, 512, 1, 32, 768, 768, 768, 512]
+    - [3, 39.2313]
+  - - [832, 512, 1, 32, 832, 832, 832, 512]
+    - [2, 39.7191]
+  - - [896, 512, 1, 32, 896, 896, 896, 512]
+    - [1, 332.877]
+  - - [960, 512, 1, 32, 960, 960, 960, 512]
+    - [1, 316.344]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 512]
+    - [0, 48.3693]
+  - - [64, 576, 1, 32, 64, 64, 64, 576]
+    - [3, 3.86628]
+  - - [128, 576, 1, 32, 128, 128, 128, 576]
+    - [3, 169.246]
+  - - [192, 576, 1, 32, 192, 192, 192, 576]
+    - [1, 11.5076]
+  - - [256, 576, 1, 32, 256, 256, 256, 576]
+    - [3, 240.984]
+  - - [320, 576, 1, 32, 320, 320, 320, 576]
+    - [1, 19.296]
+  - - [384, 576, 1, 32, 384, 384, 384, 576]
+    - [2, 23.1318]
+  - - [448, 576, 1, 32, 448, 448, 448, 576]
+    - [1, 26.9123]
+  - - [512, 576, 1, 32, 512, 512, 512, 576]
+    - [2, 30.8021]
+  - - [576, 576, 1, 32, 576, 576, 576, 576]
+    - [2, 272.506]
+  - - [640, 576, 1, 32, 640, 640, 640, 576]
+    - [3, 122.23]
+  - - [704, 576, 1, 32, 704, 704, 704, 576]
+    - [2, 41.1188]
+  - - [768, 576, 1, 32, 768, 768, 768, 576]
+    - [2, 39.9551]
+  - - [832, 576, 1, 32, 832, 832, 832, 576]
+    - [3, 47.4793]
+  - - [896, 576, 1, 32, 896, 896, 896, 576]
+    - [1, 46.8264]
+  - - [960, 576, 1, 32, 960, 960, 960, 576]
+    - [3, 52.0216]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 576]
+    - [0, 53.3314]
+  - - [64, 640, 1, 32, 64, 64, 64, 640]
+    - [2, 4.331]
+  - - [128, 640, 1, 32, 128, 128, 128, 640]
+    - [1, 8.52829]
+  - - [192, 640, 1, 32, 192, 192, 192, 640]
+    - [2, 12.8344]
+  - - [256, 640, 1, 32, 256, 256, 256, 640]
+    - [2, 17.1025]
+  - - [320, 640, 1, 32, 320, 320, 320, 640]
+    - [3, 21.6428]
+  - - [384, 640, 1, 32, 384, 384, 384, 640]
+    - [3, 25.6713]
+  - - [448, 640, 1, 32, 448, 448, 448, 640]
+    - [3, 29.9567]
+  - - [512, 640, 1, 32, 512, 512, 512, 640]
+    - [1, 33.6966]
+  - - [576, 640, 1, 32, 576, 576, 576, 640]
+    - [3, 34.7046]
+  - - [640, 640, 1, 32, 640, 640, 640, 640]
+    - [3, 38.7075]
+  - - [704, 640, 1, 32, 704, 704, 704, 640]
+    - [2, 41.7002]
+  - - [768, 640, 1, 32, 768, 768, 768, 640]
+    - [3, 268.407]
+  - - [832, 640, 1, 32, 832, 832, 832, 640]
+    - [0, 47.4228]
+  - - [896, 640, 1, 32, 896, 896, 896, 640]
+    - [3, 53.5508]
+  - - [960, 640, 1, 32, 960, 960, 960, 640]
+    - [3, 57.2031]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 640]
+    - [3, 61.6009]
+  - - [64, 704, 1, 32, 64, 64, 64, 704]
+    - [3, 4.74723]
+  - - [128, 704, 1, 32, 128, 128, 128, 704]
+    - [2, 9.33162]
+  - - [192, 704, 1, 32, 192, 192, 192, 704]
+    - [3, 14.165]
+  - - [256, 704, 1, 32, 256, 256, 256, 704]
+    - [3, 18.904]
+  - - [320, 704, 1, 32, 320, 320, 320, 704]
+    - [2, 23.5144]
+  - - [384, 704, 1, 32, 384, 384, 384, 704]
+    - [3, 249.301]
+  - - [448, 704, 1, 32, 448, 448, 448, 704]
+    - [1, 304.727]
+  - - [512, 704, 1, 32, 512, 512, 512, 704]
+    - [2, 33.8328]
+  - - [576, 704, 1, 32, 576, 576, 576, 704]
+    - [3, 37.3401]
+  - - [640, 704, 1, 32, 640, 640, 640, 704]
+    - [2, 41.8036]
+  - - [704, 704, 1, 32, 704, 704, 704, 704]
+    - [1, 45.7716]
+  - - [768, 704, 1, 32, 768, 768, 768, 704]
+    - [2, 50.4436]
+  - - [832, 704, 1, 32, 832, 832, 832, 704]
+    - [3, 53.7131]
+  - - [896, 704, 1, 32, 896, 896, 896, 704]
+    - [1, 56.0678]
+  - - [960, 704, 1, 32, 960, 960, 960, 704]
+    - [2, 307.985]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 704]
+    - [2, 67.1612]
+  - - [64, 768, 1, 32, 64, 64, 64, 768]
+    - [3, 5.19884]
+  - - [128, 768, 1, 32, 128, 128, 128, 768]
+    - [2, 10.2936]
+  - - [192, 768, 1, 32, 192, 192, 192, 768]
+    - [2, 15.3667]
+  - - [256, 768, 1, 32, 256, 256, 256, 768]
+    - [3, 20.6856]
+  - - [320, 768, 1, 32, 320, 320, 320, 768]
+    - [2, 25.3605]
+  - - [384, 768, 1, 32, 384, 384, 384, 768]
+    - [3, 30.9622]
+  - - [448, 768, 1, 32, 448, 448, 448, 768]
+    - [2, 35.5596]
+  - - [512, 768, 1, 32, 512, 512, 512, 768]
+    - [3, 253.685]
+  - - [576, 768, 1, 32, 576, 576, 576, 768]
+    - [1, 319.252]
+  - - [640, 768, 1, 32, 640, 640, 640, 768]
+    - [1, 241.292]
+  - - [704, 768, 1, 32, 704, 704, 704, 768]
+    - [1, 300.788]
+  - - [768, 768, 1, 32, 768, 768, 768, 768]
+    - [1, 313.942]
+  - - [832, 768, 1, 32, 832, 832, 832, 768]
+    - [2, 307.385]
+  - - [896, 768, 1, 32, 896, 896, 896, 768]
+    - [3, 304.819]
+  - - [960, 768, 1, 32, 960, 960, 960, 768]
+    - [1, 353.821]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 768]
+    - [1, 358.792]
+  - - [64, 832, 1, 32, 64, 64, 64, 832]
+    - [3, 87.2025]
+  - - [128, 832, 1, 32, 128, 128, 128, 832]
+    - [3, 61.0068]
+  - - [192, 832, 1, 32, 192, 192, 192, 832]
+    - [2, 88.1567]
+  - - [256, 832, 1, 32, 256, 256, 256, 832]
+    - [3, 121.006]
+  - - [320, 832, 1, 32, 320, 320, 320, 832]
+    - [3, 145.996]
+  - - [384, 832, 1, 32, 384, 384, 384, 832]
+    - [1, 159.358]
+  - - [448, 832, 1, 32, 448, 448, 448, 832]
+    - [2, 196.644]
+  - - [512, 832, 1, 32, 512, 512, 512, 832]
+    - [3, 39.8819]
+  - - [576, 832, 1, 32, 576, 576, 576, 832]
+    - [0, 44.024]
+  - - [640, 832, 1, 32, 640, 640, 640, 832]
+    - [3, 49.7875]
+  - - [704, 832, 1, 32, 704, 704, 704, 832]
+    - [2, 54.7966]
+  - - [768, 832, 1, 32, 768, 768, 768, 832]
+    - [3, 59.57]
+  - - [832, 832, 1, 32, 832, 832, 832, 832]
+    - [2, 64.4347]
+  - - [896, 832, 1, 32, 896, 896, 896, 832]
+    - [3, 62.0957]
+  - - [960, 832, 1, 32, 960, 960, 960, 832]
+    - [3, 73.2347]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 832]
+    - [1, 76.9799]
+  - - [64, 896, 1, 32, 64, 64, 64, 896]
+    - [1, 6.00575]
+  - - [128, 896, 1, 32, 128, 128, 128, 896]
+    - [2, 11.8982]
+  - - [192, 896, 1, 32, 192, 192, 192, 896]
+    - [3, 17.0944]
+  - - [256, 896, 1, 32, 256, 256, 256, 896]
+    - [2, 146.566]
+  - - [320, 896, 1, 32, 320, 320, 320, 896]
+    - [2, 170.017]
+  - - [384, 896, 1, 32, 384, 384, 384, 896]
+    - [1, 316.017]
+  - - [448, 896, 1, 32, 448, 448, 448, 896]
+    - [2, 221.179]
+  - - [512, 896, 1, 32, 512, 512, 512, 896]
+    - [3, 277.503]
+  - - [576, 896, 1, 32, 576, 576, 576, 896]
+    - [1, 306.855]
+  - - [640, 896, 1, 32, 640, 640, 640, 896]
+    - [1, 345.316]
+  - - [704, 896, 1, 32, 704, 704, 704, 896]
+    - [1, 354.619]
+  - - [768, 896, 1, 32, 768, 768, 768, 896]
+    - [2, 307.715]
+  - - [832, 896, 1, 32, 832, 832, 832, 896]
+    - [3, 314.626]
+  - - [896, 896, 1, 32, 896, 896, 896, 896]
+    - [3, 321.929]
+  - - [960, 896, 1, 32, 960, 960, 960, 896]
+    - [3, 308.716]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 896]
+    - [2, 320.174]
+  - - [64, 960, 1, 32, 64, 64, 64, 960]
+    - [2, 65.8874]
+  - - [128, 960, 1, 32, 128, 128, 128, 960]
+    - [1, 78.462]
+  - - [192, 960, 1, 32, 192, 192, 192, 960]
+    - [2, 113.755]
+  - - [256, 960, 1, 32, 256, 256, 256, 960]
+    - [1, 152.986]
+  - - [320, 960, 1, 32, 320, 320, 320, 960]
+    - [3, 189.192]
+  - - [384, 960, 1, 32, 384, 384, 384, 960]
+    - [2, 228.769]
+  - - [448, 960, 1, 32, 448, 448, 448, 960]
+    - [3, 286.598]
+  - - [512, 960, 1, 32, 512, 512, 512, 960]
+    - [2, 278.088]
+  - - [576, 960, 1, 32, 576, 576, 576, 960]
+    - [1, 321.953]
+  - - [640, 960, 1, 32, 640, 640, 640, 960]
+    - [2, 304.064]
+  - - [704, 960, 1, 32, 704, 704, 704, 960]
+    - [2, 311.268]
+  - - [768, 960, 1, 32, 768, 768, 768, 960]
+    - [2, 312.572]
+  - - [832, 960, 1, 32, 832, 832, 832, 960]
+    - [3, 296.232]
+  - - [896, 960, 1, 32, 896, 896, 896, 960]
+    - [2, 319.019]
+  - - [960, 960, 1, 32, 960, 960, 960, 960]
+    - [3, 320.415]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 960]
+    - [3, 85.4244]
+  - - [64, 1024, 1, 32, 64, 64, 64, 1024]
+    - [1, 6.77317]
+  - - [128, 1024, 1, 32, 128, 128, 128, 1024]
+    - [2, 13.688]
+  - - [192, 1024, 1, 32, 192, 192, 192, 1024]
+    - [2, 20.3846]
+  - - [256, 1024, 1, 32, 256, 256, 256, 1024]
+    - [2, 27.202]
+  - - [320, 1024, 1, 32, 320, 320, 320, 1024]
+    - [2, 33.9201]
+  - - [384, 1024, 1, 32, 384, 384, 384, 1024]
+    - [3, 39.4082]
+  - - [448, 1024, 1, 32, 448, 448, 448, 1024]
+    - [1, 36.7013]
+  - - [512, 1024, 1, 32, 512, 512, 512, 1024]
+    - [2, 292.896]
+  - - [576, 1024, 1, 32, 576, 576, 576, 1024]
+    - [2, 55.0864]
+  - - [640, 1024, 1, 32, 640, 640, 640, 1024]
+    - [2, 61.8052]
+  - - [704, 1024, 1, 32, 704, 704, 704, 1024]
+    - [2, 66.8208]
+  - - [768, 1024, 1, 32, 768, 768, 768, 1024]
+    - [1, 71.9595]
+  - - [832, 1024, 1, 32, 832, 832, 832, 1024]
+    - [2, 76.7081]
+  - - [896, 1024, 1, 32, 896, 896, 896, 1024]
+    - [2, 81.1912]
+  - - [960, 1024, 1, 32, 960, 960, 960, 1024]
+    - [1, 88.5319]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 1024]
+    - [2, 90.0024]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi31
+- gfx1100
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 32]
+    - [2, 1.15233]
+  - - [128, 64, 1, 32, 128, 128, 128, 32]
+    - [2, 2.30557]
+  - - [192, 64, 1, 32, 192, 192, 192, 32]
+    - [2, 3.45926]
+  - - [256, 64, 1, 32, 256, 256, 256, 32]
+    - [2, 4.61702]
+  - - [320, 64, 1, 32, 320, 320, 320, 32]
+    - [2, 5.75784]
+  - - [384, 64, 1, 32, 384, 384, 384, 32]
+    - [3, 73.7741]
+  - - [448, 64, 1, 32, 448, 448, 448, 32]
+    - [2, 86.557]
+  - - [512, 64, 1, 32, 512, 512, 512, 32]
+    - [2, 97.4513]
+  - - [576, 64, 1, 32, 576, 576, 576, 32]
+    - [2, 107.241]
+  - - [640, 64, 1, 32, 640, 640, 640, 32]
+    - [0, 11.4934]
+  - - [704, 64, 1, 32, 704, 704, 704, 32]
+    - [3, 12.5832]
+  - - [768, 64, 1, 32, 768, 768, 768, 32]
+    - [1, 129.56]
+  - - [832, 64, 1, 32, 832, 832, 832, 32]
+    - [0, 14.8445]
+  - - [896, 64, 1, 32, 896, 896, 896, 32]
+    - [2, 16.0774]
+  - - [960, 64, 1, 32, 960, 960, 960, 32]
+    - [3, 17.2047]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 18.3397]
+  - - [64, 128, 1, 32, 64, 64, 64, 32]
+    - [2, 2.29779]
+  - - [128, 128, 1, 32, 128, 128, 128, 32]
+    - [1, 49.1827]
+  - - [192, 128, 1, 32, 192, 192, 192, 32]
+    - [2, 6.90061]
+  - - [256, 128, 1, 32, 256, 256, 256, 32]
+    - [3, 9.25727]
+  - - [320, 128, 1, 32, 320, 320, 320, 32]
+    - [1, 11.4929]
+  - - [384, 128, 1, 32, 384, 384, 384, 32]
+    - [3, 13.7801]
+  - - [448, 128, 1, 32, 448, 448, 448, 32]
+    - [2, 16.0311]
+  - - [512, 128, 1, 32, 512, 512, 512, 32]
+    - [0, 18.3654]
+  - - [576, 128, 1, 32, 576, 576, 576, 32]
+    - [1, 20.671]
+  - - [640, 128, 1, 32, 640, 640, 640, 32]
+    - [3, 22.9547]
+  - - [704, 128, 1, 32, 704, 704, 704, 32]
+    - [2, 25.2049]
+  - - [768, 128, 1, 32, 768, 768, 768, 32]
+    - [3, 191.34]
+  - - [832, 128, 1, 32, 832, 832, 832, 32]
+    - [1, 194.291]
+  - - [896, 128, 1, 32, 896, 896, 896, 32]
+    - [3, 32.0944]
+  - - [960, 128, 1, 32, 960, 960, 960, 32]
+    - [1, 34.426]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 36.7083]
+  - - [64, 192, 1, 32, 64, 64, 64, 32]
+    - [0, 3.43462]
+  - - [128, 192, 1, 32, 128, 128, 128, 32]
+    - [0, 6.89094]
+  - - [192, 192, 1, 32, 192, 192, 192, 32]
+    - [3, 10.3477]
+  - - [256, 192, 1, 32, 256, 256, 256, 32]
+    - [0, 13.7716]
+  - - [320, 192, 1, 32, 320, 320, 320, 32]
+    - [1, 17.2334]
+  - - [384, 192, 1, 32, 384, 384, 384, 32]
+    - [1, 20.7037]
+  - - [448, 192, 1, 32, 448, 448, 448, 32]
+    - [1, 176.217]
+  - - [512, 192, 1, 32, 512, 512, 512, 32]
+    - [2, 27.5457]
+  - - [576, 192, 1, 32, 576, 576, 576, 32]
+    - [2, 30.9428]
+  - - [640, 192, 1, 32, 640, 640, 640, 32]
+    - [1, 34.4411]
+  - - [704, 192, 1, 32, 704, 704, 704, 32]
+    - [1, 37.5628]
+  - - [768, 192, 1, 32, 768, 768, 768, 32]
+    - [3, 41.3149]
+  - - [832, 192, 1, 32, 832, 832, 832, 32]
+    - [1, 44.7695]
+  - - [896, 192, 1, 32, 896, 896, 896, 32]
+    - [1, 48.1164]
+  - - [960, 192, 1, 32, 960, 960, 960, 32]
+    - [3, 51.5691]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 55.0576]
+  - - [64, 256, 1, 32, 64, 64, 64, 32]
+    - [3, 4.62759]
+  - - [128, 256, 1, 32, 128, 128, 128, 32]
+    - [1, 9.19316]
+  - - [192, 256, 1, 32, 192, 192, 192, 32]
+    - [3, 13.7734]
+  - - [256, 256, 1, 32, 256, 256, 256, 32]
+    - [0, 18.3645]
+  - - [320, 256, 1, 32, 320, 320, 320, 32]
+    - [1, 22.9336]
+  - - [384, 256, 1, 32, 384, 384, 384, 32]
+    - [1, 27.5204]
+  - - [448, 256, 1, 32, 448, 448, 448, 32]
+    - [3, 32.1352]
+  - - [512, 256, 1, 32, 512, 512, 512, 32]
+    - [0, 36.7067]
+  - - [576, 256, 1, 32, 576, 576, 576, 32]
+    - [0, 41.2282]
+  - - [640, 256, 1, 32, 640, 640, 640, 32]
+    - [2, 45.845]
+  - - [704, 256, 1, 32, 704, 704, 704, 32]
+    - [3, 50.4231]
+  - - [768, 256, 1, 32, 768, 768, 768, 32]
+    - [2, 54.9251]
+  - - [832, 256, 1, 32, 832, 832, 832, 32]
+    - [3, 59.4115]
+  - - [896, 256, 1, 32, 896, 896, 896, 32]
+    - [2, 64.1858]
+  - - [960, 256, 1, 32, 960, 960, 960, 32]
+    - [2, 254.016]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 32]
+    - [0, 254.969]
+  - - [64, 320, 1, 32, 64, 64, 64, 32]
+    - [3, 7.61467]
+  - - [128, 320, 1, 32, 128, 128, 128, 32]
+    - [2, 14.2299]
+  - - [192, 320, 1, 32, 192, 192, 192, 32]
+    - [3, 128.163]
+  - - [256, 320, 1, 32, 256, 256, 256, 32]
+    - [3, 56.1577]
+  - - [320, 320, 1, 32, 320, 320, 320, 32]
+    - [2, 77.3195]
+  - - [384, 320, 1, 32, 384, 384, 384, 32]
+    - [2, 94.9098]
+  - - [448, 320, 1, 32, 448, 448, 448, 32]
+    - [2, 106.13]
+  - - [512, 320, 1, 32, 512, 512, 512, 32]
+    - [1, 114.111]
+  - - [576, 320, 1, 32, 576, 576, 576, 32]
+    - [2, 136.423]
+  - - [640, 320, 1, 32, 640, 640, 640, 32]
+    - [1, 145.136]
+  - - [704, 320, 1, 32, 704, 704, 704, 32]
+    - [3, 178.043]
+  - - [768, 320, 1, 32, 768, 768, 768, 32]
+    - [3, 187.805]
+  - - [832, 320, 1, 32, 832, 832, 832, 32]
+    - [2, 201.408]
+  - - [896, 320, 1, 32, 896, 896, 896, 32]
+    - [2, 215.225]
+  - - [960, 320, 1, 32, 960, 960, 960, 32]
+    - [2, 234.057]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 208.317]
+  - - [64, 384, 1, 32, 64, 64, 64, 32]
+    - [3, 9.21145]
+  - - [128, 384, 1, 32, 128, 128, 128, 32]
+    - [1, 17.025]
+  - - [192, 384, 1, 32, 192, 192, 192, 32]
+    - [1, 7.75723]
+  - - [256, 384, 1, 32, 256, 256, 256, 32]
+    - [2, 10.3896]
+  - - [320, 384, 1, 32, 320, 320, 320, 32]
+    - [1, 223.666]
+  - - [384, 384, 1, 32, 384, 384, 384, 32]
+    - [2, 15.4626]
+  - - [448, 384, 1, 32, 448, 448, 448, 32]
+    - [2, 18.1659]
+  - - [512, 384, 1, 32, 512, 512, 512, 32]
+    - [2, 20.8546]
+  - - [576, 384, 1, 32, 576, 576, 576, 32]
+    - [1, 23.0688]
+  - - [640, 384, 1, 32, 640, 640, 640, 32]
+    - [3, 25.9462]
+  - - [704, 384, 1, 32, 704, 704, 704, 32]
+    - [3, 28.3835]
+  - - [768, 384, 1, 32, 768, 768, 768, 32]
+    - [2, 27.8558]
+  - - [832, 384, 1, 32, 832, 832, 832, 32]
+    - [3, 32.9007]
+  - - [896, 384, 1, 32, 896, 896, 896, 32]
+    - [1, 36.1089]
+  - - [960, 384, 1, 32, 960, 960, 960, 32]
+    - [1, 33.7818]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 36.0871]
+  - - [64, 448, 1, 32, 64, 64, 64, 32]
+    - [1, 3.07978]
+  - - [128, 448, 1, 32, 128, 128, 128, 32]
+    - [2, 136.533]
+  - - [192, 448, 1, 32, 192, 192, 192, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 256, 32]
+    - [1, 207.34]
+  - - [320, 448, 1, 32, 320, 320, 320, 32]
+    - [1, 234.296]
+  - - [384, 448, 1, 32, 384, 384, 384, 32]
+    - [3, 18.1899]
+  - - [448, 448, 1, 32, 448, 448, 448, 32]
+    - [2, 21.0968]
+  - - [512, 448, 1, 32, 512, 512, 512, 32]
+    - [3, 24.1189]
+  - - [576, 448, 1, 32, 576, 576, 576, 32]
+    - [3, 24.1095]
+  - - [640, 448, 1, 32, 640, 640, 640, 32]
+    - [2, 269.221]
+  - - [704, 448, 1, 32, 704, 704, 704, 32]
+    - [3, 204.303]
+  - - [768, 448, 1, 32, 768, 768, 768, 32]
+    - [3, 228.899]
+  - - [832, 448, 1, 32, 832, 832, 832, 32]
+    - [2, 248.18]
+  - - [896, 448, 1, 32, 896, 896, 896, 32]
+    - [3, 267.157]
+  - - [960, 448, 1, 32, 960, 960, 960, 32]
+    - [3, 278.144]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 291.966]
+  - - [64, 512, 1, 32, 64, 64, 64, 32]
+    - [3, 10.8942]
+  - - [128, 512, 1, 32, 128, 128, 128, 32]
+    - [2, 55.8645]
+  - - [192, 512, 1, 32, 192, 192, 192, 32]
+    - [2, 65.906]
+  - - [256, 512, 1, 32, 256, 256, 256, 32]
+    - [2, 86.2139]
+  - - [320, 512, 1, 32, 320, 320, 320, 32]
+    - [2, 106.66]
+  - - [384, 512, 1, 32, 384, 384, 384, 32]
+    - [1, 124.202]
+  - - [448, 512, 1, 32, 448, 448, 448, 32]
+    - [1, 139.478]
+  - - [512, 512, 1, 32, 512, 512, 512, 32]
+    - [3, 177.031]
+  - - [576, 512, 1, 32, 576, 576, 576, 32]
+    - [3, 194.86]
+  - - [640, 512, 1, 32, 640, 640, 640, 32]
+    - [3, 205.36]
+  - - [704, 512, 1, 32, 704, 704, 704, 32]
+    - [3, 266.013]
+  - - [768, 512, 1, 32, 768, 768, 768, 32]
+    - [3, 36.8442]
+  - - [832, 512, 1, 32, 832, 832, 832, 32]
+    - [2, 40.0112]
+  - - [896, 512, 1, 32, 896, 896, 896, 32]
+    - [3, 45.583]
+  - - [960, 512, 1, 32, 960, 960, 960, 32]
+    - [2, 45.1471]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 632.613]
+  - - [64, 576, 1, 32, 64, 64, 64, 32]
+    - [2, 12.9474]
+  - - [128, 576, 1, 32, 128, 128, 128, 32]
+    - [2, 50.4554]
+  - - [192, 576, 1, 32, 192, 192, 192, 32]
+    - [2, 84.8362]
+  - - [256, 576, 1, 32, 256, 256, 256, 32]
+    - [2, 111.643]
+  - - [320, 576, 1, 32, 320, 320, 320, 32]
+    - [1, 130.896]
+  - - [384, 576, 1, 32, 384, 384, 384, 32]
+    - [3, 61.5439]
+  - - [448, 576, 1, 32, 448, 448, 448, 32]
+    - [1, 71.8731]
+  - - [512, 576, 1, 32, 512, 512, 512, 32]
+    - [2, 81.845]
+  - - [576, 576, 1, 32, 576, 576, 576, 32]
+    - [3, 93.0358]
+  - - [640, 576, 1, 32, 640, 640, 640, 32]
+    - [1, 103.328]
+  - - [704, 576, 1, 32, 704, 704, 704, 32]
+    - [3, 113.566]
+  - - [768, 576, 1, 32, 768, 768, 768, 32]
+    - [2, 123.809]
+  - - [832, 576, 1, 32, 832, 832, 832, 32]
+    - [2, 135.286]
+  - - [896, 576, 1, 32, 896, 896, 896, 32]
+    - [0, 144.16]
+  - - [960, 576, 1, 32, 960, 960, 960, 32]
+    - [0, 154.289]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 55.2663]
+  - - [64, 640, 1, 32, 64, 64, 64, 32]
+    - [3, 4.32657]
+  - - [128, 640, 1, 32, 128, 128, 128, 32]
+    - [3, 8.54722]
+  - - [192, 640, 1, 32, 192, 192, 192, 32]
+    - [3, 210.501]
+  - - [256, 640, 1, 32, 256, 256, 256, 32]
+    - [1, 248.478]
+  - - [320, 640, 1, 32, 320, 320, 320, 32]
+    - [1, 20.9872]
+  - - [384, 640, 1, 32, 384, 384, 384, 32]
+    - [3, 25.903]
+  - - [448, 640, 1, 32, 448, 448, 448, 32]
+    - [1, 26.54]
+  - - [512, 640, 1, 32, 512, 512, 512, 32]
+    - [3, 33.82]
+  - - [576, 640, 1, 32, 576, 576, 576, 32]
+    - [1, 37.43]
+  - - [640, 640, 1, 32, 640, 640, 640, 32]
+    - [3, 34.0321]
+  - - [704, 640, 1, 32, 704, 704, 704, 32]
+    - [2, 45.0431]
+  - - [768, 640, 1, 32, 768, 768, 768, 32]
+    - [3, 45.9295]
+  - - [832, 640, 1, 32, 832, 832, 832, 32]
+    - [3, 276.88]
+  - - [896, 640, 1, 32, 896, 896, 896, 32]
+    - [2, 53.7209]
+  - - [960, 640, 1, 32, 960, 960, 960, 32]
+    - [2, 57.1025]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 59.7382]
+  - - [64, 704, 1, 32, 64, 64, 64, 32]
+    - [3, 4.74053]
+  - - [128, 704, 1, 32, 128, 128, 128, 32]
+    - [2, 9.37091]
+  - - [192, 704, 1, 32, 192, 192, 192, 32]
+    - [2, 14.1319]
+  - - [256, 704, 1, 32, 256, 256, 256, 32]
+    - [2, 19.5838]
+  - - [320, 704, 1, 32, 320, 320, 320, 32]
+    - [3, 23.6964]
+  - - [384, 704, 1, 32, 384, 384, 384, 32]
+    - [3, 27.7649]
+  - - [448, 704, 1, 32, 448, 448, 448, 32]
+    - [2, 32.7588]
+  - - [512, 704, 1, 32, 512, 512, 512, 32]
+    - [2, 33.4895]
+  - - [576, 704, 1, 32, 576, 576, 576, 32]
+    - [2, 37.6538]
+  - - [640, 704, 1, 32, 640, 640, 640, 32]
+    - [0, 36.5703]
+  - - [704, 704, 1, 32, 704, 704, 704, 32]
+    - [3, 46.5967]
+  - - [768, 704, 1, 32, 768, 768, 768, 32]
+    - [1, 49.955]
+  - - [832, 704, 1, 32, 832, 832, 832, 32]
+    - [2, 54.7614]
+  - - [896, 704, 1, 32, 896, 896, 896, 32]
+    - [2, 58.6893]
+  - - [960, 704, 1, 32, 960, 960, 960, 32]
+    - [1, 53.1547]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 66.2851]
+  - - [64, 768, 1, 32, 64, 64, 64, 32]
+    - [3, 5.20244]
+  - - [128, 768, 1, 32, 128, 128, 128, 32]
+    - [2, 10.3143]
+  - - [192, 768, 1, 32, 192, 192, 192, 32]
+    - [3, 15.5431]
+  - - [256, 768, 1, 32, 256, 256, 256, 32]
+    - [3, 20.7303]
+  - - [320, 768, 1, 32, 320, 320, 320, 32]
+    - [3, 25.6257]
+  - - [384, 768, 1, 32, 384, 384, 384, 32]
+    - [3, 30.8031]
+  - - [448, 768, 1, 32, 448, 448, 448, 32]
+    - [2, 32.4291]
+  - - [512, 768, 1, 32, 512, 512, 512, 32]
+    - [3, 39.7506]
+  - - [576, 768, 1, 32, 576, 576, 576, 32]
+    - [2, 41.4418]
+  - - [640, 768, 1, 32, 640, 640, 640, 32]
+    - [2, 295.426]
+  - - [704, 768, 1, 32, 704, 704, 704, 32]
+    - [2, 50.5342]
+  - - [768, 768, 1, 32, 768, 768, 768, 32]
+    - [2, 54.939]
+  - - [832, 768, 1, 32, 832, 832, 832, 32]
+    - [3, 58.1719]
+  - - [896, 768, 1, 32, 896, 896, 896, 32]
+    - [1, 63.765]
+  - - [960, 768, 1, 32, 960, 960, 960, 32]
+    - [2, 68.1401]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 70.5119]
+  - - [64, 832, 1, 32, 64, 64, 64, 32]
+    - [2, 131.274]
+  - - [128, 832, 1, 32, 128, 128, 128, 32]
+    - [1, 193.19]
+  - - [192, 832, 1, 32, 192, 192, 192, 32]
+    - [1, 242.72]
+  - - [256, 832, 1, 32, 256, 256, 256, 32]
+    - [1, 269.392]
+  - - [320, 832, 1, 32, 320, 320, 320, 32]
+    - [0, 72.9044]
+  - - [384, 832, 1, 32, 384, 384, 384, 32]
+    - [2, 29.7413]
+  - - [448, 832, 1, 32, 448, 448, 448, 32]
+    - [2, 37.9717]
+  - - [512, 832, 1, 32, 512, 512, 512, 32]
+    - [3, 42.7618]
+  - - [576, 832, 1, 32, 576, 576, 576, 32]
+    - [1, 36.6624]
+  - - [640, 832, 1, 32, 640, 640, 640, 32]
+    - [3, 49.675]
+  - - [704, 832, 1, 32, 704, 704, 704, 32]
+    - [2, 56.5567]
+  - - [768, 832, 1, 32, 768, 768, 768, 32]
+    - [3, 59.3651]
+  - - [832, 832, 1, 32, 832, 832, 832, 32]
+    - [3, 64.4816]
+  - - [896, 832, 1, 32, 896, 896, 896, 32]
+    - [2, 68.9171]
+  - - [960, 832, 1, 32, 960, 960, 960, 32]
+    - [1, 63.7849]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 79.2627]
+  - - [64, 896, 1, 32, 64, 64, 64, 32]
+    - [2, 6.0592]
+  - - [128, 896, 1, 32, 128, 128, 128, 32]
+    - [3, 12.0502]
+  - - [192, 896, 1, 32, 192, 192, 192, 32]
+    - [3, 249.774]
+  - - [256, 896, 1, 32, 256, 256, 256, 32]
+    - [2, 23.7929]
+  - - [320, 896, 1, 32, 320, 320, 320, 32]
+    - [2, 83.3031]
+  - - [384, 896, 1, 32, 384, 384, 384, 32]
+    - [3, 34.9013]
+  - - [448, 896, 1, 32, 448, 448, 448, 32]
+    - [1, 35.9602]
+  - - [512, 896, 1, 32, 512, 512, 512, 32]
+    - [1, 42.0896]
+  - - [576, 896, 1, 32, 576, 576, 576, 32]
+    - [3, 48.2746]
+  - - [640, 896, 1, 32, 640, 640, 640, 32]
+    - [1, 53.1706]
+  - - [704, 896, 1, 32, 704, 704, 704, 32]
+    - [2, 59.3754]
+  - - [768, 896, 1, 32, 768, 768, 768, 32]
+    - [3, 63.9902]
+  - - [832, 896, 1, 32, 832, 832, 832, 32]
+    - [0, 67.4584]
+  - - [896, 896, 1, 32, 896, 896, 896, 32]
+    - [2, 72.8681]
+  - - [960, 896, 1, 32, 960, 960, 960, 32]
+    - [1, 79.6003]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 82.539]
+  - - [64, 960, 1, 32, 64, 64, 64, 32]
+    - [1, 6.40329]
+  - - [128, 960, 1, 32, 128, 128, 128, 32]
+    - [2, 12.9321]
+  - - [192, 960, 1, 32, 192, 192, 192, 32]
+    - [2, 19.3689]
+  - - [256, 960, 1, 32, 256, 256, 256, 32]
+    - [1, 25.2785]
+  - - [320, 960, 1, 32, 320, 320, 320, 32]
+    - [1, 31.4692]
+  - - [384, 960, 1, 32, 384, 384, 384, 32]
+    - [2, 34.3398]
+  - - [448, 960, 1, 32, 448, 448, 448, 32]
+    - [2, 40.19]
+  - - [512, 960, 1, 32, 512, 512, 512, 32]
+    - [3, 45.686]
+  - - [576, 960, 1, 32, 576, 576, 576, 32]
+    - [3, 51.5217]
+  - - [640, 960, 1, 32, 640, 640, 640, 32]
+    - [2, 57.8128]
+  - - [704, 960, 1, 32, 704, 704, 704, 32]
+    - [0, 61.3229]
+  - - [768, 960, 1, 32, 768, 768, 768, 32]
+    - [0, 65.2042]
+  - - [832, 960, 1, 32, 832, 832, 832, 32]
+    - [2, 72.6756]
+  - - [896, 960, 1, 32, 896, 896, 896, 32]
+    - [1, 79.4669]
+  - - [960, 960, 1, 32, 960, 960, 960, 32]
+    - [2, 78.536]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 85.7013]
+  - - [64, 1024, 1, 32, 64, 64, 64, 32]
+    - [3, 6.90076]
+  - - [128, 1024, 1, 32, 128, 128, 128, 32]
+    - [3, 13.7965]
+  - - [192, 1024, 1, 32, 192, 192, 192, 32]
+    - [3, 20.4795]
+  - - [256, 1024, 1, 32, 256, 256, 256, 32]
+    - [3, 27.4706]
+  - - [320, 1024, 1, 32, 320, 320, 320, 32]
+    - [0, 29.5718]
+  - - [384, 1024, 1, 32, 384, 384, 384, 32]
+    - [2, 40.0721]
+  - - [448, 1024, 1, 32, 448, 448, 448, 32]
+    - [2, 42.8763]
+  - - [512, 1024, 1, 32, 512, 512, 512, 32]
+    - [3, 48.9415]
+  - - [576, 1024, 1, 32, 576, 576, 576, 32]
+    - [0, 53.6033]
+  - - [640, 1024, 1, 32, 640, 640, 640, 32]
+    - [1, 59.8688]
+  - - [704, 1024, 1, 32, 704, 704, 704, 32]
+    - [0, 64.5626]
+  - - [768, 1024, 1, 32, 768, 768, 768, 32]
+    - [2, 61.8968]
+  - - [832, 1024, 1, 32, 832, 832, 832, 32]
+    - [1, 78.4519]
+  - - [896, 1024, 1, 32, 896, 896, 896, 32]
+    - [2, 69.6129]
+  - - [960, 1024, 1, 32, 960, 960, 960, 32]
+    - [3, 85.3746]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 90.2469]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi31
+- gfx1100
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 64]
+    - [1, 1.15726]
+  - - [128, 64, 1, 32, 128, 128, 32, 64]
+    - [3, 2.31821]
+  - - [192, 64, 1, 32, 192, 192, 32, 64]
+    - [2, 3.47424]
+  - - [256, 64, 1, 32, 256, 256, 32, 64]
+    - [2, 4.63209]
+  - - [320, 64, 1, 32, 320, 320, 32, 64]
+    - [2, 5.79552]
+  - - [384, 64, 1, 32, 384, 384, 32, 64]
+    - [3, 6.95431]
+  - - [448, 64, 1, 32, 448, 448, 32, 64]
+    - [3, 76.2046]
+  - - [512, 64, 1, 32, 512, 512, 32, 64]
+    - [1, 9.2716]
+  - - [576, 64, 1, 32, 576, 576, 32, 64]
+    - [0, 102.578]
+  - - [640, 64, 1, 32, 640, 640, 32, 64]
+    - [3, 11.5757]
+  - - [704, 64, 1, 32, 704, 704, 32, 64]
+    - [2, 12.7349]
+  - - [768, 64, 1, 32, 768, 768, 32, 64]
+    - [2, 13.8773]
+  - - [832, 64, 1, 32, 832, 832, 32, 64]
+    - [2, 14.9677]
+  - - [896, 64, 1, 32, 896, 896, 32, 64]
+    - [0, 16.1127]
+  - - [960, 64, 1, 32, 960, 960, 32, 64]
+    - [3, 17.2894]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 64]
+    - [2, 18.451]
+  - - [64, 128, 1, 32, 64, 64, 32, 128]
+    - [3, 24.1385]
+  - - [128, 128, 1, 32, 128, 128, 32, 128]
+    - [0, 55.8942]
+  - - [192, 128, 1, 32, 192, 192, 32, 128]
+    - [2, 77.5536]
+  - - [256, 128, 1, 32, 256, 256, 32, 128]
+    - [3, 3.71372]
+  - - [320, 128, 1, 32, 320, 320, 32, 128]
+    - [3, 4.61828]
+  - - [384, 128, 1, 32, 384, 384, 32, 128]
+    - [1, 5.23804]
+  - - [448, 128, 1, 32, 448, 448, 32, 128]
+    - [3, 6.42685]
+  - - [512, 128, 1, 32, 512, 512, 32, 128]
+    - [1, 6.90462]
+  - - [576, 128, 1, 32, 576, 576, 32, 128]
+    - [3, 7.89334]
+  - - [640, 128, 1, 32, 640, 640, 32, 128]
+    - [2, 8.75149]
+  - - [704, 128, 1, 32, 704, 704, 32, 128]
+    - [3, 9.61092]
+  - - [768, 128, 1, 32, 768, 768, 32, 128]
+    - [3, 10.4859]
+  - - [832, 128, 1, 32, 832, 832, 32, 128]
+    - [1, 11.2858]
+  - - [896, 128, 1, 32, 896, 896, 32, 128]
+    - [1, 213.125]
+  - - [960, 128, 1, 32, 960, 960, 32, 128]
+    - [2, 13.1457]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 128]
+    - [2, 14.0183]
+  - - [64, 192, 1, 32, 64, 64, 32, 192]
+    - [3, 1.32088]
+  - - [128, 192, 1, 32, 128, 128, 32, 192]
+    - [2, 2.64208]
+  - - [192, 192, 1, 32, 192, 192, 32, 192]
+    - [2, 3.91608]
+  - - [256, 192, 1, 32, 256, 256, 32, 192]
+    - [3, 5.28406]
+  - - [320, 192, 1, 32, 320, 320, 32, 192]
+    - [2, 6.54701]
+  - - [384, 192, 1, 32, 384, 384, 32, 192]
+    - [1, 7.81296]
+  - - [448, 192, 1, 32, 448, 448, 32, 192]
+    - [2, 9.13691]
+  - - [512, 192, 1, 32, 512, 512, 32, 192]
+    - [1, 10.4083]
+  - - [576, 192, 1, 32, 576, 576, 32, 192]
+    - [2, 11.7711]
+  - - [640, 192, 1, 32, 640, 640, 32, 192]
+    - [3, 13.14]
+  - - [704, 192, 1, 32, 704, 704, 32, 192]
+    - [1, 14.2987]
+  - - [768, 192, 1, 32, 768, 768, 32, 192]
+    - [2, 15.7448]
+  - - [832, 192, 1, 32, 832, 832, 32, 192]
+    - [2, 17.0191]
+  - - [896, 192, 1, 32, 896, 896, 32, 192]
+    - [2, 18.3705]
+  - - [960, 192, 1, 32, 960, 960, 32, 192]
+    - [1, 19.4195]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 192]
+    - [3, 20.9334]
+  - - [64, 256, 1, 32, 64, 64, 32, 256]
+    - [2, 1.73956]
+  - - [128, 256, 1, 32, 128, 128, 32, 256]
+    - [1, 3.50886]
+  - - [192, 256, 1, 32, 192, 192, 32, 256]
+    - [3, 5.30402]
+  - - [256, 256, 1, 32, 256, 256, 32, 256]
+    - [3, 7.03596]
+  - - [320, 256, 1, 32, 320, 320, 32, 256]
+    - [3, 8.79437]
+  - - [384, 256, 1, 32, 384, 384, 32, 256]
+    - [2, 10.3936]
+  - - [448, 256, 1, 32, 448, 448, 32, 256]
+    - [2, 12.1206]
+  - - [512, 256, 1, 32, 512, 512, 32, 256]
+    - [3, 14.0427]
+  - - [576, 256, 1, 32, 576, 576, 32, 256]
+    - [3, 15.7864]
+  - - [640, 256, 1, 32, 640, 640, 32, 256]
+    - [3, 17.4744]
+  - - [704, 256, 1, 32, 704, 704, 32, 256]
+    - [1, 247.513]
+  - - [768, 256, 1, 32, 768, 768, 32, 256]
+    - [2, 20.6236]
+  - - [832, 256, 1, 32, 832, 832, 32, 256]
+    - [3, 22.6944]
+  - - [896, 256, 1, 32, 896, 896, 32, 256]
+    - [3, 24.3493]
+  - - [960, 256, 1, 32, 960, 960, 32, 256]
+    - [2, 25.8264]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 256]
+    - [1, 24.3747]
+  - - [64, 320, 1, 32, 64, 64, 32, 320]
+    - [2, 1.92099]
+  - - [128, 320, 1, 32, 128, 128, 32, 320]
+    - [2, 112.993]
+  - - [192, 320, 1, 32, 192, 192, 32, 320]
+    - [2, 15.7677]
+  - - [256, 320, 1, 32, 256, 256, 32, 320]
+    - [2, 170.445]
+  - - [320, 320, 1, 32, 320, 320, 32, 320]
+    - [2, 10.8445]
+  - - [384, 320, 1, 32, 384, 384, 32, 320]
+    - [1, 12.7485]
+  - - [448, 320, 1, 32, 448, 448, 32, 320]
+    - [1, 15.127]
+  - - [512, 320, 1, 32, 512, 512, 32, 320]
+    - [2, 17.4663]
+  - - [576, 320, 1, 32, 576, 576, 32, 320]
+    - [2, 14.4937]
+  - - [640, 320, 1, 32, 640, 640, 32, 320]
+    - [3, 21.761]
+  - - [704, 320, 1, 32, 704, 704, 32, 320]
+    - [3, 24.1234]
+  - - [768, 320, 1, 32, 768, 768, 32, 320]
+    - [1, 26.199]
+  - - [832, 320, 1, 32, 832, 832, 32, 320]
+    - [2, 28.1632]
+  - - [896, 320, 1, 32, 896, 896, 32, 320]
+    - [2, 30.1531]
+  - - [960, 320, 1, 32, 960, 960, 32, 320]
+    - [3, 31.8247]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 320]
+    - [2, 34.0556]
+  - - [64, 384, 1, 32, 64, 64, 32, 384]
+    - [3, 2.66269]
+  - - [128, 384, 1, 32, 128, 128, 32, 384]
+    - [1, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 384]
+    - [3, 7.91506]
+  - - [256, 384, 1, 32, 256, 256, 32, 384]
+    - [2, 10.4834]
+  - - [320, 384, 1, 32, 320, 320, 32, 384]
+    - [3, 13.1668]
+  - - [384, 384, 1, 32, 384, 384, 32, 384]
+    - [2, 15.7136]
+  - - [448, 384, 1, 32, 448, 448, 32, 384]
+    - [3, 18.5612]
+  - - [512, 384, 1, 32, 512, 512, 32, 384]
+    - [3, 21.012]
+  - - [576, 384, 1, 32, 576, 576, 32, 384]
+    - [2, 23.57]
+  - - [640, 384, 1, 32, 640, 640, 32, 384]
+    - [1, 26.1267]
+  - - [704, 384, 1, 32, 704, 704, 32, 384]
+    - [2, 25.9286]
+  - - [768, 384, 1, 32, 768, 768, 32, 384]
+    - [3, 30.459]
+  - - [832, 384, 1, 32, 832, 832, 32, 384]
+    - [3, 32.9458]
+  - - [896, 384, 1, 32, 896, 896, 32, 384]
+    - [2, 35.4332]
+  - - [960, 384, 1, 32, 960, 960, 32, 384]
+    - [1, 321.255]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 384]
+    - [3, 35.291]
+  - - [64, 448, 1, 32, 64, 64, 32, 448]
+    - [1, 3.08144]
+  - - [128, 448, 1, 32, 128, 128, 32, 448]
+    - [1, 6.12932]
+  - - [192, 448, 1, 32, 192, 192, 32, 448]
+    - [1, 9.12646]
+  - - [256, 448, 1, 32, 256, 256, 32, 448]
+    - [2, 12.2539]
+  - - [320, 448, 1, 32, 320, 320, 32, 448]
+    - [2, 15.2543]
+  - - [384, 448, 1, 32, 384, 384, 32, 448]
+    - [2, 18.3503]
+  - - [448, 448, 1, 32, 448, 448, 32, 448]
+    - [2, 21.3375]
+  - - [512, 448, 1, 32, 512, 512, 32, 448]
+    - [2, 250.342]
+  - - [576, 448, 1, 32, 576, 576, 32, 448]
+    - [3, 27.1378]
+  - - [640, 448, 1, 32, 640, 640, 32, 448]
+    - [3, 29.9288]
+  - - [704, 448, 1, 32, 704, 704, 32, 448]
+    - [3, 30.1579]
+  - - [768, 448, 1, 32, 768, 768, 32, 448]
+    - [2, 31.8502]
+  - - [832, 448, 1, 32, 832, 832, 32, 448]
+    - [3, 35.3894]
+  - - [896, 448, 1, 32, 896, 896, 32, 448]
+    - [1, 37.6614]
+  - - [960, 448, 1, 32, 960, 960, 32, 448]
+    - [2, 41.1963]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 448]
+    - [2, 44.0087]
+  - - [64, 512, 1, 32, 64, 64, 32, 512]
+    - [1, 3.52295]
+  - - [128, 512, 1, 32, 128, 128, 32, 512]
+    - [1, 6.94911]
+  - - [192, 512, 1, 32, 192, 192, 32, 512]
+    - [3, 10.5167]
+  - - [256, 512, 1, 32, 256, 256, 32, 512]
+    - [2, 14.0604]
+  - - [320, 512, 1, 32, 320, 320, 32, 512]
+    - [2, 17.2647]
+  - - [384, 512, 1, 32, 384, 384, 32, 512]
+    - [3, 18.5058]
+  - - [448, 512, 1, 32, 448, 448, 32, 512]
+    - [2, 24.1574]
+  - - [512, 512, 1, 32, 512, 512, 32, 512]
+    - [3, 23.8816]
+  - - [576, 512, 1, 32, 576, 576, 32, 512]
+    - [1, 30.8791]
+  - - [640, 512, 1, 32, 640, 640, 32, 512]
+    - [1, 30.8095]
+  - - [704, 512, 1, 32, 704, 704, 32, 512]
+    - [1, 31.2565]
+  - - [768, 512, 1, 32, 768, 768, 32, 512]
+    - [3, 37.0819]
+  - - [832, 512, 1, 32, 832, 832, 32, 512]
+    - [0, 38.4813]
+  - - [896, 512, 1, 32, 896, 896, 32, 512]
+    - [3, 272.76]
+  - - [960, 512, 1, 32, 960, 960, 32, 512]
+    - [2, 285.143]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 512]
+    - [2, 300.344]
+  - - [64, 576, 1, 32, 64, 64, 32, 576]
+    - [1, 3.94252]
+  - - [128, 576, 1, 32, 128, 128, 32, 576]
+    - [2, 7.85877]
+  - - [192, 576, 1, 32, 192, 192, 32, 576]
+    - [1, 11.7529]
+  - - [256, 576, 1, 32, 256, 256, 32, 576]
+    - [2, 15.6784]
+  - - [320, 576, 1, 32, 320, 320, 32, 576]
+    - [2, 19.6958]
+  - - [384, 576, 1, 32, 384, 384, 32, 576]
+    - [3, 23.6192]
+  - - [448, 576, 1, 32, 448, 448, 32, 576]
+    - [2, 27.2277]
+  - - [512, 576, 1, 32, 512, 512, 32, 576]
+    - [1, 303.057]
+  - - [576, 576, 1, 32, 576, 576, 32, 576]
+    - [2, 56.6076]
+  - - [640, 576, 1, 32, 640, 640, 32, 576]
+    - [3, 37.3097]
+  - - [704, 576, 1, 32, 704, 704, 32, 576]
+    - [3, 40.4755]
+  - - [768, 576, 1, 32, 768, 768, 32, 576]
+    - [3, 42.0593]
+  - - [832, 576, 1, 32, 832, 832, 32, 576]
+    - [3, 45.7279]
+  - - [896, 576, 1, 32, 896, 896, 32, 576]
+    - [1, 48.5906]
+  - - [960, 576, 1, 32, 960, 960, 32, 576]
+    - [2, 52.451]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 576]
+    - [1, 52.4547]
+  - - [64, 640, 1, 32, 64, 64, 32, 640]
+    - [2, 4.36809]
+  - - [128, 640, 1, 32, 128, 128, 32, 640]
+    - [1, 8.54343]
+  - - [192, 640, 1, 32, 192, 192, 32, 640]
+    - [2, 13.0236]
+  - - [256, 640, 1, 32, 256, 256, 32, 640]
+    - [3, 17.4794]
+  - - [320, 640, 1, 32, 320, 320, 32, 640]
+    - [2, 21.473]
+  - - [384, 640, 1, 32, 384, 384, 32, 640]
+    - [1, 25.7238]
+  - - [448, 640, 1, 32, 448, 448, 32, 640]
+    - [1, 28.8571]
+  - - [512, 640, 1, 32, 512, 512, 32, 640]
+    - [3, 31.1338]
+  - - [576, 640, 1, 32, 576, 576, 32, 640]
+    - [3, 37.6695]
+  - - [640, 640, 1, 32, 640, 640, 32, 640]
+    - [3, 41.3063]
+  - - [704, 640, 1, 32, 704, 704, 32, 640]
+    - [2, 282.038]
+  - - [768, 640, 1, 32, 768, 768, 32, 640]
+    - [1, 44.3651]
+  - - [832, 640, 1, 32, 832, 832, 32, 640]
+    - [1, 339.561]
+  - - [896, 640, 1, 32, 896, 896, 32, 640]
+    - [1, 342.221]
+  - - [960, 640, 1, 32, 960, 960, 32, 640]
+    - [2, 54.8507]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 640]
+    - [1, 60.763]
+  - - [64, 704, 1, 32, 64, 64, 32, 704]
+    - [2, 4.83657]
+  - - [128, 704, 1, 32, 128, 128, 32, 704]
+    - [2, 9.51187]
+  - - [192, 704, 1, 32, 192, 192, 32, 704]
+    - [3, 14.5053]
+  - - [256, 704, 1, 32, 256, 256, 32, 704]
+    - [1, 19.0363]
+  - - [320, 704, 1, 32, 320, 320, 32, 704]
+    - [1, 267.593]
+  - - [384, 704, 1, 32, 384, 384, 32, 704]
+    - [2, 28.4469]
+  - - [448, 704, 1, 32, 448, 448, 32, 704]
+    - [2, 32.8767]
+  - - [512, 704, 1, 32, 512, 512, 32, 704]
+    - [1, 32.7986]
+  - - [576, 704, 1, 32, 576, 576, 32, 704]
+    - [1, 319.605]
+  - - [640, 704, 1, 32, 640, 640, 32, 704]
+    - [3, 44.8045]
+  - - [704, 704, 1, 32, 704, 704, 32, 704]
+    - [3, 46.3515]
+  - - [768, 704, 1, 32, 768, 768, 32, 704]
+    - [1, 50.2597]
+  - - [832, 704, 1, 32, 832, 832, 32, 704]
+    - [2, 54.9452]
+  - - [896, 704, 1, 32, 896, 896, 32, 704]
+    - [1, 58.9238]
+  - - [960, 704, 1, 32, 960, 960, 32, 704]
+    - [3, 57.3889]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 704]
+    - [1, 67.3308]
+  - - [64, 768, 1, 32, 64, 64, 32, 768]
+    - [2, 5.13066]
+  - - [128, 768, 1, 32, 128, 128, 32, 768]
+    - [3, 10.4063]
+  - - [192, 768, 1, 32, 192, 192, 32, 768]
+    - [3, 15.5295]
+  - - [256, 768, 1, 32, 256, 256, 32, 768]
+    - [2, 235.635]
+  - - [320, 768, 1, 32, 320, 320, 32, 768]
+    - [3, 25.7752]
+  - - [384, 768, 1, 32, 384, 384, 32, 768]
+    - [2, 27.6193]
+  - - [448, 768, 1, 32, 448, 448, 32, 768]
+    - [2, 35.5029]
+  - - [512, 768, 1, 32, 512, 512, 32, 768]
+    - [0, 283.396]
+  - - [576, 768, 1, 32, 576, 576, 32, 768]
+    - [3, 41.5159]
+  - - [640, 768, 1, 32, 640, 640, 32, 768]
+    - [1, 318.394]
+  - - [704, 768, 1, 32, 704, 704, 32, 768]
+    - [1, 151.018]
+  - - [768, 768, 1, 32, 768, 768, 32, 768]
+    - [2, 54.769]
+  - - [832, 768, 1, 32, 832, 832, 32, 768]
+    - [3, 59.8533]
+  - - [896, 768, 1, 32, 896, 896, 32, 768]
+    - [3, 64.697]
+  - - [960, 768, 1, 32, 960, 960, 32, 768]
+    - [3, 272.639]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 768]
+    - [0, 158.739]
+  - - [64, 832, 1, 32, 64, 64, 32, 832]
+    - [3, 5.6198]
+  - - [128, 832, 1, 32, 128, 128, 32, 832]
+    - [3, 11.2135]
+  - - [192, 832, 1, 32, 192, 192, 32, 832]
+    - [1, 12.6673]
+  - - [256, 832, 1, 32, 256, 256, 32, 832]
+    - [2, 21.8459]
+  - - [320, 832, 1, 32, 320, 320, 32, 832]
+    - [2, 27.6993]
+  - - [384, 832, 1, 32, 384, 384, 32, 832]
+    - [2, 33.2084]
+  - - [448, 832, 1, 32, 448, 448, 32, 832]
+    - [1, 34.47]
+  - - [512, 832, 1, 32, 512, 512, 32, 832]
+    - [3, 38.4699]
+  - - [576, 832, 1, 32, 576, 576, 32, 832]
+    - [3, 44.7355]
+  - - [640, 832, 1, 32, 640, 640, 32, 832]
+    - [2, 49.7729]
+  - - [704, 832, 1, 32, 704, 704, 32, 832]
+    - [0, 51.9778]
+  - - [768, 832, 1, 32, 768, 768, 32, 832]
+    - [2, 60.0476]
+  - - [832, 832, 1, 32, 832, 832, 32, 832]
+    - [3, 61.0171]
+  - - [896, 832, 1, 32, 896, 896, 32, 832]
+    - [3, 68.7008]
+  - - [960, 832, 1, 32, 960, 960, 32, 832]
+    - [1, 73.7301]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 832]
+    - [2, 76.7188]
+  - - [64, 896, 1, 32, 64, 64, 32, 896]
+    - [3, 6.0638]
+  - - [128, 896, 1, 32, 128, 128, 32, 896]
+    - [1, 11.8097]
+  - - [192, 896, 1, 32, 192, 192, 32, 896]
+    - [1, 260.408]
+  - - [256, 896, 1, 32, 256, 256, 32, 896]
+    - [1, 112.061]
+  - - [320, 896, 1, 32, 320, 320, 32, 896]
+    - [1, 21.646]
+  - - [384, 896, 1, 32, 384, 384, 32, 896]
+    - [3, 35.1622]
+  - - [448, 896, 1, 32, 448, 448, 32, 896]
+    - [2, 40.6641]
+  - - [512, 896, 1, 32, 512, 512, 32, 896]
+    - [2, 42.9101]
+  - - [576, 896, 1, 32, 576, 576, 32, 896]
+    - [0, 43.0245]
+  - - [640, 896, 1, 32, 640, 640, 32, 896]
+    - [3, 79.8571]
+  - - [704, 896, 1, 32, 704, 704, 32, 896]
+    - [1, 49.3707]
+  - - [768, 896, 1, 32, 768, 768, 32, 896]
+    - [3, 63.6994]
+  - - [832, 896, 1, 32, 832, 832, 32, 896]
+    - [2, 61.6821]
+  - - [896, 896, 1, 32, 896, 896, 32, 896]
+    - [2, 72.8566]
+  - - [960, 896, 1, 32, 960, 960, 32, 896]
+    - [1, 354.886]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 896]
+    - [0, 317.886]
+  - - [64, 960, 1, 32, 64, 64, 32, 960]
+    - [1, 53.3971]
+  - - [128, 960, 1, 32, 128, 128, 32, 960]
+    - [3, 90.4142]
+  - - [192, 960, 1, 32, 192, 192, 32, 960]
+    - [2, 122.611]
+  - - [256, 960, 1, 32, 256, 256, 32, 960]
+    - [3, 183.744]
+  - - [320, 960, 1, 32, 320, 320, 32, 960]
+    - [3, 223.215]
+  - - [384, 960, 1, 32, 384, 384, 32, 960]
+    - [3, 254.894]
+  - - [448, 960, 1, 32, 448, 448, 32, 960]
+    - [1, 281.213]
+  - - [512, 960, 1, 32, 512, 512, 32, 960]
+    - [1, 112.761]
+  - - [576, 960, 1, 32, 576, 576, 32, 960]
+    - [3, 48.9911]
+  - - [640, 960, 1, 32, 640, 640, 32, 960]
+    - [3, 55.7371]
+  - - [704, 960, 1, 32, 704, 704, 32, 960]
+    - [2, 63.3231]
+  - - [768, 960, 1, 32, 768, 768, 32, 960]
+    - [3, 68.2938]
+  - - [832, 960, 1, 32, 832, 832, 32, 960]
+    - [2, 72.4314]
+  - - [896, 960, 1, 32, 896, 896, 32, 960]
+    - [1, 77.3032]
+  - - [960, 960, 1, 32, 960, 960, 32, 960]
+    - [1, 81.6484]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 960]
+    - [1, 88.853]
+  - - [64, 1024, 1, 32, 64, 64, 32, 1024]
+    - [1, 6.85587]
+  - - [128, 1024, 1, 32, 128, 128, 32, 1024]
+    - [2, 13.7617]
+  - - [192, 1024, 1, 32, 192, 192, 32, 1024]
+    - [3, 20.7908]
+  - - [256, 1024, 1, 32, 256, 256, 32, 1024]
+    - [2, 264.621]
+  - - [320, 1024, 1, 32, 320, 320, 32, 1024]
+    - [0, 110.725]
+  - - [384, 1024, 1, 32, 384, 384, 32, 1024]
+    - [1, 34.0459]
+  - - [448, 1024, 1, 32, 448, 448, 32, 1024]
+    - [1, 329.589]
+  - - [512, 1024, 1, 32, 512, 512, 32, 1024]
+    - [1, 49.0545]
+  - - [576, 1024, 1, 32, 576, 576, 32, 1024]
+    - [3, 51.7861]
+  - - [640, 1024, 1, 32, 640, 640, 32, 1024]
+    - [3, 60.799]
+  - - [704, 1024, 1, 32, 704, 704, 32, 1024]
+    - [3, 66.7098]
+  - - [768, 1024, 1, 32, 768, 768, 32, 1024]
+    - [1, 73.2018]
+  - - [832, 1024, 1, 32, 832, 832, 32, 1024]
+    - [0, 76.422]
+  - - [896, 1024, 1, 32, 896, 896, 32, 1024]
+    - [1, 83.9504]
+  - - [960, 1024, 1, 32, 960, 960, 32, 1024]
+    - [1, 88.6428]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 1024]
+    - [0, 89.8096]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi31/Equality/navi31_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi31
+- gfx1100
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 0]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 32]
+    - [1, 1.15885]
+  - - [128, 64, 1, 32, 128, 128, 32, 32]
+    - [3, 2.32324]
+  - - [192, 64, 1, 32, 192, 192, 32, 32]
+    - [2, 3.48116]
+  - - [256, 64, 1, 32, 256, 256, 32, 32]
+    - [2, 4.67611]
+  - - [320, 64, 1, 32, 320, 320, 32, 32]
+    - [3, 5.79706]
+  - - [384, 64, 1, 32, 384, 384, 32, 32]
+    - [3, 72.9529]
+  - - [448, 64, 1, 32, 448, 448, 32, 32]
+    - [2, 8.11405]
+  - - [512, 64, 1, 32, 512, 512, 32, 32]
+    - [3, 85.8082]
+  - - [576, 64, 1, 32, 576, 576, 32, 32]
+    - [3, 10.4384]
+  - - [640, 64, 1, 32, 640, 640, 32, 32]
+    - [1, 11.5436]
+  - - [704, 64, 1, 32, 704, 704, 32, 32]
+    - [3, 117.41]
+  - - [768, 64, 1, 32, 768, 768, 32, 32]
+    - [0, 13.8645]
+  - - [832, 64, 1, 32, 832, 832, 32, 32]
+    - [3, 14.9874]
+  - - [896, 64, 1, 32, 896, 896, 32, 32]
+    - [3, 16.1559]
+  - - [960, 64, 1, 32, 960, 960, 32, 32]
+    - [0, 17.3001]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 32]
+    - [2, 18.4299]
+  - - [64, 128, 1, 32, 64, 64, 32, 32]
+    - [2, 2.31268]
+  - - [128, 128, 1, 32, 128, 128, 32, 32]
+    - [3, 47.0636]
+  - - [192, 128, 1, 32, 192, 192, 32, 32]
+    - [2, 75.4733]
+  - - [256, 128, 1, 32, 256, 256, 32, 32]
+    - [2, 93.9542]
+  - - [320, 128, 1, 32, 320, 320, 32, 32]
+    - [2, 109.227]
+  - - [384, 128, 1, 32, 384, 384, 32, 32]
+    - [1, 13.8266]
+  - - [448, 128, 1, 32, 448, 448, 32, 32]
+    - [3, 124.83]
+  - - [512, 128, 1, 32, 512, 512, 32, 32]
+    - [3, 18.2917]
+  - - [576, 128, 1, 32, 576, 576, 32, 32]
+    - [0, 20.7346]
+  - - [640, 128, 1, 32, 640, 640, 32, 32]
+    - [1, 23.0505]
+  - - [704, 128, 1, 32, 704, 704, 32, 32]
+    - [2, 25.3635]
+  - - [768, 128, 1, 32, 768, 768, 32, 32]
+    - [1, 27.6814]
+  - - [832, 128, 1, 32, 832, 832, 32, 32]
+    - [1, 29.9696]
+  - - [896, 128, 1, 32, 896, 896, 32, 32]
+    - [2, 32.2652]
+  - - [960, 128, 1, 32, 960, 960, 32, 32]
+    - [2, 34.5972]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 32]
+    - [2, 36.8745]
+  - - [64, 192, 1, 32, 64, 64, 32, 32]
+    - [0, 3.46628]
+  - - [128, 192, 1, 32, 128, 128, 32, 32]
+    - [3, 6.93591]
+  - - [192, 192, 1, 32, 192, 192, 32, 32]
+    - [3, 10.3805]
+  - - [256, 192, 1, 32, 256, 256, 32, 32]
+    - [2, 13.8505]
+  - - [320, 192, 1, 32, 320, 320, 32, 32]
+    - [3, 17.316]
+  - - [384, 192, 1, 32, 384, 384, 32, 32]
+    - [1, 7.68846]
+  - - [448, 192, 1, 32, 448, 448, 32, 32]
+    - [3, 9.14738]
+  - - [512, 192, 1, 32, 512, 512, 32, 32]
+    - [2, 10.3843]
+  - - [576, 192, 1, 32, 576, 576, 32, 32]
+    - [1, 11.6535]
+  - - [640, 192, 1, 32, 640, 640, 32, 32]
+    - [2, 12.944]
+  - - [704, 192, 1, 32, 704, 704, 32, 32]
+    - [2, 14.3917]
+  - - [768, 192, 1, 32, 768, 768, 32, 32]
+    - [2, 15.7115]
+  - - [832, 192, 1, 32, 832, 832, 32, 32]
+    - [2, 220.337]
+  - - [896, 192, 1, 32, 896, 896, 32, 32]
+    - [2, 18.3103]
+  - - [960, 192, 1, 32, 960, 960, 32, 32]
+    - [1, 19.5163]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 32]
+    - [3, 137.893]
+  - - [64, 256, 1, 32, 64, 64, 32, 32]
+    - [3, 5.97204]
+  - - [128, 256, 1, 32, 128, 128, 32, 32]
+    - [2, 3.49203]
+  - - [192, 256, 1, 32, 192, 192, 32, 32]
+    - [2, 5.33651]
+  - - [256, 256, 1, 32, 256, 256, 32, 32]
+    - [3, 6.97152]
+  - - [320, 256, 1, 32, 320, 320, 32, 32]
+    - [2, 8.71078]
+  - - [384, 256, 1, 32, 384, 384, 32, 32]
+    - [3, 10.4597]
+  - - [448, 256, 1, 32, 448, 448, 32, 32]
+    - [1, 203.663]
+  - - [512, 256, 1, 32, 512, 512, 32, 32]
+    - [2, 13.9188]
+  - - [576, 256, 1, 32, 576, 576, 32, 32]
+    - [2, 29.9022]
+  - - [640, 256, 1, 32, 640, 640, 32, 32]
+    - [2, 17.1125]
+  - - [704, 256, 1, 32, 704, 704, 32, 32]
+    - [2, 19.0225]
+  - - [768, 256, 1, 32, 768, 768, 32, 32]
+    - [3, 20.817]
+  - - [832, 256, 1, 32, 832, 832, 32, 32]
+    - [3, 22.6918]
+  - - [896, 256, 1, 32, 896, 896, 32, 32]
+    - [3, 24.2741]
+  - - [960, 256, 1, 32, 960, 960, 32, 32]
+    - [3, 20.772]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 32]
+    - [3, 237.638]
+  - - [64, 320, 1, 32, 64, 64, 32, 32]
+    - [2, 62.7739]
+  - - [128, 320, 1, 32, 128, 128, 32, 32]
+    - [2, 4.32093]
+  - - [192, 320, 1, 32, 192, 192, 32, 32]
+    - [1, 6.51134]
+  - - [256, 320, 1, 32, 256, 256, 32, 32]
+    - [3, 8.74086]
+  - - [320, 320, 1, 32, 320, 320, 32, 32]
+    - [2, 10.8937]
+  - - [384, 320, 1, 32, 384, 384, 32, 32]
+    - [2, 12.66]
+  - - [448, 320, 1, 32, 448, 448, 32, 32]
+    - [2, 15.2365]
+  - - [512, 320, 1, 32, 512, 512, 32, 32]
+    - [2, 17.4799]
+  - - [576, 320, 1, 32, 576, 576, 32, 32]
+    - [2, 19.514]
+  - - [640, 320, 1, 32, 640, 640, 32, 32]
+    - [2, 21.8103]
+  - - [704, 320, 1, 32, 704, 704, 32, 32]
+    - [1, 23.6307]
+  - - [768, 320, 1, 32, 768, 768, 32, 32]
+    - [1, 25.6416]
+  - - [832, 320, 1, 32, 832, 832, 32, 32]
+    - [3, 28.0408]
+  - - [896, 320, 1, 32, 896, 896, 32, 32]
+    - [1, 29.8762]
+  - - [960, 320, 1, 32, 960, 960, 32, 32]
+    - [1, 32.2111]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 32]
+    - [3, 31.1564]
+  - - [64, 384, 1, 32, 64, 64, 32, 32]
+    - [1, 2.61567]
+  - - [128, 384, 1, 32, 128, 128, 32, 32]
+    - [3, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 32]
+    - [2, 7.81608]
+  - - [256, 384, 1, 32, 256, 256, 32, 32]
+    - [1, 10.3665]
+  - - [320, 384, 1, 32, 320, 320, 32, 32]
+    - [2, 13.0853]
+  - - [384, 384, 1, 32, 384, 384, 32, 32]
+    - [2, 15.5012]
+  - - [448, 384, 1, 32, 448, 448, 32, 32]
+    - [2, 18.2013]
+  - - [512, 384, 1, 32, 512, 512, 32, 32]
+    - [3, 21.0359]
+  - - [576, 384, 1, 32, 576, 576, 32, 32]
+    - [2, 23.2003]
+  - - [640, 384, 1, 32, 640, 640, 32, 32]
+    - [3, 233.224]
+  - - [704, 384, 1, 32, 704, 704, 32, 32]
+    - [2, 28.4422]
+  - - [768, 384, 1, 32, 768, 768, 32, 32]
+    - [2, 30.8141]
+  - - [832, 384, 1, 32, 832, 832, 32, 32]
+    - [3, 32.5949]
+  - - [896, 384, 1, 32, 896, 896, 32, 32]
+    - [3, 34.7521]
+  - - [960, 384, 1, 32, 960, 960, 32, 32]
+    - [3, 33.5664]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 32]
+    - [3, 37.4289]
+  - - [64, 448, 1, 32, 64, 64, 32, 32]
+    - [1, 3.0641]
+  - - [128, 448, 1, 32, 128, 128, 32, 32]
+    - [2, 6.09522]
+  - - [192, 448, 1, 32, 192, 192, 32, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 32, 32]
+    - [2, 11.7963]
+  - - [320, 448, 1, 32, 320, 320, 32, 32]
+    - [2, 15.1838]
+  - - [384, 448, 1, 32, 384, 384, 32, 32]
+    - [3, 18.3064]
+  - - [448, 448, 1, 32, 448, 448, 32, 32]
+    - [3, 21.3841]
+  - - [512, 448, 1, 32, 512, 512, 32, 32]
+    - [3, 18.3367]
+  - - [576, 448, 1, 32, 576, 576, 32, 32]
+    - [3, 27.083]
+  - - [640, 448, 1, 32, 640, 640, 32, 32]
+    - [3, 26.9496]
+  - - [704, 448, 1, 32, 704, 704, 32, 32]
+    - [1, 32.8944]
+  - - [768, 448, 1, 32, 768, 768, 32, 32]
+    - [3, 35.0341]
+  - - [832, 448, 1, 32, 832, 832, 32, 32]
+    - [2, 26.0992]
+  - - [896, 448, 1, 32, 896, 896, 32, 32]
+    - [1, 41.1343]
+  - - [960, 448, 1, 32, 960, 960, 32, 32]
+    - [3, 40.0223]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 32]
+    - [3, 38.111]
+  - - [64, 512, 1, 32, 64, 64, 32, 32]
+    - [2, 3.53227]
+  - - [128, 512, 1, 32, 128, 128, 32, 32]
+    - [1, 6.93958]
+  - - [192, 512, 1, 32, 192, 192, 32, 32]
+    - [3, 10.4611]
+  - - [256, 512, 1, 32, 256, 256, 32, 32]
+    - [1, 13.7945]
+  - - [320, 512, 1, 32, 320, 320, 32, 32]
+    - [2, 17.3286]
+  - - [384, 512, 1, 32, 384, 384, 32, 32]
+    - [2, 20.6608]
+  - - [448, 512, 1, 32, 448, 448, 32, 32]
+    - [2, 24.2853]
+  - - [512, 512, 1, 32, 512, 512, 32, 32]
+    - [1, 27.4679]
+  - - [576, 512, 1, 32, 576, 576, 32, 32]
+    - [0, 17.8717]
+  - - [640, 512, 1, 32, 640, 640, 32, 32]
+    - [2, 270.667]
+  - - [704, 512, 1, 32, 704, 704, 32, 32]
+    - [2, 36.9238]
+  - - [768, 512, 1, 32, 768, 768, 32, 32]
+    - [3, 39.3362]
+  - - [832, 512, 1, 32, 832, 832, 32, 32]
+    - [3, 40.6126]
+  - - [896, 512, 1, 32, 896, 896, 32, 32]
+    - [3, 37.5678]
+  - - [960, 512, 1, 32, 960, 960, 32, 32]
+    - [2, 46.6799]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 32]
+    - [1, 49.4521]
+  - - [64, 576, 1, 32, 64, 64, 32, 32]
+    - [3, 4.16165]
+  - - [128, 576, 1, 32, 128, 128, 32, 32]
+    - [1, 165.211]
+  - - [192, 576, 1, 32, 192, 192, 32, 32]
+    - [1, 11.6914]
+  - - [256, 576, 1, 32, 256, 256, 32, 32]
+    - [2, 15.6145]
+  - - [320, 576, 1, 32, 320, 320, 32, 32]
+    - [3, 19.5201]
+  - - [384, 576, 1, 32, 384, 384, 32, 32]
+    - [2, 23.3173]
+  - - [448, 576, 1, 32, 448, 448, 32, 32]
+    - [2, 26.4926]
+  - - [512, 576, 1, 32, 512, 512, 32, 32]
+    - [2, 30.8559]
+  - - [576, 576, 1, 32, 576, 576, 32, 32]
+    - [1, 25.7695]
+  - - [640, 576, 1, 32, 640, 640, 32, 32]
+    - [1, 38.4963]
+  - - [704, 576, 1, 32, 704, 704, 32, 32]
+    - [1, 38.0312]
+  - - [768, 576, 1, 32, 768, 768, 32, 32]
+    - [1, 45.0796]
+  - - [832, 576, 1, 32, 832, 832, 32, 32]
+    - [2, 47.4484]
+  - - [896, 576, 1, 32, 896, 896, 32, 32]
+    - [2, 48.7268]
+  - - [960, 576, 1, 32, 960, 960, 32, 32]
+    - [2, 49.2269]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 32]
+    - [2, 55.1113]
+  - - [64, 640, 1, 32, 64, 64, 32, 32]
+    - [1, 4.31759]
+  - - [128, 640, 1, 32, 128, 128, 32, 32]
+    - [3, 8.77126]
+  - - [192, 640, 1, 32, 192, 192, 32, 32]
+    - [2, 13.0281]
+  - - [256, 640, 1, 32, 256, 256, 32, 32]
+    - [3, 17.3725]
+  - - [320, 640, 1, 32, 320, 320, 32, 32]
+    - [2, 21.5674]
+  - - [384, 640, 1, 32, 384, 384, 32, 32]
+    - [2, 25.8732]
+  - - [448, 640, 1, 32, 448, 448, 32, 32]
+    - [3, 233.34]
+  - - [512, 640, 1, 32, 512, 512, 32, 32]
+    - [1, 29.7957]
+  - - [576, 640, 1, 32, 576, 576, 32, 32]
+    - [2, 37.6816]
+  - - [640, 640, 1, 32, 640, 640, 32, 32]
+    - [3, 39.1071]
+  - - [704, 640, 1, 32, 704, 704, 32, 32]
+    - [3, 44.6269]
+  - - [768, 640, 1, 32, 768, 768, 32, 32]
+    - [0, 45.3769]
+  - - [832, 640, 1, 32, 832, 832, 32, 32]
+    - [1, 50.2744]
+  - - [896, 640, 1, 32, 896, 896, 32, 32]
+    - [0, 53.1083]
+  - - [960, 640, 1, 32, 960, 960, 32, 32]
+    - [3, 55.344]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 32]
+    - [1, 61.5259]
+  - - [64, 704, 1, 32, 64, 64, 32, 32]
+    - [1, 4.78203]
+  - - [128, 704, 1, 32, 128, 128, 32, 32]
+    - [1, 9.11814]
+  - - [192, 704, 1, 32, 192, 192, 32, 32]
+    - [3, 14.38]
+  - - [256, 704, 1, 32, 256, 256, 32, 32]
+    - [3, 19.1484]
+  - - [320, 704, 1, 32, 320, 320, 32, 32]
+    - [2, 23.4029]
+  - - [384, 704, 1, 32, 384, 384, 32, 32]
+    - [1, 28.2559]
+  - - [448, 704, 1, 32, 448, 448, 32, 32]
+    - [3, 22.4257]
+  - - [512, 704, 1, 32, 512, 512, 32, 32]
+    - [3, 36.3124]
+  - - [576, 704, 1, 32, 576, 576, 32, 32]
+    - [0, 37.5889]
+  - - [640, 704, 1, 32, 640, 640, 32, 32]
+    - [3, 42.7372]
+  - - [704, 704, 1, 32, 704, 704, 32, 32]
+    - [2, 46.9011]
+  - - [768, 704, 1, 32, 768, 768, 32, 32]
+    - [2, 50.9832]
+  - - [832, 704, 1, 32, 832, 832, 32, 32]
+    - [2, 54.8969]
+  - - [896, 704, 1, 32, 896, 896, 32, 32]
+    - [1, 49.5075]
+  - - [960, 704, 1, 32, 960, 960, 32, 32]
+    - [2, 63.639]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 32]
+    - [2, 66.0261]
+  - - [64, 768, 1, 32, 64, 64, 32, 32]
+    - [1, 5.19274]
+  - - [128, 768, 1, 32, 128, 128, 32, 32]
+    - [2, 10.3992]
+  - - [192, 768, 1, 32, 192, 192, 32, 32]
+    - [3, 223.418]
+  - - [256, 768, 1, 32, 256, 256, 32, 32]
+    - [1, 266.136]
+  - - [320, 768, 1, 32, 320, 320, 32, 32]
+    - [3, 231.986]
+  - - [384, 768, 1, 32, 384, 384, 32, 32]
+    - [3, 30.6112]
+  - - [448, 768, 1, 32, 448, 448, 32, 32]
+    - [2, 31.5821]
+  - - [512, 768, 1, 32, 512, 512, 32, 32]
+    - [1, 40.6042]
+  - - [576, 768, 1, 32, 576, 576, 32, 32]
+    - [3, 41.8486]
+  - - [640, 768, 1, 32, 640, 640, 32, 32]
+    - [1, 41.7104]
+  - - [704, 768, 1, 32, 704, 704, 32, 32]
+    - [3, 275.064]
+  - - [768, 768, 1, 32, 768, 768, 32, 32]
+    - [1, 55.7396]
+  - - [832, 768, 1, 32, 832, 832, 32, 32]
+    - [3, 51.1568]
+  - - [896, 768, 1, 32, 896, 896, 32, 32]
+    - [1, 61.4199]
+  - - [960, 768, 1, 32, 960, 960, 32, 32]
+    - [3, 67.4196]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 32]
+    - [1, 73.2776]
+  - - [64, 832, 1, 32, 64, 64, 32, 32]
+    - [1, 5.63096]
+  - - [128, 832, 1, 32, 128, 128, 32, 32]
+    - [1, 11.1455]
+  - - [192, 832, 1, 32, 192, 192, 32, 32]
+    - [3, 16.7104]
+  - - [256, 832, 1, 32, 256, 256, 32, 32]
+    - [1, 22.388]
+  - - [320, 832, 1, 32, 320, 320, 32, 32]
+    - [0, 24.4102]
+  - - [384, 832, 1, 32, 384, 384, 32, 32]
+    - [1, 29.782]
+  - - [448, 832, 1, 32, 448, 448, 32, 32]
+    - [0, 31.3102]
+  - - [512, 832, 1, 32, 512, 512, 32, 32]
+    - [1, 39.0439]
+  - - [576, 832, 1, 32, 576, 576, 32, 32]
+    - [3, 44.3718]
+  - - [640, 832, 1, 32, 640, 640, 32, 32]
+    - [3, 48.3954]
+  - - [704, 832, 1, 32, 704, 704, 32, 32]
+    - [3, 45.2543]
+  - - [768, 832, 1, 32, 768, 768, 32, 32]
+    - [1, 56.8015]
+  - - [832, 832, 1, 32, 832, 832, 32, 32]
+    - [1, 54.7432]
+  - - [896, 832, 1, 32, 896, 896, 32, 32]
+    - [3, 58.3343]
+  - - [960, 832, 1, 32, 960, 960, 32, 32]
+    - [3, 71.7503]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 32]
+    - [1, 79.1776]
+  - - [64, 896, 1, 32, 64, 64, 32, 32]
+    - [1, 6.06912]
+  - - [128, 896, 1, 32, 128, 128, 32, 32]
+    - [2, 12.1569]
+  - - [192, 896, 1, 32, 192, 192, 32, 32]
+    - [2, 18.2019]
+  - - [256, 896, 1, 32, 256, 256, 32, 32]
+    - [2, 245.482]
+  - - [320, 896, 1, 32, 320, 320, 32, 32]
+    - [1, 29.0058]
+  - - [384, 896, 1, 32, 384, 384, 32, 32]
+    - [2, 35.5104]
+  - - [448, 896, 1, 32, 448, 448, 32, 32]
+    - [3, 28.1229]
+  - - [512, 896, 1, 32, 512, 512, 32, 32]
+    - [0, 42.3518]
+  - - [576, 896, 1, 32, 576, 576, 32, 32]
+    - [2, 48.9644]
+  - - [640, 896, 1, 32, 640, 640, 32, 32]
+    - [2, 45.7064]
+  - - [704, 896, 1, 32, 704, 704, 32, 32]
+    - [1, 59.4734]
+  - - [768, 896, 1, 32, 768, 768, 32, 32]
+    - [3, 51.5563]
+  - - [832, 896, 1, 32, 832, 832, 32, 32]
+    - [1, 70.0206]
+  - - [896, 896, 1, 32, 896, 896, 32, 32]
+    - [2, 72.8327]
+  - - [960, 896, 1, 32, 960, 960, 32, 32]
+    - [3, 75.7387]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 32]
+    - [3, 316.72]
+  - - [64, 960, 1, 32, 64, 64, 32, 32]
+    - [3, 47.761]
+  - - [128, 960, 1, 32, 128, 128, 32, 32]
+    - [3, 73.8913]
+  - - [192, 960, 1, 32, 192, 192, 32, 32]
+    - [2, 19.4311]
+  - - [256, 960, 1, 32, 256, 256, 32, 32]
+    - [2, 24.6167]
+  - - [320, 960, 1, 32, 320, 320, 32, 32]
+    - [2, 32.1022]
+  - - [384, 960, 1, 32, 384, 384, 32, 32]
+    - [3, 37.3233]
+  - - [448, 960, 1, 32, 448, 448, 32, 32]
+    - [0, 39.6573]
+  - - [512, 960, 1, 32, 512, 512, 32, 32]
+    - [1, 317.879]
+  - - [576, 960, 1, 32, 576, 576, 32, 32]
+    - [2, 47.8887]
+  - - [640, 960, 1, 32, 640, 640, 32, 32]
+    - [3, 45.7758]
+  - - [704, 960, 1, 32, 704, 704, 32, 32]
+    - [0, 62.4041]
+  - - [768, 960, 1, 32, 768, 768, 32, 32]
+    - [1, 69.5882]
+  - - [832, 960, 1, 32, 832, 832, 32, 32]
+    - [2, 72.5228]
+  - - [896, 960, 1, 32, 896, 896, 32, 32]
+    - [2, 77.1612]
+  - - [960, 960, 1, 32, 960, 960, 32, 32]
+    - [1, 84.0368]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 32]
+    - [3, 84.7878]
+  - - [64, 1024, 1, 32, 64, 64, 32, 32]
+    - [2, 6.94924]
+  - - [128, 1024, 1, 32, 128, 128, 32, 32]
+    - [1, 13.864]
+  - - [192, 1024, 1, 32, 192, 192, 32, 32]
+    - [3, 20.9498]
+  - - [256, 1024, 1, 32, 256, 256, 32, 32]
+    - [3, 27.3377]
+  - - [320, 1024, 1, 32, 320, 320, 32, 32]
+    - [1, 30.6626]
+  - - [384, 1024, 1, 32, 384, 384, 32, 32]
+    - [3, 37.2913]
+  - - [448, 1024, 1, 32, 448, 448, 32, 32]
+    - [3, 43.6989]
+  - - [512, 1024, 1, 32, 512, 512, 32, 32]
+    - [1, 49.0983]
+  - - [576, 1024, 1, 32, 576, 576, 32, 32]
+    - [2, 55.7223]
+  - - [640, 1024, 1, 32, 640, 640, 32, 32]
+    - [1, 61.4772]
+  - - [704, 1024, 1, 32, 704, 704, 32, 32]
+    - [1, 65.5096]
+  - - [768, 1024, 1, 32, 768, 768, 32, 32]
+    - [2, 71.6308]
+  - - [832, 1024, 1, 32, 832, 832, 32, 32]
+    - [3, 76.1074]
+  - - [896, 1024, 1, 32, 896, 896, 32, 32]
+    - [1, 83.761]
+  - - [960, 1024, 1, 32, 960, 960, 32, 32]
+    - [0, 85.4755]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 32]
+    - [0, 519.579]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi32
+- gfx1101
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 64]
+    - [1, 1.15349]
+  - - [128, 64, 1, 32, 128, 128, 128, 64]
+    - [2, 2.30698]
+  - - [192, 64, 1, 32, 192, 192, 192, 64]
+    - [3, 3.45378]
+  - - [256, 64, 1, 32, 256, 256, 256, 64]
+    - [1, 4.61519]
+  - - [320, 64, 1, 32, 320, 320, 320, 64]
+    - [1, 5.7695]
+  - - [384, 64, 1, 32, 384, 384, 384, 64]
+    - [1, 6.93928]
+  - - [448, 64, 1, 32, 448, 448, 448, 64]
+    - [3, 8.07161]
+  - - [512, 64, 1, 32, 512, 512, 512, 64]
+    - [1, 9.23197]
+  - - [576, 64, 1, 32, 576, 576, 576, 64]
+    - [0, 26.473]
+  - - [640, 64, 1, 32, 640, 640, 640, 64]
+    - [3, 11.5263]
+  - - [704, 64, 1, 32, 704, 704, 704, 64]
+    - [3, 12.6861]
+  - - [768, 64, 1, 32, 768, 768, 768, 64]
+    - [3, 13.8206]
+  - - [832, 64, 1, 32, 832, 832, 832, 64]
+    - [1, 14.9244]
+  - - [896, 64, 1, 32, 896, 896, 896, 64]
+    - [2, 16.0613]
+  - - [960, 64, 1, 32, 960, 960, 960, 64]
+    - [3, 17.1941]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 64]
+    - [1, 156.972]
+  - - [64, 128, 1, 32, 64, 64, 64, 128]
+    - [2, 28.9982]
+  - - [128, 128, 1, 32, 128, 128, 128, 128]
+    - [3, 49.9322]
+  - - [192, 128, 1, 32, 192, 192, 192, 128]
+    - [3, 75.0412]
+  - - [256, 128, 1, 32, 256, 256, 256, 128]
+    - [3, 87.9678]
+  - - [320, 128, 1, 32, 320, 320, 320, 128]
+    - [0, 11.4678]
+  - - [384, 128, 1, 32, 384, 384, 384, 128]
+    - [2, 13.7349]
+  - - [448, 128, 1, 32, 448, 448, 448, 128]
+    - [0, 16.0824]
+  - - [512, 128, 1, 32, 512, 512, 512, 128]
+    - [0, 18.2957]
+  - - [576, 128, 1, 32, 576, 576, 576, 128]
+    - [3, 171.71]
+  - - [640, 128, 1, 32, 640, 640, 640, 128]
+    - [3, 41.8958]
+  - - [704, 128, 1, 32, 704, 704, 704, 128]
+    - [3, 184.137]
+  - - [768, 128, 1, 32, 768, 768, 768, 128]
+    - [2, 9.67241]
+  - - [832, 128, 1, 32, 832, 832, 832, 128]
+    - [2, 10.4909]
+  - - [896, 128, 1, 32, 896, 896, 896, 128]
+    - [3, 11.1885]
+  - - [960, 128, 1, 32, 960, 960, 960, 128]
+    - [1, 11.9394]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 128]
+    - [3, 221.452]
+  - - [64, 192, 1, 32, 64, 64, 64, 192]
+    - [3, 37.4474]
+  - - [128, 192, 1, 32, 128, 128, 128, 192]
+    - [2, 77.4047]
+  - - [192, 192, 1, 32, 192, 192, 192, 192]
+    - [3, 98.304]
+  - - [256, 192, 1, 32, 256, 256, 256, 192]
+    - [3, 5.21919]
+  - - [320, 192, 1, 32, 320, 320, 320, 192]
+    - [1, 6.03876]
+  - - [384, 192, 1, 32, 384, 384, 384, 192]
+    - [1, 7.71751]
+  - - [448, 192, 1, 32, 448, 448, 448, 192]
+    - [2, 9.04163]
+  - - [512, 192, 1, 32, 512, 512, 512, 192]
+    - [1, 10.2895]
+  - - [576, 192, 1, 32, 576, 576, 576, 192]
+    - [1, 11.56]
+  - - [640, 192, 1, 32, 640, 640, 640, 192]
+    - [2, 12.9306]
+  - - [704, 192, 1, 32, 704, 704, 704, 192]
+    - [3, 14.0882]
+  - - [768, 192, 1, 32, 768, 768, 768, 192]
+    - [1, 15.4489]
+  - - [832, 192, 1, 32, 832, 832, 832, 192]
+    - [1, 16.6423]
+  - - [896, 192, 1, 32, 896, 896, 896, 192]
+    - [1, 17.955]
+  - - [960, 192, 1, 32, 960, 960, 960, 192]
+    - [3, 19.4074]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 192]
+    - [2, 20.6185]
+  - - [64, 256, 1, 32, 64, 64, 64, 256]
+    - [3, 1.74497]
+  - - [128, 256, 1, 32, 128, 128, 128, 256]
+    - [3, 3.48907]
+  - - [192, 256, 1, 32, 192, 192, 192, 256]
+    - [2, 5.19085]
+  - - [256, 256, 1, 32, 256, 256, 256, 256]
+    - [1, 6.85968]
+  - - [320, 256, 1, 32, 320, 320, 320, 256]
+    - [1, 8.58146]
+  - - [384, 256, 1, 32, 384, 384, 384, 256]
+    - [2, 10.2789]
+  - - [448, 256, 1, 32, 448, 448, 448, 256]
+    - [1, 12.0221]
+  - - [512, 256, 1, 32, 512, 512, 512, 256]
+    - [2, 13.7992]
+  - - [576, 256, 1, 32, 576, 576, 576, 256]
+    - [2, 15.4454]
+  - - [640, 256, 1, 32, 640, 640, 640, 256]
+    - [2, 17.294]
+  - - [704, 256, 1, 32, 704, 704, 704, 256]
+    - [3, 243.546]
+  - - [768, 256, 1, 32, 768, 768, 768, 256]
+    - [1, 267.488]
+  - - [832, 256, 1, 32, 832, 832, 832, 256]
+    - [2, 22.3451]
+  - - [896, 256, 1, 32, 896, 896, 896, 256]
+    - [3, 23.9841]
+  - - [960, 256, 1, 32, 960, 960, 960, 256]
+    - [3, 25.715]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 256]
+    - [2, 22.0262]
+  - - [64, 320, 1, 32, 64, 64, 64, 320]
+    - [1, 2.18056]
+  - - [128, 320, 1, 32, 128, 128, 128, 320]
+    - [3, 4.34212]
+  - - [192, 320, 1, 32, 192, 192, 192, 320]
+    - [2, 6.47766]
+  - - [256, 320, 1, 32, 256, 256, 256, 320]
+    - [3, 8.64858]
+  - - [320, 320, 1, 32, 320, 320, 320, 320]
+    - [1, 10.7349]
+  - - [384, 320, 1, 32, 384, 384, 384, 320]
+    - [2, 12.5973]
+  - - [448, 320, 1, 32, 448, 448, 448, 320]
+    - [2, 15.1357]
+  - - [512, 320, 1, 32, 512, 512, 512, 320]
+    - [3, 252.547]
+  - - [576, 320, 1, 32, 576, 576, 576, 320]
+    - [1, 248.661]
+  - - [640, 320, 1, 32, 640, 640, 640, 320]
+    - [1, 21.5383]
+  - - [704, 320, 1, 32, 704, 704, 704, 320]
+    - [2, 23.9253]
+  - - [768, 320, 1, 32, 768, 768, 768, 320]
+    - [1, 25.7457]
+  - - [832, 320, 1, 32, 832, 832, 832, 320]
+    - [3, 28.0186]
+  - - [896, 320, 1, 32, 896, 896, 896, 320]
+    - [1, 29.7589]
+  - - [960, 320, 1, 32, 960, 960, 960, 320]
+    - [3, 31.8639]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 320]
+    - [3, 33.5333]
+  - - [64, 384, 1, 32, 64, 64, 64, 384]
+    - [3, 2.61959]
+  - - [128, 384, 1, 32, 128, 128, 128, 384]
+    - [2, 5.19532]
+  - - [192, 384, 1, 32, 192, 192, 192, 384]
+    - [1, 7.73864]
+  - - [256, 384, 1, 32, 256, 256, 256, 384]
+    - [2, 10.3442]
+  - - [320, 384, 1, 32, 320, 320, 320, 384]
+    - [3, 13.0091]
+  - - [384, 384, 1, 32, 384, 384, 384, 384]
+    - [2, 15.506]
+  - - [448, 384, 1, 32, 448, 448, 448, 384]
+    - [3, 18.2215]
+  - - [512, 384, 1, 32, 512, 512, 512, 384]
+    - [3, 20.7071]
+  - - [576, 384, 1, 32, 576, 576, 576, 384]
+    - [2, 23.2403]
+  - - [640, 384, 1, 32, 640, 640, 640, 384]
+    - [1, 25.7196]
+  - - [704, 384, 1, 32, 704, 704, 704, 384]
+    - [3, 28.3867]
+  - - [768, 384, 1, 32, 768, 768, 768, 384]
+    - [3, 30.7539]
+  - - [832, 384, 1, 32, 832, 832, 832, 384]
+    - [3, 32.7878]
+  - - [896, 384, 1, 32, 896, 896, 896, 384]
+    - [2, 35.4019]
+  - - [960, 384, 1, 32, 960, 960, 960, 384]
+    - [1, 317.618]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 384]
+    - [3, 39.8052]
+  - - [64, 448, 1, 32, 64, 64, 64, 448]
+    - [3, 3.04604]
+  - - [128, 448, 1, 32, 128, 128, 128, 448]
+    - [1, 6.00949]
+  - - [192, 448, 1, 32, 192, 192, 192, 448]
+    - [3, 9.07966]
+  - - [256, 448, 1, 32, 256, 256, 256, 448]
+    - [1, 11.9952]
+  - - [320, 448, 1, 32, 320, 320, 320, 448]
+    - [2, 15.0959]
+  - - [384, 448, 1, 32, 384, 384, 384, 448]
+    - [3, 18.0005]
+  - - [448, 448, 1, 32, 448, 448, 448, 448]
+    - [3, 21.2546]
+  - - [512, 448, 1, 32, 512, 512, 512, 448]
+    - [2, 23.9822]
+  - - [576, 448, 1, 32, 576, 576, 576, 448]
+    - [2, 27.2094]
+  - - [640, 448, 1, 32, 640, 640, 640, 448]
+    - [2, 30.0287]
+  - - [704, 448, 1, 32, 704, 704, 704, 448]
+    - [1, 307.512]
+  - - [768, 448, 1, 32, 768, 768, 768, 448]
+    - [3, 29.7306]
+  - - [832, 448, 1, 32, 832, 832, 832, 448]
+    - [0, 34.5814]
+  - - [896, 448, 1, 32, 896, 896, 896, 448]
+    - [2, 40.7985]
+  - - [960, 448, 1, 32, 960, 960, 960, 448]
+    - [2, 39.8658]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 448]
+    - [2, 42.8819]
+  - - [64, 512, 1, 32, 64, 64, 64, 512]
+    - [1, 3.44874]
+  - - [128, 512, 1, 32, 128, 128, 128, 512]
+    - [2, 6.86934]
+  - - [192, 512, 1, 32, 192, 192, 192, 512]
+    - [3, 10.369]
+  - - [256, 512, 1, 32, 256, 256, 256, 512]
+    - [1, 13.5592]
+  - - [320, 512, 1, 32, 320, 320, 320, 512]
+    - [3, 17.1914]
+  - - [384, 512, 1, 32, 384, 384, 384, 512]
+    - [2, 20.7593]
+  - - [448, 512, 1, 32, 448, 448, 448, 512]
+    - [2, 24.1348]
+  - - [512, 512, 1, 32, 512, 512, 512, 512]
+    - [2, 27.674]
+  - - [576, 512, 1, 32, 576, 576, 576, 512]
+    - [3, 27.5609]
+  - - [640, 512, 1, 32, 640, 640, 640, 512]
+    - [1, 30.388]
+  - - [704, 512, 1, 32, 704, 704, 704, 512]
+    - [3, 36.7949]
+  - - [768, 512, 1, 32, 768, 768, 768, 512]
+    - [3, 39.2313]
+  - - [832, 512, 1, 32, 832, 832, 832, 512]
+    - [2, 39.7191]
+  - - [896, 512, 1, 32, 896, 896, 896, 512]
+    - [1, 332.877]
+  - - [960, 512, 1, 32, 960, 960, 960, 512]
+    - [1, 316.344]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 512]
+    - [0, 48.3693]
+  - - [64, 576, 1, 32, 64, 64, 64, 576]
+    - [3, 3.86628]
+  - - [128, 576, 1, 32, 128, 128, 128, 576]
+    - [3, 169.246]
+  - - [192, 576, 1, 32, 192, 192, 192, 576]
+    - [1, 11.5076]
+  - - [256, 576, 1, 32, 256, 256, 256, 576]
+    - [3, 240.984]
+  - - [320, 576, 1, 32, 320, 320, 320, 576]
+    - [1, 19.296]
+  - - [384, 576, 1, 32, 384, 384, 384, 576]
+    - [2, 23.1318]
+  - - [448, 576, 1, 32, 448, 448, 448, 576]
+    - [1, 26.9123]
+  - - [512, 576, 1, 32, 512, 512, 512, 576]
+    - [2, 30.8021]
+  - - [576, 576, 1, 32, 576, 576, 576, 576]
+    - [2, 272.506]
+  - - [640, 576, 1, 32, 640, 640, 640, 576]
+    - [3, 122.23]
+  - - [704, 576, 1, 32, 704, 704, 704, 576]
+    - [2, 41.1188]
+  - - [768, 576, 1, 32, 768, 768, 768, 576]
+    - [2, 39.9551]
+  - - [832, 576, 1, 32, 832, 832, 832, 576]
+    - [3, 47.4793]
+  - - [896, 576, 1, 32, 896, 896, 896, 576]
+    - [1, 46.8264]
+  - - [960, 576, 1, 32, 960, 960, 960, 576]
+    - [3, 52.0216]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 576]
+    - [0, 53.3314]
+  - - [64, 640, 1, 32, 64, 64, 64, 640]
+    - [2, 4.331]
+  - - [128, 640, 1, 32, 128, 128, 128, 640]
+    - [1, 8.52829]
+  - - [192, 640, 1, 32, 192, 192, 192, 640]
+    - [2, 12.8344]
+  - - [256, 640, 1, 32, 256, 256, 256, 640]
+    - [2, 17.1025]
+  - - [320, 640, 1, 32, 320, 320, 320, 640]
+    - [3, 21.6428]
+  - - [384, 640, 1, 32, 384, 384, 384, 640]
+    - [3, 25.6713]
+  - - [448, 640, 1, 32, 448, 448, 448, 640]
+    - [3, 29.9567]
+  - - [512, 640, 1, 32, 512, 512, 512, 640]
+    - [1, 33.6966]
+  - - [576, 640, 1, 32, 576, 576, 576, 640]
+    - [3, 34.7046]
+  - - [640, 640, 1, 32, 640, 640, 640, 640]
+    - [3, 38.7075]
+  - - [704, 640, 1, 32, 704, 704, 704, 640]
+    - [2, 41.7002]
+  - - [768, 640, 1, 32, 768, 768, 768, 640]
+    - [3, 268.407]
+  - - [832, 640, 1, 32, 832, 832, 832, 640]
+    - [0, 47.4228]
+  - - [896, 640, 1, 32, 896, 896, 896, 640]
+    - [3, 53.5508]
+  - - [960, 640, 1, 32, 960, 960, 960, 640]
+    - [3, 57.2031]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 640]
+    - [3, 61.6009]
+  - - [64, 704, 1, 32, 64, 64, 64, 704]
+    - [3, 4.74723]
+  - - [128, 704, 1, 32, 128, 128, 128, 704]
+    - [2, 9.33162]
+  - - [192, 704, 1, 32, 192, 192, 192, 704]
+    - [3, 14.165]
+  - - [256, 704, 1, 32, 256, 256, 256, 704]
+    - [3, 18.904]
+  - - [320, 704, 1, 32, 320, 320, 320, 704]
+    - [2, 23.5144]
+  - - [384, 704, 1, 32, 384, 384, 384, 704]
+    - [3, 249.301]
+  - - [448, 704, 1, 32, 448, 448, 448, 704]
+    - [1, 304.727]
+  - - [512, 704, 1, 32, 512, 512, 512, 704]
+    - [2, 33.8328]
+  - - [576, 704, 1, 32, 576, 576, 576, 704]
+    - [3, 37.3401]
+  - - [640, 704, 1, 32, 640, 640, 640, 704]
+    - [2, 41.8036]
+  - - [704, 704, 1, 32, 704, 704, 704, 704]
+    - [1, 45.7716]
+  - - [768, 704, 1, 32, 768, 768, 768, 704]
+    - [2, 50.4436]
+  - - [832, 704, 1, 32, 832, 832, 832, 704]
+    - [3, 53.7131]
+  - - [896, 704, 1, 32, 896, 896, 896, 704]
+    - [1, 56.0678]
+  - - [960, 704, 1, 32, 960, 960, 960, 704]
+    - [2, 307.985]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 704]
+    - [2, 67.1612]
+  - - [64, 768, 1, 32, 64, 64, 64, 768]
+    - [3, 5.19884]
+  - - [128, 768, 1, 32, 128, 128, 128, 768]
+    - [2, 10.2936]
+  - - [192, 768, 1, 32, 192, 192, 192, 768]
+    - [2, 15.3667]
+  - - [256, 768, 1, 32, 256, 256, 256, 768]
+    - [3, 20.6856]
+  - - [320, 768, 1, 32, 320, 320, 320, 768]
+    - [2, 25.3605]
+  - - [384, 768, 1, 32, 384, 384, 384, 768]
+    - [3, 30.9622]
+  - - [448, 768, 1, 32, 448, 448, 448, 768]
+    - [2, 35.5596]
+  - - [512, 768, 1, 32, 512, 512, 512, 768]
+    - [3, 253.685]
+  - - [576, 768, 1, 32, 576, 576, 576, 768]
+    - [1, 319.252]
+  - - [640, 768, 1, 32, 640, 640, 640, 768]
+    - [1, 241.292]
+  - - [704, 768, 1, 32, 704, 704, 704, 768]
+    - [1, 300.788]
+  - - [768, 768, 1, 32, 768, 768, 768, 768]
+    - [1, 313.942]
+  - - [832, 768, 1, 32, 832, 832, 832, 768]
+    - [2, 307.385]
+  - - [896, 768, 1, 32, 896, 896, 896, 768]
+    - [3, 304.819]
+  - - [960, 768, 1, 32, 960, 960, 960, 768]
+    - [1, 353.821]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 768]
+    - [1, 358.792]
+  - - [64, 832, 1, 32, 64, 64, 64, 832]
+    - [3, 87.2025]
+  - - [128, 832, 1, 32, 128, 128, 128, 832]
+    - [3, 61.0068]
+  - - [192, 832, 1, 32, 192, 192, 192, 832]
+    - [2, 88.1567]
+  - - [256, 832, 1, 32, 256, 256, 256, 832]
+    - [3, 121.006]
+  - - [320, 832, 1, 32, 320, 320, 320, 832]
+    - [3, 145.996]
+  - - [384, 832, 1, 32, 384, 384, 384, 832]
+    - [1, 159.358]
+  - - [448, 832, 1, 32, 448, 448, 448, 832]
+    - [2, 196.644]
+  - - [512, 832, 1, 32, 512, 512, 512, 832]
+    - [3, 39.8819]
+  - - [576, 832, 1, 32, 576, 576, 576, 832]
+    - [0, 44.024]
+  - - [640, 832, 1, 32, 640, 640, 640, 832]
+    - [3, 49.7875]
+  - - [704, 832, 1, 32, 704, 704, 704, 832]
+    - [2, 54.7966]
+  - - [768, 832, 1, 32, 768, 768, 768, 832]
+    - [3, 59.57]
+  - - [832, 832, 1, 32, 832, 832, 832, 832]
+    - [2, 64.4347]
+  - - [896, 832, 1, 32, 896, 896, 896, 832]
+    - [3, 62.0957]
+  - - [960, 832, 1, 32, 960, 960, 960, 832]
+    - [3, 73.2347]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 832]
+    - [1, 76.9799]
+  - - [64, 896, 1, 32, 64, 64, 64, 896]
+    - [1, 6.00575]
+  - - [128, 896, 1, 32, 128, 128, 128, 896]
+    - [2, 11.8982]
+  - - [192, 896, 1, 32, 192, 192, 192, 896]
+    - [3, 17.0944]
+  - - [256, 896, 1, 32, 256, 256, 256, 896]
+    - [2, 146.566]
+  - - [320, 896, 1, 32, 320, 320, 320, 896]
+    - [2, 170.017]
+  - - [384, 896, 1, 32, 384, 384, 384, 896]
+    - [1, 316.017]
+  - - [448, 896, 1, 32, 448, 448, 448, 896]
+    - [2, 221.179]
+  - - [512, 896, 1, 32, 512, 512, 512, 896]
+    - [3, 277.503]
+  - - [576, 896, 1, 32, 576, 576, 576, 896]
+    - [1, 306.855]
+  - - [640, 896, 1, 32, 640, 640, 640, 896]
+    - [1, 345.316]
+  - - [704, 896, 1, 32, 704, 704, 704, 896]
+    - [1, 354.619]
+  - - [768, 896, 1, 32, 768, 768, 768, 896]
+    - [2, 307.715]
+  - - [832, 896, 1, 32, 832, 832, 832, 896]
+    - [3, 314.626]
+  - - [896, 896, 1, 32, 896, 896, 896, 896]
+    - [3, 321.929]
+  - - [960, 896, 1, 32, 960, 960, 960, 896]
+    - [3, 308.716]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 896]
+    - [2, 320.174]
+  - - [64, 960, 1, 32, 64, 64, 64, 960]
+    - [2, 65.8874]
+  - - [128, 960, 1, 32, 128, 128, 128, 960]
+    - [1, 78.462]
+  - - [192, 960, 1, 32, 192, 192, 192, 960]
+    - [2, 113.755]
+  - - [256, 960, 1, 32, 256, 256, 256, 960]
+    - [1, 152.986]
+  - - [320, 960, 1, 32, 320, 320, 320, 960]
+    - [3, 189.192]
+  - - [384, 960, 1, 32, 384, 384, 384, 960]
+    - [2, 228.769]
+  - - [448, 960, 1, 32, 448, 448, 448, 960]
+    - [3, 286.598]
+  - - [512, 960, 1, 32, 512, 512, 512, 960]
+    - [2, 278.088]
+  - - [576, 960, 1, 32, 576, 576, 576, 960]
+    - [1, 321.953]
+  - - [640, 960, 1, 32, 640, 640, 640, 960]
+    - [2, 304.064]
+  - - [704, 960, 1, 32, 704, 704, 704, 960]
+    - [2, 311.268]
+  - - [768, 960, 1, 32, 768, 768, 768, 960]
+    - [2, 312.572]
+  - - [832, 960, 1, 32, 832, 832, 832, 960]
+    - [3, 296.232]
+  - - [896, 960, 1, 32, 896, 896, 896, 960]
+    - [2, 319.019]
+  - - [960, 960, 1, 32, 960, 960, 960, 960]
+    - [3, 320.415]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 960]
+    - [3, 85.4244]
+  - - [64, 1024, 1, 32, 64, 64, 64, 1024]
+    - [1, 6.77317]
+  - - [128, 1024, 1, 32, 128, 128, 128, 1024]
+    - [2, 13.688]
+  - - [192, 1024, 1, 32, 192, 192, 192, 1024]
+    - [2, 20.3846]
+  - - [256, 1024, 1, 32, 256, 256, 256, 1024]
+    - [2, 27.202]
+  - - [320, 1024, 1, 32, 320, 320, 320, 1024]
+    - [2, 33.9201]
+  - - [384, 1024, 1, 32, 384, 384, 384, 1024]
+    - [3, 39.4082]
+  - - [448, 1024, 1, 32, 448, 448, 448, 1024]
+    - [1, 36.7013]
+  - - [512, 1024, 1, 32, 512, 512, 512, 1024]
+    - [2, 292.896]
+  - - [576, 1024, 1, 32, 576, 576, 576, 1024]
+    - [2, 55.0864]
+  - - [640, 1024, 1, 32, 640, 640, 640, 1024]
+    - [2, 61.8052]
+  - - [704, 1024, 1, 32, 704, 704, 704, 1024]
+    - [2, 66.8208]
+  - - [768, 1024, 1, 32, 768, 768, 768, 1024]
+    - [1, 71.9595]
+  - - [832, 1024, 1, 32, 832, 832, 832, 1024]
+    - [2, 76.7081]
+  - - [896, 1024, 1, 32, 896, 896, 896, 1024]
+    - [2, 81.1912]
+  - - [960, 1024, 1, 32, 960, 960, 960, 1024]
+    - [1, 88.5319]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 1024]
+    - [2, 90.0024]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi32
+- gfx1101
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 32]
+    - [2, 1.15233]
+  - - [128, 64, 1, 32, 128, 128, 128, 32]
+    - [2, 2.30557]
+  - - [192, 64, 1, 32, 192, 192, 192, 32]
+    - [2, 3.45926]
+  - - [256, 64, 1, 32, 256, 256, 256, 32]
+    - [2, 4.61702]
+  - - [320, 64, 1, 32, 320, 320, 320, 32]
+    - [2, 5.75784]
+  - - [384, 64, 1, 32, 384, 384, 384, 32]
+    - [3, 73.7741]
+  - - [448, 64, 1, 32, 448, 448, 448, 32]
+    - [2, 86.557]
+  - - [512, 64, 1, 32, 512, 512, 512, 32]
+    - [2, 97.4513]
+  - - [576, 64, 1, 32, 576, 576, 576, 32]
+    - [2, 107.241]
+  - - [640, 64, 1, 32, 640, 640, 640, 32]
+    - [0, 11.4934]
+  - - [704, 64, 1, 32, 704, 704, 704, 32]
+    - [3, 12.5832]
+  - - [768, 64, 1, 32, 768, 768, 768, 32]
+    - [1, 129.56]
+  - - [832, 64, 1, 32, 832, 832, 832, 32]
+    - [0, 14.8445]
+  - - [896, 64, 1, 32, 896, 896, 896, 32]
+    - [2, 16.0774]
+  - - [960, 64, 1, 32, 960, 960, 960, 32]
+    - [3, 17.2047]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 18.3397]
+  - - [64, 128, 1, 32, 64, 64, 64, 32]
+    - [2, 2.29779]
+  - - [128, 128, 1, 32, 128, 128, 128, 32]
+    - [1, 49.1827]
+  - - [192, 128, 1, 32, 192, 192, 192, 32]
+    - [2, 6.90061]
+  - - [256, 128, 1, 32, 256, 256, 256, 32]
+    - [3, 9.25727]
+  - - [320, 128, 1, 32, 320, 320, 320, 32]
+    - [1, 11.4929]
+  - - [384, 128, 1, 32, 384, 384, 384, 32]
+    - [3, 13.7801]
+  - - [448, 128, 1, 32, 448, 448, 448, 32]
+    - [2, 16.0311]
+  - - [512, 128, 1, 32, 512, 512, 512, 32]
+    - [0, 18.3654]
+  - - [576, 128, 1, 32, 576, 576, 576, 32]
+    - [1, 20.671]
+  - - [640, 128, 1, 32, 640, 640, 640, 32]
+    - [3, 22.9547]
+  - - [704, 128, 1, 32, 704, 704, 704, 32]
+    - [2, 25.2049]
+  - - [768, 128, 1, 32, 768, 768, 768, 32]
+    - [3, 191.34]
+  - - [832, 128, 1, 32, 832, 832, 832, 32]
+    - [1, 194.291]
+  - - [896, 128, 1, 32, 896, 896, 896, 32]
+    - [3, 32.0944]
+  - - [960, 128, 1, 32, 960, 960, 960, 32]
+    - [1, 34.426]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 36.7083]
+  - - [64, 192, 1, 32, 64, 64, 64, 32]
+    - [0, 3.43462]
+  - - [128, 192, 1, 32, 128, 128, 128, 32]
+    - [0, 6.89094]
+  - - [192, 192, 1, 32, 192, 192, 192, 32]
+    - [3, 10.3477]
+  - - [256, 192, 1, 32, 256, 256, 256, 32]
+    - [0, 13.7716]
+  - - [320, 192, 1, 32, 320, 320, 320, 32]
+    - [1, 17.2334]
+  - - [384, 192, 1, 32, 384, 384, 384, 32]
+    - [1, 20.7037]
+  - - [448, 192, 1, 32, 448, 448, 448, 32]
+    - [1, 176.217]
+  - - [512, 192, 1, 32, 512, 512, 512, 32]
+    - [2, 27.5457]
+  - - [576, 192, 1, 32, 576, 576, 576, 32]
+    - [2, 30.9428]
+  - - [640, 192, 1, 32, 640, 640, 640, 32]
+    - [1, 34.4411]
+  - - [704, 192, 1, 32, 704, 704, 704, 32]
+    - [1, 37.5628]
+  - - [768, 192, 1, 32, 768, 768, 768, 32]
+    - [3, 41.3149]
+  - - [832, 192, 1, 32, 832, 832, 832, 32]
+    - [1, 44.7695]
+  - - [896, 192, 1, 32, 896, 896, 896, 32]
+    - [1, 48.1164]
+  - - [960, 192, 1, 32, 960, 960, 960, 32]
+    - [3, 51.5691]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 55.0576]
+  - - [64, 256, 1, 32, 64, 64, 64, 32]
+    - [3, 4.62759]
+  - - [128, 256, 1, 32, 128, 128, 128, 32]
+    - [1, 9.19316]
+  - - [192, 256, 1, 32, 192, 192, 192, 32]
+    - [3, 13.7734]
+  - - [256, 256, 1, 32, 256, 256, 256, 32]
+    - [0, 18.3645]
+  - - [320, 256, 1, 32, 320, 320, 320, 32]
+    - [1, 22.9336]
+  - - [384, 256, 1, 32, 384, 384, 384, 32]
+    - [1, 27.5204]
+  - - [448, 256, 1, 32, 448, 448, 448, 32]
+    - [3, 32.1352]
+  - - [512, 256, 1, 32, 512, 512, 512, 32]
+    - [0, 36.7067]
+  - - [576, 256, 1, 32, 576, 576, 576, 32]
+    - [0, 41.2282]
+  - - [640, 256, 1, 32, 640, 640, 640, 32]
+    - [2, 45.845]
+  - - [704, 256, 1, 32, 704, 704, 704, 32]
+    - [3, 50.4231]
+  - - [768, 256, 1, 32, 768, 768, 768, 32]
+    - [2, 54.9251]
+  - - [832, 256, 1, 32, 832, 832, 832, 32]
+    - [3, 59.4115]
+  - - [896, 256, 1, 32, 896, 896, 896, 32]
+    - [2, 64.1858]
+  - - [960, 256, 1, 32, 960, 960, 960, 32]
+    - [2, 254.016]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 32]
+    - [0, 254.969]
+  - - [64, 320, 1, 32, 64, 64, 64, 32]
+    - [3, 7.61467]
+  - - [128, 320, 1, 32, 128, 128, 128, 32]
+    - [2, 14.2299]
+  - - [192, 320, 1, 32, 192, 192, 192, 32]
+    - [3, 128.163]
+  - - [256, 320, 1, 32, 256, 256, 256, 32]
+    - [3, 56.1577]
+  - - [320, 320, 1, 32, 320, 320, 320, 32]
+    - [2, 77.3195]
+  - - [384, 320, 1, 32, 384, 384, 384, 32]
+    - [2, 94.9098]
+  - - [448, 320, 1, 32, 448, 448, 448, 32]
+    - [2, 106.13]
+  - - [512, 320, 1, 32, 512, 512, 512, 32]
+    - [1, 114.111]
+  - - [576, 320, 1, 32, 576, 576, 576, 32]
+    - [2, 136.423]
+  - - [640, 320, 1, 32, 640, 640, 640, 32]
+    - [1, 145.136]
+  - - [704, 320, 1, 32, 704, 704, 704, 32]
+    - [3, 178.043]
+  - - [768, 320, 1, 32, 768, 768, 768, 32]
+    - [3, 187.805]
+  - - [832, 320, 1, 32, 832, 832, 832, 32]
+    - [2, 201.408]
+  - - [896, 320, 1, 32, 896, 896, 896, 32]
+    - [2, 215.225]
+  - - [960, 320, 1, 32, 960, 960, 960, 32]
+    - [2, 234.057]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 208.317]
+  - - [64, 384, 1, 32, 64, 64, 64, 32]
+    - [3, 9.21145]
+  - - [128, 384, 1, 32, 128, 128, 128, 32]
+    - [1, 17.025]
+  - - [192, 384, 1, 32, 192, 192, 192, 32]
+    - [1, 7.75723]
+  - - [256, 384, 1, 32, 256, 256, 256, 32]
+    - [2, 10.3896]
+  - - [320, 384, 1, 32, 320, 320, 320, 32]
+    - [1, 223.666]
+  - - [384, 384, 1, 32, 384, 384, 384, 32]
+    - [2, 15.4626]
+  - - [448, 384, 1, 32, 448, 448, 448, 32]
+    - [2, 18.1659]
+  - - [512, 384, 1, 32, 512, 512, 512, 32]
+    - [2, 20.8546]
+  - - [576, 384, 1, 32, 576, 576, 576, 32]
+    - [1, 23.0688]
+  - - [640, 384, 1, 32, 640, 640, 640, 32]
+    - [3, 25.9462]
+  - - [704, 384, 1, 32, 704, 704, 704, 32]
+    - [3, 28.3835]
+  - - [768, 384, 1, 32, 768, 768, 768, 32]
+    - [2, 27.8558]
+  - - [832, 384, 1, 32, 832, 832, 832, 32]
+    - [3, 32.9007]
+  - - [896, 384, 1, 32, 896, 896, 896, 32]
+    - [1, 36.1089]
+  - - [960, 384, 1, 32, 960, 960, 960, 32]
+    - [1, 33.7818]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 36.0871]
+  - - [64, 448, 1, 32, 64, 64, 64, 32]
+    - [1, 3.07978]
+  - - [128, 448, 1, 32, 128, 128, 128, 32]
+    - [2, 136.533]
+  - - [192, 448, 1, 32, 192, 192, 192, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 256, 32]
+    - [1, 207.34]
+  - - [320, 448, 1, 32, 320, 320, 320, 32]
+    - [1, 234.296]
+  - - [384, 448, 1, 32, 384, 384, 384, 32]
+    - [3, 18.1899]
+  - - [448, 448, 1, 32, 448, 448, 448, 32]
+    - [2, 21.0968]
+  - - [512, 448, 1, 32, 512, 512, 512, 32]
+    - [3, 24.1189]
+  - - [576, 448, 1, 32, 576, 576, 576, 32]
+    - [3, 24.1095]
+  - - [640, 448, 1, 32, 640, 640, 640, 32]
+    - [2, 269.221]
+  - - [704, 448, 1, 32, 704, 704, 704, 32]
+    - [3, 204.303]
+  - - [768, 448, 1, 32, 768, 768, 768, 32]
+    - [3, 228.899]
+  - - [832, 448, 1, 32, 832, 832, 832, 32]
+    - [2, 248.18]
+  - - [896, 448, 1, 32, 896, 896, 896, 32]
+    - [3, 267.157]
+  - - [960, 448, 1, 32, 960, 960, 960, 32]
+    - [3, 278.144]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 291.966]
+  - - [64, 512, 1, 32, 64, 64, 64, 32]
+    - [3, 10.8942]
+  - - [128, 512, 1, 32, 128, 128, 128, 32]
+    - [2, 55.8645]
+  - - [192, 512, 1, 32, 192, 192, 192, 32]
+    - [2, 65.906]
+  - - [256, 512, 1, 32, 256, 256, 256, 32]
+    - [2, 86.2139]
+  - - [320, 512, 1, 32, 320, 320, 320, 32]
+    - [2, 106.66]
+  - - [384, 512, 1, 32, 384, 384, 384, 32]
+    - [1, 124.202]
+  - - [448, 512, 1, 32, 448, 448, 448, 32]
+    - [1, 139.478]
+  - - [512, 512, 1, 32, 512, 512, 512, 32]
+    - [3, 177.031]
+  - - [576, 512, 1, 32, 576, 576, 576, 32]
+    - [3, 194.86]
+  - - [640, 512, 1, 32, 640, 640, 640, 32]
+    - [3, 205.36]
+  - - [704, 512, 1, 32, 704, 704, 704, 32]
+    - [3, 266.013]
+  - - [768, 512, 1, 32, 768, 768, 768, 32]
+    - [3, 36.8442]
+  - - [832, 512, 1, 32, 832, 832, 832, 32]
+    - [2, 40.0112]
+  - - [896, 512, 1, 32, 896, 896, 896, 32]
+    - [3, 45.583]
+  - - [960, 512, 1, 32, 960, 960, 960, 32]
+    - [2, 45.1471]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 632.613]
+  - - [64, 576, 1, 32, 64, 64, 64, 32]
+    - [2, 12.9474]
+  - - [128, 576, 1, 32, 128, 128, 128, 32]
+    - [2, 50.4554]
+  - - [192, 576, 1, 32, 192, 192, 192, 32]
+    - [2, 84.8362]
+  - - [256, 576, 1, 32, 256, 256, 256, 32]
+    - [2, 111.643]
+  - - [320, 576, 1, 32, 320, 320, 320, 32]
+    - [1, 130.896]
+  - - [384, 576, 1, 32, 384, 384, 384, 32]
+    - [3, 61.5439]
+  - - [448, 576, 1, 32, 448, 448, 448, 32]
+    - [1, 71.8731]
+  - - [512, 576, 1, 32, 512, 512, 512, 32]
+    - [2, 81.845]
+  - - [576, 576, 1, 32, 576, 576, 576, 32]
+    - [3, 93.0358]
+  - - [640, 576, 1, 32, 640, 640, 640, 32]
+    - [1, 103.328]
+  - - [704, 576, 1, 32, 704, 704, 704, 32]
+    - [3, 113.566]
+  - - [768, 576, 1, 32, 768, 768, 768, 32]
+    - [2, 123.809]
+  - - [832, 576, 1, 32, 832, 832, 832, 32]
+    - [2, 135.286]
+  - - [896, 576, 1, 32, 896, 896, 896, 32]
+    - [0, 144.16]
+  - - [960, 576, 1, 32, 960, 960, 960, 32]
+    - [0, 154.289]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 55.2663]
+  - - [64, 640, 1, 32, 64, 64, 64, 32]
+    - [3, 4.32657]
+  - - [128, 640, 1, 32, 128, 128, 128, 32]
+    - [3, 8.54722]
+  - - [192, 640, 1, 32, 192, 192, 192, 32]
+    - [3, 210.501]
+  - - [256, 640, 1, 32, 256, 256, 256, 32]
+    - [1, 248.478]
+  - - [320, 640, 1, 32, 320, 320, 320, 32]
+    - [1, 20.9872]
+  - - [384, 640, 1, 32, 384, 384, 384, 32]
+    - [3, 25.903]
+  - - [448, 640, 1, 32, 448, 448, 448, 32]
+    - [1, 26.54]
+  - - [512, 640, 1, 32, 512, 512, 512, 32]
+    - [3, 33.82]
+  - - [576, 640, 1, 32, 576, 576, 576, 32]
+    - [1, 37.43]
+  - - [640, 640, 1, 32, 640, 640, 640, 32]
+    - [3, 34.0321]
+  - - [704, 640, 1, 32, 704, 704, 704, 32]
+    - [2, 45.0431]
+  - - [768, 640, 1, 32, 768, 768, 768, 32]
+    - [3, 45.9295]
+  - - [832, 640, 1, 32, 832, 832, 832, 32]
+    - [3, 276.88]
+  - - [896, 640, 1, 32, 896, 896, 896, 32]
+    - [2, 53.7209]
+  - - [960, 640, 1, 32, 960, 960, 960, 32]
+    - [2, 57.1025]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 59.7382]
+  - - [64, 704, 1, 32, 64, 64, 64, 32]
+    - [3, 4.74053]
+  - - [128, 704, 1, 32, 128, 128, 128, 32]
+    - [2, 9.37091]
+  - - [192, 704, 1, 32, 192, 192, 192, 32]
+    - [2, 14.1319]
+  - - [256, 704, 1, 32, 256, 256, 256, 32]
+    - [2, 19.5838]
+  - - [320, 704, 1, 32, 320, 320, 320, 32]
+    - [3, 23.6964]
+  - - [384, 704, 1, 32, 384, 384, 384, 32]
+    - [3, 27.7649]
+  - - [448, 704, 1, 32, 448, 448, 448, 32]
+    - [2, 32.7588]
+  - - [512, 704, 1, 32, 512, 512, 512, 32]
+    - [2, 33.4895]
+  - - [576, 704, 1, 32, 576, 576, 576, 32]
+    - [2, 37.6538]
+  - - [640, 704, 1, 32, 640, 640, 640, 32]
+    - [0, 36.5703]
+  - - [704, 704, 1, 32, 704, 704, 704, 32]
+    - [3, 46.5967]
+  - - [768, 704, 1, 32, 768, 768, 768, 32]
+    - [1, 49.955]
+  - - [832, 704, 1, 32, 832, 832, 832, 32]
+    - [2, 54.7614]
+  - - [896, 704, 1, 32, 896, 896, 896, 32]
+    - [2, 58.6893]
+  - - [960, 704, 1, 32, 960, 960, 960, 32]
+    - [1, 53.1547]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 66.2851]
+  - - [64, 768, 1, 32, 64, 64, 64, 32]
+    - [3, 5.20244]
+  - - [128, 768, 1, 32, 128, 128, 128, 32]
+    - [2, 10.3143]
+  - - [192, 768, 1, 32, 192, 192, 192, 32]
+    - [3, 15.5431]
+  - - [256, 768, 1, 32, 256, 256, 256, 32]
+    - [3, 20.7303]
+  - - [320, 768, 1, 32, 320, 320, 320, 32]
+    - [3, 25.6257]
+  - - [384, 768, 1, 32, 384, 384, 384, 32]
+    - [3, 30.8031]
+  - - [448, 768, 1, 32, 448, 448, 448, 32]
+    - [2, 32.4291]
+  - - [512, 768, 1, 32, 512, 512, 512, 32]
+    - [3, 39.7506]
+  - - [576, 768, 1, 32, 576, 576, 576, 32]
+    - [2, 41.4418]
+  - - [640, 768, 1, 32, 640, 640, 640, 32]
+    - [2, 295.426]
+  - - [704, 768, 1, 32, 704, 704, 704, 32]
+    - [2, 50.5342]
+  - - [768, 768, 1, 32, 768, 768, 768, 32]
+    - [2, 54.939]
+  - - [832, 768, 1, 32, 832, 832, 832, 32]
+    - [3, 58.1719]
+  - - [896, 768, 1, 32, 896, 896, 896, 32]
+    - [1, 63.765]
+  - - [960, 768, 1, 32, 960, 960, 960, 32]
+    - [2, 68.1401]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 70.5119]
+  - - [64, 832, 1, 32, 64, 64, 64, 32]
+    - [2, 131.274]
+  - - [128, 832, 1, 32, 128, 128, 128, 32]
+    - [1, 193.19]
+  - - [192, 832, 1, 32, 192, 192, 192, 32]
+    - [1, 242.72]
+  - - [256, 832, 1, 32, 256, 256, 256, 32]
+    - [1, 269.392]
+  - - [320, 832, 1, 32, 320, 320, 320, 32]
+    - [0, 72.9044]
+  - - [384, 832, 1, 32, 384, 384, 384, 32]
+    - [2, 29.7413]
+  - - [448, 832, 1, 32, 448, 448, 448, 32]
+    - [2, 37.9717]
+  - - [512, 832, 1, 32, 512, 512, 512, 32]
+    - [3, 42.7618]
+  - - [576, 832, 1, 32, 576, 576, 576, 32]
+    - [1, 36.6624]
+  - - [640, 832, 1, 32, 640, 640, 640, 32]
+    - [3, 49.675]
+  - - [704, 832, 1, 32, 704, 704, 704, 32]
+    - [2, 56.5567]
+  - - [768, 832, 1, 32, 768, 768, 768, 32]
+    - [3, 59.3651]
+  - - [832, 832, 1, 32, 832, 832, 832, 32]
+    - [3, 64.4816]
+  - - [896, 832, 1, 32, 896, 896, 896, 32]
+    - [2, 68.9171]
+  - - [960, 832, 1, 32, 960, 960, 960, 32]
+    - [1, 63.7849]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 79.2627]
+  - - [64, 896, 1, 32, 64, 64, 64, 32]
+    - [2, 6.0592]
+  - - [128, 896, 1, 32, 128, 128, 128, 32]
+    - [3, 12.0502]
+  - - [192, 896, 1, 32, 192, 192, 192, 32]
+    - [3, 249.774]
+  - - [256, 896, 1, 32, 256, 256, 256, 32]
+    - [2, 23.7929]
+  - - [320, 896, 1, 32, 320, 320, 320, 32]
+    - [2, 83.3031]
+  - - [384, 896, 1, 32, 384, 384, 384, 32]
+    - [3, 34.9013]
+  - - [448, 896, 1, 32, 448, 448, 448, 32]
+    - [1, 35.9602]
+  - - [512, 896, 1, 32, 512, 512, 512, 32]
+    - [1, 42.0896]
+  - - [576, 896, 1, 32, 576, 576, 576, 32]
+    - [3, 48.2746]
+  - - [640, 896, 1, 32, 640, 640, 640, 32]
+    - [1, 53.1706]
+  - - [704, 896, 1, 32, 704, 704, 704, 32]
+    - [2, 59.3754]
+  - - [768, 896, 1, 32, 768, 768, 768, 32]
+    - [3, 63.9902]
+  - - [832, 896, 1, 32, 832, 832, 832, 32]
+    - [0, 67.4584]
+  - - [896, 896, 1, 32, 896, 896, 896, 32]
+    - [2, 72.8681]
+  - - [960, 896, 1, 32, 960, 960, 960, 32]
+    - [1, 79.6003]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 82.539]
+  - - [64, 960, 1, 32, 64, 64, 64, 32]
+    - [1, 6.40329]
+  - - [128, 960, 1, 32, 128, 128, 128, 32]
+    - [2, 12.9321]
+  - - [192, 960, 1, 32, 192, 192, 192, 32]
+    - [2, 19.3689]
+  - - [256, 960, 1, 32, 256, 256, 256, 32]
+    - [1, 25.2785]
+  - - [320, 960, 1, 32, 320, 320, 320, 32]
+    - [1, 31.4692]
+  - - [384, 960, 1, 32, 384, 384, 384, 32]
+    - [2, 34.3398]
+  - - [448, 960, 1, 32, 448, 448, 448, 32]
+    - [2, 40.19]
+  - - [512, 960, 1, 32, 512, 512, 512, 32]
+    - [3, 45.686]
+  - - [576, 960, 1, 32, 576, 576, 576, 32]
+    - [3, 51.5217]
+  - - [640, 960, 1, 32, 640, 640, 640, 32]
+    - [2, 57.8128]
+  - - [704, 960, 1, 32, 704, 704, 704, 32]
+    - [0, 61.3229]
+  - - [768, 960, 1, 32, 768, 768, 768, 32]
+    - [0, 65.2042]
+  - - [832, 960, 1, 32, 832, 832, 832, 32]
+    - [2, 72.6756]
+  - - [896, 960, 1, 32, 896, 896, 896, 32]
+    - [1, 79.4669]
+  - - [960, 960, 1, 32, 960, 960, 960, 32]
+    - [2, 78.536]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 85.7013]
+  - - [64, 1024, 1, 32, 64, 64, 64, 32]
+    - [3, 6.90076]
+  - - [128, 1024, 1, 32, 128, 128, 128, 32]
+    - [3, 13.7965]
+  - - [192, 1024, 1, 32, 192, 192, 192, 32]
+    - [3, 20.4795]
+  - - [256, 1024, 1, 32, 256, 256, 256, 32]
+    - [3, 27.4706]
+  - - [320, 1024, 1, 32, 320, 320, 320, 32]
+    - [0, 29.5718]
+  - - [384, 1024, 1, 32, 384, 384, 384, 32]
+    - [2, 40.0721]
+  - - [448, 1024, 1, 32, 448, 448, 448, 32]
+    - [2, 42.8763]
+  - - [512, 1024, 1, 32, 512, 512, 512, 32]
+    - [3, 48.9415]
+  - - [576, 1024, 1, 32, 576, 576, 576, 32]
+    - [0, 53.6033]
+  - - [640, 1024, 1, 32, 640, 640, 640, 32]
+    - [1, 59.8688]
+  - - [704, 1024, 1, 32, 704, 704, 704, 32]
+    - [0, 64.5626]
+  - - [768, 1024, 1, 32, 768, 768, 768, 32]
+    - [2, 61.8968]
+  - - [832, 1024, 1, 32, 832, 832, 832, 32]
+    - [1, 78.4519]
+  - - [896, 1024, 1, 32, 896, 896, 896, 32]
+    - [2, 69.6129]
+  - - [960, 1024, 1, 32, 960, 960, 960, 32]
+    - [3, 85.3746]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 90.2469]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi32
+- gfx1101
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 64]
+    - [1, 1.15726]
+  - - [128, 64, 1, 32, 128, 128, 32, 64]
+    - [3, 2.31821]
+  - - [192, 64, 1, 32, 192, 192, 32, 64]
+    - [2, 3.47424]
+  - - [256, 64, 1, 32, 256, 256, 32, 64]
+    - [2, 4.63209]
+  - - [320, 64, 1, 32, 320, 320, 32, 64]
+    - [2, 5.79552]
+  - - [384, 64, 1, 32, 384, 384, 32, 64]
+    - [3, 6.95431]
+  - - [448, 64, 1, 32, 448, 448, 32, 64]
+    - [3, 76.2046]
+  - - [512, 64, 1, 32, 512, 512, 32, 64]
+    - [1, 9.2716]
+  - - [576, 64, 1, 32, 576, 576, 32, 64]
+    - [0, 102.578]
+  - - [640, 64, 1, 32, 640, 640, 32, 64]
+    - [3, 11.5757]
+  - - [704, 64, 1, 32, 704, 704, 32, 64]
+    - [2, 12.7349]
+  - - [768, 64, 1, 32, 768, 768, 32, 64]
+    - [2, 13.8773]
+  - - [832, 64, 1, 32, 832, 832, 32, 64]
+    - [2, 14.9677]
+  - - [896, 64, 1, 32, 896, 896, 32, 64]
+    - [0, 16.1127]
+  - - [960, 64, 1, 32, 960, 960, 32, 64]
+    - [3, 17.2894]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 64]
+    - [2, 18.451]
+  - - [64, 128, 1, 32, 64, 64, 32, 128]
+    - [3, 24.1385]
+  - - [128, 128, 1, 32, 128, 128, 32, 128]
+    - [0, 55.8942]
+  - - [192, 128, 1, 32, 192, 192, 32, 128]
+    - [2, 77.5536]
+  - - [256, 128, 1, 32, 256, 256, 32, 128]
+    - [3, 3.71372]
+  - - [320, 128, 1, 32, 320, 320, 32, 128]
+    - [3, 4.61828]
+  - - [384, 128, 1, 32, 384, 384, 32, 128]
+    - [1, 5.23804]
+  - - [448, 128, 1, 32, 448, 448, 32, 128]
+    - [3, 6.42685]
+  - - [512, 128, 1, 32, 512, 512, 32, 128]
+    - [1, 6.90462]
+  - - [576, 128, 1, 32, 576, 576, 32, 128]
+    - [3, 7.89334]
+  - - [640, 128, 1, 32, 640, 640, 32, 128]
+    - [2, 8.75149]
+  - - [704, 128, 1, 32, 704, 704, 32, 128]
+    - [3, 9.61092]
+  - - [768, 128, 1, 32, 768, 768, 32, 128]
+    - [3, 10.4859]
+  - - [832, 128, 1, 32, 832, 832, 32, 128]
+    - [1, 11.2858]
+  - - [896, 128, 1, 32, 896, 896, 32, 128]
+    - [1, 213.125]
+  - - [960, 128, 1, 32, 960, 960, 32, 128]
+    - [2, 13.1457]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 128]
+    - [2, 14.0183]
+  - - [64, 192, 1, 32, 64, 64, 32, 192]
+    - [3, 1.32088]
+  - - [128, 192, 1, 32, 128, 128, 32, 192]
+    - [2, 2.64208]
+  - - [192, 192, 1, 32, 192, 192, 32, 192]
+    - [2, 3.91608]
+  - - [256, 192, 1, 32, 256, 256, 32, 192]
+    - [3, 5.28406]
+  - - [320, 192, 1, 32, 320, 320, 32, 192]
+    - [2, 6.54701]
+  - - [384, 192, 1, 32, 384, 384, 32, 192]
+    - [1, 7.81296]
+  - - [448, 192, 1, 32, 448, 448, 32, 192]
+    - [2, 9.13691]
+  - - [512, 192, 1, 32, 512, 512, 32, 192]
+    - [1, 10.4083]
+  - - [576, 192, 1, 32, 576, 576, 32, 192]
+    - [2, 11.7711]
+  - - [640, 192, 1, 32, 640, 640, 32, 192]
+    - [3, 13.14]
+  - - [704, 192, 1, 32, 704, 704, 32, 192]
+    - [1, 14.2987]
+  - - [768, 192, 1, 32, 768, 768, 32, 192]
+    - [2, 15.7448]
+  - - [832, 192, 1, 32, 832, 832, 32, 192]
+    - [2, 17.0191]
+  - - [896, 192, 1, 32, 896, 896, 32, 192]
+    - [2, 18.3705]
+  - - [960, 192, 1, 32, 960, 960, 32, 192]
+    - [1, 19.4195]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 192]
+    - [3, 20.9334]
+  - - [64, 256, 1, 32, 64, 64, 32, 256]
+    - [2, 1.73956]
+  - - [128, 256, 1, 32, 128, 128, 32, 256]
+    - [1, 3.50886]
+  - - [192, 256, 1, 32, 192, 192, 32, 256]
+    - [3, 5.30402]
+  - - [256, 256, 1, 32, 256, 256, 32, 256]
+    - [3, 7.03596]
+  - - [320, 256, 1, 32, 320, 320, 32, 256]
+    - [3, 8.79437]
+  - - [384, 256, 1, 32, 384, 384, 32, 256]
+    - [2, 10.3936]
+  - - [448, 256, 1, 32, 448, 448, 32, 256]
+    - [2, 12.1206]
+  - - [512, 256, 1, 32, 512, 512, 32, 256]
+    - [3, 14.0427]
+  - - [576, 256, 1, 32, 576, 576, 32, 256]
+    - [3, 15.7864]
+  - - [640, 256, 1, 32, 640, 640, 32, 256]
+    - [3, 17.4744]
+  - - [704, 256, 1, 32, 704, 704, 32, 256]
+    - [1, 247.513]
+  - - [768, 256, 1, 32, 768, 768, 32, 256]
+    - [2, 20.6236]
+  - - [832, 256, 1, 32, 832, 832, 32, 256]
+    - [3, 22.6944]
+  - - [896, 256, 1, 32, 896, 896, 32, 256]
+    - [3, 24.3493]
+  - - [960, 256, 1, 32, 960, 960, 32, 256]
+    - [2, 25.8264]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 256]
+    - [1, 24.3747]
+  - - [64, 320, 1, 32, 64, 64, 32, 320]
+    - [2, 1.92099]
+  - - [128, 320, 1, 32, 128, 128, 32, 320]
+    - [2, 112.993]
+  - - [192, 320, 1, 32, 192, 192, 32, 320]
+    - [2, 15.7677]
+  - - [256, 320, 1, 32, 256, 256, 32, 320]
+    - [2, 170.445]
+  - - [320, 320, 1, 32, 320, 320, 32, 320]
+    - [2, 10.8445]
+  - - [384, 320, 1, 32, 384, 384, 32, 320]
+    - [1, 12.7485]
+  - - [448, 320, 1, 32, 448, 448, 32, 320]
+    - [1, 15.127]
+  - - [512, 320, 1, 32, 512, 512, 32, 320]
+    - [2, 17.4663]
+  - - [576, 320, 1, 32, 576, 576, 32, 320]
+    - [2, 14.4937]
+  - - [640, 320, 1, 32, 640, 640, 32, 320]
+    - [3, 21.761]
+  - - [704, 320, 1, 32, 704, 704, 32, 320]
+    - [3, 24.1234]
+  - - [768, 320, 1, 32, 768, 768, 32, 320]
+    - [1, 26.199]
+  - - [832, 320, 1, 32, 832, 832, 32, 320]
+    - [2, 28.1632]
+  - - [896, 320, 1, 32, 896, 896, 32, 320]
+    - [2, 30.1531]
+  - - [960, 320, 1, 32, 960, 960, 32, 320]
+    - [3, 31.8247]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 320]
+    - [2, 34.0556]
+  - - [64, 384, 1, 32, 64, 64, 32, 384]
+    - [3, 2.66269]
+  - - [128, 384, 1, 32, 128, 128, 32, 384]
+    - [1, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 384]
+    - [3, 7.91506]
+  - - [256, 384, 1, 32, 256, 256, 32, 384]
+    - [2, 10.4834]
+  - - [320, 384, 1, 32, 320, 320, 32, 384]
+    - [3, 13.1668]
+  - - [384, 384, 1, 32, 384, 384, 32, 384]
+    - [2, 15.7136]
+  - - [448, 384, 1, 32, 448, 448, 32, 384]
+    - [3, 18.5612]
+  - - [512, 384, 1, 32, 512, 512, 32, 384]
+    - [3, 21.012]
+  - - [576, 384, 1, 32, 576, 576, 32, 384]
+    - [2, 23.57]
+  - - [640, 384, 1, 32, 640, 640, 32, 384]
+    - [1, 26.1267]
+  - - [704, 384, 1, 32, 704, 704, 32, 384]
+    - [2, 25.9286]
+  - - [768, 384, 1, 32, 768, 768, 32, 384]
+    - [3, 30.459]
+  - - [832, 384, 1, 32, 832, 832, 32, 384]
+    - [3, 32.9458]
+  - - [896, 384, 1, 32, 896, 896, 32, 384]
+    - [2, 35.4332]
+  - - [960, 384, 1, 32, 960, 960, 32, 384]
+    - [1, 321.255]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 384]
+    - [3, 35.291]
+  - - [64, 448, 1, 32, 64, 64, 32, 448]
+    - [1, 3.08144]
+  - - [128, 448, 1, 32, 128, 128, 32, 448]
+    - [1, 6.12932]
+  - - [192, 448, 1, 32, 192, 192, 32, 448]
+    - [1, 9.12646]
+  - - [256, 448, 1, 32, 256, 256, 32, 448]
+    - [2, 12.2539]
+  - - [320, 448, 1, 32, 320, 320, 32, 448]
+    - [2, 15.2543]
+  - - [384, 448, 1, 32, 384, 384, 32, 448]
+    - [2, 18.3503]
+  - - [448, 448, 1, 32, 448, 448, 32, 448]
+    - [2, 21.3375]
+  - - [512, 448, 1, 32, 512, 512, 32, 448]
+    - [2, 250.342]
+  - - [576, 448, 1, 32, 576, 576, 32, 448]
+    - [3, 27.1378]
+  - - [640, 448, 1, 32, 640, 640, 32, 448]
+    - [3, 29.9288]
+  - - [704, 448, 1, 32, 704, 704, 32, 448]
+    - [3, 30.1579]
+  - - [768, 448, 1, 32, 768, 768, 32, 448]
+    - [2, 31.8502]
+  - - [832, 448, 1, 32, 832, 832, 32, 448]
+    - [3, 35.3894]
+  - - [896, 448, 1, 32, 896, 896, 32, 448]
+    - [1, 37.6614]
+  - - [960, 448, 1, 32, 960, 960, 32, 448]
+    - [2, 41.1963]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 448]
+    - [2, 44.0087]
+  - - [64, 512, 1, 32, 64, 64, 32, 512]
+    - [1, 3.52295]
+  - - [128, 512, 1, 32, 128, 128, 32, 512]
+    - [1, 6.94911]
+  - - [192, 512, 1, 32, 192, 192, 32, 512]
+    - [3, 10.5167]
+  - - [256, 512, 1, 32, 256, 256, 32, 512]
+    - [2, 14.0604]
+  - - [320, 512, 1, 32, 320, 320, 32, 512]
+    - [2, 17.2647]
+  - - [384, 512, 1, 32, 384, 384, 32, 512]
+    - [3, 18.5058]
+  - - [448, 512, 1, 32, 448, 448, 32, 512]
+    - [2, 24.1574]
+  - - [512, 512, 1, 32, 512, 512, 32, 512]
+    - [3, 23.8816]
+  - - [576, 512, 1, 32, 576, 576, 32, 512]
+    - [1, 30.8791]
+  - - [640, 512, 1, 32, 640, 640, 32, 512]
+    - [1, 30.8095]
+  - - [704, 512, 1, 32, 704, 704, 32, 512]
+    - [1, 31.2565]
+  - - [768, 512, 1, 32, 768, 768, 32, 512]
+    - [3, 37.0819]
+  - - [832, 512, 1, 32, 832, 832, 32, 512]
+    - [0, 38.4813]
+  - - [896, 512, 1, 32, 896, 896, 32, 512]
+    - [3, 272.76]
+  - - [960, 512, 1, 32, 960, 960, 32, 512]
+    - [2, 285.143]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 512]
+    - [2, 300.344]
+  - - [64, 576, 1, 32, 64, 64, 32, 576]
+    - [1, 3.94252]
+  - - [128, 576, 1, 32, 128, 128, 32, 576]
+    - [2, 7.85877]
+  - - [192, 576, 1, 32, 192, 192, 32, 576]
+    - [1, 11.7529]
+  - - [256, 576, 1, 32, 256, 256, 32, 576]
+    - [2, 15.6784]
+  - - [320, 576, 1, 32, 320, 320, 32, 576]
+    - [2, 19.6958]
+  - - [384, 576, 1, 32, 384, 384, 32, 576]
+    - [3, 23.6192]
+  - - [448, 576, 1, 32, 448, 448, 32, 576]
+    - [2, 27.2277]
+  - - [512, 576, 1, 32, 512, 512, 32, 576]
+    - [1, 303.057]
+  - - [576, 576, 1, 32, 576, 576, 32, 576]
+    - [2, 56.6076]
+  - - [640, 576, 1, 32, 640, 640, 32, 576]
+    - [3, 37.3097]
+  - - [704, 576, 1, 32, 704, 704, 32, 576]
+    - [3, 40.4755]
+  - - [768, 576, 1, 32, 768, 768, 32, 576]
+    - [3, 42.0593]
+  - - [832, 576, 1, 32, 832, 832, 32, 576]
+    - [3, 45.7279]
+  - - [896, 576, 1, 32, 896, 896, 32, 576]
+    - [1, 48.5906]
+  - - [960, 576, 1, 32, 960, 960, 32, 576]
+    - [2, 52.451]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 576]
+    - [1, 52.4547]
+  - - [64, 640, 1, 32, 64, 64, 32, 640]
+    - [2, 4.36809]
+  - - [128, 640, 1, 32, 128, 128, 32, 640]
+    - [1, 8.54343]
+  - - [192, 640, 1, 32, 192, 192, 32, 640]
+    - [2, 13.0236]
+  - - [256, 640, 1, 32, 256, 256, 32, 640]
+    - [3, 17.4794]
+  - - [320, 640, 1, 32, 320, 320, 32, 640]
+    - [2, 21.473]
+  - - [384, 640, 1, 32, 384, 384, 32, 640]
+    - [1, 25.7238]
+  - - [448, 640, 1, 32, 448, 448, 32, 640]
+    - [1, 28.8571]
+  - - [512, 640, 1, 32, 512, 512, 32, 640]
+    - [3, 31.1338]
+  - - [576, 640, 1, 32, 576, 576, 32, 640]
+    - [3, 37.6695]
+  - - [640, 640, 1, 32, 640, 640, 32, 640]
+    - [3, 41.3063]
+  - - [704, 640, 1, 32, 704, 704, 32, 640]
+    - [2, 282.038]
+  - - [768, 640, 1, 32, 768, 768, 32, 640]
+    - [1, 44.3651]
+  - - [832, 640, 1, 32, 832, 832, 32, 640]
+    - [1, 339.561]
+  - - [896, 640, 1, 32, 896, 896, 32, 640]
+    - [1, 342.221]
+  - - [960, 640, 1, 32, 960, 960, 32, 640]
+    - [2, 54.8507]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 640]
+    - [1, 60.763]
+  - - [64, 704, 1, 32, 64, 64, 32, 704]
+    - [2, 4.83657]
+  - - [128, 704, 1, 32, 128, 128, 32, 704]
+    - [2, 9.51187]
+  - - [192, 704, 1, 32, 192, 192, 32, 704]
+    - [3, 14.5053]
+  - - [256, 704, 1, 32, 256, 256, 32, 704]
+    - [1, 19.0363]
+  - - [320, 704, 1, 32, 320, 320, 32, 704]
+    - [1, 267.593]
+  - - [384, 704, 1, 32, 384, 384, 32, 704]
+    - [2, 28.4469]
+  - - [448, 704, 1, 32, 448, 448, 32, 704]
+    - [2, 32.8767]
+  - - [512, 704, 1, 32, 512, 512, 32, 704]
+    - [1, 32.7986]
+  - - [576, 704, 1, 32, 576, 576, 32, 704]
+    - [1, 319.605]
+  - - [640, 704, 1, 32, 640, 640, 32, 704]
+    - [3, 44.8045]
+  - - [704, 704, 1, 32, 704, 704, 32, 704]
+    - [3, 46.3515]
+  - - [768, 704, 1, 32, 768, 768, 32, 704]
+    - [1, 50.2597]
+  - - [832, 704, 1, 32, 832, 832, 32, 704]
+    - [2, 54.9452]
+  - - [896, 704, 1, 32, 896, 896, 32, 704]
+    - [1, 58.9238]
+  - - [960, 704, 1, 32, 960, 960, 32, 704]
+    - [3, 57.3889]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 704]
+    - [1, 67.3308]
+  - - [64, 768, 1, 32, 64, 64, 32, 768]
+    - [2, 5.13066]
+  - - [128, 768, 1, 32, 128, 128, 32, 768]
+    - [3, 10.4063]
+  - - [192, 768, 1, 32, 192, 192, 32, 768]
+    - [3, 15.5295]
+  - - [256, 768, 1, 32, 256, 256, 32, 768]
+    - [2, 235.635]
+  - - [320, 768, 1, 32, 320, 320, 32, 768]
+    - [3, 25.7752]
+  - - [384, 768, 1, 32, 384, 384, 32, 768]
+    - [2, 27.6193]
+  - - [448, 768, 1, 32, 448, 448, 32, 768]
+    - [2, 35.5029]
+  - - [512, 768, 1, 32, 512, 512, 32, 768]
+    - [0, 283.396]
+  - - [576, 768, 1, 32, 576, 576, 32, 768]
+    - [3, 41.5159]
+  - - [640, 768, 1, 32, 640, 640, 32, 768]
+    - [1, 318.394]
+  - - [704, 768, 1, 32, 704, 704, 32, 768]
+    - [1, 151.018]
+  - - [768, 768, 1, 32, 768, 768, 32, 768]
+    - [2, 54.769]
+  - - [832, 768, 1, 32, 832, 832, 32, 768]
+    - [3, 59.8533]
+  - - [896, 768, 1, 32, 896, 896, 32, 768]
+    - [3, 64.697]
+  - - [960, 768, 1, 32, 960, 960, 32, 768]
+    - [3, 272.639]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 768]
+    - [0, 158.739]
+  - - [64, 832, 1, 32, 64, 64, 32, 832]
+    - [3, 5.6198]
+  - - [128, 832, 1, 32, 128, 128, 32, 832]
+    - [3, 11.2135]
+  - - [192, 832, 1, 32, 192, 192, 32, 832]
+    - [1, 12.6673]
+  - - [256, 832, 1, 32, 256, 256, 32, 832]
+    - [2, 21.8459]
+  - - [320, 832, 1, 32, 320, 320, 32, 832]
+    - [2, 27.6993]
+  - - [384, 832, 1, 32, 384, 384, 32, 832]
+    - [2, 33.2084]
+  - - [448, 832, 1, 32, 448, 448, 32, 832]
+    - [1, 34.47]
+  - - [512, 832, 1, 32, 512, 512, 32, 832]
+    - [3, 38.4699]
+  - - [576, 832, 1, 32, 576, 576, 32, 832]
+    - [3, 44.7355]
+  - - [640, 832, 1, 32, 640, 640, 32, 832]
+    - [2, 49.7729]
+  - - [704, 832, 1, 32, 704, 704, 32, 832]
+    - [0, 51.9778]
+  - - [768, 832, 1, 32, 768, 768, 32, 832]
+    - [2, 60.0476]
+  - - [832, 832, 1, 32, 832, 832, 32, 832]
+    - [3, 61.0171]
+  - - [896, 832, 1, 32, 896, 896, 32, 832]
+    - [3, 68.7008]
+  - - [960, 832, 1, 32, 960, 960, 32, 832]
+    - [1, 73.7301]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 832]
+    - [2, 76.7188]
+  - - [64, 896, 1, 32, 64, 64, 32, 896]
+    - [3, 6.0638]
+  - - [128, 896, 1, 32, 128, 128, 32, 896]
+    - [1, 11.8097]
+  - - [192, 896, 1, 32, 192, 192, 32, 896]
+    - [1, 260.408]
+  - - [256, 896, 1, 32, 256, 256, 32, 896]
+    - [1, 112.061]
+  - - [320, 896, 1, 32, 320, 320, 32, 896]
+    - [1, 21.646]
+  - - [384, 896, 1, 32, 384, 384, 32, 896]
+    - [3, 35.1622]
+  - - [448, 896, 1, 32, 448, 448, 32, 896]
+    - [2, 40.6641]
+  - - [512, 896, 1, 32, 512, 512, 32, 896]
+    - [2, 42.9101]
+  - - [576, 896, 1, 32, 576, 576, 32, 896]
+    - [0, 43.0245]
+  - - [640, 896, 1, 32, 640, 640, 32, 896]
+    - [3, 79.8571]
+  - - [704, 896, 1, 32, 704, 704, 32, 896]
+    - [1, 49.3707]
+  - - [768, 896, 1, 32, 768, 768, 32, 896]
+    - [3, 63.6994]
+  - - [832, 896, 1, 32, 832, 832, 32, 896]
+    - [2, 61.6821]
+  - - [896, 896, 1, 32, 896, 896, 32, 896]
+    - [2, 72.8566]
+  - - [960, 896, 1, 32, 960, 960, 32, 896]
+    - [1, 354.886]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 896]
+    - [0, 317.886]
+  - - [64, 960, 1, 32, 64, 64, 32, 960]
+    - [1, 53.3971]
+  - - [128, 960, 1, 32, 128, 128, 32, 960]
+    - [3, 90.4142]
+  - - [192, 960, 1, 32, 192, 192, 32, 960]
+    - [2, 122.611]
+  - - [256, 960, 1, 32, 256, 256, 32, 960]
+    - [3, 183.744]
+  - - [320, 960, 1, 32, 320, 320, 32, 960]
+    - [3, 223.215]
+  - - [384, 960, 1, 32, 384, 384, 32, 960]
+    - [3, 254.894]
+  - - [448, 960, 1, 32, 448, 448, 32, 960]
+    - [1, 281.213]
+  - - [512, 960, 1, 32, 512, 512, 32, 960]
+    - [1, 112.761]
+  - - [576, 960, 1, 32, 576, 576, 32, 960]
+    - [3, 48.9911]
+  - - [640, 960, 1, 32, 640, 640, 32, 960]
+    - [3, 55.7371]
+  - - [704, 960, 1, 32, 704, 704, 32, 960]
+    - [2, 63.3231]
+  - - [768, 960, 1, 32, 768, 768, 32, 960]
+    - [3, 68.2938]
+  - - [832, 960, 1, 32, 832, 832, 32, 960]
+    - [2, 72.4314]
+  - - [896, 960, 1, 32, 896, 896, 32, 960]
+    - [1, 77.3032]
+  - - [960, 960, 1, 32, 960, 960, 32, 960]
+    - [1, 81.6484]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 960]
+    - [1, 88.853]
+  - - [64, 1024, 1, 32, 64, 64, 32, 1024]
+    - [1, 6.85587]
+  - - [128, 1024, 1, 32, 128, 128, 32, 1024]
+    - [2, 13.7617]
+  - - [192, 1024, 1, 32, 192, 192, 32, 1024]
+    - [3, 20.7908]
+  - - [256, 1024, 1, 32, 256, 256, 32, 1024]
+    - [2, 264.621]
+  - - [320, 1024, 1, 32, 320, 320, 32, 1024]
+    - [0, 110.725]
+  - - [384, 1024, 1, 32, 384, 384, 32, 1024]
+    - [1, 34.0459]
+  - - [448, 1024, 1, 32, 448, 448, 32, 1024]
+    - [1, 329.589]
+  - - [512, 1024, 1, 32, 512, 512, 32, 1024]
+    - [1, 49.0545]
+  - - [576, 1024, 1, 32, 576, 576, 32, 1024]
+    - [3, 51.7861]
+  - - [640, 1024, 1, 32, 640, 640, 32, 1024]
+    - [3, 60.799]
+  - - [704, 1024, 1, 32, 704, 704, 32, 1024]
+    - [3, 66.7098]
+  - - [768, 1024, 1, 32, 768, 768, 32, 1024]
+    - [1, 73.2018]
+  - - [832, 1024, 1, 32, 832, 832, 32, 1024]
+    - [0, 76.422]
+  - - [896, 1024, 1, 32, 896, 896, 32, 1024]
+    - [1, 83.9504]
+  - - [960, 1024, 1, 32, 960, 960, 32, 1024]
+    - [1, 88.6428]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 1024]
+    - [0, 89.8096]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi32/Equality/navi32_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi32
+- gfx1101
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 1]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 32]
+    - [1, 1.15885]
+  - - [128, 64, 1, 32, 128, 128, 32, 32]
+    - [3, 2.32324]
+  - - [192, 64, 1, 32, 192, 192, 32, 32]
+    - [2, 3.48116]
+  - - [256, 64, 1, 32, 256, 256, 32, 32]
+    - [2, 4.67611]
+  - - [320, 64, 1, 32, 320, 320, 32, 32]
+    - [3, 5.79706]
+  - - [384, 64, 1, 32, 384, 384, 32, 32]
+    - [3, 72.9529]
+  - - [448, 64, 1, 32, 448, 448, 32, 32]
+    - [2, 8.11405]
+  - - [512, 64, 1, 32, 512, 512, 32, 32]
+    - [3, 85.8082]
+  - - [576, 64, 1, 32, 576, 576, 32, 32]
+    - [3, 10.4384]
+  - - [640, 64, 1, 32, 640, 640, 32, 32]
+    - [1, 11.5436]
+  - - [704, 64, 1, 32, 704, 704, 32, 32]
+    - [3, 117.41]
+  - - [768, 64, 1, 32, 768, 768, 32, 32]
+    - [0, 13.8645]
+  - - [832, 64, 1, 32, 832, 832, 32, 32]
+    - [3, 14.9874]
+  - - [896, 64, 1, 32, 896, 896, 32, 32]
+    - [3, 16.1559]
+  - - [960, 64, 1, 32, 960, 960, 32, 32]
+    - [0, 17.3001]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 32]
+    - [2, 18.4299]
+  - - [64, 128, 1, 32, 64, 64, 32, 32]
+    - [2, 2.31268]
+  - - [128, 128, 1, 32, 128, 128, 32, 32]
+    - [3, 47.0636]
+  - - [192, 128, 1, 32, 192, 192, 32, 32]
+    - [2, 75.4733]
+  - - [256, 128, 1, 32, 256, 256, 32, 32]
+    - [2, 93.9542]
+  - - [320, 128, 1, 32, 320, 320, 32, 32]
+    - [2, 109.227]
+  - - [384, 128, 1, 32, 384, 384, 32, 32]
+    - [1, 13.8266]
+  - - [448, 128, 1, 32, 448, 448, 32, 32]
+    - [3, 124.83]
+  - - [512, 128, 1, 32, 512, 512, 32, 32]
+    - [3, 18.2917]
+  - - [576, 128, 1, 32, 576, 576, 32, 32]
+    - [0, 20.7346]
+  - - [640, 128, 1, 32, 640, 640, 32, 32]
+    - [1, 23.0505]
+  - - [704, 128, 1, 32, 704, 704, 32, 32]
+    - [2, 25.3635]
+  - - [768, 128, 1, 32, 768, 768, 32, 32]
+    - [1, 27.6814]
+  - - [832, 128, 1, 32, 832, 832, 32, 32]
+    - [1, 29.9696]
+  - - [896, 128, 1, 32, 896, 896, 32, 32]
+    - [2, 32.2652]
+  - - [960, 128, 1, 32, 960, 960, 32, 32]
+    - [2, 34.5972]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 32]
+    - [2, 36.8745]
+  - - [64, 192, 1, 32, 64, 64, 32, 32]
+    - [0, 3.46628]
+  - - [128, 192, 1, 32, 128, 128, 32, 32]
+    - [3, 6.93591]
+  - - [192, 192, 1, 32, 192, 192, 32, 32]
+    - [3, 10.3805]
+  - - [256, 192, 1, 32, 256, 256, 32, 32]
+    - [2, 13.8505]
+  - - [320, 192, 1, 32, 320, 320, 32, 32]
+    - [3, 17.316]
+  - - [384, 192, 1, 32, 384, 384, 32, 32]
+    - [1, 7.68846]
+  - - [448, 192, 1, 32, 448, 448, 32, 32]
+    - [3, 9.14738]
+  - - [512, 192, 1, 32, 512, 512, 32, 32]
+    - [2, 10.3843]
+  - - [576, 192, 1, 32, 576, 576, 32, 32]
+    - [1, 11.6535]
+  - - [640, 192, 1, 32, 640, 640, 32, 32]
+    - [2, 12.944]
+  - - [704, 192, 1, 32, 704, 704, 32, 32]
+    - [2, 14.3917]
+  - - [768, 192, 1, 32, 768, 768, 32, 32]
+    - [2, 15.7115]
+  - - [832, 192, 1, 32, 832, 832, 32, 32]
+    - [2, 220.337]
+  - - [896, 192, 1, 32, 896, 896, 32, 32]
+    - [2, 18.3103]
+  - - [960, 192, 1, 32, 960, 960, 32, 32]
+    - [1, 19.5163]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 32]
+    - [3, 137.893]
+  - - [64, 256, 1, 32, 64, 64, 32, 32]
+    - [3, 5.97204]
+  - - [128, 256, 1, 32, 128, 128, 32, 32]
+    - [2, 3.49203]
+  - - [192, 256, 1, 32, 192, 192, 32, 32]
+    - [2, 5.33651]
+  - - [256, 256, 1, 32, 256, 256, 32, 32]
+    - [3, 6.97152]
+  - - [320, 256, 1, 32, 320, 320, 32, 32]
+    - [2, 8.71078]
+  - - [384, 256, 1, 32, 384, 384, 32, 32]
+    - [3, 10.4597]
+  - - [448, 256, 1, 32, 448, 448, 32, 32]
+    - [1, 203.663]
+  - - [512, 256, 1, 32, 512, 512, 32, 32]
+    - [2, 13.9188]
+  - - [576, 256, 1, 32, 576, 576, 32, 32]
+    - [2, 29.9022]
+  - - [640, 256, 1, 32, 640, 640, 32, 32]
+    - [2, 17.1125]
+  - - [704, 256, 1, 32, 704, 704, 32, 32]
+    - [2, 19.0225]
+  - - [768, 256, 1, 32, 768, 768, 32, 32]
+    - [3, 20.817]
+  - - [832, 256, 1, 32, 832, 832, 32, 32]
+    - [3, 22.6918]
+  - - [896, 256, 1, 32, 896, 896, 32, 32]
+    - [3, 24.2741]
+  - - [960, 256, 1, 32, 960, 960, 32, 32]
+    - [3, 20.772]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 32]
+    - [3, 237.638]
+  - - [64, 320, 1, 32, 64, 64, 32, 32]
+    - [2, 62.7739]
+  - - [128, 320, 1, 32, 128, 128, 32, 32]
+    - [2, 4.32093]
+  - - [192, 320, 1, 32, 192, 192, 32, 32]
+    - [1, 6.51134]
+  - - [256, 320, 1, 32, 256, 256, 32, 32]
+    - [3, 8.74086]
+  - - [320, 320, 1, 32, 320, 320, 32, 32]
+    - [2, 10.8937]
+  - - [384, 320, 1, 32, 384, 384, 32, 32]
+    - [2, 12.66]
+  - - [448, 320, 1, 32, 448, 448, 32, 32]
+    - [2, 15.2365]
+  - - [512, 320, 1, 32, 512, 512, 32, 32]
+    - [2, 17.4799]
+  - - [576, 320, 1, 32, 576, 576, 32, 32]
+    - [2, 19.514]
+  - - [640, 320, 1, 32, 640, 640, 32, 32]
+    - [2, 21.8103]
+  - - [704, 320, 1, 32, 704, 704, 32, 32]
+    - [1, 23.6307]
+  - - [768, 320, 1, 32, 768, 768, 32, 32]
+    - [1, 25.6416]
+  - - [832, 320, 1, 32, 832, 832, 32, 32]
+    - [3, 28.0408]
+  - - [896, 320, 1, 32, 896, 896, 32, 32]
+    - [1, 29.8762]
+  - - [960, 320, 1, 32, 960, 960, 32, 32]
+    - [1, 32.2111]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 32]
+    - [3, 31.1564]
+  - - [64, 384, 1, 32, 64, 64, 32, 32]
+    - [1, 2.61567]
+  - - [128, 384, 1, 32, 128, 128, 32, 32]
+    - [3, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 32]
+    - [2, 7.81608]
+  - - [256, 384, 1, 32, 256, 256, 32, 32]
+    - [1, 10.3665]
+  - - [320, 384, 1, 32, 320, 320, 32, 32]
+    - [2, 13.0853]
+  - - [384, 384, 1, 32, 384, 384, 32, 32]
+    - [2, 15.5012]
+  - - [448, 384, 1, 32, 448, 448, 32, 32]
+    - [2, 18.2013]
+  - - [512, 384, 1, 32, 512, 512, 32, 32]
+    - [3, 21.0359]
+  - - [576, 384, 1, 32, 576, 576, 32, 32]
+    - [2, 23.2003]
+  - - [640, 384, 1, 32, 640, 640, 32, 32]
+    - [3, 233.224]
+  - - [704, 384, 1, 32, 704, 704, 32, 32]
+    - [2, 28.4422]
+  - - [768, 384, 1, 32, 768, 768, 32, 32]
+    - [2, 30.8141]
+  - - [832, 384, 1, 32, 832, 832, 32, 32]
+    - [3, 32.5949]
+  - - [896, 384, 1, 32, 896, 896, 32, 32]
+    - [3, 34.7521]
+  - - [960, 384, 1, 32, 960, 960, 32, 32]
+    - [3, 33.5664]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 32]
+    - [3, 37.4289]
+  - - [64, 448, 1, 32, 64, 64, 32, 32]
+    - [1, 3.0641]
+  - - [128, 448, 1, 32, 128, 128, 32, 32]
+    - [2, 6.09522]
+  - - [192, 448, 1, 32, 192, 192, 32, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 32, 32]
+    - [2, 11.7963]
+  - - [320, 448, 1, 32, 320, 320, 32, 32]
+    - [2, 15.1838]
+  - - [384, 448, 1, 32, 384, 384, 32, 32]
+    - [3, 18.3064]
+  - - [448, 448, 1, 32, 448, 448, 32, 32]
+    - [3, 21.3841]
+  - - [512, 448, 1, 32, 512, 512, 32, 32]
+    - [3, 18.3367]
+  - - [576, 448, 1, 32, 576, 576, 32, 32]
+    - [3, 27.083]
+  - - [640, 448, 1, 32, 640, 640, 32, 32]
+    - [3, 26.9496]
+  - - [704, 448, 1, 32, 704, 704, 32, 32]
+    - [1, 32.8944]
+  - - [768, 448, 1, 32, 768, 768, 32, 32]
+    - [3, 35.0341]
+  - - [832, 448, 1, 32, 832, 832, 32, 32]
+    - [2, 26.0992]
+  - - [896, 448, 1, 32, 896, 896, 32, 32]
+    - [1, 41.1343]
+  - - [960, 448, 1, 32, 960, 960, 32, 32]
+    - [3, 40.0223]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 32]
+    - [3, 38.111]
+  - - [64, 512, 1, 32, 64, 64, 32, 32]
+    - [2, 3.53227]
+  - - [128, 512, 1, 32, 128, 128, 32, 32]
+    - [1, 6.93958]
+  - - [192, 512, 1, 32, 192, 192, 32, 32]
+    - [3, 10.4611]
+  - - [256, 512, 1, 32, 256, 256, 32, 32]
+    - [1, 13.7945]
+  - - [320, 512, 1, 32, 320, 320, 32, 32]
+    - [2, 17.3286]
+  - - [384, 512, 1, 32, 384, 384, 32, 32]
+    - [2, 20.6608]
+  - - [448, 512, 1, 32, 448, 448, 32, 32]
+    - [2, 24.2853]
+  - - [512, 512, 1, 32, 512, 512, 32, 32]
+    - [1, 27.4679]
+  - - [576, 512, 1, 32, 576, 576, 32, 32]
+    - [0, 17.8717]
+  - - [640, 512, 1, 32, 640, 640, 32, 32]
+    - [2, 270.667]
+  - - [704, 512, 1, 32, 704, 704, 32, 32]
+    - [2, 36.9238]
+  - - [768, 512, 1, 32, 768, 768, 32, 32]
+    - [3, 39.3362]
+  - - [832, 512, 1, 32, 832, 832, 32, 32]
+    - [3, 40.6126]
+  - - [896, 512, 1, 32, 896, 896, 32, 32]
+    - [3, 37.5678]
+  - - [960, 512, 1, 32, 960, 960, 32, 32]
+    - [2, 46.6799]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 32]
+    - [1, 49.4521]
+  - - [64, 576, 1, 32, 64, 64, 32, 32]
+    - [3, 4.16165]
+  - - [128, 576, 1, 32, 128, 128, 32, 32]
+    - [1, 165.211]
+  - - [192, 576, 1, 32, 192, 192, 32, 32]
+    - [1, 11.6914]
+  - - [256, 576, 1, 32, 256, 256, 32, 32]
+    - [2, 15.6145]
+  - - [320, 576, 1, 32, 320, 320, 32, 32]
+    - [3, 19.5201]
+  - - [384, 576, 1, 32, 384, 384, 32, 32]
+    - [2, 23.3173]
+  - - [448, 576, 1, 32, 448, 448, 32, 32]
+    - [2, 26.4926]
+  - - [512, 576, 1, 32, 512, 512, 32, 32]
+    - [2, 30.8559]
+  - - [576, 576, 1, 32, 576, 576, 32, 32]
+    - [1, 25.7695]
+  - - [640, 576, 1, 32, 640, 640, 32, 32]
+    - [1, 38.4963]
+  - - [704, 576, 1, 32, 704, 704, 32, 32]
+    - [1, 38.0312]
+  - - [768, 576, 1, 32, 768, 768, 32, 32]
+    - [1, 45.0796]
+  - - [832, 576, 1, 32, 832, 832, 32, 32]
+    - [2, 47.4484]
+  - - [896, 576, 1, 32, 896, 896, 32, 32]
+    - [2, 48.7268]
+  - - [960, 576, 1, 32, 960, 960, 32, 32]
+    - [2, 49.2269]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 32]
+    - [2, 55.1113]
+  - - [64, 640, 1, 32, 64, 64, 32, 32]
+    - [1, 4.31759]
+  - - [128, 640, 1, 32, 128, 128, 32, 32]
+    - [3, 8.77126]
+  - - [192, 640, 1, 32, 192, 192, 32, 32]
+    - [2, 13.0281]
+  - - [256, 640, 1, 32, 256, 256, 32, 32]
+    - [3, 17.3725]
+  - - [320, 640, 1, 32, 320, 320, 32, 32]
+    - [2, 21.5674]
+  - - [384, 640, 1, 32, 384, 384, 32, 32]
+    - [2, 25.8732]
+  - - [448, 640, 1, 32, 448, 448, 32, 32]
+    - [3, 233.34]
+  - - [512, 640, 1, 32, 512, 512, 32, 32]
+    - [1, 29.7957]
+  - - [576, 640, 1, 32, 576, 576, 32, 32]
+    - [2, 37.6816]
+  - - [640, 640, 1, 32, 640, 640, 32, 32]
+    - [3, 39.1071]
+  - - [704, 640, 1, 32, 704, 704, 32, 32]
+    - [3, 44.6269]
+  - - [768, 640, 1, 32, 768, 768, 32, 32]
+    - [0, 45.3769]
+  - - [832, 640, 1, 32, 832, 832, 32, 32]
+    - [1, 50.2744]
+  - - [896, 640, 1, 32, 896, 896, 32, 32]
+    - [0, 53.1083]
+  - - [960, 640, 1, 32, 960, 960, 32, 32]
+    - [3, 55.344]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 32]
+    - [1, 61.5259]
+  - - [64, 704, 1, 32, 64, 64, 32, 32]
+    - [1, 4.78203]
+  - - [128, 704, 1, 32, 128, 128, 32, 32]
+    - [1, 9.11814]
+  - - [192, 704, 1, 32, 192, 192, 32, 32]
+    - [3, 14.38]
+  - - [256, 704, 1, 32, 256, 256, 32, 32]
+    - [3, 19.1484]
+  - - [320, 704, 1, 32, 320, 320, 32, 32]
+    - [2, 23.4029]
+  - - [384, 704, 1, 32, 384, 384, 32, 32]
+    - [1, 28.2559]
+  - - [448, 704, 1, 32, 448, 448, 32, 32]
+    - [3, 22.4257]
+  - - [512, 704, 1, 32, 512, 512, 32, 32]
+    - [3, 36.3124]
+  - - [576, 704, 1, 32, 576, 576, 32, 32]
+    - [0, 37.5889]
+  - - [640, 704, 1, 32, 640, 640, 32, 32]
+    - [3, 42.7372]
+  - - [704, 704, 1, 32, 704, 704, 32, 32]
+    - [2, 46.9011]
+  - - [768, 704, 1, 32, 768, 768, 32, 32]
+    - [2, 50.9832]
+  - - [832, 704, 1, 32, 832, 832, 32, 32]
+    - [2, 54.8969]
+  - - [896, 704, 1, 32, 896, 896, 32, 32]
+    - [1, 49.5075]
+  - - [960, 704, 1, 32, 960, 960, 32, 32]
+    - [2, 63.639]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 32]
+    - [2, 66.0261]
+  - - [64, 768, 1, 32, 64, 64, 32, 32]
+    - [1, 5.19274]
+  - - [128, 768, 1, 32, 128, 128, 32, 32]
+    - [2, 10.3992]
+  - - [192, 768, 1, 32, 192, 192, 32, 32]
+    - [3, 223.418]
+  - - [256, 768, 1, 32, 256, 256, 32, 32]
+    - [1, 266.136]
+  - - [320, 768, 1, 32, 320, 320, 32, 32]
+    - [3, 231.986]
+  - - [384, 768, 1, 32, 384, 384, 32, 32]
+    - [3, 30.6112]
+  - - [448, 768, 1, 32, 448, 448, 32, 32]
+    - [2, 31.5821]
+  - - [512, 768, 1, 32, 512, 512, 32, 32]
+    - [1, 40.6042]
+  - - [576, 768, 1, 32, 576, 576, 32, 32]
+    - [3, 41.8486]
+  - - [640, 768, 1, 32, 640, 640, 32, 32]
+    - [1, 41.7104]
+  - - [704, 768, 1, 32, 704, 704, 32, 32]
+    - [3, 275.064]
+  - - [768, 768, 1, 32, 768, 768, 32, 32]
+    - [1, 55.7396]
+  - - [832, 768, 1, 32, 832, 832, 32, 32]
+    - [3, 51.1568]
+  - - [896, 768, 1, 32, 896, 896, 32, 32]
+    - [1, 61.4199]
+  - - [960, 768, 1, 32, 960, 960, 32, 32]
+    - [3, 67.4196]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 32]
+    - [1, 73.2776]
+  - - [64, 832, 1, 32, 64, 64, 32, 32]
+    - [1, 5.63096]
+  - - [128, 832, 1, 32, 128, 128, 32, 32]
+    - [1, 11.1455]
+  - - [192, 832, 1, 32, 192, 192, 32, 32]
+    - [3, 16.7104]
+  - - [256, 832, 1, 32, 256, 256, 32, 32]
+    - [1, 22.388]
+  - - [320, 832, 1, 32, 320, 320, 32, 32]
+    - [0, 24.4102]
+  - - [384, 832, 1, 32, 384, 384, 32, 32]
+    - [1, 29.782]
+  - - [448, 832, 1, 32, 448, 448, 32, 32]
+    - [0, 31.3102]
+  - - [512, 832, 1, 32, 512, 512, 32, 32]
+    - [1, 39.0439]
+  - - [576, 832, 1, 32, 576, 576, 32, 32]
+    - [3, 44.3718]
+  - - [640, 832, 1, 32, 640, 640, 32, 32]
+    - [3, 48.3954]
+  - - [704, 832, 1, 32, 704, 704, 32, 32]
+    - [3, 45.2543]
+  - - [768, 832, 1, 32, 768, 768, 32, 32]
+    - [1, 56.8015]
+  - - [832, 832, 1, 32, 832, 832, 32, 32]
+    - [1, 54.7432]
+  - - [896, 832, 1, 32, 896, 896, 32, 32]
+    - [3, 58.3343]
+  - - [960, 832, 1, 32, 960, 960, 32, 32]
+    - [3, 71.7503]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 32]
+    - [1, 79.1776]
+  - - [64, 896, 1, 32, 64, 64, 32, 32]
+    - [1, 6.06912]
+  - - [128, 896, 1, 32, 128, 128, 32, 32]
+    - [2, 12.1569]
+  - - [192, 896, 1, 32, 192, 192, 32, 32]
+    - [2, 18.2019]
+  - - [256, 896, 1, 32, 256, 256, 32, 32]
+    - [2, 245.482]
+  - - [320, 896, 1, 32, 320, 320, 32, 32]
+    - [1, 29.0058]
+  - - [384, 896, 1, 32, 384, 384, 32, 32]
+    - [2, 35.5104]
+  - - [448, 896, 1, 32, 448, 448, 32, 32]
+    - [3, 28.1229]
+  - - [512, 896, 1, 32, 512, 512, 32, 32]
+    - [0, 42.3518]
+  - - [576, 896, 1, 32, 576, 576, 32, 32]
+    - [2, 48.9644]
+  - - [640, 896, 1, 32, 640, 640, 32, 32]
+    - [2, 45.7064]
+  - - [704, 896, 1, 32, 704, 704, 32, 32]
+    - [1, 59.4734]
+  - - [768, 896, 1, 32, 768, 768, 32, 32]
+    - [3, 51.5563]
+  - - [832, 896, 1, 32, 832, 832, 32, 32]
+    - [1, 70.0206]
+  - - [896, 896, 1, 32, 896, 896, 32, 32]
+    - [2, 72.8327]
+  - - [960, 896, 1, 32, 960, 960, 32, 32]
+    - [3, 75.7387]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 32]
+    - [3, 316.72]
+  - - [64, 960, 1, 32, 64, 64, 32, 32]
+    - [3, 47.761]
+  - - [128, 960, 1, 32, 128, 128, 32, 32]
+    - [3, 73.8913]
+  - - [192, 960, 1, 32, 192, 192, 32, 32]
+    - [2, 19.4311]
+  - - [256, 960, 1, 32, 256, 256, 32, 32]
+    - [2, 24.6167]
+  - - [320, 960, 1, 32, 320, 320, 32, 32]
+    - [2, 32.1022]
+  - - [384, 960, 1, 32, 384, 384, 32, 32]
+    - [3, 37.3233]
+  - - [448, 960, 1, 32, 448, 448, 32, 32]
+    - [0, 39.6573]
+  - - [512, 960, 1, 32, 512, 512, 32, 32]
+    - [1, 317.879]
+  - - [576, 960, 1, 32, 576, 576, 32, 32]
+    - [2, 47.8887]
+  - - [640, 960, 1, 32, 640, 640, 32, 32]
+    - [3, 45.7758]
+  - - [704, 960, 1, 32, 704, 704, 32, 32]
+    - [0, 62.4041]
+  - - [768, 960, 1, 32, 768, 768, 32, 32]
+    - [1, 69.5882]
+  - - [832, 960, 1, 32, 832, 832, 32, 32]
+    - [2, 72.5228]
+  - - [896, 960, 1, 32, 896, 896, 32, 32]
+    - [2, 77.1612]
+  - - [960, 960, 1, 32, 960, 960, 32, 32]
+    - [1, 84.0368]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 32]
+    - [3, 84.7878]
+  - - [64, 1024, 1, 32, 64, 64, 32, 32]
+    - [2, 6.94924]
+  - - [128, 1024, 1, 32, 128, 128, 32, 32]
+    - [1, 13.864]
+  - - [192, 1024, 1, 32, 192, 192, 32, 32]
+    - [3, 20.9498]
+  - - [256, 1024, 1, 32, 256, 256, 32, 32]
+    - [3, 27.3377]
+  - - [320, 1024, 1, 32, 320, 320, 32, 32]
+    - [1, 30.6626]
+  - - [384, 1024, 1, 32, 384, 384, 32, 32]
+    - [3, 37.2913]
+  - - [448, 1024, 1, 32, 448, 448, 32, 32]
+    - [3, 43.6989]
+  - - [512, 1024, 1, 32, 512, 512, 32, 32]
+    - [1, 49.0983]
+  - - [576, 1024, 1, 32, 576, 576, 32, 32]
+    - [2, 55.7223]
+  - - [640, 1024, 1, 32, 640, 640, 32, 32]
+    - [1, 61.4772]
+  - - [704, 1024, 1, 32, 704, 704, 32, 32]
+    - [1, 65.5096]
+  - - [768, 1024, 1, 32, 768, 768, 32, 32]
+    - [2, 71.6308]
+  - - [832, 1024, 1, 32, 832, 832, 32, 32]
+    - [3, 76.1074]
+  - - [896, 1024, 1, 32, 896, 896, 32, 32]
+    - [1, 83.761]
+  - - [960, 1024, 1, 32, 960, 960, 32, 32]
+    - [0, 85.4755]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 32]
+    - [0, 519.579]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Ailk_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi33
+- gfx1102
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 64]
+    - [1, 1.15349]
+  - - [128, 64, 1, 32, 128, 128, 128, 64]
+    - [2, 2.30698]
+  - - [192, 64, 1, 32, 192, 192, 192, 64]
+    - [3, 3.45378]
+  - - [256, 64, 1, 32, 256, 256, 256, 64]
+    - [1, 4.61519]
+  - - [320, 64, 1, 32, 320, 320, 320, 64]
+    - [1, 5.7695]
+  - - [384, 64, 1, 32, 384, 384, 384, 64]
+    - [1, 6.93928]
+  - - [448, 64, 1, 32, 448, 448, 448, 64]
+    - [3, 8.07161]
+  - - [512, 64, 1, 32, 512, 512, 512, 64]
+    - [1, 9.23197]
+  - - [576, 64, 1, 32, 576, 576, 576, 64]
+    - [0, 26.473]
+  - - [640, 64, 1, 32, 640, 640, 640, 64]
+    - [3, 11.5263]
+  - - [704, 64, 1, 32, 704, 704, 704, 64]
+    - [3, 12.6861]
+  - - [768, 64, 1, 32, 768, 768, 768, 64]
+    - [3, 13.8206]
+  - - [832, 64, 1, 32, 832, 832, 832, 64]
+    - [1, 14.9244]
+  - - [896, 64, 1, 32, 896, 896, 896, 64]
+    - [2, 16.0613]
+  - - [960, 64, 1, 32, 960, 960, 960, 64]
+    - [3, 17.1941]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 64]
+    - [1, 156.972]
+  - - [64, 128, 1, 32, 64, 64, 64, 128]
+    - [2, 28.9982]
+  - - [128, 128, 1, 32, 128, 128, 128, 128]
+    - [3, 49.9322]
+  - - [192, 128, 1, 32, 192, 192, 192, 128]
+    - [3, 75.0412]
+  - - [256, 128, 1, 32, 256, 256, 256, 128]
+    - [3, 87.9678]
+  - - [320, 128, 1, 32, 320, 320, 320, 128]
+    - [0, 11.4678]
+  - - [384, 128, 1, 32, 384, 384, 384, 128]
+    - [2, 13.7349]
+  - - [448, 128, 1, 32, 448, 448, 448, 128]
+    - [0, 16.0824]
+  - - [512, 128, 1, 32, 512, 512, 512, 128]
+    - [0, 18.2957]
+  - - [576, 128, 1, 32, 576, 576, 576, 128]
+    - [3, 171.71]
+  - - [640, 128, 1, 32, 640, 640, 640, 128]
+    - [3, 41.8958]
+  - - [704, 128, 1, 32, 704, 704, 704, 128]
+    - [3, 184.137]
+  - - [768, 128, 1, 32, 768, 768, 768, 128]
+    - [2, 9.67241]
+  - - [832, 128, 1, 32, 832, 832, 832, 128]
+    - [2, 10.4909]
+  - - [896, 128, 1, 32, 896, 896, 896, 128]
+    - [3, 11.1885]
+  - - [960, 128, 1, 32, 960, 960, 960, 128]
+    - [1, 11.9394]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 128]
+    - [3, 221.452]
+  - - [64, 192, 1, 32, 64, 64, 64, 192]
+    - [3, 37.4474]
+  - - [128, 192, 1, 32, 128, 128, 128, 192]
+    - [2, 77.4047]
+  - - [192, 192, 1, 32, 192, 192, 192, 192]
+    - [3, 98.304]
+  - - [256, 192, 1, 32, 256, 256, 256, 192]
+    - [3, 5.21919]
+  - - [320, 192, 1, 32, 320, 320, 320, 192]
+    - [1, 6.03876]
+  - - [384, 192, 1, 32, 384, 384, 384, 192]
+    - [1, 7.71751]
+  - - [448, 192, 1, 32, 448, 448, 448, 192]
+    - [2, 9.04163]
+  - - [512, 192, 1, 32, 512, 512, 512, 192]
+    - [1, 10.2895]
+  - - [576, 192, 1, 32, 576, 576, 576, 192]
+    - [1, 11.56]
+  - - [640, 192, 1, 32, 640, 640, 640, 192]
+    - [2, 12.9306]
+  - - [704, 192, 1, 32, 704, 704, 704, 192]
+    - [3, 14.0882]
+  - - [768, 192, 1, 32, 768, 768, 768, 192]
+    - [1, 15.4489]
+  - - [832, 192, 1, 32, 832, 832, 832, 192]
+    - [1, 16.6423]
+  - - [896, 192, 1, 32, 896, 896, 896, 192]
+    - [1, 17.955]
+  - - [960, 192, 1, 32, 960, 960, 960, 192]
+    - [3, 19.4074]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 192]
+    - [2, 20.6185]
+  - - [64, 256, 1, 32, 64, 64, 64, 256]
+    - [3, 1.74497]
+  - - [128, 256, 1, 32, 128, 128, 128, 256]
+    - [3, 3.48907]
+  - - [192, 256, 1, 32, 192, 192, 192, 256]
+    - [2, 5.19085]
+  - - [256, 256, 1, 32, 256, 256, 256, 256]
+    - [1, 6.85968]
+  - - [320, 256, 1, 32, 320, 320, 320, 256]
+    - [1, 8.58146]
+  - - [384, 256, 1, 32, 384, 384, 384, 256]
+    - [2, 10.2789]
+  - - [448, 256, 1, 32, 448, 448, 448, 256]
+    - [1, 12.0221]
+  - - [512, 256, 1, 32, 512, 512, 512, 256]
+    - [2, 13.7992]
+  - - [576, 256, 1, 32, 576, 576, 576, 256]
+    - [2, 15.4454]
+  - - [640, 256, 1, 32, 640, 640, 640, 256]
+    - [2, 17.294]
+  - - [704, 256, 1, 32, 704, 704, 704, 256]
+    - [3, 243.546]
+  - - [768, 256, 1, 32, 768, 768, 768, 256]
+    - [1, 267.488]
+  - - [832, 256, 1, 32, 832, 832, 832, 256]
+    - [2, 22.3451]
+  - - [896, 256, 1, 32, 896, 896, 896, 256]
+    - [3, 23.9841]
+  - - [960, 256, 1, 32, 960, 960, 960, 256]
+    - [3, 25.715]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 256]
+    - [2, 22.0262]
+  - - [64, 320, 1, 32, 64, 64, 64, 320]
+    - [1, 2.18056]
+  - - [128, 320, 1, 32, 128, 128, 128, 320]
+    - [3, 4.34212]
+  - - [192, 320, 1, 32, 192, 192, 192, 320]
+    - [2, 6.47766]
+  - - [256, 320, 1, 32, 256, 256, 256, 320]
+    - [3, 8.64858]
+  - - [320, 320, 1, 32, 320, 320, 320, 320]
+    - [1, 10.7349]
+  - - [384, 320, 1, 32, 384, 384, 384, 320]
+    - [2, 12.5973]
+  - - [448, 320, 1, 32, 448, 448, 448, 320]
+    - [2, 15.1357]
+  - - [512, 320, 1, 32, 512, 512, 512, 320]
+    - [3, 252.547]
+  - - [576, 320, 1, 32, 576, 576, 576, 320]
+    - [1, 248.661]
+  - - [640, 320, 1, 32, 640, 640, 640, 320]
+    - [1, 21.5383]
+  - - [704, 320, 1, 32, 704, 704, 704, 320]
+    - [2, 23.9253]
+  - - [768, 320, 1, 32, 768, 768, 768, 320]
+    - [1, 25.7457]
+  - - [832, 320, 1, 32, 832, 832, 832, 320]
+    - [3, 28.0186]
+  - - [896, 320, 1, 32, 896, 896, 896, 320]
+    - [1, 29.7589]
+  - - [960, 320, 1, 32, 960, 960, 960, 320]
+    - [3, 31.8639]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 320]
+    - [3, 33.5333]
+  - - [64, 384, 1, 32, 64, 64, 64, 384]
+    - [3, 2.61959]
+  - - [128, 384, 1, 32, 128, 128, 128, 384]
+    - [2, 5.19532]
+  - - [192, 384, 1, 32, 192, 192, 192, 384]
+    - [1, 7.73864]
+  - - [256, 384, 1, 32, 256, 256, 256, 384]
+    - [2, 10.3442]
+  - - [320, 384, 1, 32, 320, 320, 320, 384]
+    - [3, 13.0091]
+  - - [384, 384, 1, 32, 384, 384, 384, 384]
+    - [2, 15.506]
+  - - [448, 384, 1, 32, 448, 448, 448, 384]
+    - [3, 18.2215]
+  - - [512, 384, 1, 32, 512, 512, 512, 384]
+    - [3, 20.7071]
+  - - [576, 384, 1, 32, 576, 576, 576, 384]
+    - [2, 23.2403]
+  - - [640, 384, 1, 32, 640, 640, 640, 384]
+    - [1, 25.7196]
+  - - [704, 384, 1, 32, 704, 704, 704, 384]
+    - [3, 28.3867]
+  - - [768, 384, 1, 32, 768, 768, 768, 384]
+    - [3, 30.7539]
+  - - [832, 384, 1, 32, 832, 832, 832, 384]
+    - [3, 32.7878]
+  - - [896, 384, 1, 32, 896, 896, 896, 384]
+    - [2, 35.4019]
+  - - [960, 384, 1, 32, 960, 960, 960, 384]
+    - [1, 317.618]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 384]
+    - [3, 39.8052]
+  - - [64, 448, 1, 32, 64, 64, 64, 448]
+    - [3, 3.04604]
+  - - [128, 448, 1, 32, 128, 128, 128, 448]
+    - [1, 6.00949]
+  - - [192, 448, 1, 32, 192, 192, 192, 448]
+    - [3, 9.07966]
+  - - [256, 448, 1, 32, 256, 256, 256, 448]
+    - [1, 11.9952]
+  - - [320, 448, 1, 32, 320, 320, 320, 448]
+    - [2, 15.0959]
+  - - [384, 448, 1, 32, 384, 384, 384, 448]
+    - [3, 18.0005]
+  - - [448, 448, 1, 32, 448, 448, 448, 448]
+    - [3, 21.2546]
+  - - [512, 448, 1, 32, 512, 512, 512, 448]
+    - [2, 23.9822]
+  - - [576, 448, 1, 32, 576, 576, 576, 448]
+    - [2, 27.2094]
+  - - [640, 448, 1, 32, 640, 640, 640, 448]
+    - [2, 30.0287]
+  - - [704, 448, 1, 32, 704, 704, 704, 448]
+    - [1, 307.512]
+  - - [768, 448, 1, 32, 768, 768, 768, 448]
+    - [3, 29.7306]
+  - - [832, 448, 1, 32, 832, 832, 832, 448]
+    - [0, 34.5814]
+  - - [896, 448, 1, 32, 896, 896, 896, 448]
+    - [2, 40.7985]
+  - - [960, 448, 1, 32, 960, 960, 960, 448]
+    - [2, 39.8658]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 448]
+    - [2, 42.8819]
+  - - [64, 512, 1, 32, 64, 64, 64, 512]
+    - [1, 3.44874]
+  - - [128, 512, 1, 32, 128, 128, 128, 512]
+    - [2, 6.86934]
+  - - [192, 512, 1, 32, 192, 192, 192, 512]
+    - [3, 10.369]
+  - - [256, 512, 1, 32, 256, 256, 256, 512]
+    - [1, 13.5592]
+  - - [320, 512, 1, 32, 320, 320, 320, 512]
+    - [3, 17.1914]
+  - - [384, 512, 1, 32, 384, 384, 384, 512]
+    - [2, 20.7593]
+  - - [448, 512, 1, 32, 448, 448, 448, 512]
+    - [2, 24.1348]
+  - - [512, 512, 1, 32, 512, 512, 512, 512]
+    - [2, 27.674]
+  - - [576, 512, 1, 32, 576, 576, 576, 512]
+    - [3, 27.5609]
+  - - [640, 512, 1, 32, 640, 640, 640, 512]
+    - [1, 30.388]
+  - - [704, 512, 1, 32, 704, 704, 704, 512]
+    - [3, 36.7949]
+  - - [768, 512, 1, 32, 768, 768, 768, 512]
+    - [3, 39.2313]
+  - - [832, 512, 1, 32, 832, 832, 832, 512]
+    - [2, 39.7191]
+  - - [896, 512, 1, 32, 896, 896, 896, 512]
+    - [1, 332.877]
+  - - [960, 512, 1, 32, 960, 960, 960, 512]
+    - [1, 316.344]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 512]
+    - [0, 48.3693]
+  - - [64, 576, 1, 32, 64, 64, 64, 576]
+    - [3, 3.86628]
+  - - [128, 576, 1, 32, 128, 128, 128, 576]
+    - [3, 169.246]
+  - - [192, 576, 1, 32, 192, 192, 192, 576]
+    - [1, 11.5076]
+  - - [256, 576, 1, 32, 256, 256, 256, 576]
+    - [3, 240.984]
+  - - [320, 576, 1, 32, 320, 320, 320, 576]
+    - [1, 19.296]
+  - - [384, 576, 1, 32, 384, 384, 384, 576]
+    - [2, 23.1318]
+  - - [448, 576, 1, 32, 448, 448, 448, 576]
+    - [1, 26.9123]
+  - - [512, 576, 1, 32, 512, 512, 512, 576]
+    - [2, 30.8021]
+  - - [576, 576, 1, 32, 576, 576, 576, 576]
+    - [2, 272.506]
+  - - [640, 576, 1, 32, 640, 640, 640, 576]
+    - [3, 122.23]
+  - - [704, 576, 1, 32, 704, 704, 704, 576]
+    - [2, 41.1188]
+  - - [768, 576, 1, 32, 768, 768, 768, 576]
+    - [2, 39.9551]
+  - - [832, 576, 1, 32, 832, 832, 832, 576]
+    - [3, 47.4793]
+  - - [896, 576, 1, 32, 896, 896, 896, 576]
+    - [1, 46.8264]
+  - - [960, 576, 1, 32, 960, 960, 960, 576]
+    - [3, 52.0216]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 576]
+    - [0, 53.3314]
+  - - [64, 640, 1, 32, 64, 64, 64, 640]
+    - [2, 4.331]
+  - - [128, 640, 1, 32, 128, 128, 128, 640]
+    - [1, 8.52829]
+  - - [192, 640, 1, 32, 192, 192, 192, 640]
+    - [2, 12.8344]
+  - - [256, 640, 1, 32, 256, 256, 256, 640]
+    - [2, 17.1025]
+  - - [320, 640, 1, 32, 320, 320, 320, 640]
+    - [3, 21.6428]
+  - - [384, 640, 1, 32, 384, 384, 384, 640]
+    - [3, 25.6713]
+  - - [448, 640, 1, 32, 448, 448, 448, 640]
+    - [3, 29.9567]
+  - - [512, 640, 1, 32, 512, 512, 512, 640]
+    - [1, 33.6966]
+  - - [576, 640, 1, 32, 576, 576, 576, 640]
+    - [3, 34.7046]
+  - - [640, 640, 1, 32, 640, 640, 640, 640]
+    - [3, 38.7075]
+  - - [704, 640, 1, 32, 704, 704, 704, 640]
+    - [2, 41.7002]
+  - - [768, 640, 1, 32, 768, 768, 768, 640]
+    - [3, 268.407]
+  - - [832, 640, 1, 32, 832, 832, 832, 640]
+    - [0, 47.4228]
+  - - [896, 640, 1, 32, 896, 896, 896, 640]
+    - [3, 53.5508]
+  - - [960, 640, 1, 32, 960, 960, 960, 640]
+    - [3, 57.2031]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 640]
+    - [3, 61.6009]
+  - - [64, 704, 1, 32, 64, 64, 64, 704]
+    - [3, 4.74723]
+  - - [128, 704, 1, 32, 128, 128, 128, 704]
+    - [2, 9.33162]
+  - - [192, 704, 1, 32, 192, 192, 192, 704]
+    - [3, 14.165]
+  - - [256, 704, 1, 32, 256, 256, 256, 704]
+    - [3, 18.904]
+  - - [320, 704, 1, 32, 320, 320, 320, 704]
+    - [2, 23.5144]
+  - - [384, 704, 1, 32, 384, 384, 384, 704]
+    - [3, 249.301]
+  - - [448, 704, 1, 32, 448, 448, 448, 704]
+    - [1, 304.727]
+  - - [512, 704, 1, 32, 512, 512, 512, 704]
+    - [2, 33.8328]
+  - - [576, 704, 1, 32, 576, 576, 576, 704]
+    - [3, 37.3401]
+  - - [640, 704, 1, 32, 640, 640, 640, 704]
+    - [2, 41.8036]
+  - - [704, 704, 1, 32, 704, 704, 704, 704]
+    - [1, 45.7716]
+  - - [768, 704, 1, 32, 768, 768, 768, 704]
+    - [2, 50.4436]
+  - - [832, 704, 1, 32, 832, 832, 832, 704]
+    - [3, 53.7131]
+  - - [896, 704, 1, 32, 896, 896, 896, 704]
+    - [1, 56.0678]
+  - - [960, 704, 1, 32, 960, 960, 960, 704]
+    - [2, 307.985]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 704]
+    - [2, 67.1612]
+  - - [64, 768, 1, 32, 64, 64, 64, 768]
+    - [3, 5.19884]
+  - - [128, 768, 1, 32, 128, 128, 128, 768]
+    - [2, 10.2936]
+  - - [192, 768, 1, 32, 192, 192, 192, 768]
+    - [2, 15.3667]
+  - - [256, 768, 1, 32, 256, 256, 256, 768]
+    - [3, 20.6856]
+  - - [320, 768, 1, 32, 320, 320, 320, 768]
+    - [2, 25.3605]
+  - - [384, 768, 1, 32, 384, 384, 384, 768]
+    - [3, 30.9622]
+  - - [448, 768, 1, 32, 448, 448, 448, 768]
+    - [2, 35.5596]
+  - - [512, 768, 1, 32, 512, 512, 512, 768]
+    - [3, 253.685]
+  - - [576, 768, 1, 32, 576, 576, 576, 768]
+    - [1, 319.252]
+  - - [640, 768, 1, 32, 640, 640, 640, 768]
+    - [1, 241.292]
+  - - [704, 768, 1, 32, 704, 704, 704, 768]
+    - [1, 300.788]
+  - - [768, 768, 1, 32, 768, 768, 768, 768]
+    - [1, 313.942]
+  - - [832, 768, 1, 32, 832, 832, 832, 768]
+    - [2, 307.385]
+  - - [896, 768, 1, 32, 896, 896, 896, 768]
+    - [3, 304.819]
+  - - [960, 768, 1, 32, 960, 960, 960, 768]
+    - [1, 353.821]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 768]
+    - [1, 358.792]
+  - - [64, 832, 1, 32, 64, 64, 64, 832]
+    - [3, 87.2025]
+  - - [128, 832, 1, 32, 128, 128, 128, 832]
+    - [3, 61.0068]
+  - - [192, 832, 1, 32, 192, 192, 192, 832]
+    - [2, 88.1567]
+  - - [256, 832, 1, 32, 256, 256, 256, 832]
+    - [3, 121.006]
+  - - [320, 832, 1, 32, 320, 320, 320, 832]
+    - [3, 145.996]
+  - - [384, 832, 1, 32, 384, 384, 384, 832]
+    - [1, 159.358]
+  - - [448, 832, 1, 32, 448, 448, 448, 832]
+    - [2, 196.644]
+  - - [512, 832, 1, 32, 512, 512, 512, 832]
+    - [3, 39.8819]
+  - - [576, 832, 1, 32, 576, 576, 576, 832]
+    - [0, 44.024]
+  - - [640, 832, 1, 32, 640, 640, 640, 832]
+    - [3, 49.7875]
+  - - [704, 832, 1, 32, 704, 704, 704, 832]
+    - [2, 54.7966]
+  - - [768, 832, 1, 32, 768, 768, 768, 832]
+    - [3, 59.57]
+  - - [832, 832, 1, 32, 832, 832, 832, 832]
+    - [2, 64.4347]
+  - - [896, 832, 1, 32, 896, 896, 896, 832]
+    - [3, 62.0957]
+  - - [960, 832, 1, 32, 960, 960, 960, 832]
+    - [3, 73.2347]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 832]
+    - [1, 76.9799]
+  - - [64, 896, 1, 32, 64, 64, 64, 896]
+    - [1, 6.00575]
+  - - [128, 896, 1, 32, 128, 128, 128, 896]
+    - [2, 11.8982]
+  - - [192, 896, 1, 32, 192, 192, 192, 896]
+    - [3, 17.0944]
+  - - [256, 896, 1, 32, 256, 256, 256, 896]
+    - [2, 146.566]
+  - - [320, 896, 1, 32, 320, 320, 320, 896]
+    - [2, 170.017]
+  - - [384, 896, 1, 32, 384, 384, 384, 896]
+    - [1, 316.017]
+  - - [448, 896, 1, 32, 448, 448, 448, 896]
+    - [2, 221.179]
+  - - [512, 896, 1, 32, 512, 512, 512, 896]
+    - [3, 277.503]
+  - - [576, 896, 1, 32, 576, 576, 576, 896]
+    - [1, 306.855]
+  - - [640, 896, 1, 32, 640, 640, 640, 896]
+    - [1, 345.316]
+  - - [704, 896, 1, 32, 704, 704, 704, 896]
+    - [1, 354.619]
+  - - [768, 896, 1, 32, 768, 768, 768, 896]
+    - [2, 307.715]
+  - - [832, 896, 1, 32, 832, 832, 832, 896]
+    - [3, 314.626]
+  - - [896, 896, 1, 32, 896, 896, 896, 896]
+    - [3, 321.929]
+  - - [960, 896, 1, 32, 960, 960, 960, 896]
+    - [3, 308.716]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 896]
+    - [2, 320.174]
+  - - [64, 960, 1, 32, 64, 64, 64, 960]
+    - [2, 65.8874]
+  - - [128, 960, 1, 32, 128, 128, 128, 960]
+    - [1, 78.462]
+  - - [192, 960, 1, 32, 192, 192, 192, 960]
+    - [2, 113.755]
+  - - [256, 960, 1, 32, 256, 256, 256, 960]
+    - [1, 152.986]
+  - - [320, 960, 1, 32, 320, 320, 320, 960]
+    - [3, 189.192]
+  - - [384, 960, 1, 32, 384, 384, 384, 960]
+    - [2, 228.769]
+  - - [448, 960, 1, 32, 448, 448, 448, 960]
+    - [3, 286.598]
+  - - [512, 960, 1, 32, 512, 512, 512, 960]
+    - [2, 278.088]
+  - - [576, 960, 1, 32, 576, 576, 576, 960]
+    - [1, 321.953]
+  - - [640, 960, 1, 32, 640, 640, 640, 960]
+    - [2, 304.064]
+  - - [704, 960, 1, 32, 704, 704, 704, 960]
+    - [2, 311.268]
+  - - [768, 960, 1, 32, 768, 768, 768, 960]
+    - [2, 312.572]
+  - - [832, 960, 1, 32, 832, 832, 832, 960]
+    - [3, 296.232]
+  - - [896, 960, 1, 32, 896, 896, 896, 960]
+    - [2, 319.019]
+  - - [960, 960, 1, 32, 960, 960, 960, 960]
+    - [3, 320.415]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 960]
+    - [3, 85.4244]
+  - - [64, 1024, 1, 32, 64, 64, 64, 1024]
+    - [1, 6.77317]
+  - - [128, 1024, 1, 32, 128, 128, 128, 1024]
+    - [2, 13.688]
+  - - [192, 1024, 1, 32, 192, 192, 192, 1024]
+    - [2, 20.3846]
+  - - [256, 1024, 1, 32, 256, 256, 256, 1024]
+    - [2, 27.202]
+  - - [320, 1024, 1, 32, 320, 320, 320, 1024]
+    - [2, 33.9201]
+  - - [384, 1024, 1, 32, 384, 384, 384, 1024]
+    - [3, 39.4082]
+  - - [448, 1024, 1, 32, 448, 448, 448, 1024]
+    - [1, 36.7013]
+  - - [512, 1024, 1, 32, 512, 512, 512, 1024]
+    - [2, 292.896]
+  - - [576, 1024, 1, 32, 576, 576, 576, 1024]
+    - [2, 55.0864]
+  - - [640, 1024, 1, 32, 640, 640, 640, 1024]
+    - [2, 61.8052]
+  - - [704, 1024, 1, 32, 704, 704, 704, 1024]
+    - [2, 66.8208]
+  - - [768, 1024, 1, 32, 768, 768, 768, 1024]
+    - [1, 71.9595]
+  - - [832, 1024, 1, 32, 832, 832, 832, 1024]
+    - [2, 76.7081]
+  - - [896, 1024, 1, 32, 896, 896, 896, 1024]
+    - [2, 81.1912]
+  - - [960, 1024, 1, 32, 960, 960, 960, 1024]
+    - [1, 88.5319]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 1024]
+    - [2, 90.0024]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Ailk_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Ailk_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi33
+- gfx1102
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [0, 3, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 1
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: true
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: false
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [0, 3, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 1
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: true
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: false
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Ailk_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 64, 32]
+    - [2, 1.15233]
+  - - [128, 64, 1, 32, 128, 128, 128, 32]
+    - [2, 2.30557]
+  - - [192, 64, 1, 32, 192, 192, 192, 32]
+    - [2, 3.45926]
+  - - [256, 64, 1, 32, 256, 256, 256, 32]
+    - [2, 4.61702]
+  - - [320, 64, 1, 32, 320, 320, 320, 32]
+    - [2, 5.75784]
+  - - [384, 64, 1, 32, 384, 384, 384, 32]
+    - [3, 73.7741]
+  - - [448, 64, 1, 32, 448, 448, 448, 32]
+    - [2, 86.557]
+  - - [512, 64, 1, 32, 512, 512, 512, 32]
+    - [2, 97.4513]
+  - - [576, 64, 1, 32, 576, 576, 576, 32]
+    - [2, 107.241]
+  - - [640, 64, 1, 32, 640, 640, 640, 32]
+    - [0, 11.4934]
+  - - [704, 64, 1, 32, 704, 704, 704, 32]
+    - [3, 12.5832]
+  - - [768, 64, 1, 32, 768, 768, 768, 32]
+    - [1, 129.56]
+  - - [832, 64, 1, 32, 832, 832, 832, 32]
+    - [0, 14.8445]
+  - - [896, 64, 1, 32, 896, 896, 896, 32]
+    - [2, 16.0774]
+  - - [960, 64, 1, 32, 960, 960, 960, 32]
+    - [3, 17.2047]
+  - - [1024, 64, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 18.3397]
+  - - [64, 128, 1, 32, 64, 64, 64, 32]
+    - [2, 2.29779]
+  - - [128, 128, 1, 32, 128, 128, 128, 32]
+    - [1, 49.1827]
+  - - [192, 128, 1, 32, 192, 192, 192, 32]
+    - [2, 6.90061]
+  - - [256, 128, 1, 32, 256, 256, 256, 32]
+    - [3, 9.25727]
+  - - [320, 128, 1, 32, 320, 320, 320, 32]
+    - [1, 11.4929]
+  - - [384, 128, 1, 32, 384, 384, 384, 32]
+    - [3, 13.7801]
+  - - [448, 128, 1, 32, 448, 448, 448, 32]
+    - [2, 16.0311]
+  - - [512, 128, 1, 32, 512, 512, 512, 32]
+    - [0, 18.3654]
+  - - [576, 128, 1, 32, 576, 576, 576, 32]
+    - [1, 20.671]
+  - - [640, 128, 1, 32, 640, 640, 640, 32]
+    - [3, 22.9547]
+  - - [704, 128, 1, 32, 704, 704, 704, 32]
+    - [2, 25.2049]
+  - - [768, 128, 1, 32, 768, 768, 768, 32]
+    - [3, 191.34]
+  - - [832, 128, 1, 32, 832, 832, 832, 32]
+    - [1, 194.291]
+  - - [896, 128, 1, 32, 896, 896, 896, 32]
+    - [3, 32.0944]
+  - - [960, 128, 1, 32, 960, 960, 960, 32]
+    - [1, 34.426]
+  - - [1024, 128, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 36.7083]
+  - - [64, 192, 1, 32, 64, 64, 64, 32]
+    - [0, 3.43462]
+  - - [128, 192, 1, 32, 128, 128, 128, 32]
+    - [0, 6.89094]
+  - - [192, 192, 1, 32, 192, 192, 192, 32]
+    - [3, 10.3477]
+  - - [256, 192, 1, 32, 256, 256, 256, 32]
+    - [0, 13.7716]
+  - - [320, 192, 1, 32, 320, 320, 320, 32]
+    - [1, 17.2334]
+  - - [384, 192, 1, 32, 384, 384, 384, 32]
+    - [1, 20.7037]
+  - - [448, 192, 1, 32, 448, 448, 448, 32]
+    - [1, 176.217]
+  - - [512, 192, 1, 32, 512, 512, 512, 32]
+    - [2, 27.5457]
+  - - [576, 192, 1, 32, 576, 576, 576, 32]
+    - [2, 30.9428]
+  - - [640, 192, 1, 32, 640, 640, 640, 32]
+    - [1, 34.4411]
+  - - [704, 192, 1, 32, 704, 704, 704, 32]
+    - [1, 37.5628]
+  - - [768, 192, 1, 32, 768, 768, 768, 32]
+    - [3, 41.3149]
+  - - [832, 192, 1, 32, 832, 832, 832, 32]
+    - [1, 44.7695]
+  - - [896, 192, 1, 32, 896, 896, 896, 32]
+    - [1, 48.1164]
+  - - [960, 192, 1, 32, 960, 960, 960, 32]
+    - [3, 51.5691]
+  - - [1024, 192, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 55.0576]
+  - - [64, 256, 1, 32, 64, 64, 64, 32]
+    - [3, 4.62759]
+  - - [128, 256, 1, 32, 128, 128, 128, 32]
+    - [1, 9.19316]
+  - - [192, 256, 1, 32, 192, 192, 192, 32]
+    - [3, 13.7734]
+  - - [256, 256, 1, 32, 256, 256, 256, 32]
+    - [0, 18.3645]
+  - - [320, 256, 1, 32, 320, 320, 320, 32]
+    - [1, 22.9336]
+  - - [384, 256, 1, 32, 384, 384, 384, 32]
+    - [1, 27.5204]
+  - - [448, 256, 1, 32, 448, 448, 448, 32]
+    - [3, 32.1352]
+  - - [512, 256, 1, 32, 512, 512, 512, 32]
+    - [0, 36.7067]
+  - - [576, 256, 1, 32, 576, 576, 576, 32]
+    - [0, 41.2282]
+  - - [640, 256, 1, 32, 640, 640, 640, 32]
+    - [2, 45.845]
+  - - [704, 256, 1, 32, 704, 704, 704, 32]
+    - [3, 50.4231]
+  - - [768, 256, 1, 32, 768, 768, 768, 32]
+    - [2, 54.9251]
+  - - [832, 256, 1, 32, 832, 832, 832, 32]
+    - [3, 59.4115]
+  - - [896, 256, 1, 32, 896, 896, 896, 32]
+    - [2, 64.1858]
+  - - [960, 256, 1, 32, 960, 960, 960, 32]
+    - [2, 254.016]
+  - - [1024, 256, 1, 32, 1024, 1024, 1024, 32]
+    - [0, 254.969]
+  - - [64, 320, 1, 32, 64, 64, 64, 32]
+    - [3, 7.61467]
+  - - [128, 320, 1, 32, 128, 128, 128, 32]
+    - [2, 14.2299]
+  - - [192, 320, 1, 32, 192, 192, 192, 32]
+    - [3, 128.163]
+  - - [256, 320, 1, 32, 256, 256, 256, 32]
+    - [3, 56.1577]
+  - - [320, 320, 1, 32, 320, 320, 320, 32]
+    - [2, 77.3195]
+  - - [384, 320, 1, 32, 384, 384, 384, 32]
+    - [2, 94.9098]
+  - - [448, 320, 1, 32, 448, 448, 448, 32]
+    - [2, 106.13]
+  - - [512, 320, 1, 32, 512, 512, 512, 32]
+    - [1, 114.111]
+  - - [576, 320, 1, 32, 576, 576, 576, 32]
+    - [2, 136.423]
+  - - [640, 320, 1, 32, 640, 640, 640, 32]
+    - [1, 145.136]
+  - - [704, 320, 1, 32, 704, 704, 704, 32]
+    - [3, 178.043]
+  - - [768, 320, 1, 32, 768, 768, 768, 32]
+    - [3, 187.805]
+  - - [832, 320, 1, 32, 832, 832, 832, 32]
+    - [2, 201.408]
+  - - [896, 320, 1, 32, 896, 896, 896, 32]
+    - [2, 215.225]
+  - - [960, 320, 1, 32, 960, 960, 960, 32]
+    - [2, 234.057]
+  - - [1024, 320, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 208.317]
+  - - [64, 384, 1, 32, 64, 64, 64, 32]
+    - [3, 9.21145]
+  - - [128, 384, 1, 32, 128, 128, 128, 32]
+    - [1, 17.025]
+  - - [192, 384, 1, 32, 192, 192, 192, 32]
+    - [1, 7.75723]
+  - - [256, 384, 1, 32, 256, 256, 256, 32]
+    - [2, 10.3896]
+  - - [320, 384, 1, 32, 320, 320, 320, 32]
+    - [1, 223.666]
+  - - [384, 384, 1, 32, 384, 384, 384, 32]
+    - [2, 15.4626]
+  - - [448, 384, 1, 32, 448, 448, 448, 32]
+    - [2, 18.1659]
+  - - [512, 384, 1, 32, 512, 512, 512, 32]
+    - [2, 20.8546]
+  - - [576, 384, 1, 32, 576, 576, 576, 32]
+    - [1, 23.0688]
+  - - [640, 384, 1, 32, 640, 640, 640, 32]
+    - [3, 25.9462]
+  - - [704, 384, 1, 32, 704, 704, 704, 32]
+    - [3, 28.3835]
+  - - [768, 384, 1, 32, 768, 768, 768, 32]
+    - [2, 27.8558]
+  - - [832, 384, 1, 32, 832, 832, 832, 32]
+    - [3, 32.9007]
+  - - [896, 384, 1, 32, 896, 896, 896, 32]
+    - [1, 36.1089]
+  - - [960, 384, 1, 32, 960, 960, 960, 32]
+    - [1, 33.7818]
+  - - [1024, 384, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 36.0871]
+  - - [64, 448, 1, 32, 64, 64, 64, 32]
+    - [1, 3.07978]
+  - - [128, 448, 1, 32, 128, 128, 128, 32]
+    - [2, 136.533]
+  - - [192, 448, 1, 32, 192, 192, 192, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 256, 32]
+    - [1, 207.34]
+  - - [320, 448, 1, 32, 320, 320, 320, 32]
+    - [1, 234.296]
+  - - [384, 448, 1, 32, 384, 384, 384, 32]
+    - [3, 18.1899]
+  - - [448, 448, 1, 32, 448, 448, 448, 32]
+    - [2, 21.0968]
+  - - [512, 448, 1, 32, 512, 512, 512, 32]
+    - [3, 24.1189]
+  - - [576, 448, 1, 32, 576, 576, 576, 32]
+    - [3, 24.1095]
+  - - [640, 448, 1, 32, 640, 640, 640, 32]
+    - [2, 269.221]
+  - - [704, 448, 1, 32, 704, 704, 704, 32]
+    - [3, 204.303]
+  - - [768, 448, 1, 32, 768, 768, 768, 32]
+    - [3, 228.899]
+  - - [832, 448, 1, 32, 832, 832, 832, 32]
+    - [2, 248.18]
+  - - [896, 448, 1, 32, 896, 896, 896, 32]
+    - [3, 267.157]
+  - - [960, 448, 1, 32, 960, 960, 960, 32]
+    - [3, 278.144]
+  - - [1024, 448, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 291.966]
+  - - [64, 512, 1, 32, 64, 64, 64, 32]
+    - [3, 10.8942]
+  - - [128, 512, 1, 32, 128, 128, 128, 32]
+    - [2, 55.8645]
+  - - [192, 512, 1, 32, 192, 192, 192, 32]
+    - [2, 65.906]
+  - - [256, 512, 1, 32, 256, 256, 256, 32]
+    - [2, 86.2139]
+  - - [320, 512, 1, 32, 320, 320, 320, 32]
+    - [2, 106.66]
+  - - [384, 512, 1, 32, 384, 384, 384, 32]
+    - [1, 124.202]
+  - - [448, 512, 1, 32, 448, 448, 448, 32]
+    - [1, 139.478]
+  - - [512, 512, 1, 32, 512, 512, 512, 32]
+    - [3, 177.031]
+  - - [576, 512, 1, 32, 576, 576, 576, 32]
+    - [3, 194.86]
+  - - [640, 512, 1, 32, 640, 640, 640, 32]
+    - [3, 205.36]
+  - - [704, 512, 1, 32, 704, 704, 704, 32]
+    - [3, 266.013]
+  - - [768, 512, 1, 32, 768, 768, 768, 32]
+    - [3, 36.8442]
+  - - [832, 512, 1, 32, 832, 832, 832, 32]
+    - [2, 40.0112]
+  - - [896, 512, 1, 32, 896, 896, 896, 32]
+    - [3, 45.583]
+  - - [960, 512, 1, 32, 960, 960, 960, 32]
+    - [2, 45.1471]
+  - - [1024, 512, 1, 32, 1024, 1024, 1024, 32]
+    - [2, 632.613]
+  - - [64, 576, 1, 32, 64, 64, 64, 32]
+    - [2, 12.9474]
+  - - [128, 576, 1, 32, 128, 128, 128, 32]
+    - [2, 50.4554]
+  - - [192, 576, 1, 32, 192, 192, 192, 32]
+    - [2, 84.8362]
+  - - [256, 576, 1, 32, 256, 256, 256, 32]
+    - [2, 111.643]
+  - - [320, 576, 1, 32, 320, 320, 320, 32]
+    - [1, 130.896]
+  - - [384, 576, 1, 32, 384, 384, 384, 32]
+    - [3, 61.5439]
+  - - [448, 576, 1, 32, 448, 448, 448, 32]
+    - [1, 71.8731]
+  - - [512, 576, 1, 32, 512, 512, 512, 32]
+    - [2, 81.845]
+  - - [576, 576, 1, 32, 576, 576, 576, 32]
+    - [3, 93.0358]
+  - - [640, 576, 1, 32, 640, 640, 640, 32]
+    - [1, 103.328]
+  - - [704, 576, 1, 32, 704, 704, 704, 32]
+    - [3, 113.566]
+  - - [768, 576, 1, 32, 768, 768, 768, 32]
+    - [2, 123.809]
+  - - [832, 576, 1, 32, 832, 832, 832, 32]
+    - [2, 135.286]
+  - - [896, 576, 1, 32, 896, 896, 896, 32]
+    - [0, 144.16]
+  - - [960, 576, 1, 32, 960, 960, 960, 32]
+    - [0, 154.289]
+  - - [1024, 576, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 55.2663]
+  - - [64, 640, 1, 32, 64, 64, 64, 32]
+    - [3, 4.32657]
+  - - [128, 640, 1, 32, 128, 128, 128, 32]
+    - [3, 8.54722]
+  - - [192, 640, 1, 32, 192, 192, 192, 32]
+    - [3, 210.501]
+  - - [256, 640, 1, 32, 256, 256, 256, 32]
+    - [1, 248.478]
+  - - [320, 640, 1, 32, 320, 320, 320, 32]
+    - [1, 20.9872]
+  - - [384, 640, 1, 32, 384, 384, 384, 32]
+    - [3, 25.903]
+  - - [448, 640, 1, 32, 448, 448, 448, 32]
+    - [1, 26.54]
+  - - [512, 640, 1, 32, 512, 512, 512, 32]
+    - [3, 33.82]
+  - - [576, 640, 1, 32, 576, 576, 576, 32]
+    - [1, 37.43]
+  - - [640, 640, 1, 32, 640, 640, 640, 32]
+    - [3, 34.0321]
+  - - [704, 640, 1, 32, 704, 704, 704, 32]
+    - [2, 45.0431]
+  - - [768, 640, 1, 32, 768, 768, 768, 32]
+    - [3, 45.9295]
+  - - [832, 640, 1, 32, 832, 832, 832, 32]
+    - [3, 276.88]
+  - - [896, 640, 1, 32, 896, 896, 896, 32]
+    - [2, 53.7209]
+  - - [960, 640, 1, 32, 960, 960, 960, 32]
+    - [2, 57.1025]
+  - - [1024, 640, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 59.7382]
+  - - [64, 704, 1, 32, 64, 64, 64, 32]
+    - [3, 4.74053]
+  - - [128, 704, 1, 32, 128, 128, 128, 32]
+    - [2, 9.37091]
+  - - [192, 704, 1, 32, 192, 192, 192, 32]
+    - [2, 14.1319]
+  - - [256, 704, 1, 32, 256, 256, 256, 32]
+    - [2, 19.5838]
+  - - [320, 704, 1, 32, 320, 320, 320, 32]
+    - [3, 23.6964]
+  - - [384, 704, 1, 32, 384, 384, 384, 32]
+    - [3, 27.7649]
+  - - [448, 704, 1, 32, 448, 448, 448, 32]
+    - [2, 32.7588]
+  - - [512, 704, 1, 32, 512, 512, 512, 32]
+    - [2, 33.4895]
+  - - [576, 704, 1, 32, 576, 576, 576, 32]
+    - [2, 37.6538]
+  - - [640, 704, 1, 32, 640, 640, 640, 32]
+    - [0, 36.5703]
+  - - [704, 704, 1, 32, 704, 704, 704, 32]
+    - [3, 46.5967]
+  - - [768, 704, 1, 32, 768, 768, 768, 32]
+    - [1, 49.955]
+  - - [832, 704, 1, 32, 832, 832, 832, 32]
+    - [2, 54.7614]
+  - - [896, 704, 1, 32, 896, 896, 896, 32]
+    - [2, 58.6893]
+  - - [960, 704, 1, 32, 960, 960, 960, 32]
+    - [1, 53.1547]
+  - - [1024, 704, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 66.2851]
+  - - [64, 768, 1, 32, 64, 64, 64, 32]
+    - [3, 5.20244]
+  - - [128, 768, 1, 32, 128, 128, 128, 32]
+    - [2, 10.3143]
+  - - [192, 768, 1, 32, 192, 192, 192, 32]
+    - [3, 15.5431]
+  - - [256, 768, 1, 32, 256, 256, 256, 32]
+    - [3, 20.7303]
+  - - [320, 768, 1, 32, 320, 320, 320, 32]
+    - [3, 25.6257]
+  - - [384, 768, 1, 32, 384, 384, 384, 32]
+    - [3, 30.8031]
+  - - [448, 768, 1, 32, 448, 448, 448, 32]
+    - [2, 32.4291]
+  - - [512, 768, 1, 32, 512, 512, 512, 32]
+    - [3, 39.7506]
+  - - [576, 768, 1, 32, 576, 576, 576, 32]
+    - [2, 41.4418]
+  - - [640, 768, 1, 32, 640, 640, 640, 32]
+    - [2, 295.426]
+  - - [704, 768, 1, 32, 704, 704, 704, 32]
+    - [2, 50.5342]
+  - - [768, 768, 1, 32, 768, 768, 768, 32]
+    - [2, 54.939]
+  - - [832, 768, 1, 32, 832, 832, 832, 32]
+    - [3, 58.1719]
+  - - [896, 768, 1, 32, 896, 896, 896, 32]
+    - [1, 63.765]
+  - - [960, 768, 1, 32, 960, 960, 960, 32]
+    - [2, 68.1401]
+  - - [1024, 768, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 70.5119]
+  - - [64, 832, 1, 32, 64, 64, 64, 32]
+    - [2, 131.274]
+  - - [128, 832, 1, 32, 128, 128, 128, 32]
+    - [1, 193.19]
+  - - [192, 832, 1, 32, 192, 192, 192, 32]
+    - [1, 242.72]
+  - - [256, 832, 1, 32, 256, 256, 256, 32]
+    - [1, 269.392]
+  - - [320, 832, 1, 32, 320, 320, 320, 32]
+    - [0, 72.9044]
+  - - [384, 832, 1, 32, 384, 384, 384, 32]
+    - [2, 29.7413]
+  - - [448, 832, 1, 32, 448, 448, 448, 32]
+    - [2, 37.9717]
+  - - [512, 832, 1, 32, 512, 512, 512, 32]
+    - [3, 42.7618]
+  - - [576, 832, 1, 32, 576, 576, 576, 32]
+    - [1, 36.6624]
+  - - [640, 832, 1, 32, 640, 640, 640, 32]
+    - [3, 49.675]
+  - - [704, 832, 1, 32, 704, 704, 704, 32]
+    - [2, 56.5567]
+  - - [768, 832, 1, 32, 768, 768, 768, 32]
+    - [3, 59.3651]
+  - - [832, 832, 1, 32, 832, 832, 832, 32]
+    - [3, 64.4816]
+  - - [896, 832, 1, 32, 896, 896, 896, 32]
+    - [2, 68.9171]
+  - - [960, 832, 1, 32, 960, 960, 960, 32]
+    - [1, 63.7849]
+  - - [1024, 832, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 79.2627]
+  - - [64, 896, 1, 32, 64, 64, 64, 32]
+    - [2, 6.0592]
+  - - [128, 896, 1, 32, 128, 128, 128, 32]
+    - [3, 12.0502]
+  - - [192, 896, 1, 32, 192, 192, 192, 32]
+    - [3, 249.774]
+  - - [256, 896, 1, 32, 256, 256, 256, 32]
+    - [2, 23.7929]
+  - - [320, 896, 1, 32, 320, 320, 320, 32]
+    - [2, 83.3031]
+  - - [384, 896, 1, 32, 384, 384, 384, 32]
+    - [3, 34.9013]
+  - - [448, 896, 1, 32, 448, 448, 448, 32]
+    - [1, 35.9602]
+  - - [512, 896, 1, 32, 512, 512, 512, 32]
+    - [1, 42.0896]
+  - - [576, 896, 1, 32, 576, 576, 576, 32]
+    - [3, 48.2746]
+  - - [640, 896, 1, 32, 640, 640, 640, 32]
+    - [1, 53.1706]
+  - - [704, 896, 1, 32, 704, 704, 704, 32]
+    - [2, 59.3754]
+  - - [768, 896, 1, 32, 768, 768, 768, 32]
+    - [3, 63.9902]
+  - - [832, 896, 1, 32, 832, 832, 832, 32]
+    - [0, 67.4584]
+  - - [896, 896, 1, 32, 896, 896, 896, 32]
+    - [2, 72.8681]
+  - - [960, 896, 1, 32, 960, 960, 960, 32]
+    - [1, 79.6003]
+  - - [1024, 896, 1, 32, 1024, 1024, 1024, 32]
+    - [1, 82.539]
+  - - [64, 960, 1, 32, 64, 64, 64, 32]
+    - [1, 6.40329]
+  - - [128, 960, 1, 32, 128, 128, 128, 32]
+    - [2, 12.9321]
+  - - [192, 960, 1, 32, 192, 192, 192, 32]
+    - [2, 19.3689]
+  - - [256, 960, 1, 32, 256, 256, 256, 32]
+    - [1, 25.2785]
+  - - [320, 960, 1, 32, 320, 320, 320, 32]
+    - [1, 31.4692]
+  - - [384, 960, 1, 32, 384, 384, 384, 32]
+    - [2, 34.3398]
+  - - [448, 960, 1, 32, 448, 448, 448, 32]
+    - [2, 40.19]
+  - - [512, 960, 1, 32, 512, 512, 512, 32]
+    - [3, 45.686]
+  - - [576, 960, 1, 32, 576, 576, 576, 32]
+    - [3, 51.5217]
+  - - [640, 960, 1, 32, 640, 640, 640, 32]
+    - [2, 57.8128]
+  - - [704, 960, 1, 32, 704, 704, 704, 32]
+    - [0, 61.3229]
+  - - [768, 960, 1, 32, 768, 768, 768, 32]
+    - [0, 65.2042]
+  - - [832, 960, 1, 32, 832, 832, 832, 32]
+    - [2, 72.6756]
+  - - [896, 960, 1, 32, 896, 896, 896, 32]
+    - [1, 79.4669]
+  - - [960, 960, 1, 32, 960, 960, 960, 32]
+    - [2, 78.536]
+  - - [1024, 960, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 85.7013]
+  - - [64, 1024, 1, 32, 64, 64, 64, 32]
+    - [3, 6.90076]
+  - - [128, 1024, 1, 32, 128, 128, 128, 32]
+    - [3, 13.7965]
+  - - [192, 1024, 1, 32, 192, 192, 192, 32]
+    - [3, 20.4795]
+  - - [256, 1024, 1, 32, 256, 256, 256, 32]
+    - [3, 27.4706]
+  - - [320, 1024, 1, 32, 320, 320, 320, 32]
+    - [0, 29.5718]
+  - - [384, 1024, 1, 32, 384, 384, 384, 32]
+    - [2, 40.0721]
+  - - [448, 1024, 1, 32, 448, 448, 448, 32]
+    - [2, 42.8763]
+  - - [512, 1024, 1, 32, 512, 512, 512, 32]
+    - [3, 48.9415]
+  - - [576, 1024, 1, 32, 576, 576, 576, 32]
+    - [0, 53.6033]
+  - - [640, 1024, 1, 32, 640, 640, 640, 32]
+    - [1, 59.8688]
+  - - [704, 1024, 1, 32, 704, 704, 704, 32]
+    - [0, 64.5626]
+  - - [768, 1024, 1, 32, 768, 768, 768, 32]
+    - [2, 61.8968]
+  - - [832, 1024, 1, 32, 832, 832, 832, 32]
+    - [1, 78.4519]
+  - - [896, 1024, 1, 32, 896, 896, 896, 32]
+    - [2, 69.6129]
+  - - [960, 1024, 1, 32, 960, 960, 960, 32]
+    - [3, 85.3746]
+  - - [1024, 1024, 1, 32, 1024, 1024, 1024, 32]
+    - [3, 90.2469]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Alik_Bjlk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Alik_Bjlk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi33
+- gfx1102
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [1, 3, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 1
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: true
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: true
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 16
+    LSPA: 8
+    LSPB: 4
+    LVCA: 8
+    LVCB: 16
+    LVPA: 8
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 8
+    LSPA: 4
+    LSPB: 8
+    LVCA: 16
+    LVCB: 8
+    LVPA: 4
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [1, 3, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 1
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: true
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: true
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bjlk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 64]
+    - [1, 1.15726]
+  - - [128, 64, 1, 32, 128, 128, 32, 64]
+    - [3, 2.31821]
+  - - [192, 64, 1, 32, 192, 192, 32, 64]
+    - [2, 3.47424]
+  - - [256, 64, 1, 32, 256, 256, 32, 64]
+    - [2, 4.63209]
+  - - [320, 64, 1, 32, 320, 320, 32, 64]
+    - [2, 5.79552]
+  - - [384, 64, 1, 32, 384, 384, 32, 64]
+    - [3, 6.95431]
+  - - [448, 64, 1, 32, 448, 448, 32, 64]
+    - [3, 76.2046]
+  - - [512, 64, 1, 32, 512, 512, 32, 64]
+    - [1, 9.2716]
+  - - [576, 64, 1, 32, 576, 576, 32, 64]
+    - [0, 102.578]
+  - - [640, 64, 1, 32, 640, 640, 32, 64]
+    - [3, 11.5757]
+  - - [704, 64, 1, 32, 704, 704, 32, 64]
+    - [2, 12.7349]
+  - - [768, 64, 1, 32, 768, 768, 32, 64]
+    - [2, 13.8773]
+  - - [832, 64, 1, 32, 832, 832, 32, 64]
+    - [2, 14.9677]
+  - - [896, 64, 1, 32, 896, 896, 32, 64]
+    - [0, 16.1127]
+  - - [960, 64, 1, 32, 960, 960, 32, 64]
+    - [3, 17.2894]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 64]
+    - [2, 18.451]
+  - - [64, 128, 1, 32, 64, 64, 32, 128]
+    - [3, 24.1385]
+  - - [128, 128, 1, 32, 128, 128, 32, 128]
+    - [0, 55.8942]
+  - - [192, 128, 1, 32, 192, 192, 32, 128]
+    - [2, 77.5536]
+  - - [256, 128, 1, 32, 256, 256, 32, 128]
+    - [3, 3.71372]
+  - - [320, 128, 1, 32, 320, 320, 32, 128]
+    - [3, 4.61828]
+  - - [384, 128, 1, 32, 384, 384, 32, 128]
+    - [1, 5.23804]
+  - - [448, 128, 1, 32, 448, 448, 32, 128]
+    - [3, 6.42685]
+  - - [512, 128, 1, 32, 512, 512, 32, 128]
+    - [1, 6.90462]
+  - - [576, 128, 1, 32, 576, 576, 32, 128]
+    - [3, 7.89334]
+  - - [640, 128, 1, 32, 640, 640, 32, 128]
+    - [2, 8.75149]
+  - - [704, 128, 1, 32, 704, 704, 32, 128]
+    - [3, 9.61092]
+  - - [768, 128, 1, 32, 768, 768, 32, 128]
+    - [3, 10.4859]
+  - - [832, 128, 1, 32, 832, 832, 32, 128]
+    - [1, 11.2858]
+  - - [896, 128, 1, 32, 896, 896, 32, 128]
+    - [1, 213.125]
+  - - [960, 128, 1, 32, 960, 960, 32, 128]
+    - [2, 13.1457]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 128]
+    - [2, 14.0183]
+  - - [64, 192, 1, 32, 64, 64, 32, 192]
+    - [3, 1.32088]
+  - - [128, 192, 1, 32, 128, 128, 32, 192]
+    - [2, 2.64208]
+  - - [192, 192, 1, 32, 192, 192, 32, 192]
+    - [2, 3.91608]
+  - - [256, 192, 1, 32, 256, 256, 32, 192]
+    - [3, 5.28406]
+  - - [320, 192, 1, 32, 320, 320, 32, 192]
+    - [2, 6.54701]
+  - - [384, 192, 1, 32, 384, 384, 32, 192]
+    - [1, 7.81296]
+  - - [448, 192, 1, 32, 448, 448, 32, 192]
+    - [2, 9.13691]
+  - - [512, 192, 1, 32, 512, 512, 32, 192]
+    - [1, 10.4083]
+  - - [576, 192, 1, 32, 576, 576, 32, 192]
+    - [2, 11.7711]
+  - - [640, 192, 1, 32, 640, 640, 32, 192]
+    - [3, 13.14]
+  - - [704, 192, 1, 32, 704, 704, 32, 192]
+    - [1, 14.2987]
+  - - [768, 192, 1, 32, 768, 768, 32, 192]
+    - [2, 15.7448]
+  - - [832, 192, 1, 32, 832, 832, 32, 192]
+    - [2, 17.0191]
+  - - [896, 192, 1, 32, 896, 896, 32, 192]
+    - [2, 18.3705]
+  - - [960, 192, 1, 32, 960, 960, 32, 192]
+    - [1, 19.4195]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 192]
+    - [3, 20.9334]
+  - - [64, 256, 1, 32, 64, 64, 32, 256]
+    - [2, 1.73956]
+  - - [128, 256, 1, 32, 128, 128, 32, 256]
+    - [1, 3.50886]
+  - - [192, 256, 1, 32, 192, 192, 32, 256]
+    - [3, 5.30402]
+  - - [256, 256, 1, 32, 256, 256, 32, 256]
+    - [3, 7.03596]
+  - - [320, 256, 1, 32, 320, 320, 32, 256]
+    - [3, 8.79437]
+  - - [384, 256, 1, 32, 384, 384, 32, 256]
+    - [2, 10.3936]
+  - - [448, 256, 1, 32, 448, 448, 32, 256]
+    - [2, 12.1206]
+  - - [512, 256, 1, 32, 512, 512, 32, 256]
+    - [3, 14.0427]
+  - - [576, 256, 1, 32, 576, 576, 32, 256]
+    - [3, 15.7864]
+  - - [640, 256, 1, 32, 640, 640, 32, 256]
+    - [3, 17.4744]
+  - - [704, 256, 1, 32, 704, 704, 32, 256]
+    - [1, 247.513]
+  - - [768, 256, 1, 32, 768, 768, 32, 256]
+    - [2, 20.6236]
+  - - [832, 256, 1, 32, 832, 832, 32, 256]
+    - [3, 22.6944]
+  - - [896, 256, 1, 32, 896, 896, 32, 256]
+    - [3, 24.3493]
+  - - [960, 256, 1, 32, 960, 960, 32, 256]
+    - [2, 25.8264]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 256]
+    - [1, 24.3747]
+  - - [64, 320, 1, 32, 64, 64, 32, 320]
+    - [2, 1.92099]
+  - - [128, 320, 1, 32, 128, 128, 32, 320]
+    - [2, 112.993]
+  - - [192, 320, 1, 32, 192, 192, 32, 320]
+    - [2, 15.7677]
+  - - [256, 320, 1, 32, 256, 256, 32, 320]
+    - [2, 170.445]
+  - - [320, 320, 1, 32, 320, 320, 32, 320]
+    - [2, 10.8445]
+  - - [384, 320, 1, 32, 384, 384, 32, 320]
+    - [1, 12.7485]
+  - - [448, 320, 1, 32, 448, 448, 32, 320]
+    - [1, 15.127]
+  - - [512, 320, 1, 32, 512, 512, 32, 320]
+    - [2, 17.4663]
+  - - [576, 320, 1, 32, 576, 576, 32, 320]
+    - [2, 14.4937]
+  - - [640, 320, 1, 32, 640, 640, 32, 320]
+    - [3, 21.761]
+  - - [704, 320, 1, 32, 704, 704, 32, 320]
+    - [3, 24.1234]
+  - - [768, 320, 1, 32, 768, 768, 32, 320]
+    - [1, 26.199]
+  - - [832, 320, 1, 32, 832, 832, 32, 320]
+    - [2, 28.1632]
+  - - [896, 320, 1, 32, 896, 896, 32, 320]
+    - [2, 30.1531]
+  - - [960, 320, 1, 32, 960, 960, 32, 320]
+    - [3, 31.8247]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 320]
+    - [2, 34.0556]
+  - - [64, 384, 1, 32, 64, 64, 32, 384]
+    - [3, 2.66269]
+  - - [128, 384, 1, 32, 128, 128, 32, 384]
+    - [1, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 384]
+    - [3, 7.91506]
+  - - [256, 384, 1, 32, 256, 256, 32, 384]
+    - [2, 10.4834]
+  - - [320, 384, 1, 32, 320, 320, 32, 384]
+    - [3, 13.1668]
+  - - [384, 384, 1, 32, 384, 384, 32, 384]
+    - [2, 15.7136]
+  - - [448, 384, 1, 32, 448, 448, 32, 384]
+    - [3, 18.5612]
+  - - [512, 384, 1, 32, 512, 512, 32, 384]
+    - [3, 21.012]
+  - - [576, 384, 1, 32, 576, 576, 32, 384]
+    - [2, 23.57]
+  - - [640, 384, 1, 32, 640, 640, 32, 384]
+    - [1, 26.1267]
+  - - [704, 384, 1, 32, 704, 704, 32, 384]
+    - [2, 25.9286]
+  - - [768, 384, 1, 32, 768, 768, 32, 384]
+    - [3, 30.459]
+  - - [832, 384, 1, 32, 832, 832, 32, 384]
+    - [3, 32.9458]
+  - - [896, 384, 1, 32, 896, 896, 32, 384]
+    - [2, 35.4332]
+  - - [960, 384, 1, 32, 960, 960, 32, 384]
+    - [1, 321.255]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 384]
+    - [3, 35.291]
+  - - [64, 448, 1, 32, 64, 64, 32, 448]
+    - [1, 3.08144]
+  - - [128, 448, 1, 32, 128, 128, 32, 448]
+    - [1, 6.12932]
+  - - [192, 448, 1, 32, 192, 192, 32, 448]
+    - [1, 9.12646]
+  - - [256, 448, 1, 32, 256, 256, 32, 448]
+    - [2, 12.2539]
+  - - [320, 448, 1, 32, 320, 320, 32, 448]
+    - [2, 15.2543]
+  - - [384, 448, 1, 32, 384, 384, 32, 448]
+    - [2, 18.3503]
+  - - [448, 448, 1, 32, 448, 448, 32, 448]
+    - [2, 21.3375]
+  - - [512, 448, 1, 32, 512, 512, 32, 448]
+    - [2, 250.342]
+  - - [576, 448, 1, 32, 576, 576, 32, 448]
+    - [3, 27.1378]
+  - - [640, 448, 1, 32, 640, 640, 32, 448]
+    - [3, 29.9288]
+  - - [704, 448, 1, 32, 704, 704, 32, 448]
+    - [3, 30.1579]
+  - - [768, 448, 1, 32, 768, 768, 32, 448]
+    - [2, 31.8502]
+  - - [832, 448, 1, 32, 832, 832, 32, 448]
+    - [3, 35.3894]
+  - - [896, 448, 1, 32, 896, 896, 32, 448]
+    - [1, 37.6614]
+  - - [960, 448, 1, 32, 960, 960, 32, 448]
+    - [2, 41.1963]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 448]
+    - [2, 44.0087]
+  - - [64, 512, 1, 32, 64, 64, 32, 512]
+    - [1, 3.52295]
+  - - [128, 512, 1, 32, 128, 128, 32, 512]
+    - [1, 6.94911]
+  - - [192, 512, 1, 32, 192, 192, 32, 512]
+    - [3, 10.5167]
+  - - [256, 512, 1, 32, 256, 256, 32, 512]
+    - [2, 14.0604]
+  - - [320, 512, 1, 32, 320, 320, 32, 512]
+    - [2, 17.2647]
+  - - [384, 512, 1, 32, 384, 384, 32, 512]
+    - [3, 18.5058]
+  - - [448, 512, 1, 32, 448, 448, 32, 512]
+    - [2, 24.1574]
+  - - [512, 512, 1, 32, 512, 512, 32, 512]
+    - [3, 23.8816]
+  - - [576, 512, 1, 32, 576, 576, 32, 512]
+    - [1, 30.8791]
+  - - [640, 512, 1, 32, 640, 640, 32, 512]
+    - [1, 30.8095]
+  - - [704, 512, 1, 32, 704, 704, 32, 512]
+    - [1, 31.2565]
+  - - [768, 512, 1, 32, 768, 768, 32, 512]
+    - [3, 37.0819]
+  - - [832, 512, 1, 32, 832, 832, 32, 512]
+    - [0, 38.4813]
+  - - [896, 512, 1, 32, 896, 896, 32, 512]
+    - [3, 272.76]
+  - - [960, 512, 1, 32, 960, 960, 32, 512]
+    - [2, 285.143]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 512]
+    - [2, 300.344]
+  - - [64, 576, 1, 32, 64, 64, 32, 576]
+    - [1, 3.94252]
+  - - [128, 576, 1, 32, 128, 128, 32, 576]
+    - [2, 7.85877]
+  - - [192, 576, 1, 32, 192, 192, 32, 576]
+    - [1, 11.7529]
+  - - [256, 576, 1, 32, 256, 256, 32, 576]
+    - [2, 15.6784]
+  - - [320, 576, 1, 32, 320, 320, 32, 576]
+    - [2, 19.6958]
+  - - [384, 576, 1, 32, 384, 384, 32, 576]
+    - [3, 23.6192]
+  - - [448, 576, 1, 32, 448, 448, 32, 576]
+    - [2, 27.2277]
+  - - [512, 576, 1, 32, 512, 512, 32, 576]
+    - [1, 303.057]
+  - - [576, 576, 1, 32, 576, 576, 32, 576]
+    - [2, 56.6076]
+  - - [640, 576, 1, 32, 640, 640, 32, 576]
+    - [3, 37.3097]
+  - - [704, 576, 1, 32, 704, 704, 32, 576]
+    - [3, 40.4755]
+  - - [768, 576, 1, 32, 768, 768, 32, 576]
+    - [3, 42.0593]
+  - - [832, 576, 1, 32, 832, 832, 32, 576]
+    - [3, 45.7279]
+  - - [896, 576, 1, 32, 896, 896, 32, 576]
+    - [1, 48.5906]
+  - - [960, 576, 1, 32, 960, 960, 32, 576]
+    - [2, 52.451]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 576]
+    - [1, 52.4547]
+  - - [64, 640, 1, 32, 64, 64, 32, 640]
+    - [2, 4.36809]
+  - - [128, 640, 1, 32, 128, 128, 32, 640]
+    - [1, 8.54343]
+  - - [192, 640, 1, 32, 192, 192, 32, 640]
+    - [2, 13.0236]
+  - - [256, 640, 1, 32, 256, 256, 32, 640]
+    - [3, 17.4794]
+  - - [320, 640, 1, 32, 320, 320, 32, 640]
+    - [2, 21.473]
+  - - [384, 640, 1, 32, 384, 384, 32, 640]
+    - [1, 25.7238]
+  - - [448, 640, 1, 32, 448, 448, 32, 640]
+    - [1, 28.8571]
+  - - [512, 640, 1, 32, 512, 512, 32, 640]
+    - [3, 31.1338]
+  - - [576, 640, 1, 32, 576, 576, 32, 640]
+    - [3, 37.6695]
+  - - [640, 640, 1, 32, 640, 640, 32, 640]
+    - [3, 41.3063]
+  - - [704, 640, 1, 32, 704, 704, 32, 640]
+    - [2, 282.038]
+  - - [768, 640, 1, 32, 768, 768, 32, 640]
+    - [1, 44.3651]
+  - - [832, 640, 1, 32, 832, 832, 32, 640]
+    - [1, 339.561]
+  - - [896, 640, 1, 32, 896, 896, 32, 640]
+    - [1, 342.221]
+  - - [960, 640, 1, 32, 960, 960, 32, 640]
+    - [2, 54.8507]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 640]
+    - [1, 60.763]
+  - - [64, 704, 1, 32, 64, 64, 32, 704]
+    - [2, 4.83657]
+  - - [128, 704, 1, 32, 128, 128, 32, 704]
+    - [2, 9.51187]
+  - - [192, 704, 1, 32, 192, 192, 32, 704]
+    - [3, 14.5053]
+  - - [256, 704, 1, 32, 256, 256, 32, 704]
+    - [1, 19.0363]
+  - - [320, 704, 1, 32, 320, 320, 32, 704]
+    - [1, 267.593]
+  - - [384, 704, 1, 32, 384, 384, 32, 704]
+    - [2, 28.4469]
+  - - [448, 704, 1, 32, 448, 448, 32, 704]
+    - [2, 32.8767]
+  - - [512, 704, 1, 32, 512, 512, 32, 704]
+    - [1, 32.7986]
+  - - [576, 704, 1, 32, 576, 576, 32, 704]
+    - [1, 319.605]
+  - - [640, 704, 1, 32, 640, 640, 32, 704]
+    - [3, 44.8045]
+  - - [704, 704, 1, 32, 704, 704, 32, 704]
+    - [3, 46.3515]
+  - - [768, 704, 1, 32, 768, 768, 32, 704]
+    - [1, 50.2597]
+  - - [832, 704, 1, 32, 832, 832, 32, 704]
+    - [2, 54.9452]
+  - - [896, 704, 1, 32, 896, 896, 32, 704]
+    - [1, 58.9238]
+  - - [960, 704, 1, 32, 960, 960, 32, 704]
+    - [3, 57.3889]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 704]
+    - [1, 67.3308]
+  - - [64, 768, 1, 32, 64, 64, 32, 768]
+    - [2, 5.13066]
+  - - [128, 768, 1, 32, 128, 128, 32, 768]
+    - [3, 10.4063]
+  - - [192, 768, 1, 32, 192, 192, 32, 768]
+    - [3, 15.5295]
+  - - [256, 768, 1, 32, 256, 256, 32, 768]
+    - [2, 235.635]
+  - - [320, 768, 1, 32, 320, 320, 32, 768]
+    - [3, 25.7752]
+  - - [384, 768, 1, 32, 384, 384, 32, 768]
+    - [2, 27.6193]
+  - - [448, 768, 1, 32, 448, 448, 32, 768]
+    - [2, 35.5029]
+  - - [512, 768, 1, 32, 512, 512, 32, 768]
+    - [0, 283.396]
+  - - [576, 768, 1, 32, 576, 576, 32, 768]
+    - [3, 41.5159]
+  - - [640, 768, 1, 32, 640, 640, 32, 768]
+    - [1, 318.394]
+  - - [704, 768, 1, 32, 704, 704, 32, 768]
+    - [1, 151.018]
+  - - [768, 768, 1, 32, 768, 768, 32, 768]
+    - [2, 54.769]
+  - - [832, 768, 1, 32, 832, 832, 32, 768]
+    - [3, 59.8533]
+  - - [896, 768, 1, 32, 896, 896, 32, 768]
+    - [3, 64.697]
+  - - [960, 768, 1, 32, 960, 960, 32, 768]
+    - [3, 272.639]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 768]
+    - [0, 158.739]
+  - - [64, 832, 1, 32, 64, 64, 32, 832]
+    - [3, 5.6198]
+  - - [128, 832, 1, 32, 128, 128, 32, 832]
+    - [3, 11.2135]
+  - - [192, 832, 1, 32, 192, 192, 32, 832]
+    - [1, 12.6673]
+  - - [256, 832, 1, 32, 256, 256, 32, 832]
+    - [2, 21.8459]
+  - - [320, 832, 1, 32, 320, 320, 32, 832]
+    - [2, 27.6993]
+  - - [384, 832, 1, 32, 384, 384, 32, 832]
+    - [2, 33.2084]
+  - - [448, 832, 1, 32, 448, 448, 32, 832]
+    - [1, 34.47]
+  - - [512, 832, 1, 32, 512, 512, 32, 832]
+    - [3, 38.4699]
+  - - [576, 832, 1, 32, 576, 576, 32, 832]
+    - [3, 44.7355]
+  - - [640, 832, 1, 32, 640, 640, 32, 832]
+    - [2, 49.7729]
+  - - [704, 832, 1, 32, 704, 704, 32, 832]
+    - [0, 51.9778]
+  - - [768, 832, 1, 32, 768, 768, 32, 832]
+    - [2, 60.0476]
+  - - [832, 832, 1, 32, 832, 832, 32, 832]
+    - [3, 61.0171]
+  - - [896, 832, 1, 32, 896, 896, 32, 832]
+    - [3, 68.7008]
+  - - [960, 832, 1, 32, 960, 960, 32, 832]
+    - [1, 73.7301]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 832]
+    - [2, 76.7188]
+  - - [64, 896, 1, 32, 64, 64, 32, 896]
+    - [3, 6.0638]
+  - - [128, 896, 1, 32, 128, 128, 32, 896]
+    - [1, 11.8097]
+  - - [192, 896, 1, 32, 192, 192, 32, 896]
+    - [1, 260.408]
+  - - [256, 896, 1, 32, 256, 256, 32, 896]
+    - [1, 112.061]
+  - - [320, 896, 1, 32, 320, 320, 32, 896]
+    - [1, 21.646]
+  - - [384, 896, 1, 32, 384, 384, 32, 896]
+    - [3, 35.1622]
+  - - [448, 896, 1, 32, 448, 448, 32, 896]
+    - [2, 40.6641]
+  - - [512, 896, 1, 32, 512, 512, 32, 896]
+    - [2, 42.9101]
+  - - [576, 896, 1, 32, 576, 576, 32, 896]
+    - [0, 43.0245]
+  - - [640, 896, 1, 32, 640, 640, 32, 896]
+    - [3, 79.8571]
+  - - [704, 896, 1, 32, 704, 704, 32, 896]
+    - [1, 49.3707]
+  - - [768, 896, 1, 32, 768, 768, 32, 896]
+    - [3, 63.6994]
+  - - [832, 896, 1, 32, 832, 832, 32, 896]
+    - [2, 61.6821]
+  - - [896, 896, 1, 32, 896, 896, 32, 896]
+    - [2, 72.8566]
+  - - [960, 896, 1, 32, 960, 960, 32, 896]
+    - [1, 354.886]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 896]
+    - [0, 317.886]
+  - - [64, 960, 1, 32, 64, 64, 32, 960]
+    - [1, 53.3971]
+  - - [128, 960, 1, 32, 128, 128, 32, 960]
+    - [3, 90.4142]
+  - - [192, 960, 1, 32, 192, 192, 32, 960]
+    - [2, 122.611]
+  - - [256, 960, 1, 32, 256, 256, 32, 960]
+    - [3, 183.744]
+  - - [320, 960, 1, 32, 320, 320, 32, 960]
+    - [3, 223.215]
+  - - [384, 960, 1, 32, 384, 384, 32, 960]
+    - [3, 254.894]
+  - - [448, 960, 1, 32, 448, 448, 32, 960]
+    - [1, 281.213]
+  - - [512, 960, 1, 32, 512, 512, 32, 960]
+    - [1, 112.761]
+  - - [576, 960, 1, 32, 576, 576, 32, 960]
+    - [3, 48.9911]
+  - - [640, 960, 1, 32, 640, 640, 32, 960]
+    - [3, 55.7371]
+  - - [704, 960, 1, 32, 704, 704, 32, 960]
+    - [2, 63.3231]
+  - - [768, 960, 1, 32, 768, 768, 32, 960]
+    - [3, 68.2938]
+  - - [832, 960, 1, 32, 832, 832, 32, 960]
+    - [2, 72.4314]
+  - - [896, 960, 1, 32, 896, 896, 32, 960]
+    - [1, 77.3032]
+  - - [960, 960, 1, 32, 960, 960, 32, 960]
+    - [1, 81.6484]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 960]
+    - [1, 88.853]
+  - - [64, 1024, 1, 32, 64, 64, 32, 1024]
+    - [1, 6.85587]
+  - - [128, 1024, 1, 32, 128, 128, 32, 1024]
+    - [2, 13.7617]
+  - - [192, 1024, 1, 32, 192, 192, 32, 1024]
+    - [3, 20.7908]
+  - - [256, 1024, 1, 32, 256, 256, 32, 1024]
+    - [2, 264.621]
+  - - [320, 1024, 1, 32, 320, 320, 32, 1024]
+    - [0, 110.725]
+  - - [384, 1024, 1, 32, 384, 384, 32, 1024]
+    - [1, 34.0459]
+  - - [448, 1024, 1, 32, 448, 448, 32, 1024]
+    - [1, 329.589]
+  - - [512, 1024, 1, 32, 512, 512, 32, 1024]
+    - [1, 49.0545]
+  - - [576, 1024, 1, 32, 576, 576, 32, 1024]
+    - [3, 51.7861]
+  - - [640, 1024, 1, 32, 640, 640, 32, 1024]
+    - [3, 60.799]
+  - - [704, 1024, 1, 32, 704, 704, 32, 1024]
+    - [3, 66.7098]
+  - - [768, 1024, 1, 32, 768, 768, 32, 1024]
+    - [1, 73.2018]
+  - - [832, 1024, 1, 32, 832, 832, 32, 1024]
+    - [0, 76.422]
+  - - [896, 1024, 1, 32, 896, 896, 32, 1024]
+    - [1, 83.9504]
+  - - [960, 1024, 1, 32, 960, 960, 32, 1024]
+    - [1, 88.6428]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 1024]
+    - [0, 89.8096]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Alik_Bljk_DB_UserArgs.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/navi33/Equality/navi33_Cijk_Alik_Bljk_DB_UserArgs.yaml
@@ -1,0 +1,1573 @@
+- {MinimumRequiredVersion: 4.33.0}
+- navi33
+- gfx1102
+- [Device 73f0]
+- Activation: false
+  ActivationComputeDataType: 1
+  ActivationNoGuard: false
+  ActivationType: none
+  AllowNoFreeDims: false
+  AssignedDerivedParameters: true
+  Batched: true
+  BetaOnlyUseBias: false
+  BiasDataTypeList: [1]
+  BiasSrc: D
+  ComplexConjugateA: false
+  ComplexConjugateB: false
+  ComputeDataType: 1
+  DataType: 1
+  DataTypeA: 1
+  DataTypeB: 1
+  DataTypeE: 1
+  DestDataType: 1
+  F32XdlMathOp: 0
+  Gradient: false
+  GroupedGemm: false
+  HighPrecisionAccumulate: false
+  Index0: 0
+  Index01A: 0
+  Index01B: 1
+  Index1: 1
+  IndexAssignmentsA: [3, 0, 2]
+  IndexAssignmentsB: [3, 1, 2]
+  IndexAssignmentsLD: [4, 5, 6, 7]
+  IndexAssignmentsMetadata: [3, 0, 2]
+  IndexUnroll: 3
+  IndexUnrollA: 0
+  IndexUnrollB: 0
+  IndexUnrollM: 0
+  IndicesBatch: [2]
+  IndicesFree: [0, 1]
+  IndicesSummation: [3]
+  MirrorDimsA: []
+  MirrorDimsB: []
+  MirrorDimsMetadata: []
+  NumIndicesBatch: 1
+  NumIndicesC: 3
+  NumIndicesFree: 2
+  NumIndicesLD: 4
+  NumIndicesSummation: 1
+  OperationType: GEMM
+  SetConstStrideA: []
+  SetConstStrideB: []
+  SetConstStrideBias: []
+  SilentHighPrecisionAccumulate: false
+  Sparse: 0
+  StochasticRounding: false
+  StridedBatched: true
+  SupportUserArgs: true
+  TLUA: false
+  TLUB: false
+  Tensor0: 0
+  Tensor1: 1
+  TileA: 0
+  TileAwareSelection: false
+  TileB: 1
+  TotalIndices: 4
+  TransposeA: true
+  TransposeB: false
+  UseBeta: true
+  UseBias: 0
+  UseE: false
+  UseInitialStridesAB: false
+  UseInitialStridesCD: false
+  UseScaleAB: ""
+  UseScaleAlphaVec: 0
+  UseScaleCD: false
+- - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_TT1_1
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 2048
+    LdsNumElementsAlignedA: 512
+    LdsNumElementsAlignedB: 512
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 1024
+    LdsOffsetB: 512
+    LdsOffsetB_Blk: 1536
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 512
+    LdsOffsetMetadata_Blk: 1536
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 1
+    NumLoadsB: 1
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 1
+    NumLoadsPerpendicularB: 1
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 0
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x8_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 8
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_TT2_2
+    LSCA: 8
+    LSCB: 8
+    LSPA: 8
+    LSPB: 8
+    LVCA: 8
+    LVCB: 8
+    LVPA: 8
+    LVPB: 8
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 8
+    LoopUnroll: 8
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 1
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x8_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 8
+    _DepthUA: 8
+    _DepthUB: 8
+    _DepthUMetadata: 8
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 2
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_TT1_1
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 4096
+    LdsNumElementsAlignedA: 1024
+    LdsNumElementsAlignedB: 1024
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 2048
+    LdsOffsetB: 1024
+    LdsOffsetB_Blk: 3072
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 1024
+    LdsOffsetMetadata_Blk: 3072
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 8
+    MacroTile1: 8
+    MacroTileA: 8
+    MacroTileB: 8
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 1
+    NumGlobalWriteVectorsPerThread: 1
+    NumLoadsA: 2
+    NumLoadsB: 2
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 2
+    NumLoadsPerpendicularB: 2
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 2
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT8x8x16_SN_GSU1_SU32_SUM0_SUS256_TT1_1_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [1, 1]
+    ThreadTile0: 1
+    ThreadTile1: 1
+    ThreadTileA: 1
+    ThreadTileB: 1
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+  - 1LDSBuffer: 0
+    ActivationAlt: false
+    ActivationFuncCall: false
+    ActivationFused: true
+    AssertFree0ElementMultiple: 1
+    AssertFree1ElementMultiple: 1
+    AssertSummationElementMultiple: 1
+    AssignedDerivedParameters: true
+    AssignedProblemIndependentDerivedParameters: true
+    BufferLoad: true
+    BufferStore: true
+    CUCount: null
+    ClusterLocalRead: 0
+    CodeObjectVersion: default
+    ConvertAfterDS: false
+    CustomKernelName: ''
+    DepthU: 16
+    DirectToLds: false
+    DirectToLdsA: false
+    DirectToLdsB: false
+    DirectToVgprSparseMetadata: false
+    EdgeType: ShiftPtr
+    EnableF32XdlMathOp: false
+    EnableMatrixInstruction: false
+    ExpandPointerSwap: true
+    ForceDisableShadowInit: false
+    GlobalReadPerMfma: 1
+    GlobalReadVectorWidthA: 1
+    GlobalReadVectorWidthB: 1
+    GlobalSplitU: 1
+    GlobalSplitUAlgorithm: MultipleBuffer
+    GlobalSplitUCoalesced: false
+    GlobalWriteVectorWidth: 1
+    GroupLoadStore: false
+    GuaranteeNoPartialA: true
+    GuaranteeNoPartialB: true
+    GuaranteeNoPartialMetadata: true
+    ISA: [11, 0, 2]
+    InnerUnroll: 1
+    InterleaveAlpha: 0
+    InternalSupportParams: {KernArgsVersion: 1, SupportCustomStaggerU: true, SupportCustomWGM: true,
+      SupportUserGSU: true, UseUniversalArgs: true}
+    KernelLanguage: Assembly
+    KernelNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_TT2_2
+    LSCA: 16
+    LSCB: 16
+    LSPA: 4
+    LSPB: 4
+    LVCA: 16
+    LVCB: 16
+    LVPA: 4
+    LVPB: 4
+    LdsBlockSizePerPadA: 0
+    LdsBlockSizePerPadB: 0
+    LdsBlockSizePerPadMetadata: 0
+    LdsInitCVgprs: false
+    LdsNumBytes: 8192
+    LdsNumElementsAlignedA: 2048
+    LdsNumElementsAlignedB: 2048
+    LdsNumElementsAlignedMetadata: 0
+    LdsOffsetA: 0
+    LdsOffsetA_Blk: 4096
+    LdsOffsetB: 2048
+    LdsOffsetB_Blk: 6144
+    LdsOffsetBias: 0
+    LdsOffsetBiasGSU: 0
+    LdsOffsetBiasNonGSU: 0
+    LdsOffsetMetadata: 2048
+    LdsOffsetMetadata_Blk: 6144
+    LdsPadA: 0
+    LdsPadB: 0
+    LdsPadMetadata: 0
+    LocalReadVectorWidth: 1
+    LocalSplitU: 1
+    LocalWritePerMfma: -1
+    LocalWriteUseSgprA: false
+    LocalWriteUseSgprB: false
+    LoopIters: 16
+    LoopUnroll: 16
+    MIArchVgpr: false
+    MIWaveTileMetadata: 0
+    MacroTile0: 16
+    MacroTile1: 16
+    MacroTileA: 16
+    MacroTileB: 16
+    MagicDivAlg: 2
+    MatrixInstruction: []
+    MaxOccupancy: 40
+    MaxVgprNumber: 256
+    MinVgprNumber: 0
+    NoLdsWriteCode: false
+    NoReject: false
+    NoTailLoop: false
+    NonTemporal: -1
+    NonTemporalA: 0
+    NonTemporalB: 0
+    NonTemporalC: 0
+    NonTemporalD: 0
+    NonTemporalE: 0
+    NonTemporalMetadata: 0
+    NumElementsPerBatchStore: 0
+    NumElementsPerThread: 4
+    NumGlobalWriteVectorsPerThread: 4
+    NumLoadsA: 4
+    NumLoadsB: 4
+    NumLoadsCoalescedA: 1
+    NumLoadsCoalescedB: 1
+    NumLoadsPerpendicularA: 4
+    NumLoadsPerpendicularB: 4
+    NumThreads: 64
+    OptNoLoadLoop: 1
+    PackedC0IdxChars: [I]
+    PackedC0IndicesX: [0]
+    PackedC1IdxChars: [J]
+    PackedC1IndicesX: [1]
+    PrefetchGlobalRead: 1
+    PrefetchLocalRead: 0
+    PreloadKernArgs: 0
+    ProblemType:
+      Activation: false
+      ActivationComputeDataType: 1
+      ActivationNoGuard: false
+      ActivationType: none
+      AllowNoFreeDims: false
+      AssignedDerivedParameters: true
+      Batched: true
+      BetaOnlyUseBias: false
+      BiasDataTypeList: [1]
+      BiasSrc: D
+      ComplexConjugateA: false
+      ComplexConjugateB: false
+      ComputeDataType: 1
+      DataType: 1
+      DataTypeA: 1
+      DataTypeB: 1
+      DataTypeE: 1
+      DestDataType: 1
+      F32XdlMathOp: 0
+      Gradient: false
+      GroupedGemm: false
+      HighPrecisionAccumulate: false
+      Index0: 0
+      Index01A: 0
+      Index01B: 1
+      Index1: 1
+      IndexAssignmentsA: [3, 0, 2]
+      IndexAssignmentsB: [3, 1, 2]
+      IndexAssignmentsLD: [4, 5, 6, 7]
+      IndexAssignmentsMetadata: [3, 0, 2]
+      IndexUnroll: 3
+      IndexUnrollA: 0
+      IndexUnrollB: 0
+      IndexUnrollM: 0
+      IndicesBatch: [2]
+      IndicesFree: [0, 1]
+      IndicesSummation: [3]
+      MirrorDimsA: []
+      MirrorDimsB: []
+      MirrorDimsMetadata: []
+      NumIndicesBatch: 1
+      NumIndicesC: 3
+      NumIndicesFree: 2
+      NumIndicesLD: 4
+      NumIndicesSummation: 1
+      OperationType: GEMM
+      SetConstStrideA: []
+      SetConstStrideB: []
+      SetConstStrideBias: []
+      SilentHighPrecisionAccumulate: false
+      Sparse: 0
+      StochasticRounding: false
+      StridedBatched: true
+      SupportUserArgs: true
+      TLUA: false
+      TLUB: false
+      Tensor0: 0
+      Tensor1: 1
+      TileA: 0
+      TileAwareSelection: false
+      TileB: 1
+      TotalIndices: 4
+      TransposeA: true
+      TransposeB: false
+      UseBeta: true
+      UseBias: 0
+      UseE: false
+      UseInitialStridesAB: false
+      UseInitialStridesCD: false
+      UseScaleAB: ""
+      UseScaleAlphaVec: 0
+      UseScaleCD: false
+    ScheduleGlobalRead: 1
+    ScheduleIterAlg: 1
+    ScheduleLocalWrite: 1
+    SolutionIndex: 3
+    SolutionNameMin: Cijk_Alik_Bljk_DB_UserArgs_MT16x16x16_SN_GSU1_SU32_SUM0_SUS256_TT2_2_WGM1
+    SourceSwap: false
+    StaggerU: 32
+    StaggerUMapping: 0
+    StaggerUStride: 256
+    StorePriorityOpt: false
+    StoreRemapVectorWidth: 0
+    StoreSyncOpt: 0
+    StoreVectorWidth: 1
+    SubGroup0: 8
+    SubGroup1: 8
+    SubGroupA: 8
+    SubGroupB: 8
+    SuppressNoLoadLoop: false
+    ThreadTile: [2, 2]
+    ThreadTile0: 2
+    ThreadTile1: 2
+    ThreadTileA: 2
+    ThreadTileB: 2
+    TransposeLDS: 0
+    TransposeLDSMetadata: true
+    UnrollMajorLDSA: false
+    UnrollMajorLDSB: false
+    UnrollMajorLDSMetadata: true
+    Use64bShadowLimit: 1
+    UseInstOffsetForGRO: 0
+    UseSgprForGRO: -1
+    Valid: true
+    VectorStore: -1
+    VectorWidthA: 1
+    VectorWidthB: 1
+    WaveSeparateGlobalReadA: 0
+    WaveSeparateGlobalReadB: 0
+    WaveSeparateGlobalReadMetadata: 0
+    WavefrontSize: 32
+    WorkGroup: [8, 8, 1]
+    WorkGroupMapping: 1
+    WorkGroupMappingXCC: 1
+    WorkGroupReduction: false
+    WorkspaceCheck: [8, 0, 1]
+    _DepthU: 16
+    _DepthUA: 16
+    _DepthUB: 16
+    _DepthUMetadata: 16
+    _GlobalAccumulation: MultipleBuffer
+    _UseSgprForGRO: 1
+    _VectorStore: 1
+    _WorkspaceSizePerElemBias: 0
+    _WorkspaceSizePerElemC: 8
+    _staggerStrideShift: 1
+- [2, 3, 0, 1]
+- - - [64, 64, 1, 32, 64, 64, 32, 32]
+    - [1, 1.15885]
+  - - [128, 64, 1, 32, 128, 128, 32, 32]
+    - [3, 2.32324]
+  - - [192, 64, 1, 32, 192, 192, 32, 32]
+    - [2, 3.48116]
+  - - [256, 64, 1, 32, 256, 256, 32, 32]
+    - [2, 4.67611]
+  - - [320, 64, 1, 32, 320, 320, 32, 32]
+    - [3, 5.79706]
+  - - [384, 64, 1, 32, 384, 384, 32, 32]
+    - [3, 72.9529]
+  - - [448, 64, 1, 32, 448, 448, 32, 32]
+    - [2, 8.11405]
+  - - [512, 64, 1, 32, 512, 512, 32, 32]
+    - [3, 85.8082]
+  - - [576, 64, 1, 32, 576, 576, 32, 32]
+    - [3, 10.4384]
+  - - [640, 64, 1, 32, 640, 640, 32, 32]
+    - [1, 11.5436]
+  - - [704, 64, 1, 32, 704, 704, 32, 32]
+    - [3, 117.41]
+  - - [768, 64, 1, 32, 768, 768, 32, 32]
+    - [0, 13.8645]
+  - - [832, 64, 1, 32, 832, 832, 32, 32]
+    - [3, 14.9874]
+  - - [896, 64, 1, 32, 896, 896, 32, 32]
+    - [3, 16.1559]
+  - - [960, 64, 1, 32, 960, 960, 32, 32]
+    - [0, 17.3001]
+  - - [1024, 64, 1, 32, 1024, 1024, 32, 32]
+    - [2, 18.4299]
+  - - [64, 128, 1, 32, 64, 64, 32, 32]
+    - [2, 2.31268]
+  - - [128, 128, 1, 32, 128, 128, 32, 32]
+    - [3, 47.0636]
+  - - [192, 128, 1, 32, 192, 192, 32, 32]
+    - [2, 75.4733]
+  - - [256, 128, 1, 32, 256, 256, 32, 32]
+    - [2, 93.9542]
+  - - [320, 128, 1, 32, 320, 320, 32, 32]
+    - [2, 109.227]
+  - - [384, 128, 1, 32, 384, 384, 32, 32]
+    - [1, 13.8266]
+  - - [448, 128, 1, 32, 448, 448, 32, 32]
+    - [3, 124.83]
+  - - [512, 128, 1, 32, 512, 512, 32, 32]
+    - [3, 18.2917]
+  - - [576, 128, 1, 32, 576, 576, 32, 32]
+    - [0, 20.7346]
+  - - [640, 128, 1, 32, 640, 640, 32, 32]
+    - [1, 23.0505]
+  - - [704, 128, 1, 32, 704, 704, 32, 32]
+    - [2, 25.3635]
+  - - [768, 128, 1, 32, 768, 768, 32, 32]
+    - [1, 27.6814]
+  - - [832, 128, 1, 32, 832, 832, 32, 32]
+    - [1, 29.9696]
+  - - [896, 128, 1, 32, 896, 896, 32, 32]
+    - [2, 32.2652]
+  - - [960, 128, 1, 32, 960, 960, 32, 32]
+    - [2, 34.5972]
+  - - [1024, 128, 1, 32, 1024, 1024, 32, 32]
+    - [2, 36.8745]
+  - - [64, 192, 1, 32, 64, 64, 32, 32]
+    - [0, 3.46628]
+  - - [128, 192, 1, 32, 128, 128, 32, 32]
+    - [3, 6.93591]
+  - - [192, 192, 1, 32, 192, 192, 32, 32]
+    - [3, 10.3805]
+  - - [256, 192, 1, 32, 256, 256, 32, 32]
+    - [2, 13.8505]
+  - - [320, 192, 1, 32, 320, 320, 32, 32]
+    - [3, 17.316]
+  - - [384, 192, 1, 32, 384, 384, 32, 32]
+    - [1, 7.68846]
+  - - [448, 192, 1, 32, 448, 448, 32, 32]
+    - [3, 9.14738]
+  - - [512, 192, 1, 32, 512, 512, 32, 32]
+    - [2, 10.3843]
+  - - [576, 192, 1, 32, 576, 576, 32, 32]
+    - [1, 11.6535]
+  - - [640, 192, 1, 32, 640, 640, 32, 32]
+    - [2, 12.944]
+  - - [704, 192, 1, 32, 704, 704, 32, 32]
+    - [2, 14.3917]
+  - - [768, 192, 1, 32, 768, 768, 32, 32]
+    - [2, 15.7115]
+  - - [832, 192, 1, 32, 832, 832, 32, 32]
+    - [2, 220.337]
+  - - [896, 192, 1, 32, 896, 896, 32, 32]
+    - [2, 18.3103]
+  - - [960, 192, 1, 32, 960, 960, 32, 32]
+    - [1, 19.5163]
+  - - [1024, 192, 1, 32, 1024, 1024, 32, 32]
+    - [3, 137.893]
+  - - [64, 256, 1, 32, 64, 64, 32, 32]
+    - [3, 5.97204]
+  - - [128, 256, 1, 32, 128, 128, 32, 32]
+    - [2, 3.49203]
+  - - [192, 256, 1, 32, 192, 192, 32, 32]
+    - [2, 5.33651]
+  - - [256, 256, 1, 32, 256, 256, 32, 32]
+    - [3, 6.97152]
+  - - [320, 256, 1, 32, 320, 320, 32, 32]
+    - [2, 8.71078]
+  - - [384, 256, 1, 32, 384, 384, 32, 32]
+    - [3, 10.4597]
+  - - [448, 256, 1, 32, 448, 448, 32, 32]
+    - [1, 203.663]
+  - - [512, 256, 1, 32, 512, 512, 32, 32]
+    - [2, 13.9188]
+  - - [576, 256, 1, 32, 576, 576, 32, 32]
+    - [2, 29.9022]
+  - - [640, 256, 1, 32, 640, 640, 32, 32]
+    - [2, 17.1125]
+  - - [704, 256, 1, 32, 704, 704, 32, 32]
+    - [2, 19.0225]
+  - - [768, 256, 1, 32, 768, 768, 32, 32]
+    - [3, 20.817]
+  - - [832, 256, 1, 32, 832, 832, 32, 32]
+    - [3, 22.6918]
+  - - [896, 256, 1, 32, 896, 896, 32, 32]
+    - [3, 24.2741]
+  - - [960, 256, 1, 32, 960, 960, 32, 32]
+    - [3, 20.772]
+  - - [1024, 256, 1, 32, 1024, 1024, 32, 32]
+    - [3, 237.638]
+  - - [64, 320, 1, 32, 64, 64, 32, 32]
+    - [2, 62.7739]
+  - - [128, 320, 1, 32, 128, 128, 32, 32]
+    - [2, 4.32093]
+  - - [192, 320, 1, 32, 192, 192, 32, 32]
+    - [1, 6.51134]
+  - - [256, 320, 1, 32, 256, 256, 32, 32]
+    - [3, 8.74086]
+  - - [320, 320, 1, 32, 320, 320, 32, 32]
+    - [2, 10.8937]
+  - - [384, 320, 1, 32, 384, 384, 32, 32]
+    - [2, 12.66]
+  - - [448, 320, 1, 32, 448, 448, 32, 32]
+    - [2, 15.2365]
+  - - [512, 320, 1, 32, 512, 512, 32, 32]
+    - [2, 17.4799]
+  - - [576, 320, 1, 32, 576, 576, 32, 32]
+    - [2, 19.514]
+  - - [640, 320, 1, 32, 640, 640, 32, 32]
+    - [2, 21.8103]
+  - - [704, 320, 1, 32, 704, 704, 32, 32]
+    - [1, 23.6307]
+  - - [768, 320, 1, 32, 768, 768, 32, 32]
+    - [1, 25.6416]
+  - - [832, 320, 1, 32, 832, 832, 32, 32]
+    - [3, 28.0408]
+  - - [896, 320, 1, 32, 896, 896, 32, 32]
+    - [1, 29.8762]
+  - - [960, 320, 1, 32, 960, 960, 32, 32]
+    - [1, 32.2111]
+  - - [1024, 320, 1, 32, 1024, 1024, 32, 32]
+    - [3, 31.1564]
+  - - [64, 384, 1, 32, 64, 64, 32, 32]
+    - [1, 2.61567]
+  - - [128, 384, 1, 32, 128, 128, 32, 32]
+    - [3, 5.26381]
+  - - [192, 384, 1, 32, 192, 192, 32, 32]
+    - [2, 7.81608]
+  - - [256, 384, 1, 32, 256, 256, 32, 32]
+    - [1, 10.3665]
+  - - [320, 384, 1, 32, 320, 320, 32, 32]
+    - [2, 13.0853]
+  - - [384, 384, 1, 32, 384, 384, 32, 32]
+    - [2, 15.5012]
+  - - [448, 384, 1, 32, 448, 448, 32, 32]
+    - [2, 18.2013]
+  - - [512, 384, 1, 32, 512, 512, 32, 32]
+    - [3, 21.0359]
+  - - [576, 384, 1, 32, 576, 576, 32, 32]
+    - [2, 23.2003]
+  - - [640, 384, 1, 32, 640, 640, 32, 32]
+    - [3, 233.224]
+  - - [704, 384, 1, 32, 704, 704, 32, 32]
+    - [2, 28.4422]
+  - - [768, 384, 1, 32, 768, 768, 32, 32]
+    - [2, 30.8141]
+  - - [832, 384, 1, 32, 832, 832, 32, 32]
+    - [3, 32.5949]
+  - - [896, 384, 1, 32, 896, 896, 32, 32]
+    - [3, 34.7521]
+  - - [960, 384, 1, 32, 960, 960, 32, 32]
+    - [3, 33.5664]
+  - - [1024, 384, 1, 32, 1024, 1024, 32, 32]
+    - [3, 37.4289]
+  - - [64, 448, 1, 32, 64, 64, 32, 32]
+    - [1, 3.0641]
+  - - [128, 448, 1, 32, 128, 128, 32, 32]
+    - [2, 6.09522]
+  - - [192, 448, 1, 32, 192, 192, 32, 32]
+    - [1, 179.903]
+  - - [256, 448, 1, 32, 256, 256, 32, 32]
+    - [2, 11.7963]
+  - - [320, 448, 1, 32, 320, 320, 32, 32]
+    - [2, 15.1838]
+  - - [384, 448, 1, 32, 384, 384, 32, 32]
+    - [3, 18.3064]
+  - - [448, 448, 1, 32, 448, 448, 32, 32]
+    - [3, 21.3841]
+  - - [512, 448, 1, 32, 512, 512, 32, 32]
+    - [3, 18.3367]
+  - - [576, 448, 1, 32, 576, 576, 32, 32]
+    - [3, 27.083]
+  - - [640, 448, 1, 32, 640, 640, 32, 32]
+    - [3, 26.9496]
+  - - [704, 448, 1, 32, 704, 704, 32, 32]
+    - [1, 32.8944]
+  - - [768, 448, 1, 32, 768, 768, 32, 32]
+    - [3, 35.0341]
+  - - [832, 448, 1, 32, 832, 832, 32, 32]
+    - [2, 26.0992]
+  - - [896, 448, 1, 32, 896, 896, 32, 32]
+    - [1, 41.1343]
+  - - [960, 448, 1, 32, 960, 960, 32, 32]
+    - [3, 40.0223]
+  - - [1024, 448, 1, 32, 1024, 1024, 32, 32]
+    - [3, 38.111]
+  - - [64, 512, 1, 32, 64, 64, 32, 32]
+    - [2, 3.53227]
+  - - [128, 512, 1, 32, 128, 128, 32, 32]
+    - [1, 6.93958]
+  - - [192, 512, 1, 32, 192, 192, 32, 32]
+    - [3, 10.4611]
+  - - [256, 512, 1, 32, 256, 256, 32, 32]
+    - [1, 13.7945]
+  - - [320, 512, 1, 32, 320, 320, 32, 32]
+    - [2, 17.3286]
+  - - [384, 512, 1, 32, 384, 384, 32, 32]
+    - [2, 20.6608]
+  - - [448, 512, 1, 32, 448, 448, 32, 32]
+    - [2, 24.2853]
+  - - [512, 512, 1, 32, 512, 512, 32, 32]
+    - [1, 27.4679]
+  - - [576, 512, 1, 32, 576, 576, 32, 32]
+    - [0, 17.8717]
+  - - [640, 512, 1, 32, 640, 640, 32, 32]
+    - [2, 270.667]
+  - - [704, 512, 1, 32, 704, 704, 32, 32]
+    - [2, 36.9238]
+  - - [768, 512, 1, 32, 768, 768, 32, 32]
+    - [3, 39.3362]
+  - - [832, 512, 1, 32, 832, 832, 32, 32]
+    - [3, 40.6126]
+  - - [896, 512, 1, 32, 896, 896, 32, 32]
+    - [3, 37.5678]
+  - - [960, 512, 1, 32, 960, 960, 32, 32]
+    - [2, 46.6799]
+  - - [1024, 512, 1, 32, 1024, 1024, 32, 32]
+    - [1, 49.4521]
+  - - [64, 576, 1, 32, 64, 64, 32, 32]
+    - [3, 4.16165]
+  - - [128, 576, 1, 32, 128, 128, 32, 32]
+    - [1, 165.211]
+  - - [192, 576, 1, 32, 192, 192, 32, 32]
+    - [1, 11.6914]
+  - - [256, 576, 1, 32, 256, 256, 32, 32]
+    - [2, 15.6145]
+  - - [320, 576, 1, 32, 320, 320, 32, 32]
+    - [3, 19.5201]
+  - - [384, 576, 1, 32, 384, 384, 32, 32]
+    - [2, 23.3173]
+  - - [448, 576, 1, 32, 448, 448, 32, 32]
+    - [2, 26.4926]
+  - - [512, 576, 1, 32, 512, 512, 32, 32]
+    - [2, 30.8559]
+  - - [576, 576, 1, 32, 576, 576, 32, 32]
+    - [1, 25.7695]
+  - - [640, 576, 1, 32, 640, 640, 32, 32]
+    - [1, 38.4963]
+  - - [704, 576, 1, 32, 704, 704, 32, 32]
+    - [1, 38.0312]
+  - - [768, 576, 1, 32, 768, 768, 32, 32]
+    - [1, 45.0796]
+  - - [832, 576, 1, 32, 832, 832, 32, 32]
+    - [2, 47.4484]
+  - - [896, 576, 1, 32, 896, 896, 32, 32]
+    - [2, 48.7268]
+  - - [960, 576, 1, 32, 960, 960, 32, 32]
+    - [2, 49.2269]
+  - - [1024, 576, 1, 32, 1024, 1024, 32, 32]
+    - [2, 55.1113]
+  - - [64, 640, 1, 32, 64, 64, 32, 32]
+    - [1, 4.31759]
+  - - [128, 640, 1, 32, 128, 128, 32, 32]
+    - [3, 8.77126]
+  - - [192, 640, 1, 32, 192, 192, 32, 32]
+    - [2, 13.0281]
+  - - [256, 640, 1, 32, 256, 256, 32, 32]
+    - [3, 17.3725]
+  - - [320, 640, 1, 32, 320, 320, 32, 32]
+    - [2, 21.5674]
+  - - [384, 640, 1, 32, 384, 384, 32, 32]
+    - [2, 25.8732]
+  - - [448, 640, 1, 32, 448, 448, 32, 32]
+    - [3, 233.34]
+  - - [512, 640, 1, 32, 512, 512, 32, 32]
+    - [1, 29.7957]
+  - - [576, 640, 1, 32, 576, 576, 32, 32]
+    - [2, 37.6816]
+  - - [640, 640, 1, 32, 640, 640, 32, 32]
+    - [3, 39.1071]
+  - - [704, 640, 1, 32, 704, 704, 32, 32]
+    - [3, 44.6269]
+  - - [768, 640, 1, 32, 768, 768, 32, 32]
+    - [0, 45.3769]
+  - - [832, 640, 1, 32, 832, 832, 32, 32]
+    - [1, 50.2744]
+  - - [896, 640, 1, 32, 896, 896, 32, 32]
+    - [0, 53.1083]
+  - - [960, 640, 1, 32, 960, 960, 32, 32]
+    - [3, 55.344]
+  - - [1024, 640, 1, 32, 1024, 1024, 32, 32]
+    - [1, 61.5259]
+  - - [64, 704, 1, 32, 64, 64, 32, 32]
+    - [1, 4.78203]
+  - - [128, 704, 1, 32, 128, 128, 32, 32]
+    - [1, 9.11814]
+  - - [192, 704, 1, 32, 192, 192, 32, 32]
+    - [3, 14.38]
+  - - [256, 704, 1, 32, 256, 256, 32, 32]
+    - [3, 19.1484]
+  - - [320, 704, 1, 32, 320, 320, 32, 32]
+    - [2, 23.4029]
+  - - [384, 704, 1, 32, 384, 384, 32, 32]
+    - [1, 28.2559]
+  - - [448, 704, 1, 32, 448, 448, 32, 32]
+    - [3, 22.4257]
+  - - [512, 704, 1, 32, 512, 512, 32, 32]
+    - [3, 36.3124]
+  - - [576, 704, 1, 32, 576, 576, 32, 32]
+    - [0, 37.5889]
+  - - [640, 704, 1, 32, 640, 640, 32, 32]
+    - [3, 42.7372]
+  - - [704, 704, 1, 32, 704, 704, 32, 32]
+    - [2, 46.9011]
+  - - [768, 704, 1, 32, 768, 768, 32, 32]
+    - [2, 50.9832]
+  - - [832, 704, 1, 32, 832, 832, 32, 32]
+    - [2, 54.8969]
+  - - [896, 704, 1, 32, 896, 896, 32, 32]
+    - [1, 49.5075]
+  - - [960, 704, 1, 32, 960, 960, 32, 32]
+    - [2, 63.639]
+  - - [1024, 704, 1, 32, 1024, 1024, 32, 32]
+    - [2, 66.0261]
+  - - [64, 768, 1, 32, 64, 64, 32, 32]
+    - [1, 5.19274]
+  - - [128, 768, 1, 32, 128, 128, 32, 32]
+    - [2, 10.3992]
+  - - [192, 768, 1, 32, 192, 192, 32, 32]
+    - [3, 223.418]
+  - - [256, 768, 1, 32, 256, 256, 32, 32]
+    - [1, 266.136]
+  - - [320, 768, 1, 32, 320, 320, 32, 32]
+    - [3, 231.986]
+  - - [384, 768, 1, 32, 384, 384, 32, 32]
+    - [3, 30.6112]
+  - - [448, 768, 1, 32, 448, 448, 32, 32]
+    - [2, 31.5821]
+  - - [512, 768, 1, 32, 512, 512, 32, 32]
+    - [1, 40.6042]
+  - - [576, 768, 1, 32, 576, 576, 32, 32]
+    - [3, 41.8486]
+  - - [640, 768, 1, 32, 640, 640, 32, 32]
+    - [1, 41.7104]
+  - - [704, 768, 1, 32, 704, 704, 32, 32]
+    - [3, 275.064]
+  - - [768, 768, 1, 32, 768, 768, 32, 32]
+    - [1, 55.7396]
+  - - [832, 768, 1, 32, 832, 832, 32, 32]
+    - [3, 51.1568]
+  - - [896, 768, 1, 32, 896, 896, 32, 32]
+    - [1, 61.4199]
+  - - [960, 768, 1, 32, 960, 960, 32, 32]
+    - [3, 67.4196]
+  - - [1024, 768, 1, 32, 1024, 1024, 32, 32]
+    - [1, 73.2776]
+  - - [64, 832, 1, 32, 64, 64, 32, 32]
+    - [1, 5.63096]
+  - - [128, 832, 1, 32, 128, 128, 32, 32]
+    - [1, 11.1455]
+  - - [192, 832, 1, 32, 192, 192, 32, 32]
+    - [3, 16.7104]
+  - - [256, 832, 1, 32, 256, 256, 32, 32]
+    - [1, 22.388]
+  - - [320, 832, 1, 32, 320, 320, 32, 32]
+    - [0, 24.4102]
+  - - [384, 832, 1, 32, 384, 384, 32, 32]
+    - [1, 29.782]
+  - - [448, 832, 1, 32, 448, 448, 32, 32]
+    - [0, 31.3102]
+  - - [512, 832, 1, 32, 512, 512, 32, 32]
+    - [1, 39.0439]
+  - - [576, 832, 1, 32, 576, 576, 32, 32]
+    - [3, 44.3718]
+  - - [640, 832, 1, 32, 640, 640, 32, 32]
+    - [3, 48.3954]
+  - - [704, 832, 1, 32, 704, 704, 32, 32]
+    - [3, 45.2543]
+  - - [768, 832, 1, 32, 768, 768, 32, 32]
+    - [1, 56.8015]
+  - - [832, 832, 1, 32, 832, 832, 32, 32]
+    - [1, 54.7432]
+  - - [896, 832, 1, 32, 896, 896, 32, 32]
+    - [3, 58.3343]
+  - - [960, 832, 1, 32, 960, 960, 32, 32]
+    - [3, 71.7503]
+  - - [1024, 832, 1, 32, 1024, 1024, 32, 32]
+    - [1, 79.1776]
+  - - [64, 896, 1, 32, 64, 64, 32, 32]
+    - [1, 6.06912]
+  - - [128, 896, 1, 32, 128, 128, 32, 32]
+    - [2, 12.1569]
+  - - [192, 896, 1, 32, 192, 192, 32, 32]
+    - [2, 18.2019]
+  - - [256, 896, 1, 32, 256, 256, 32, 32]
+    - [2, 245.482]
+  - - [320, 896, 1, 32, 320, 320, 32, 32]
+    - [1, 29.0058]
+  - - [384, 896, 1, 32, 384, 384, 32, 32]
+    - [2, 35.5104]
+  - - [448, 896, 1, 32, 448, 448, 32, 32]
+    - [3, 28.1229]
+  - - [512, 896, 1, 32, 512, 512, 32, 32]
+    - [0, 42.3518]
+  - - [576, 896, 1, 32, 576, 576, 32, 32]
+    - [2, 48.9644]
+  - - [640, 896, 1, 32, 640, 640, 32, 32]
+    - [2, 45.7064]
+  - - [704, 896, 1, 32, 704, 704, 32, 32]
+    - [1, 59.4734]
+  - - [768, 896, 1, 32, 768, 768, 32, 32]
+    - [3, 51.5563]
+  - - [832, 896, 1, 32, 832, 832, 32, 32]
+    - [1, 70.0206]
+  - - [896, 896, 1, 32, 896, 896, 32, 32]
+    - [2, 72.8327]
+  - - [960, 896, 1, 32, 960, 960, 32, 32]
+    - [3, 75.7387]
+  - - [1024, 896, 1, 32, 1024, 1024, 32, 32]
+    - [3, 316.72]
+  - - [64, 960, 1, 32, 64, 64, 32, 32]
+    - [3, 47.761]
+  - - [128, 960, 1, 32, 128, 128, 32, 32]
+    - [3, 73.8913]
+  - - [192, 960, 1, 32, 192, 192, 32, 32]
+    - [2, 19.4311]
+  - - [256, 960, 1, 32, 256, 256, 32, 32]
+    - [2, 24.6167]
+  - - [320, 960, 1, 32, 320, 320, 32, 32]
+    - [2, 32.1022]
+  - - [384, 960, 1, 32, 384, 384, 32, 32]
+    - [3, 37.3233]
+  - - [448, 960, 1, 32, 448, 448, 32, 32]
+    - [0, 39.6573]
+  - - [512, 960, 1, 32, 512, 512, 32, 32]
+    - [1, 317.879]
+  - - [576, 960, 1, 32, 576, 576, 32, 32]
+    - [2, 47.8887]
+  - - [640, 960, 1, 32, 640, 640, 32, 32]
+    - [3, 45.7758]
+  - - [704, 960, 1, 32, 704, 704, 32, 32]
+    - [0, 62.4041]
+  - - [768, 960, 1, 32, 768, 768, 32, 32]
+    - [1, 69.5882]
+  - - [832, 960, 1, 32, 832, 832, 32, 32]
+    - [2, 72.5228]
+  - - [896, 960, 1, 32, 896, 896, 32, 32]
+    - [2, 77.1612]
+  - - [960, 960, 1, 32, 960, 960, 32, 32]
+    - [1, 84.0368]
+  - - [1024, 960, 1, 32, 1024, 1024, 32, 32]
+    - [3, 84.7878]
+  - - [64, 1024, 1, 32, 64, 64, 32, 32]
+    - [2, 6.94924]
+  - - [128, 1024, 1, 32, 128, 128, 32, 32]
+    - [1, 13.864]
+  - - [192, 1024, 1, 32, 192, 192, 32, 32]
+    - [3, 20.9498]
+  - - [256, 1024, 1, 32, 256, 256, 32, 32]
+    - [3, 27.3377]
+  - - [320, 1024, 1, 32, 320, 320, 32, 32]
+    - [1, 30.6626]
+  - - [384, 1024, 1, 32, 384, 384, 32, 32]
+    - [3, 37.2913]
+  - - [448, 1024, 1, 32, 448, 448, 32, 32]
+    - [3, 43.6989]
+  - - [512, 1024, 1, 32, 512, 512, 32, 32]
+    - [1, 49.0983]
+  - - [576, 1024, 1, 32, 576, 576, 32, 32]
+    - [2, 55.7223]
+  - - [640, 1024, 1, 32, 640, 640, 32, 32]
+    - [1, 61.4772]
+  - - [704, 1024, 1, 32, 704, 704, 32, 32]
+    - [1, 65.5096]
+  - - [768, 1024, 1, 32, 768, 768, 32, 32]
+    - [2, 71.6308]
+  - - [832, 1024, 1, 32, 832, 832, 32, 32]
+    - [3, 76.1074]
+  - - [896, 1024, 1, 32, 896, 896, 32, 32]
+    - [1, 83.761]
+  - - [960, 1024, 1, 32, 960, 960, 32, 32]
+    - [0, 85.4755]
+  - - [1024, 1024, 1, 32, 1024, 1024, 32, 32]
+    - [0, 519.579]
+- null
+- null
+- DeviceEfficiency
+- Equality

--- a/tensilelite/Tensile/Components/ComputeStoreVgprs.py
+++ b/tensilelite/Tensile/Components/ComputeStoreVgprs.py
@@ -100,9 +100,9 @@ class ComputeStoreVgprsVALU(ComputeStoreVgprs):
             module.add(SMulI32(dst=sgpr(tmpS0), src0=hex(kernel["MacroTile0"]), src1=sgpr(wg0), comment="%s = wg0*MT0"%sgpr(tmpS0)))
 
             # coord = tid*VW + workgroup offset
-            module.add(VAddCOU32(dst=vgpr(tid0), dst1="vcc", src0=sgpr(tmpS0), src1=vgpr(tid0), comment="coord0 = tid0*VW + wg0*MT0"))
+            module.add(VAddU32(dst=vgpr(tid0), src0=sgpr(tmpS0), src1=vgpr(tid0), comment="coord0 = tid0*VW + wg0*MT0"))
             module.add(SMulI32(dst=sgpr(wgMT1), src0=hex(kernel["MacroTile1"]), src1=sgpr(wg1), comment="<- wg1*MT1"))
-            module.add(VAddCOU32(dst=vgpr(tid1), dst1="vcc", src0=sgpr(wgMT1), src1=vgpr(tid1), comment="coord1 = tid1*VW + wg1*MT1"))
+            module.add(VAddU32(dst=vgpr(tid1), src0=sgpr(wgMT1), src1=vgpr(tid1), comment="coord1 = tid1*VW + wg1*MT1"))
 
             if len(packedC1) > 1:
                 module.add(writer.extractPackedCoord1ToRowStart(kernel, packedC1, tid1, 'D'))

--- a/tensilelite/Tensile/Components/MAC_F32.py
+++ b/tensilelite/Tensile/Components/MAC_F32.py
@@ -61,7 +61,8 @@ class MAC_F32_Plain(MAC):
                     bStr = "ValuB_X{m}_I{iui}+{b}".format_map(vars)
 
                     module.add(VMacF32(dst=vgpr(cStr), src0=vgpr(aStr), src1=vgpr(bStr)))
-                    module.add(SSetPrior(prior=1, comment="Raise priority while processing macs"))
+                    if (idx1 is 0) and (idx0 is 0) and (iui is 0):
+                        module.add(SSetPrior(prior=1, comment="Raise priority while processing macs"))
 
         module.add(SSetPrior(prior=0, comment="Reset priority after macs"))
 

--- a/tensilelite/Tensile/Components/MAC_F64.py
+++ b/tensilelite/Tensile/Components/MAC_F64.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,18 +22,21 @@
 #
 ################################################################################
 
-from ..TensileInstructions import DataType, Module
+from ..TensileInstructions import DataType, Module, vgpr, VFmaF64, SSetPrior
 from ..Component import Component, MAC
 
 class FMA_F64_Plain(MAC):
+    """
+    Plain MAC instruction implementation
+    """
     asmCaps = {"v_fma_f64": True}
     kernel = {"ProblemType": {"DataType": DataType(DataType.double)}}
 
-    def __call__(self, writer, m, innerUnroll):
+    def __call__(self, writer, tPA, tPB, m, innerUnroll):
         kernel = writer.states.kernel
-        module = Module("FMA_F64_Plain")
+
+        module = Module("MAC_F64_Plain")
         module.addComment(self.commentHeader())
-        priority = Component.Priority.find(writer)
 
         vars = {}
         vars["m"] = m
@@ -45,11 +48,16 @@ class FMA_F64_Plain(MAC):
                 vars["a"] = a
                 for iui in range(0, innerUnroll):
                     vars["iui"] = iui
-                    cStr        = "v[vgprValuC+({a}+{b}*{ThreadTile0})*2:(vgprValuC+{a}+{b}*{ThreadTile0})*2+1]".format_map(vars)
-                    aStr        = "v[vgprValuA_X{m}_I{iui}+{a}*2:vgprValuA_X{m}_I{iui}+{a}*2+1]".format_map(vars)
-                    bStr        = "v[vgprValuB_X{m}_I{iui}+{b}*2:vgprValuB_X{m}_I{iui}+{b}*2+1]".format_map(vars)
-                    module.addInst("v_fma_f64", cStr, aStr, bStr, cStr, "")
-                    module.add(priority(writer, 1, "Raise priority while processing macs"))
 
-        module.add(priority(writer, 0, "Reset priority after macs"))
+                    cStr = "ValuC+%d" % ((vars["a"]+vars["b"]*vars["ThreadTile0"])*2)
+                    aStr = "ValuA_X%d_I%d+%d" % (vars["m"], vars["iui"], vars["a"]*2)
+                    bStr = "ValuB_X%d_I%d+%d" % (vars["m"], vars["iui"], vars["b"]*2)
+
+                    module.add(VFmaF64(dst=vgpr(cStr, 2), src0=vgpr(aStr, 2),
+                                       src1=vgpr(bStr, 2), src2=vgpr(cStr, 2)))
+                    if (b is 0) and (a is 0) and (iui is 0):
+                        module.add(SSetPrior(prior=1, comment="Raise priority while processing macs"))
+
+        module.add(SSetPrior(prior=0, comment="Reset priority after macs"))
+
         return module

--- a/tensilelite/Tensile/Tests/common/gemm/gfx11/f32_mac.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx11/f32_mac.yaml
@@ -1,0 +1,203 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.14.0
+  SleepPercent: 50
+  NumElementsToValidate: 128
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      ComputeDataType: s
+      TransposeA: false
+      TransposeB: false
+      UseScaleAlphaVec: 1
+      UseBeta: true
+      UseBias: 1
+      Batched: true
+      Activation: true
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+          - [Enum: gelu]
+          - [Enum: geluscaling]
+          - [Enum: relu]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      ComputeDataType: s
+      TransposeA: false
+      TransposeB: true
+      UseScaleAlphaVec: 1
+      UseBeta: true
+      UseBias: 1
+      Batched: true
+      Activation: true
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+          - [Enum: gelu]
+          - [Enum: geluscaling]
+          - [Enum: relu]
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      ComputeDataType: s
+      TransposeA: true
+      TransposeB: false
+      UseScaleAlphaVec: 1
+      UseBeta: true
+      UseBias: 1
+      Batched: true
+      Activation: true
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+          - [Enum: gelu]
+          - [Enum: geluscaling]
+          - [Enum: relu]
+
+  ########################################
+  # TT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      ComputeDataType: s
+      TransposeA: true
+      TransposeB: true
+      UseScaleAlphaVec: 1
+      UseBeta: true
+      UseBias: 1
+      Batched: true
+      Activation: true
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+          - [Enum: gelu]
+          - [Enum: geluscaling]
+          - [Enum: relu]

--- a/tensilelite/Tensile/Tests/common/gemm/gfx11/f64_mac.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx11/f64_mac.yaml
@@ -1,0 +1,175 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030] # not supported by arch
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.14.0
+  SleepPercent: 50
+  NumElementsToValidate: 128
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+  PrintSolutionRejectionReason: True
+
+BenchmarkProblems:
+  ########################################
+  # NN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: false
+      TransposeB: false
+      UseScaleAlphaVec: 0
+      UseBeta: true
+      UseBias: 0
+      Batched: true
+      Activation: false
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+
+  ########################################
+  # NT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: false
+      TransposeB: true
+      UseScaleAlphaVec: 0
+      UseBeta: true
+      UseBias: 0
+      Batched: true
+      Activation: false
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+
+  ########################################
+  # TN - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: true
+      TransposeB: false
+      UseScaleAlphaVec: 0
+      UseBeta: true
+      UseBias: 0
+      Batched: true
+      Activation: false
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]
+
+  ########################################
+  # TT - standard
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: d
+      TransposeA: true
+      TransposeB: true
+      UseScaleAlphaVec: 0
+      UseBeta: true
+      UseBias: 0
+      Batched: true
+      Activation: false
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: [Assembly]
+      ForkParameters:
+        - PrefetchGlobalRead: [1]
+        - PrefetchLocalRead: [1]
+        - WavefrontSize: [32]
+        - ThreadTile:
+          - [1, 1]
+          - [2, 2]
+        - WorkGroup:
+          - [8, 8, 1]
+        - DepthU: [8, 16]
+        - VectorWidthA: [1]
+        - VectorWidthB: [1]
+        - ScheduleIterAlg: [1]
+        - WorkGroupMapping: [1]
+        - GlobalSplitU: [1]
+        - LdsPadA: [0]
+        - LdsPadB: [0]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [ [64, 64, 1024], [64, 64, 1024], [1], [32] ]


### PR DESCRIPTION
Add f64 mac instruction for tensilelite and f64 tuning yamls as well. Also add testing yamls including f32 and f64 for tensiltelite/Tensile/Tests.