### PR TITLE
Fix I8I8I SDWA Fail for gfx12

### DIFF
--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -1370,7 +1370,7 @@ class GlobalWriteBatchWriter:
           if self.kernel["ProblemType"]["ComputeDataType"].isSingle() and ((self.parentWriter.states.useBias == DataDirection.READ) or self.kernel["ActivationFuncCall"] or self.applyAlpha or self.beta):
             convertModule = convertData(self.gwvw, self.ss.elementSumIdx[elementIdx], cvtType=CvtType.CVT_F32_to_I32, roundType=RoundType.ROUND_TO_NEAREST_EVEN, \
                                         inputPrefix="ValuC+", prefixOffset=self.parentWriter.states.c.startVgprValu)
-          packModule = self.packdata(self.gwvw, destIdx, self.ss.elementSumIdx[elementIdx], self.tmpVgpr, self.tmpS01,
+          packModule = self.packdata(self.gwvw, destIdx, self.ss.elementSumIdx[elementIdx], self.cvtVgprStruct, self.tmpS01,
                                      SaturateTypeInt8=SaturateTypeInt8, inputPrefix="ValuC+", prefixOffset=self.parentWriter.states.c.startVgprValu)
 
       if self.parentWriter.states.asmCaps["HasWMMA_V1"] and self.kernel["EnableMatrixInstruction"] and self.kernel["ProblemType"]["DestDataType"].isHalf() and (not self.kernel["ProblemType"]["HighPrecisionAccumulate"]):

--- a/tensilelite/Tensile/Components/PackData.py
+++ b/tensilelite/Tensile/Components/PackData.py
@@ -26,7 +26,8 @@ from ..TensileInstructions import Module, SDWAModifiers, SelectBit, UnusedBit, \
                             VCmpUF32, VCndMaskB32, VCvtPkF32toFP8, VCvtPkF32toBF8, \
                             VOP3PModifiers, VCmpClassF32, VOrB32, VPackF16toB32, \
                             VAndOrB32, VBfeU32, VLShiftLeftB16, SNop, VMed3F32, \
-                            vgpr, sgpr, DataType, TensileInstructions
+                            vgpr, sgpr, DataType, TensileInstructions, VAndB32, \
+                            VMovB32, VLShiftLeftB32
 from ..Component import PackData
 from ..Common import globalParameters
 
@@ -165,7 +166,12 @@ class PackData_BF8(PackData):
 
 class PackData_INT8(PackData):
     kernel = {"ProblemType": {"ComputeDataType": DataType(DataType.int32), "DestDataType": DataType(DataType.int8)}}
-    def __call__(self, gwvw, destIdx, elementSumIdx, tmpVgpr, tmpS01, SaturateTypeInt8 = SaturateCastType.NORMAL, inputPrefix="", prefixOffset=0):
+    def __call__(self, gwvw, destIdx, elementSumIdx, i8CVTVgprStruct, tmpS01, SaturateTypeInt8 = SaturateCastType.NORMAL, inputPrefix="", prefixOffset=0):
+        vgprI8Mask0 = i8CVTVgprStruct.vgprI8Mask0
+        vgprI8Mask1 = i8CVTVgprStruct.vgprI8Mask1
+        vgprI8Temp0 = i8CVTVgprStruct.vgprI8Temp0
+        vgprI8Temp1 = i8CVTVgprStruct.vgprI8Temp1
+
         ti = TensileInstructions()
         module = Module("PackData int8")
         gwvw4 = (gwvw // 4) * 4
@@ -176,25 +182,47 @@ class PackData_INT8(PackData):
             if vi%4 == 3:
                 d = destIdx + vi//4
                 for i in reversed(range(0, 4)):
-                    module.add(VSaturateCastInt(vgpr(formatting(sumIdxV-i, inputPrefix, prefixOffset)), tmpVgpr, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=(i%4 == 3)))
+                    module.add(VSaturateCastInt(vgpr(formatting(sumIdxV-i, inputPrefix, prefixOffset)), vgprI8Temp0, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=(i%4 == 3)))
                 module.add(VLShiftLeftB16(dst=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), shiftHex=8, src=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset))))
                 module.add(VLShiftLeftB16(dst=vgpr(formatting(sumIdxV-0, inputPrefix, prefixOffset)), shiftHex=8, src=vgpr(formatting(sumIdxV-0, inputPrefix, prefixOffset))))
