### PR TITLE
Simplify client building in tensilelite test

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -377,6 +377,10 @@ def main(config, useCache):
     """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
     ClientExecutable.getClientExecutable()
 
+    if config is None:
+        print(f'No config specified in {globalParameters["ConfigPath"]}, built client only')
+        return
+
     dataPath = os.path.join(globalParameters["WorkingPath"], globalParameters["BenchmarkDataPath"])
     pushWorkingPath(globalParameters["BenchmarkProblemsPath"])
     ensurePath(dataPath)

--- a/tensilelite/Tensile/Tests/build_client.yaml
+++ b/tensilelite/Tensile/Tests/build_client.yaml
@@ -20,18 +20,3 @@ GlobalParameters:
   DataInitTypeBeta : 0
 
 BenchmarkProblems:
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: h
-      HighPrecisionAccumulate: True
-
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      ForkParameters:
-        - KernelLanguage: ["Assembly"]
-        - MatrixInstruction: [[16, 16, 16, 1, 1, 2, 2, 1, 1]]
-        - DepthU: [32]
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [ 128, 128, 128 ]

--- a/tensilelite/Tensile/Tests/common/client/rotate.yaml
+++ b/tensilelite/Tensile/Tests/common/client/rotate.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: 0

--- a/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
+++ b/tensilelite/Tensile/Tests/common/exception/f16_cf32_nan.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported yet
+  marks: [skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported yet
 
 GlobalParameters:
   MinimumRequiredVersion: 4.14.0

--- a/tensilelite/Tensile/Tests/common/gemm/xfp32.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/xfp32.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1


### PR DESCRIPTION
## Brief ##
This PR simplifies client building in tensilelite test.

## Implenentation ##
 - [x] Emptied `BenchmarkProblems` section in `build_client.yaml` for tensilelite test
 - [x] Added early return logic in  `BenchmarkProblems.py:main` if the input `config` is `None`.
 - [x] Added missing `skip-{arch}`s in some testing YAMLs for tensilelite test. 