### PR TITLE
Modify for getting solutions when setting alpha to 0 with A/B is nullptr

### DIFF
--- a/clients/gtest/auxiliary_gtest.cpp
+++ b/clients/gtest/auxiliary_gtest.cpp
@@ -114,6 +114,8 @@ namespace
                 testing_aux_get_sol_with_null_biasaddr(arg);
             else if(!strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b"))
                 testing_aux_get_sol_with_zero_alpha_null_a_b(arg);
+            else if(!strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b_ext"))
+                testing_aux_get_sol_with_zero_alpha_null_a_b_ext(arg);
             else if(!strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg"))
                 testing_aux_matmul_alg_get_attr_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_matmul_plan_init_bad_arg"))
@@ -156,6 +158,7 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_alg_init")
                    || !strcmp(arg.function, "aux_get_sol_with_null_biasaddr")
                    || !strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b")
+                   || !strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b_ext")
                    || !strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init")

--- a/clients/gtest/auxiliary_gtest.cpp
+++ b/clients/gtest/auxiliary_gtest.cpp
@@ -112,6 +112,8 @@ namespace
                 testing_aux_matmul_alg_init(arg);
             else if(!strcmp(arg.function, "aux_get_sol_with_null_biasaddr"))
                 testing_aux_get_sol_with_null_biasaddr(arg);
+            else if(!strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b"))
+                testing_aux_get_sol_with_zero_alpha_null_a_b(arg);
             else if(!strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg"))
                 testing_aux_matmul_alg_get_attr_bad_arg(arg);
             else if(!strcmp(arg.function, "aux_matmul_plan_init_bad_arg"))
@@ -153,6 +155,7 @@ namespace
                    || !strcmp(arg.function, "aux_matmul_alg_init_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_alg_init")
                    || !strcmp(arg.function, "aux_get_sol_with_null_biasaddr")
+                   || !strcmp(arg.function, "aux_get_sol_with_zero_alpha_null_a_b")
                    || !strcmp(arg.function, "aux_matmul_alg_get_attr_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init_bad_arg")
                    || !strcmp(arg.function, "aux_matmul_plan_init")

--- a/clients/gtest/auxiliary_gtest.yaml
+++ b/clients/gtest/auxiliary_gtest.yaml
@@ -89,12 +89,14 @@ Tests:
   function:
     - aux_get_sol_with_zero_alpha_null_a_b: *hpa_half_precision
   alpha: 0
+  beta: 1
 
 - name: aux_get_sol_with_zero_alpha_null_a_b_ext
   category: pre_checkin
   function:
     - aux_get_sol_with_zero_alpha_null_a_b_ext: *hpa_half_precision
   alpha: 0
+  beta: 1
 
 - name: aux_matmul_alg_get_attr_bad_arg
   category: pre_checkin

--- a/clients/gtest/auxiliary_gtest.yaml
+++ b/clients/gtest/auxiliary_gtest.yaml
@@ -84,6 +84,11 @@ Tests:
   function:
     - aux_get_sol_with_null_biasaddr: *hpa_half_precision
 
+- name: aux_get_sol_with_zero_alpha_null_a_b
+  category: pre_checkin
+  function:
+    - aux_get_sol_with_zero_alpha_null_a_b: *hpa_half_precision
+
 - name: aux_matmul_alg_get_attr_bad_arg
   category: pre_checkin
   function:

--- a/clients/gtest/auxiliary_gtest.yaml
+++ b/clients/gtest/auxiliary_gtest.yaml
@@ -88,6 +88,13 @@ Tests:
   category: pre_checkin
   function:
     - aux_get_sol_with_zero_alpha_null_a_b: *hpa_half_precision
+  alpha: 0
+
+- name: aux_get_sol_with_zero_alpha_null_a_b_ext
+  category: pre_checkin
+  function:
+    - aux_get_sol_with_zero_alpha_null_a_b_ext: *hpa_half_precision
+  alpha: 0
 
 - name: aux_matmul_alg_get_attr_bad_arg
   category: pre_checkin

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -439,7 +439,7 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
     CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, arg.a_type, m, n, m));
 
     hipblasLtMatmulDesc_t matmul;
-    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_BIAS;
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_DEFAULT;
     CHECK_HIPBLASLT_ERROR(
         hipblasLtMatmulDescCreate(&matmul, arg.compute_type, arg.scale_type));
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
@@ -448,6 +448,24 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
         matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
         matmul, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue,sizeof(epilogue)));
+
+    // Validation for solution running.
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
+                                          matmul,
+                                          &alpha,
+                                          d_a,
+                                          matA,
+                                          d_b,
+                                          matB,
+                                          &beta,
+                                          d_c,
+                                          matC,
+                                          d_d,
+                                          matD,
+                                          nullptr,
+                                          nullptr,
+                                          0,
+                                          0));
 
     hipblasLtMatmulPreference_t pref;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -413,15 +413,11 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
     // Setting alpha = 0.
     float              alpha = 0;
     float              beta = arg.beta;