-                module.add(VOrB32(dst=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
-                           src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
-                           sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
-                                              src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD) if not ti.getArchCaps()["NoSDWA"] else None))
+                if ti.getArchCaps()["NoSDWA"]:
+                    module.add(VMovB32(vgpr(vgprI8Mask0), "0xFF", "bits 7:0")) # src0_sel=SelectBit.BYTE_0
+                    module.add(VAndB32(dst=vgpr(vgprI8Temp0), src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
+                                       src1=vgpr(vgprI8Mask0)))
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), src0=vgpr(vgprI8Temp0), \
+                                      src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), sdwa=None))
+                else:
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
+                                      src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
+                                      src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
+                                      sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
+                                                         src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD)))
                 if ti.getArchCaps()["SDWAWait"]:
                     module.add(SNop(waitState=0, comment="1 wait states"))
-                module.add(VOrB32(dst=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
-                           src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
-                           src1=vgpr(formatVgpr), \
-                           sdwa=SDWAModifiers(dst_sel=SelectBit.WORD_1, dst_unused=UnusedBit.UNUSED_PAD, \
-                                              src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD) if not ti.getArchCaps()["NoSDWA"] else None))
+                if ti.getArchCaps()["NoSDWA"]:
+                    module.add(VMovB32(vgpr(vgprI8Mask0), "0xFF", "bits 7:0")) # src0_sel=SelectBit.BYTE_0
+                    module.add(VAndB32(dst=vgpr(vgprI8Temp0), src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
+                                       src1=vgpr(vgprI8Mask0)))
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), src0=vgpr(vgprI8Temp0), src1=vgpr(formatVgpr), sdwa=None))
+                    module.add(VLShiftLeftB32(dst=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), src=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), shiftHex=16, comment=""))
+                else:
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
+                                      src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), src1=vgpr(formatVgpr), \
+                                      sdwa=SDWAModifiers(dst_sel=SelectBit.WORD_1, dst_unused=UnusedBit.UNUSED_PAD, \
+                                                         src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD)))
                 if ti.getArchCaps()["SDWAWait"]:
                     module.add(SNop(waitState=0, comment="1 wait states"))
-                module.add(VOrB32(dst=vgpr(d), src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
-                           sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
-                                              src0_sel=SelectBit.WORD_0, src1_sel=SelectBit.DWORD) if not ti.getArchCaps()["NoSDWA"] else None))
+                if ti.getArchCaps()["NoSDWA"]:
+                    module.add(VMovB32(vgpr(vgprI8Mask0), "0xFFFF", "bits 15:0")) # src0_sel=SelectBit.WORD_0
+                    module.add(VAndB32(dst=vgpr(vgprI8Temp0), src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
+                                       src1=vgpr(vgprI8Mask0)))
+                    module.add(VOrB32(dst=vgpr(d), src0=vgpr(vgprI8Temp0), \
+                                      src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), sdwa=None))
+                else:
+                    module.add(VOrB32(dst=vgpr(d), src0=vgpr(formatting(sumIdxV-3, inputPrefix, prefixOffset)), \
+                                      src1=vgpr(formatting(sumIdxV-2, inputPrefix, prefixOffset)), \
+                                      sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
+                                                         src0_sel=SelectBit.WORD_0, src1_sel=SelectBit.DWORD)))
                 if ti.getArchCaps()["SDWAWait"]:
                     module.add(SNop(waitState=0, comment="1 wait states"))
         # Left
@@ -205,21 +233,29 @@ class PackData_INT8(PackData):
 
             if vi%2 == 1:
                 for i in reversed(range(0, 2)):
-                    module.add(VSaturateCastInt(vgpr(formatting(sumIdxV-i, inputPrefix, prefixOffset)), tmpVgpr, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=(i%2 == 1)))
+                    module.add(VSaturateCastInt(vgpr(formatting(sumIdxV-i, inputPrefix, prefixOffset)), vgprI8Temp0, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=(i%2 == 1)))
                 module.add(VLShiftLeftB16(dst=vgpr(formatVgpr), shiftHex=8, src=vgpr(formatVgpr)))
-                module.add(VOrB32(dst=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
-                           src1=vgpr(formatVgpr), \
-                           sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
-                                              src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD) if not ti.getArchCaps()["NoSDWA"] else None))
+                if ti.getArchCaps()["NoSDWA"]:
+                    module.add(VMovB32(vgpr(vgprI8Mask0), "0xFF", "bits 7:0")) # src0_sel=SelectBit.BYTE_0
+                    module.add(VAndB32(dst=vgpr(vgprI8Temp0), src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
+                                       src1=vgpr(vgprI8Mask0)))
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
+                                      src0=vgpr(vgprI8Temp0), src1=vgpr(formatVgpr), sdwa=None))
+                else:
+                    module.add(VOrB32(dst=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
+                                      src0=vgpr(formatting(sumIdxV-1, inputPrefix, prefixOffset)), \
+                                      src1=vgpr(formatVgpr), \
+                                      sdwa=SDWAModifiers(dst_sel=SelectBit.DWORD, dst_unused=UnusedBit.UNUSED_PAD, \
+                                                         src0_sel=SelectBit.BYTE_0, src1_sel=SelectBit.DWORD)))
                 if ti.getArchCaps()["SDWAWait"]:
                     module.add(SNop(waitState=0, comment="1 wait states"))
             elif vi + 1 >= gwvw:
