### PR TITLE
Support different GRVWA and GRVWB for UnrollLoopSwapGlobalReadOrder.

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -646,15 +646,19 @@ class KernelWriterAssembly(KernelWriter):
           self.startVgprGlobalReadAddressesB))
 
     if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
-        module.add(RegSet("v", "vgprG2LA", self.states.a.startVgprG2L))
+      module.add(RegSet("v", "vgprG2LA", self.states.a.startVgprG2L))
     if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
-        module.add(RegSet("v", "vgprG2LB", self.states.b.startVgprG2L))
+      module.add(RegSet("v", "vgprG2LB", self.states.b.startVgprG2L))
     if kernel["UnrollLoopSwapGlobalReadOrder"] and not kernel["DirectToLdsA"] and not kernel["DirectToLdsB"]:
+      if kernel["ULSGRODoubleG2L"] == 0:
         module.add(RegSet("v", "vgprG2LB2", self.states.a.startVgprG2L))
         module.add(RegSet("v", "vgprG2LA2", self.states.a.startVgprG2L + self.states.b.numVgprG2LAllocated))
+      else:
+        module.add(RegSet("v", "vgprG2LA2", self.states.a.startVgprG2L + self.states.a.numVgprG2LAllocated))
+        module.add(RegSet("v", "vgprG2LB2", self.states.b.startVgprG2L + self.states.b.numVgprG2LAllocated))
 
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
-        module.add(RegSet("v", "vgprG2LMetadata", self.states.m.startVgprG2L))
+      module.add(RegSet("v", "vgprG2LMetadata", self.states.m.startVgprG2L))
 
     if ((tPA["bpe"] < 4 and not kernel["UnrollMajorLDSA"]) or (tPB["bpe"] < 4 and not kernel["UnrollMajorLDSB"])) \
         and (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3539,14 +3539,15 @@ class Solution(collections.abc.Mapping):
     if state["UseInstOffsetForGRO"] == -1:
       state["UseInstOffsetForGRO"] = 1 if state["DirectToLds"] else 0
 
+    state["ULSGRODoubleG2L"] = 0
     if state["UnrollLoopSwapGlobalReadOrder"] == 1:
+      if state["GlobalReadVectorWidthA"] != state["GlobalReadVectorWidthB"]:
+        # TODO: Add a configuration to schedule better.
+        state["ULSGRODoubleG2L"] = 1
       if state["ExpandPointerSwap"] == 1:
         reject(state, "ExpandPointerSwap need to be 0 if UnrollLoopSwapGlobalReadOrder")
       if state["PrefetchGlobalRead"] != 2:
         reject(state, "PrefetchGlobalRead need to be 2 if UnrollLoopSwapGlobalReadOrder")
-      if state["GlobalReadVectorWidthA"] != state["GlobalReadVectorWidthB"]:
-        reject(state, "TODO: UnrollLoopSwapGlobalReadOrder only support GRVWA=GRVWB. (%u!=%u)"
-        % (state["GlobalReadVectorWidthA"], state["GlobalReadVectorWidthB"]))
       if state["ProblemType"]["DataTypeA"].numBytes() != state["ProblemType"]["DataTypeB"].numBytes():
         reject(state, "UnrollLoopSwapGlobalReadOrder doesn't support mixed precision.")
 

--- a/tensilelite/Tensile/Tests/common/gemm/ulsgro1.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/ulsgro1.yaml
@@ -47,8 +47,8 @@ BenchmarkProblems:
         - DepthU: [64]
         - VectorWidthA: [-1]
         - VectorWidthB: [-1]
-        - GlobalReadVectorWidthA: [-1]
-        - GlobalReadVectorWidthB: [-1]
+        - GlobalReadVectorWidthA: [-1,1,2,4]
+        - GlobalReadVectorWidthB: [-1,1,2,4]
         - LocalReadVectorWidth: [-1]
         - TransposeLDS: [1]
         - LdsBlockSizePerPadA: [-1]
@@ -122,6 +122,8 @@ BenchmarkProblems:
         - DepthU: [128]
         - VectorWidthA: [-1]
         - VectorWidthB: [-1]
+        - GlobalReadVectorWidthA: [-1,1,2,4]
+        - GlobalReadVectorWidthB: [-1,1,2,4]
         - LocalReadVectorWidth: [-1]
         - TransposeLDS: [1]
         - LdsBlockSizePerPadA: [0]
@@ -144,15 +146,6 @@ BenchmarkProblems:
         - NumElementsPerBatchStore: [0]
         - ClusterLocalRead: [1]
         - UnrollLoopSwapGlobalReadOrder: [1]
-        - Groups:
-          - - GlobalReadVectorWidthA: 8
-              GlobalReadVectorWidthB: 8
-            - GlobalReadVectorWidthA: 4
-              GlobalReadVectorWidthB: 4
-            - GlobalReadVectorWidthA: 2
-              GlobalReadVectorWidthB: 2
-            - GlobalReadVectorWidthA: 1
-              GlobalReadVectorWidthB: 1
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:


### PR DESCRIPTION
1. double VGPRs to support GRVWA!=GRVWB.
2. Fix a bug in NGLL.