-    // Setting d_a, d_b, a, b as nullptr.
+    // Setting d_a, d_b as nullptr.
     void*              d_a = NULL;
     void*              d_b = NULL;
     void*              d_c;
     void*              d_d;
-    void*              a = NULL;
-    void*              b = NULL;
-    void*              c;
-    void*              d;
     // Setting max_workspace_size_in_bytes.
     int64_t max_workspace_size = 32 * 1024 * 1024;
     void* d_workspace;
@@ -430,13 +426,8 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
     CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
     CHECK_HIP_ERROR(hipMalloc(&d_c, m * n * batch_count * sizeof(OutType)));
     CHECK_HIP_ERROR(hipMalloc(&d_d, m * n * batch_count * sizeof(OutType)));
-    CHECK_HIP_ERROR(hipHostMalloc(&c, m * n * batch_count * sizeof(OutType)));
-    CHECK_HIP_ERROR(hipHostMalloc(&d, m * n * batch_count * sizeof(OutType)));
     // Allocate space for max_workspace_size.
     CHECK_HIP_ERROR(hipMalloc(&d_workspace, max_workspace_size));
-    
-    CHECK_HIP_ERROR(hipMemcpyAsync(
-        d_c, c, m * n * batch_count * sizeof(OutType), hipMemcpyHostToDevice, stream));
 
     hipblasLtMatrixLayout_t matA, matB, matC, matD;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, arg.a_type, m, k, m));
@@ -459,6 +450,12 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
     // Set User Preference attributes
     hipblasLtMatmulPreference_t pref;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+    CHECK_HIPBLASLT_ERROR(
+        hipblasLtMatmulPreferenceSetAttribute(pref,
+                                              HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                                              &max_workspace_size,
+                                              sizeof(max_workspace_size)));
+                                              
     const int                        request_solutions = 1;
     hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
     int                              returnedAlgoCount = 0;
@@ -493,14 +490,9 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
                                           max_workspace_size,
                                           stream));
 
-    CHECK_HIP_ERROR(hipFree(a));
-    CHECK_HIP_ERROR(hipFree(b));
-    CHECK_HIP_ERROR(hipFree(c));
-    CHECK_HIP_ERROR(hipFree(d));
-    CHECK_HIP_ERROR(hipFree(d_a));
-    CHECK_HIP_ERROR(hipFree(d_b));
     CHECK_HIP_ERROR(hipFree(d_c));
     CHECK_HIP_ERROR(hipFree(d_d));
+    CHECK_HIP_ERROR(hipFree(d_workspace));
     CHECK_HIPBLASLT_ERROR(hipblasLtDestroy(handle));
     CHECK_HIP_ERROR(hipStreamDestroy(stream));
 }
@@ -525,15 +517,11 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b_ext(const Arguments& arg)
     // Setting alpha = 0.
     float              alpha = 0;
     float              beta = arg.beta;
-    // Setting d_a, d_b, a, b as nullptr.
+    // Setting d_a, d_b as nullptr.
     void*              d_a = NULL;
     void*              d_b = NULL;
     void*              d_c;
     void*              d_d;
-    void*              a = NULL;
-    void*              b = NULL;
-    void*              c;
-    void*              d;
     // Setting max_workspace_size_in_bytes.
     int64_t max_workspace_size = 32 * 1024 * 1024;
     void* d_workspace;
@@ -542,13 +530,8 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b_ext(const Arguments& arg)
     CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
     CHECK_HIP_ERROR(hipMalloc(&d_c, m * n * batch_count * sizeof(OutType)));
     CHECK_HIP_ERROR(hipMalloc(&d_d, m * n * batch_count * sizeof(OutType)));
-    CHECK_HIP_ERROR(hipHostMalloc(&c, m * n * batch_count * sizeof(OutType)));
-    CHECK_HIP_ERROR(hipHostMalloc(&d, m * n * batch_count * sizeof(OutType)));
     // Allocate space for max_workspace_size.
     CHECK_HIP_ERROR(hipMalloc(&d_workspace, max_workspace_size));
-
-    CHECK_HIP_ERROR(hipMemcpyAsync(
-        d_c, c, m * n * batch_count * sizeof(OutType), hipMemcpyHostToDevice, stream));
 
     hipblaslt_ext::GemmPreference gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
