### PR TITLE
Add GemmPreferenceV2 and GemmTuningV2 for backward compatibility

### DIFF
--- a/clients/benchmarks/client_sequence.cpp
+++ b/clients/benchmarks/client_sequence.cpp
@@ -420,7 +420,7 @@ int main(int argc, char** argv)
     CHECK_HIP_ERROR(hipStreamCreate(&stream));
     CHECK_HIPBLASLT_ERROR(hipblasLtCreate(&handle));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResults;
     for(size_t i = 0; i < layer.size(); i++)

--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -445,7 +445,7 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b(const Arguments& arg)
     // Set User Preference attributes
     hipblasLtMatmulPreference_t pref;
     CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
-                                              
+
     const int                        request_solutions = 1;
     hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
     int                              returnedAlgoCount = 0;
@@ -517,7 +517,7 @@ void testing_aux_get_sol_with_zero_alpha_null_a_b_ext(const Arguments& arg)
     CHECK_HIP_ERROR(hipMalloc(&d_c, m * n * batch_count * sizeof(OutType)));
     CHECK_HIP_ERROR(hipMalloc(&d_d, m * n * batch_count * sizeof(OutType)));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, arg.a_type, arg.a_type, arg.a_type, arg.a_type, arg.compute_type);
 

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -1437,7 +1437,7 @@ void testing_matmul_with_bias(const Arguments& arg)
     std::vector<size_t>                           heuristicTuningIndex;
 
     // Cpp API
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     std::vector<hipblaslt_ext::Gemm>                      gemmVec;
     std::vector<hipblaslt_ext::GroupedGemm>               groupedGemmVec;

