### PR TITLE
Support Azure Linux 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 option(BUILD_DOCS "Build documentation" OFF)
 
 # This will add compile option: -std=c++17
-set(CMAKE_CXX_STANDARD 20 )
+set(CMAKE_CXX_STANDARD 17 )
 # Without this line, it will add -std=gnu++17 instead, which may have issues.
 set(CMAKE_CXX_EXTENSIONS OFF )
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -569,6 +569,15 @@ template <typename TiA,
           typename TiB,
           typename To,
           typename Tc,
+          typename TciA,
+          typename TciB,
+          typename Tbias>
+void testing_matmul_with_bias(const Arguments&);
+
+template <typename TiA,
+          typename TiB,
+          typename To,
+          typename Tc,
           typename TciA = TiA,
           typename TciB = TiB>
 void testing_matmul(const Arguments& arg)
@@ -2337,7 +2346,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                                           &K,
                                           &num_batches,
                                           &gemmIdx,
-                                          &arg]<typename Ti>(Ti* ptr) {
+                                          &arg](auto* ptr) {
                                 if(sumLd)
                                 {
                                     reduction_func<true, float>(ptr,

--- a/install.sh
+++ b/install.sh
@@ -60,10 +60,10 @@ supported_distro( )
   fi
 
   case "${ID}" in
-    ubuntu|centos|rhel|fedora|sles|opensuse-leap|mariner)
+    ubuntu|centos|rhel|fedora|sles|opensuse-leap|mariner|azurelinux)
         true
         ;;
-    *)  printf "This script is currently supported on Ubuntu, CentOS, RHEL, Fedora and SLES\n"
+    *)  printf "This script is currently supported on Ubuntu, CentOS, RHEL, Fedora, SLES, mariner and azurelinux\n"
         exit 2
         ;;
   esac
@@ -249,6 +249,14 @@ install_packages( )
       install_yum_packages "${library_dependencies_mariner[@]}"
       if [[ "${build_clients}" == true ]]; then
         install_yum_packages "${client_dependencies_mariner[@]}"
+        pip3 install pyyaml
+      fi
+      ;;
+
+    azurelinux)
+      install_dnf_packages "${library_dependencies_mariner[@]}"
+      if [[ "${build_clients}" == true ]]; then
+        install_dnf_packages "${client_dependencies_mariner[@]}"
         pip3 install pyyaml
       fi
       ;;

--- a/tensilelite/Tensile/Source/client/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/client/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(TensileClient STATIC ${client_sources})
 
 set_target_properties(TensileClient
                       PROPERTIES
-                      CXX_STANDARD 20
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 
@@ -68,7 +68,7 @@ endif()
 add_executable(tensile_client main.cpp)
 set_target_properties(tensile_client
                       PROPERTIES
-                      CXX_STANDARD 20
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 

--- a/tensilelite/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/tensilelite/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -53,6 +53,8 @@ namespace Tensile
             , m_activationComputeType(DataType::Float)
             , m_useUserArgs(false)
         {
+            using std::static_pointer_cast;
+
             std::vector<bool> isComplex;
             if(args.count("problem-identifier"))
             {

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -1844,6 +1844,7 @@ namespace Tensile
             DataInitialization::ConvertToProblemInputs(ContractionProblemGemm const& problem,
                                                        bool                          isGPU)
         {
+            using std::static_pointer_cast;
             std::shared_ptr<ProblemInputs> result;
             if(m_groupedOffsets[0].empty())
             {
@@ -2047,6 +2048,7 @@ namespace Tensile
                                                          std::shared_ptr<ProblemInputs> inputs,
                                                          hipStream_t                    stream)
         {
+            using std::static_pointer_cast;
             std::vector<std::shared_ptr<ProblemInputs>> inputArr;
             inputArr.push_back(inputs);
             if(m_rotatingBuffer == 0)

--- a/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -157,7 +157,7 @@ namespace Tensile
         {
             m_stop   = false;
             m_exit   = false;
-            m_thread = std::thread([=, this]() { this->runLoop(); });
+            m_thread = std::thread([this]() { this->runLoop(); });
         }
 
         void HardwareMonitor::addTempMonitor(rsmi_temperature_type_t   sensorType,
@@ -281,7 +281,7 @@ namespace Tensile
 
                 m_hasStopEvent = stopEvent != nullptr;
 
-                m_task   = std::move(Task([=, this]() { this->collect(startEvent, stopEvent); }));
+                m_task   = std::move(Task([this, startEvent, stopEvent]() { this->collect(startEvent, stopEvent); }));
                 m_future = m_task.get_future();
 
                 m_stop = false;

--- a/tensilelite/Tensile/Source/lib/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/lib/CMakeLists.txt
@@ -91,7 +91,7 @@ add_library (TensileHost STATIC ${tensile_sources})
 
 set_target_properties(TensileHost
                       PROPERTIES
-                      CXX_STANDARD 20
+                      CXX_STANDARD 17
                       CXX_STANDARD_REQUIRED ON
                       CXX_EXTENSIONS OFF)
 

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/MatchingLibrary.hpp
@@ -32,6 +32,7 @@
 #include <Tensile/SingleSolutionLibrary.hpp>
 
 #include <cstddef>
+#include <tuple>
 #include <unordered_set>
 
 namespace Tensile
@@ -60,6 +61,7 @@ namespace Tensile
                 {
                     using Entry  = typename Table::Entry;
                     using KBEntry = typename Table::KBEntry;
+                    using std::get;
                     auto comp    = [](Entry const& e1, Entry const& e2) {
                         return e1.key < e2.key || (e1.key == e2.key && e1.speed > e2.speed);
                     };
@@ -75,15 +77,7 @@ namespace Tensile
                                 auto k   = it->key.size() > 3 ? it->key[3] : it->key[2];
                                 auto b   = it->key.size() > 3 ? it->key[2] : 1;
                                 auto key = std::tuple(it->key[0], it->key[1]);
-                                if(table.kSolutionMap.find(key) == table.kSolutionMap.end())
-                                {
-                                    std::vector<KBEntry> v  = {KBEntry(k, b, it->value)};
-                                    table.kSolutionMap[key] = v;
-                                }
-                                else
-                                {
-                                    table.kSolutionMap[key].push_back(KBEntry(k, b, it->value));
-                                }
+                                table.kSolutionMap[key].emplace_back(KBEntry{static_cast<int32_t>(k), static_cast<int32_t>(b), it->value});
                             }
 
                             // Creating kd-tree


### PR DESCRIPTION
## Brief ##
This PR amends compatibility issues for Azure Linux 3.x, ticket: SWDEV-475885.

## Implementation ##
 - [x] Made `install.sh` support Azure Linux
 - [x] Set C++ standard to 17 due to compatibility issue of libstdc++ 13.2 and clang 17+ HIP front-end, refer to [GCC](https://github.com/gcc-mirror/gcc/commit/96482ffe60d9bdec802fcad705c69641b2a3e040) and [P1064](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1064r0.html). It seems there's no obvious way to update default the GCC version in Azure Linux, so I decided to switch to C++17 for better compatibility. 
 - [x] Minor tweaks due to C++20 -> C++17.

## Tests
Local tests are all passed in gfx90a: [test_result_azurelinux.txt](https://github.com/user-attachments/files/16452048/test_result_azurelinux.txt)