@@ -576,14 +559,9 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b_ext(const Arguments& arg)
     // Validation for solution running.
     CHECK_HIPBLASLT_ERROR(gemm.run(stream));
 
-    CHECK_HIP_ERROR(hipFree(a));
-    CHECK_HIP_ERROR(hipFree(b));
-    CHECK_HIP_ERROR(hipFree(c));
-    CHECK_HIP_ERROR(hipFree(d));
-    CHECK_HIP_ERROR(hipFree(d_a));
-    CHECK_HIP_ERROR(hipFree(d_b));
     CHECK_HIP_ERROR(hipFree(d_c));
     CHECK_HIP_ERROR(hipFree(d_d));
+    CHECK_HIP_ERROR(hipFree(d_workspace));
     CHECK_HIPBLASLT_ERROR(hipblasLtDestroy(handle));
     CHECK_HIP_ERROR(hipStreamDestroy(stream));
 }

--- a/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
@@ -184,7 +184,8 @@ inline rocblaslt_status validateMatmulArgs(int64_t     m,
         return rocblaslt_status_invalid_pointer;
 
     // pointers must be valid
-    if(n && ((k && (!a || !b || !alpha)) || !c || !d))
+    // Update for the valid case: (alpha=0 && (A=NULL || B=NULL))
+    if(n && ((k && (!alpha || ((*((float*)alpha)) && (!a || !b)))) || !c || !d))
         return rocblaslt_status_invalid_pointer;
 
     return rocblaslt_status_continue;

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -1063,8 +1063,9 @@ rocblaslt_status rocblaslt_matmul(rocblaslt_handle             handle,
     }
 
     // Check if pointer is valid
-    if(alpha == nullptr || beta == nullptr || A == nullptr || B == nullptr || C == nullptr
-       || D == nullptr)
+    // Update for the valid case: (alpha=0 && (A=NULL || B=NULL))
+    if(alpha == nullptr || beta == nullptr || ((*((float*)alpha)) && (A == nullptr
+        || B == nullptr)) || C == nullptr || D == nullptr)
     {
         log_error(__func__, "invalid data pointer");
         return rocblaslt_status_invalid_pointer;

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -1064,8 +1064,8 @@ rocblaslt_status rocblaslt_matmul(rocblaslt_handle             handle,
 
     // Check if pointer is valid
     // Update for the valid case: (alpha=0 && (A=NULL || B=NULL))
-    if(alpha == nullptr || beta == nullptr || ((*((float*)alpha)) && (A == nullptr
-        || B == nullptr)) || C == nullptr || D == nullptr)
+    if(alpha == nullptr || beta == nullptr || C == nullptr || D == nullptr
+        || ((*((float*)alpha)) && (A == nullptr || B == nullptr)))
     {
         log_error(__func__, "invalid data pointer");
         return rocblaslt_status_invalid_pointer;

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -1483,8 +1483,8 @@ rocblaslt_status gemmCreate(RocblasltContractionProblem const& problem,
     {
         // Check if pointer is valid
         // Update for the valid case: (alpha=0 && (A=NULL || B=NULL))
-        if(problem.alpha == nullptr || problem.beta == nullptr || ((*((float*)problem.alpha)) && (problem.A == nullptr
-           || problem.B == nullptr)) || problem.C == nullptr || problem.D == nullptr)
+        if(problem.alpha == nullptr || problem.beta == nullptr || problem.C == nullptr || problem.D == nullptr
+            || ((*((float*)problem.alpha)) && (problem.A == nullptr || problem.B == nullptr)))
         {
             log_error(__func__, "invalid data pointer");
             return rocblaslt_status_invalid_pointer;

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -1482,8 +1482,9 @@ rocblaslt_status gemmCreate(RocblasltContractionProblem const& problem,
     try
     {
         // Check if pointer is valid
-        if(problem.alpha == nullptr || problem.beta == nullptr || problem.A == nullptr
-           || problem.B == nullptr || problem.C == nullptr || problem.D == nullptr)
+        // Update for the valid case: (alpha=0 && (A=NULL || B=NULL))
+        if(problem.alpha == nullptr || problem.beta == nullptr || ((*((float*)problem.alpha)) && (problem.A == nullptr
+           || problem.B == nullptr)) || problem.C == nullptr || problem.D == nullptr)
         {
             log_error(__func__, "invalid data pointer");
             return rocblaslt_status_invalid_pointer;


### PR DESCRIPTION
1.  Modify conditions in tensile_host.cpp and rocblaslt_mat_utils.hpp to enable the test case to get solutions when setting alpha to 0 with A/B as nullptr.
2. Add a test case for getting solutions when setting alpha to 0 with A/B as nullptr
3. Ticket: https://ontrack-internal.amd.com/browse/SWDEV-474250