--- a/clients/samples/gemm/sample_hipblaslt_gemm_ext.cpp
+++ b/clients/samples/gemm/sample_hipblaslt_gemm_ext.cpp
@@ -97,7 +97,7 @@ void simpleGemmExt(hipblasLtHandle_t  handle,
                    int64_t            max_workspace_size,
                    hipStream_t        stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/gemm/sample_hipblaslt_gemm_ext_bgradb.cpp
+++ b/clients/samples/gemm/sample_hipblaslt_gemm_ext_bgradb.cpp
@@ -103,7 +103,7 @@ void simpleGemmEpilogueBiasVecExt(hipblasLtHandle_t   handle,
                                   int64_t             max_workspace_size,
                                   hipStream_t         stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(handle,
                              trans_a,

--- a/clients/samples/gemm_alphavec/sample_hipblaslt_gemm_alphavec_ext.cpp
+++ b/clients/samples/gemm_alphavec/sample_hipblaslt_gemm_alphavec_ext.cpp
@@ -100,7 +100,7 @@ void simpleGemmAlphaVecExt(hipblasLtHandle_t  handle,
                            int64_t            max_workspace_size,
                            hipStream_t        stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/gemm_get_algo_by_index/sample_hipblaslt_gemm_get_algo_by_index_ext.cpp
+++ b/clients/samples/gemm_get_algo_by_index/sample_hipblaslt_gemm_get_algo_by_index_ext.cpp
@@ -97,7 +97,7 @@ void simpleGemmGetAlgoByIndexExt(hipblasLtHandle_t  handle,
                                  int64_t            max_workspace_size,
                                  hipStream_t        stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/gemm_get_all_algos/sample_hipblaslt_gemm_get_all_algos_ext.cpp
+++ b/clients/samples/gemm_get_all_algos/sample_hipblaslt_gemm_get_all_algos_ext.cpp
@@ -109,7 +109,7 @@ void simpleGemmGetAllAlgosExt(hipblasLtHandle_t  handle,
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_ext.cpp
+++ b/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_ext.cpp
@@ -162,7 +162,7 @@ void simpleGemmMixPrecisionExt(hipblasLtHandle_t  handle,
                                int64_t            max_workspace_size,
                                hipStream_t        stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(handle,
                              trans_a,

--- a/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_amax_ext.cpp
+++ b/clients/samples/gemm_mix_precision/sample_hipblaslt_gemm_mix_precision_with_amax_ext.cpp
@@ -98,7 +98,7 @@ void simpleGemmMixPrecisionExt(hipblasLtHandle_t  handle,
                                int64_t            max_workspace_size,
                                hipStream_t        stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(handle,
                              trans_a,

--- a/clients/samples/gemm_tuning/sample_hipblaslt_gemm_tuning_splitk_ext.cpp
+++ b/clients/samples/gemm_tuning/sample_hipblaslt_gemm_tuning_splitk_ext.cpp
@@ -109,7 +109,7 @@ void simpleGemmTuningSplitKExt(hipblasLtHandle_t  handle,
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/gemm_tuning/sample_hipblaslt_gemm_tuning_wgm_ext.cpp
+++ b/clients/samples/gemm_tuning/sample_hipblaslt_gemm_tuning_wgm_ext.cpp
@@ -109,7 +109,7 @@ void simpleGemmTuningWGMExt(hipblasLtHandle_t  handle,
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::Gemm gemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/groupedgemm/sample_hipblaslt_groupedgemm_ext.cpp
+++ b/clients/samples/groupedgemm/sample_hipblaslt_groupedgemm_ext.cpp
@@ -102,7 +102,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
                           int64_t               max_workspace_size,
                           hipStream_t           stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::GroupedGemm groupedgemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/clients/samples/groupedgemm_fixed_mk/sample_hipblaslt_groupedgemm_fixed_mk_ext.cpp
+++ b/clients/samples/groupedgemm_fixed_mk/sample_hipblaslt_groupedgemm_fixed_mk_ext.cpp
@@ -113,7 +113,7 @@ void simpleGroupedGemmFixedMKExt(hipblasLtHandle_t     handle,
                                  int64_t               max_workspace_size,
                                  hipStream_t           stream)
 {
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::GroupedGemm groupedgemm(handle,
                                            trans_a,

--- a/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
+++ b/clients/samples/groupedgemm_get_all_algos/sample_hipblaslt_groupedgemm_get_all_algos_ext.cpp
@@ -80,7 +80,7 @@ void multipleGroupsGroupedGemmExt(hipblasLtHandle_t     handle,
                                    HIPBLAS_COMPUTE_32F,
                                    heuristicResult));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     std::vector<hipblaslt_ext::GroupedGemm>                      groupedGemms;
     std::vector<HipArrayBufferPtr<hipblaslt_ext::UserArguments>> groupedGemmUserArgs;
@@ -266,7 +266,7 @@ void simpleGroupedGemmExt(hipblasLtHandle_t     handle,
                                    HIPBLAS_COMPUTE_32F,
                                    heuristicResult));
 
-    hipblaslt_ext::GemmPreference gemmPref;
+    hipblaslt_ext::GemmPreferenceV2 gemmPref;
     gemmPref.setMaxWorkspaceBytes(max_workspace_size);
     hipblaslt_ext::GroupedGemm groupedgemm(
         handle, trans_a, trans_b, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIP_R_16F, HIPBLAS_COMPUTE_32F);

--- a/docs/ext-reference.rst
+++ b/docs/ext-reference.rst
@@ -75,6 +75,13 @@ GemmPreference
     :protected-members:
     :private-members:
 
+GemmPreferenceV2
+-------------------------------------
+.. doxygenclass:: hipblaslt_ext::GemmPreferenceV2
+    :members:
+    :protected-members:
+    :private-members:
+
 GemmInstance
 -------------------------------------
 .. doxygenclass:: hipblaslt_ext::GemmInstance
@@ -248,7 +255,7 @@ You can get heuristics and make kernel arguments with the instance. If the prope
 .. code-block:: c++
 
     // Pseudo code
-    hipblaslt_ext::GemmPreference pref;
+    hipblaslt_ext::GemmPreferenceV2 pref;
     pref.setMaxWorkspaceBytes(1000000);
     // Default epilogue mode is HIPBLASLT_EPILOGUE_DEFAULT
     hipblaslt_ext::GemmEpilogueV2 epilogue;
@@ -436,7 +443,7 @@ The following is a simple example of how this API works.
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference pref;
+    hipblaslt_ext::GemmPreferenceV2 pref;
     pref.setMaxWorkspaceBytes(1000000);
     // Step 2: Setup problem
     std::vector<int64_t> m(gemm_count);
@@ -514,7 +521,7 @@ This is the base class for ``Gemm`` and ``GroupedGemm``.
 
     // Gets huesristic from the instance.
     HIPBLASLT_EXPORT hipblasStatus_t algoGetHeuristic(const int                                      requestedAlgoCount,
-                                                      const GemmPreference&                          pref,
+                                                      const GemmPreferenceV2&                        pref,
                                                       std::vector<hipblasLtMatmulHeuristicResult_t>& heuristicResults);
 
     // Returns SUCCESS if the algo is supported, also returns the required workspace size in bytes.
@@ -639,7 +646,7 @@ Gemm
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference pref;
+    hipblaslt_ext::GemmPreferenceV2 pref;
     pref.setMaxWorkspaceBytes(1000000);
     hipblaslt_ext::GemmEpilogueV2 epilogue;
     epilogue.setMode(HIPBLASLT_EPILOGUE_GELU);
@@ -706,7 +713,7 @@ Grouped gemm
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference pref;
+    hipblaslt_ext::GemmPreferenceV2 pref;
     pref.setMaxWorkspaceBytes(1000000);
 
     std::vector<int64_t> m(gemm_count);
@@ -818,7 +825,7 @@ For example, we have a grouped gemm with gemm_count = 4. The sum of N must not e
                                                      HIPBLAS_COMPUTE_32F,
                                                      heuristicResult));
 
-    hipblaslt_ext::GemmPreference pref;
+    hipblaslt_ext::GemmPreferenceV2 pref;
     pref.setMaxWorkspaceBytes(1000000);
     // Step 2: Setup problem
     std::vector<int64_t> m(gemm_count);

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
@@ -380,6 +380,13 @@ rocblaslt_status rocblaslt_is_algo_supported_cpp(rocblaslt_handle            han
                                                  const rocblaslt::RocTuning* tuning,
                                                  size_t&                     workspaceSizeInBytes);
 
+rocblaslt_status rocblaslt_is_algo_supported_cpp(rocblaslt_handle              handle,
+                                                 rocblaslt::RocGemmType        gemmType,
+                                                 std::shared_ptr<void>         gemmData,
+                                                 rocblaslt_matmul_algo&        algo,
+                                                 const rocblaslt::RocTuningV2* tuning,
+                                                 size_t&                       workspaceSizeInBytes);
+
 rocblaslt_status
     rocblaslt_algo_get_heuristic_cpp(rocblaslt_handle       handle,
                                      rocblaslt::RocGemmType gemmType,

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-functions.h
@@ -256,6 +256,15 @@ rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle             handle,
                                             hipStream_t                  stream,
                                             std::shared_ptr<void>        gemmData);
 
+rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle              handle,
+                                            const rocblaslt::RocGemmType  gemmType,
+                                            const rocblaslt_matmul_algo&  algo,
+                                            const rocblaslt::RocTuningV2* tuning,
+                                            void*                         workspace,
+                                            bool                          useUserArgs,
+                                            hipStream_t                   stream,
+                                            std::shared_ptr<void>         gemmData);
+
 rocblaslt_status rocblaslt_get_default_user_args(rocblaslt_handle       handle,
                                                  rocblaslt::RocGemmType gemmType,
                                                  std::shared_ptr<void>  gemmData,

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
@@ -450,6 +450,13 @@ namespace rocblaslt
         uint8_t wgm = 0;
     };
 
+    class RocTuningV2
+    {
+    public:
+        uint16_t gsu = 0;
+        int16_t wgm  = 0;
+    };
+
     struct RocGemmInputs
     {
         void* a     = nullptr;

--- a/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp
@@ -302,10 +302,11 @@ rocblaslt_status groupedGemmCreate(std::vector<RocblasltContractionProblem>& pro
                                    std::shared_ptr<void>&                    gemmData,
                                    size_t&                                   gemmCount);
 
+template <typename Tuning>
 rocblaslt_status makeArgument(rocblaslt_handle             handle,
                               const rocblaslt::RocGemmType gemmType,
                               const rocblaslt_matmul_algo& algo,
-                              const rocblaslt::RocTuning*  tuning,
+                              const Tuning*                tuning,
                               void*                        workspace,
                               bool                         useUserArgs,
                               hipStream_t                  stream,
@@ -395,11 +396,12 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle             handle,
                                      rocblaslt_matmul_algo*       algo,
                                      size_t*                      workspaceSizeInBytes);
 
+template <typename Tuning>
 rocblaslt_status isSolutionSupported(rocblaslt_handle              handle,
                                      const rocblaslt::RocGemmType& gemmType,
                                      std::shared_ptr<void>         gemmData,
                                      rocblaslt_matmul_algo&        algo,
-                                     const rocblaslt::RocTuning*   tuning,
+                                     const Tuning*                 tuning,
                                      size_t&                       workspaceSizeInBytes);
 
 std::vector<std::shared_ptr<Tensile::ContractionSolution>> getBestRawSolutions(RocblasltContractionProblem const& prob,

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -1572,6 +1572,16 @@ rocblaslt_status rocblaslt_is_algo_supported_cpp(rocblaslt_handle            han
     return isSolutionSupported(handle, gemmType, gemmData, algo, tuning, workspaceSizeInBytes);
 }
 
+rocblaslt_status rocblaslt_is_algo_supported_cpp(rocblaslt_handle              handle,
+                                                 rocblaslt::RocGemmType        gemmType,
+                                                 std::shared_ptr<void>         gemmData,
+                                                 rocblaslt_matmul_algo&        algo,
+                                                 const rocblaslt::RocTuningV2* tuning,
+                                                 size_t&                       workspaceSizeInBytes)
+{
+    return isSolutionSupported(handle, gemmType, gemmData, algo, tuning, workspaceSizeInBytes);
+}
+
 rocblaslt_status
     rocblaslt_algo_get_heuristic_cpp(rocblaslt_handle       handle,
                                      rocblaslt::RocGemmType gemmType,
@@ -1621,7 +1631,7 @@ rocblaslt_status
                         if(*(int*)(results[j].algo.data)
                            == *(int*)(allSolutionsResults[i].algo.data)) //solution index
                             duplicated_sol = true;
-
+                    rocblaslt::RocTuningV2 *tuning = nullptr;
                     if(duplicated_sol == true
                        || rocblaslt_status_success
                               != isSolutionSupported(
@@ -1629,7 +1639,7 @@ rocblaslt_status
                                   static_cast<const rocblaslt::RocGemmType>(gemmType),
                                   gemmData,
                                   allSolutionsResults[i].algo,
-                                  nullptr,
+                                  tuning,
                                   workspaceSizeInBytes))
                         continue;
                     allSolutionsResults[i].workspaceSize = workspaceSizeInBytes;

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -1659,6 +1659,18 @@ rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle             handle,
     return makeArgument(handle, gemmType, algo, tuning, workspace, useUserArgs, stream, gemmData);
 }
 
+rocblaslt_status rocblaslt_makeArgument_cpp(rocblaslt_handle              handle,
+                                            const rocblaslt::RocGemmType  gemmType,
+                                            const rocblaslt_matmul_algo&  algo,
+                                            const rocblaslt::RocTuningV2* tuning,
+                                            void*                         workspace,
+                                            bool                          useUserArgs,
+                                            hipStream_t                   stream,
+                                            std::shared_ptr<void>         gemmData)
+{
+    return makeArgument(handle, gemmType, algo, tuning, workspace, useUserArgs, stream, gemmData);
+}
+
 std::string rocblaslt_get_kernel_name_from_data_cpp(rocblaslt_handle             handle,
                                                     const rocblaslt::RocGemmType gemmType,
                                                     std::shared_ptr<void>        gemmData)

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -48,7 +48,7 @@ namespace Tensile
     class TENSILE_API ContractionProblemParameters
     {
     public:
-        void setGSU(uint8_t gsu)
+        void setGSU(uint16_t gsu)
         {
             m_gsu = gsu;
         }
@@ -58,7 +58,7 @@ namespace Tensile
             return m_gsu;
         }
 
-        void setWgm(uint8_t wgm)
+        void setWgm(int16_t wgm)
         {
             m_wgm = wgm;
         }
@@ -104,8 +104,8 @@ namespace Tensile
         }
 
     private:
-        uint8_t        m_gsu            = 0; // default value
-        uint8_t        m_wgm            = 0; // default value
+        uint16_t       m_gsu            = 0; // default value
+        int16_t        m_wgm            = 0; // default value
         DataType       m_biasType       = DataType::None;
         int            m_factorDim      = 0;
         ActivationType m_activationType = ActivationType::None;


### PR DESCRIPTION
The datatypes of wgm and splitk are changed in GemmTuningV2

WGM -> int16_t: Allows negative WGM
splitK ->uint16_t: Supports large gsu values