### PR TITLE
Support different GRVWA and GRVWB for UnrollLoopSwapGlobalReadOrder

### DIFF
--- a/tensilelite/Tensile/Components/SIA.py
+++ b/tensilelite/Tensile/Components/SIA.py
@@ -36,7 +36,7 @@ class SIA3(SIA):
     def __call__(self):
         assert(0)
 
-    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode):
+    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode, isNGLL):
         # Get schedule information
         numMfmaBetweenLWandBarrier, latencyLeft = getLocalWriteMFMAEnd(writer, kernel, tensorParametersA, tensorParametersB)
         #########
@@ -60,7 +60,7 @@ class SIA3(SIA):
             itemsGRToSchedLater, lastLoadIter = noSchedGlobalRead(writer, kernel, globalReadIncACode, globalReadIncBCode)
             writer.states.grEndMfmaIndex = 0
         else:
-            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel)
+            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel, isNGLL)
             itemsGRIncToSched = appendInstToSchedSIA3(writer, kernel, numEmptyGlobalReadIncCode, globalReadIncACode, globalReadIncBCode)
             schedNumForIter0, endIter = getSchedNumForIter0SIA3(writer, kernel, itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter)
             lastLoadIter = schedGlobalRead(writer, itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter, schedNumForIter0, endIter)
@@ -83,7 +83,7 @@ class SIA2(SIA):
     def __call__(self):
         assert(0)
 
-    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode):
+    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode, isNGLL):
         # Get schedule information
         numGlobalReadInsPerIter, numLocalWriteModPerIter, numEmptyGlobalReadIncCode = getScheduleParams(kernel)
         numLocalWritesPerSched = numLocalWriteModPerIter
@@ -91,7 +91,7 @@ class SIA2(SIA):
         if not writer.states.scheduleGlobalRead:
             itemsGRToSchedLater, lastLoadIter = noSchedGlobalRead(writer, kernel, globalReadIncACode, globalReadIncBCode)
         else:
-            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel)
+            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel, isNGLL)
             itemsGRIncToSched = appendInstToSchedDefault(numEmptyGlobalReadIncCode, globalReadIncACode, globalReadIncBCode)
             schedNumForIter0, endIter = getSchedNumForIter0Default(itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter, localWriteEndIter)
             lastLoadIter = schedGlobalRead(writer, itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter, schedNumForIter0, endIter)
@@ -111,7 +111,7 @@ class SIA1(SIA):
     def __call__(self):
         assert(0)
 
-    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode):
+    def schedIntoIteration(self, writer, kernel, tensorParametersA, tensorParametersB, localWriteEndIter, firstIter, lastLoop, lastLc, maxVmcnt, globalReadIncACode, globalReadIncBCode, isNGLL):
         # Get schedule information
         numGlobalReadInsPerIter, numLocalWriteModPerIter, numEmptyGlobalReadIncCode = getScheduleParams(kernel)
         numLocalWritesPerSched = numLocalWriteModPerIter
@@ -119,7 +119,7 @@ class SIA1(SIA):
         if not writer.states.scheduleGlobalRead:
             itemsGRToSchedLater, lastLoadIter = noSchedGlobalRead(writer, kernel, globalReadIncACode, globalReadIncBCode)
         else:
-            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel)
+            itemsGRToSched, itemsGRToSchedLater = prepareGRInstToSched(writer, kernel, isNGLL)
             itemsGRIncToSched = appendInstToSchedDefault(numEmptyGlobalReadIncCode, globalReadIncACode, globalReadIncBCode)
             schedNumForIter0, endIter = getSchedNumForIter0Default(itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter, localWriteEndIter)
             lastLoadIter = schedGlobalRead(writer, itemsGRToSched, itemsGRIncToSched, numGlobalReadInsPerIter, schedNumForIter0, endIter)
@@ -430,13 +430,16 @@ def noSchedGlobalRead(writer, kernel, globalReadIncACode, globalReadIncBCode):
     lastLoadIter = 0
     return itemsGRToSchedLater, lastLoadIter
 
-def prepareGRInstToSched(writer, kernel):
+def prepareGRInstToSched(writer, kernel, isNGLL):
     writer.codes.unrollLoopHeader.add(writer.codes.globalReadA.header)
     writer.codes.unrollLoopHeader.add(writer.codes.globalReadB.header)
 
     # Add all loads from middle as individual schedulable items
     # when using PGR2, put global read instruction right after corresponding localWrite instruction
