### PR TITLE
Fix Lazy Lib Load to Improve Library Loading Time

### DIFF
--- a/tensilelite/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/PlaceholderLibrary.hpp
@@ -29,6 +29,7 @@
 #include <Tensile/MasterSolutionLibrary.hpp>
 #include <Tensile/SolutionLibrary.hpp>
 #include <Tensile/Tensile.hpp>
+#include <Tensile/Debug.hpp>
 
 #include <algorithm>
 
@@ -131,13 +132,15 @@ namespace Tensile
             // If condition in case two threads got into this function
             if(!library)
             {
-                auto newLibrary = LoadLibraryFile<MyProblem, MySolution>(
-                    (libraryDirectory + "/" + filePrefix + suffix).c_str());
+                std::string path = (libraryDirectory + "/" + filePrefix + suffix).c_str();
+                auto newLibrary = LoadLibraryFile<MyProblem, MySolution>(path);
                 auto mLibrary
                     = static_cast<MasterSolutionLibrary<MyProblem, MySolution>*>(newLibrary.get());
                 library = mLibrary->library;
                 std::lock_guard<std::mutex> lock(*solutionsGuard);
                 masterSolutions->insert(mLibrary->solutions.begin(), mLibrary->solutions.end());
+                if(Debug::Instance().printCodeObjectInfo())
+                    std::cout << "load placeholder library " << path << std::endl;
 
                 return mLibrary;
             }


### PR DESCRIPTION
This PR is from https://ontrack-internal.amd.com/browse/SWDEV-465673. The long library loading time is fixed by removing deviceSet from LoadLibraryFilePreload. However, this introduces a seg fault in getSolutionsFromIndex and isSolutionSupported due to empty library->solutions. Since getSolutionsFromIndex and isSolutionSupported are not the target of the ticket and aren't supported by rocblas as well, there is a workaround. getSolutionsFromIndex should be further designed to load corresponding placeholder library when specific index is passed in.

When using hipblaslt-bench, "--algo_method heuristic" benefits from this PR. "--algo_method all" and "--algo_method index" won't change.