### PR TITLE
Fixed out-of-bounds access of makeArgument in tensile_host.cpp

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -1747,6 +1747,7 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                 {
                     useBias.push_back(data->problem.gemms[i].useBias());
                     actType.push_back(data->problem.gemms[i].activationType());
+                    useScaleAlphaVec.push_back(data->problem.gemms[i].useScaleAlphaVec());
                     data->problem.gemms[i].setUseBias(solution->problemType.useBias);
                     data->problem.gemms[i].setActivationType(solution->problemType.activationType);
                     data->problem.gemms[i].setUseScaleAlphaVec(


### PR DESCRIPTION
## Brief ##
Fixed potential segfault caused by out-of-bound access of `makeArgument` in tensile_host.cpp.

## Implementation
The original intention of `std::vector<int> useScaleAlphaVec` seems that for state saving/restoring, but it was not implemented properly. I made a fix for it.

## Tests
Local tests on gfx942 are all passed: [test_result_pr969.txt](https://github.com/user-attachments/files/16428008/test_result_pr969.txt)
