### PR TITLE
Fix potential integer overflow in KD-tree

### DIFF
--- a/tensilelite/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
@@ -290,7 +290,7 @@ namespace Tensile
                 float d{};
                 for(size_t i = 0; i < N; ++i)
                 {
-                    d += (p.coord[i] - q.coord[i]) * (p.coord[i] - q.coord[i]);
+                    d += static_cast<float>(p.coord[i] - q.coord[i]) * (p.coord[i] - q.coord[i]);
                 }
                 return d;
             }


### PR DESCRIPTION
## Brief ##
This PR fixes potential integer overflow for distance calculation in KD-tree based solution searching.