-    if kernel["PrefetchGlobalRead"] == 2:
+    if isNGLL and kennel["UnrollLoopSwapGlobalReadOrder"] == 1:
+        itemsGRToSched =  []
+        itemsGRToSchedLater = []
+    elif kernel["PrefetchGlobalRead"] == 2:
         itemsGRToSched =  []
         itemsGRToSchedLater = list(writer.codes.globalReadA.middle.items()) + \
                          list(writer.codes.globalReadB.middle.items())

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -2169,6 +2169,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if kernel["PrefetchGlobalRead"] == 2:
         module.add(self.openPrefetchGlobalRead2(kernel))
         if kernel["UnrollLoopSwapGlobalReadOrder"] == 1:
+          # For UnrollLoopSwapGlobalReadOrder, we also need to swap ds write A/B order.
+          # In scheduling, we always schedule lwa first then lwb second,
+          # Putting lwb in lwa's code object can easily change the order.
           module.add(self.globalReadDo(kernel, 0, tensorParametersB, swapAB=1))
           module.add(self.globalReadDo(kernel, 0, tensorParametersA, swapAB=1))
         else:

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -646,12 +646,16 @@ class KernelWriterAssembly(KernelWriter):
           self.startVgprGlobalReadAddressesB))
 
     if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
-        module.add(RegSet("v", "vgprG2LA", self.states.a.startVgprG2L))
+      module.add(RegSet("v", "vgprG2LA", self.states.a.startVgprG2L))
     if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
-        module.add(RegSet("v", "vgprG2LB", self.states.b.startVgprG2L))
+      module.add(RegSet("v", "vgprG2LB", self.states.b.startVgprG2L))
     if kernel["UnrollLoopSwapGlobalReadOrder"] and not kernel["DirectToLdsA"] and not kernel["DirectToLdsB"]:
+      if kernel["ULSGRODoubleG2L"] == 0:
         module.add(RegSet("v", "vgprG2LB2", self.states.a.startVgprG2L))
         module.add(RegSet("v", "vgprG2LA2", self.states.a.startVgprG2L + self.states.b.numVgprG2LAllocated))
+      else:
+        module.add(RegSet("v", "vgprG2LB2", self.states.a.startVgprG2L + self.states.a.numVgprG2LAllocated))
+        module.add(RegSet("v", "vgprG2LA2", self.states.b.startVgprG2L + self.states.b.numVgprG2LAllocated))
 
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
         module.add(RegSet("v", "vgprG2LMetadata", self.states.m.startVgprG2L))

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3539,14 +3539,15 @@ class Solution(collections.abc.Mapping):
     if state["UseInstOffsetForGRO"] == -1:
       state["UseInstOffsetForGRO"] = 1 if state["DirectToLds"] else 0
 
+    state["ULSGRODoubleG2L"] = 0
     if state["UnrollLoopSwapGlobalReadOrder"] == 1:
+      if state["GlobalReadVectorWidthA"] != state["GlobalReadVectorWidthB"]:
+        # TODO: Add a configuration to schedule better.
+        state["ULSGRODoubleG2L"] = 1
       if state["ExpandPointerSwap"] == 1:
         reject(state, "ExpandPointerSwap need to be 0 if UnrollLoopSwapGlobalReadOrder")
       if state["PrefetchGlobalRead"] != 2:
         reject(state, "PrefetchGlobalRead need to be 2 if UnrollLoopSwapGlobalReadOrder")
-      if state["GlobalReadVectorWidthA"] != state["GlobalReadVectorWidthB"]:
-        reject(state, "TODO: UnrollLoopSwapGlobalReadOrder only support GRVWA=GRVWB. (%u!=%u)"
-        % (state["GlobalReadVectorWidthA"], state["GlobalReadVectorWidthB"]))
       if state["ProblemType"]["DataTypeA"].numBytes() != state["ProblemType"]["DataTypeB"].numBytes():
         reject(state, "UnrollLoopSwapGlobalReadOrder doesn't support mixed precision.")
 


### PR DESCRIPTION
1. double VGPRs to support GRVWA!=GRVWB.
2. Fix a bug in NGLL.