-                module.add(VSaturateCastInt(vgpr(formatVgpr), tmpVgpr, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=True))
+                module.add(VSaturateCastInt(vgpr(formatVgpr), vgprI8Temp0, tmpS01, -128, 127, type=SaturateTypeInt8, initGpr=True))
         return module
 
 # Cvt is outside of this component, this is just a wrapper for ComputeDataType == float
 class PackData_INT8_F32(PackData):
     kernel = {"ProblemType": {"ComputeDataType": DataType(DataType.single), "DestDataType": DataType(DataType.int8)}}
     packdata = PackData_INT8()
-    def __call__(self, gwvw, destIdx, elementSumIdx, tmpVgpr, tmpS01, SaturateTypeInt8 = SaturateCastType.NORMAL, inputPrefix="", prefixOffset=0):
-        return self.packdata(gwvw, destIdx, elementSumIdx, tmpVgpr, tmpS01, SaturateTypeInt8, inputPrefix, prefixOffset)
+    def __call__(self, gwvw, destIdx, elementSumIdx, i8CVTVgprStruct, tmpS01, SaturateTypeInt8 = SaturateCastType.NORMAL, inputPrefix="", prefixOffset=0):
+        return self.packdata(gwvw, destIdx, elementSumIdx, i8CVTVgprStruct, tmpS01, SaturateTypeInt8, inputPrefix, prefixOffset)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8763,6 +8763,12 @@ class KernelWriterAssembly(KernelWriter):
     vgprBF8Min: int    = -1
     vgprBF8Max: int    = -1
 
+  class I8CVTVgprStruct(NamedTuple):
+    vgprI8Temp0: int   = -1
+    vgprI8Temp1: int   = -1
+    vgprI8Mask0: int   = -1
+    vgprI8Mask1: int   = -1
+
   class ActivationSetPCStruct(NamedTuple):
     sgprOffsetActivation: int = -1
     sgprOffsetBack: int = -1
@@ -9211,6 +9217,10 @@ class KernelWriterAssembly(KernelWriter):
         cvtVgpr = self.vgprPool.checkOut(4)
         cvtVgprStruct = self.BF8CVTVgprStruct(vgprBF8Temp=cvtVgpr, vgprBF8NanInf=(cvtVgpr+1), \
                                               vgprBF8Min=(cvtVgpr+2), vgprBF8Max=(cvtVgpr+3))
+      elif kernel["ProblemType"]["DestDataType"].isInt8():
+        cvtVgpr = self.vgprPool.checkOut(4)
+        cvtVgprStruct = self.I8CVTVgprStruct(vgprI8Temp0=cvtVgpr, vgprI8Temp1=(cvtVgpr+1), \
+                                             vgprI8Mask0=(cvtVgpr+2), vgprI8Mask1=(cvtVgpr+3))
 
       activationSetPCStruct = None
       activationLabelList = None

--- a/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
@@ -724,3 +724,69 @@ BenchmarkProblems:
           - Exact: [257, 257, 1, 257]
         - ActivationArgs:
           - [Enum: none]
+
+  #######################################
+  # TN - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: i8
+      DestDataType: i8
+      ComputeDataType: i
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      #UseBias: True
+      Batched: True
+      Activation: True
+      SetConstStrideBias: [[2, 0]]
+      #BiasDataTypeList: ['s']
+ 
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1, 1, 1, 1, 4, 1 ]
+ 
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - WavefrontSize: [32]
+        - LocalReadVectorWidth: [16] #
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]       #
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]  #
+        - LdsBlockSizePerPadB: [-1]  #
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1,2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - SourceSwap: [0]
+        #- StoreRemapVectorWidth: [-1,0,4]
+        #- DirectToVgprSparseMetadata: [0]
+        #- WorkGroupMapping: [18]
+        #- StoreVectorWidth: [-1]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [15, 15, 2, 16] # classic format
+          - Exact: [15, 15, 2, 256] # classic format
+          - Exact: [32, 32, 1, 256] # classic format
+          - Exact: [32, 32, 2, 255] # classic format
+          - Exact: [255, 255, 1, 255] # classic format
+          - Exact: [255, 255, 2, 255] # classic format
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [256, 256, 1, 255] # classic format
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
gfx12 removes sdwa features, sdwa=None results in data compared fail.
The sdwa usage: https://llvm.org/docs/AMDGPUModifierSyntax.html#sdwa-modifiers 