### PR TITLE
Add f16 compute enum translation.

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -236,6 +236,8 @@ namespace
             return Tensile::DataType::Double;
         case rocblaslt_compute_i32:
             return Tensile::DataType::Int32;
+        case rocblaslt_compute_f16:
+            return Tensile::DataType::Half;
         default:
             throw std::runtime_error("Unsupported type.");
         }
@@ -249,6 +251,7 @@ namespace
     {
         switch(typeCompute)
         {
+        case rocblaslt_compute_f16:
         case rocblaslt_compute_f32_fast_f16:
             return Tensile::DataType::Half;
         case rocblaslt_compute_f32_fast_bf16:


### PR DESCRIPTION
Allows hipblaslt to return no solutions for f16 compute type, instead of an exception.