### PR TITLE
Add sample codes for scale A and scale B

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -42,6 +42,8 @@ add_executable( sample_hipblaslt_groupedgemm_get_all_algos_ext groupedgemm_get_a
 add_executable( sample_hipblaslt_ext_op_layernorm ext_op/sample_hipblaslt_ext_op_layernorm.cpp)
 add_executable( sample_hipblaslt_ext_op_amax ext_op/sample_hipblaslt_ext_op_amax.cpp)
 add_executable( sample_hipblaslt_ext_op_amax_with_scale ext_op/sample_hipblaslt_ext_op_amax_with_scale.cpp)
+add_executable( sample_hipblaslt_scale_a gemm/sample_hipblaslt_scale_a.cpp)
+add_executable( sample_hipblaslt_scale_b gemm/sample_hipblaslt_scale_b.cpp)
 
 set(samples sample_hipblaslt_gemm
             sample_hipblaslt_gemm_ext
@@ -62,7 +64,9 @@ set(samples sample_hipblaslt_gemm
             sample_hipblaslt_groupedgemm_get_all_algos_ext
             sample_hipblaslt_ext_op_layernorm
             sample_hipblaslt_ext_op_amax
-            sample_hipblaslt_ext_op_amax_with_scale)
+            sample_hipblaslt_ext_op_amax_with_scale
+            sample_hipblaslt_scale_a
+            sample_hipblaslt_scale_b)
 
 set( sample_list_all ${samples})
 

--- a/clients/samples/gemm/sample_hipblaslt_scale_a.cpp
+++ b/clients/samples/gemm/sample_hipblaslt_scale_a.cpp
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hipblaslt/hipblaslt.h>
+#include <hip/library_types.h>
+#include <iostream>
+#include <vector>
+#include <iomanip>
+#include "helper.h"
+
+void simpleGemmScaleA(hipblasLtHandle_t handle,
+                      hipblasOperation_t trans_a,
+                      hipblasOperation_t trans_b,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      int64_t batch_count,
+                      float& alpha,
+                      float& beta,
+                      void* d_a,
+                      void* d_b,
+                      void* d_c,
+                      void* d_d,
+                      void* d_workspace,
+                      int64_t max_workspace_size,
+                      hipStream_t stream,
+                      float h_scale_a);
+
+int main()
+{
+    Runner<hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hipblasLtHalf, float, float> runner(
+        128, 128, 128, 1, 1.f, 0.f, 32 * 1024 * 1024);
+
+    float scale = 0.5f;
+    runner.run([&runner, scale] {
+        simpleGemmScaleA(runner.handle,
+                         HIPBLAS_OP_N,
+                         HIPBLAS_OP_N,
+                         runner.m,
+                         runner.n,
+                         runner.k,
+                         runner.batch_count,
+                         runner.alpha,
+                         runner.beta,
+                         runner.d_a,
+                         runner.d_b,
+                         runner.d_c,
+                         runner.d_d,
+                         runner.d_workspace,
+                         runner.max_workspace_size,
+                         runner.stream,
+                         scale);
+    });
+
+    return 0;
+}
+
+void initializeMatrix(void* d_matrix, int rows, int cols, float value, hipStream_t stream, hipDataType type)
+{
+    std::vector<float> h_matrix(rows * cols, value);
+    if (type == HIP_R_8F_E4M3_FNUZ || type == HIP_R_8F_E5M2_FNUZ) {
+        std::vector<uint8_t> temp_matrix(rows * cols, static_cast<uint8_t>(value));
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, temp_matrix.data(), rows * cols * sizeof(uint8_t), hipMemcpyHostToDevice, stream));
+    } else if (type == HIP_R_16F) {
+        std::vector<__half> temp_matrix(rows * cols, __float2half(value));
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, temp_matrix.data(), rows * cols * sizeof(__half), hipMemcpyHostToDevice, stream));
+    } else {
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, h_matrix.data(), rows * cols * sizeof(float), hipMemcpyHostToDevice, stream));
+    }
+}
+
+void simpleGemmScaleA(hipblasLtHandle_t handle,
+                      hipblasOperation_t trans_a,
+                      hipblasOperation_t trans_b,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      int64_t batch_count,
+                      float& alpha,
+                      float& beta,
+                      void* d_a,
+                      void* d_b,
+                      void* d_c,
+                      void* d_d,
+                      void* d_workspace,
+                      int64_t max_workspace_size,
+                      hipStream_t stream,
+                      float h_scale_a)
+{
+    float* d_scale_a;
+    CHECK_HIP_ERROR(hipMalloc(&d_scale_a, sizeof(float)));
+    CHECK_HIP_ERROR(hipMemcpyAsync(d_scale_a, &h_scale_a, sizeof(float), hipMemcpyHostToDevice, stream));
+
+    // Initialize matrices A and B
+    initializeMatrix(d_a, m, k, 1.0f, stream, HIP_R_8F_E4M3_FNUZ);
+    initializeMatrix(d_b, k, n, 2.0f, stream, HIP_R_8F_E4M3_FNUZ);
+
+    hipblasLtMatrixLayout_t matA, matB, matC, matD;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_8F_E4M3_FNUZ, m, k, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matB, HIP_R_8F_E4M3_FNUZ, k, n, k));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matC, HIP_R_16F, m, n, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, HIP_R_16F, m, n, m));
+
+    hipblasLtMatmulDesc_t matmul;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescCreate(&matmul, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(matmul, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
+
+    // Set A matrix scale factor
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_a, sizeof(float*)));
+
+    hipblasLtMatmulPreference_t pref;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceSetAttribute(
+        pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_workspace_size, sizeof(max_workspace_size)));
+
+    const int request_solutions = 5;
+    hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
+    int returnedAlgoCount = 0;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(
+        handle, matmul, matA, matB, matC, matD, pref, request_solutions, heuristicResult, &returnedAlgoCount));
+
+    if (returnedAlgoCount == 0)
+    {
+        std::cerr << "No valid solution found!" << std::endl;
+        return;
+    }
+
+    uint64_t workspace_size = max_workspace_size;
+    for (int i = 0; i < returnedAlgoCount; i++)
+        workspace_size = std::max(workspace_size, heuristicResult[i].workspaceSize);
+
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle, matmul, &alpha, d_a, matA, d_b, matB, &beta, d_c, matC, d_d, matD, 
+                                          &heuristicResult[0].algo, d_workspace, workspace_size, stream));
+
+    // Clean up resources
+    CHECK_HIP_ERROR(hipFree(d_scale_a));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceDestroy(pref));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescDestroy(matmul));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matA));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matB));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matC));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matD));
+
+    std::cout << "Matrix multiplication completed successfully." << std::endl;
+}

--- a/clients/samples/gemm/sample_hipblaslt_scale_b.cpp
+++ b/clients/samples/gemm/sample_hipblaslt_scale_b.cpp
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <hipblaslt/hipblaslt.h>
+#include <hip/library_types.h>
+#include <iostream>
+#include <vector>
+#include "helper.h"
+
+void simpleGemmScaleB(hipblasLtHandle_t handle,
+                      hipblasOperation_t trans_a,
+                      hipblasOperation_t trans_b,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      int64_t batch_count,
+                      float& alpha,
+                      float& beta,
+                      void* d_a,
+                      void* d_b,
+                      void* d_c,
+                      void* d_d,
+                      void* d_workspace,
+                      int64_t max_workspace_size,
+                      hipStream_t stream,
+                      float h_scale_b);
+
+int main()
+{
+    Runner<hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hipblasLtHalf, float, float> runner(
+        128, 128, 128, 1, 1.f, 0.f, 32 * 1024 * 1024);
+
+    float scale = 0.5f;
+    runner.run([&runner, scale] {
+        simpleGemmScaleB(runner.handle,
+                         HIPBLAS_OP_N,
+                         HIPBLAS_OP_N,
+                         runner.m,
+                         runner.n,
+                         runner.k,
+                         runner.batch_count,
+                         runner.alpha,
+                         runner.beta,
+                         runner.d_a,
+                         runner.d_b,
+                         runner.d_c,
+                         runner.d_d,
+                         runner.d_workspace,
+                         runner.max_workspace_size,
+                         runner.stream,
+                         scale);
+    });
+
+    return 0;
+}
+
+void initializeMatrix(void* d_matrix, int rows, int cols, float value, hipStream_t stream, hipDataType type)
+{
+    std::vector<float> h_matrix(rows * cols, value);
+    if (type == HIP_R_8F_E4M3_FNUZ || type == HIP_R_8F_E5M2_FNUZ) {
+        std::vector<uint8_t> temp_matrix(rows * cols, static_cast<uint8_t>(value));
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, temp_matrix.data(), rows * cols * sizeof(uint8_t), hipMemcpyHostToDevice, stream));
+    } else if (type == HIP_R_16F) {
+        std::vector<__half> temp_matrix(rows * cols, __float2half(value));
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, temp_matrix.data(), rows * cols * sizeof(__half), hipMemcpyHostToDevice, stream));
+    } else {
+        CHECK_HIP_ERROR(hipMemcpyAsync(d_matrix, h_matrix.data(), rows * cols * sizeof(float), hipMemcpyHostToDevice, stream));
+    }
+}
+
+void simpleGemmScaleB(hipblasLtHandle_t handle,
+                      hipblasOperation_t trans_a,
+                      hipblasOperation_t trans_b,
+                      int64_t m,
+                      int64_t n,
+                      int64_t k,
+                      int64_t batch_count,
+                      float& alpha,
+                      float& beta,
+                      void* d_a,
+                      void* d_b,
+                      void* d_c,
+                      void* d_d,
+                      void* d_workspace,
+                      int64_t max_workspace_size,
+                      hipStream_t stream,
+                      float h_scale_b)
+{
+    float* d_scale_b;
+    CHECK_HIP_ERROR(hipMalloc(&d_scale_b, sizeof(float)));
+    CHECK_HIP_ERROR(hipMemcpyAsync(d_scale_b, &h_scale_b, sizeof(float), hipMemcpyHostToDevice, stream));
+
+    // Initialize matrices A and B
+    initializeMatrix(d_a, m, k, 1.0f, stream, HIP_R_8F_E4M3_FNUZ);
+    initializeMatrix(d_b, k, n, 2.0f, stream, HIP_R_8F_E4M3_FNUZ);
+
+    hipblasLtMatrixLayout_t matA, matB, matC, matD;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_8F_E4M3_FNUZ, m, k, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matB, HIP_R_8F_E4M3_FNUZ, k, n, k));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matC, HIP_R_16F, m, n, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, HIP_R_16F, m, n, m));
+
+    hipblasLtMatmulDesc_t matmul;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescCreate(&matmul, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(matmul, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
+
+    // Set B matrix scale factor
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_b, sizeof(float*)));
+
+    hipblasLtMatmulPreference_t pref;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceSetAttribute(
+        pref, HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, &max_workspace_size, sizeof(max_workspace_size)));
+
+    const int request_solutions = 5;
+    hipblasLtMatmulHeuristicResult_t heuristicResult[request_solutions];
+    int returnedAlgoCount = 0;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulAlgoGetHeuristic(
+        handle, matmul, matA, matB, matC, matD, pref, request_solutions, heuristicResult, &returnedAlgoCount));
+
+    if (returnedAlgoCount == 0)
+    {
+        std::cerr << "No valid solution found!" << std::endl;
+        return;
+    }
+
+    uint64_t workspace_size = max_workspace_size;
+    for (int i = 0; i < returnedAlgoCount; i++)
+        workspace_size = std::max(workspace_size, heuristicResult[i].workspaceSize);
+
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle, matmul, &alpha, d_a, matA, d_b, matB, &beta, d_c, matC, d_d, matD, 
+                                          &heuristicResult[0].algo, d_workspace, workspace_size, stream));
+
+    // Clean up resources
+    CHECK_HIP_ERROR(hipFree(d_scale_b));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceDestroy(pref));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescDestroy(matmul));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matA));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matB));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matC));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matD));
+
+    std::cout << "Matrix multiplication completed successfully." << std::endl;
+}


### PR DESCRIPTION
Add sample codes for **HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER** and **HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER**

### Conclusion:
The sample codes successfully demonstrate the usage of **HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER** and **HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER** for scaling matrices A and B, respectively, during matrix multiplication operations. The local validations confirm that scaling factors are correctly applied on the device, affecting the matrix multiplication results as expected. For both matrices A and B, varying the scaling factors (0.5, 1.0, and 2.0) produced corresponding changes in the output matrices, verifying the correct implementation and usage of the scaling descriptors.

Here are details of local validations for testing if 

### Validation on Matrix A
- matrix A will take effect of scale A.
- the validation result is as below.
- `root@bfb46c6707f5:/Workspace/briachou/hipBLASLt/build/release# ./clients/staging/sample_hipblaslt_scale_a

**Running with Scale A = 0.5**

Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000       0.0000      64.0000      64.0000     200.0000 
    0.0000      76.0000       0.0000     204.0000     200.0000 
  192.0000      76.0000     200.0000      64.0000     192.0000 
  204.0000      64.0000      76.0000      76.0000     192.0000 
  200.0000       0.0000     204.0000     204.0000      64.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
  200.0000   192.0000    72.0000   192.0000   192.0000 
   64.0000   192.0000    72.0000   192.0000   200.0000 
   76.0000   192.0000    64.0000    64.0000    76.0000 
   76.0000     0.0000   192.0000   204.0000   192.0000 
   72.0000    64.0000   192.0000   192.0000    76.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
  -36.5000    25.0000     7.0000    12.0000   -36.0000 
   -1.0000     7.5000   -21.0000     3.0000    16.0000 
  -16.0000   -36.0000    43.5000   -25.5000     5.0000 
  -17.0000     8.5000    50.0000    42.5000    13.0000 
   12.5000   -14.0000     3.5000    -2.0000   -29.5000 

Scale A on device: 0.5000
Matrix multiplication completed successfully.

**Running with Scale A = 1.0000**

Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000     0.0000    64.0000    64.0000   200.0000 
    0.0000    76.0000     0.0000   204.0000   200.0000 
  192.0000    76.0000   200.0000    64.0000   192.0000 
  204.0000    64.0000    76.0000    76.0000   192.0000 
  200.0000     0.0000   204.0000   204.0000    64.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
  200.0000   192.0000    72.0000   192.0000   192.0000 
   64.0000   192.0000    72.0000   192.0000   200.0000 
   76.0000   192.0000    64.0000    64.0000    76.0000 
   76.0000     0.0000   192.0000   204.0000   192.0000 
   72.0000    64.0000   192.0000   192.0000    76.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
  -73.0000    50.0000    14.0000    24.0000   -72.0000 
   -2.0000    15.0000   -42.0000     6.0000    32.0000 
  -32.0000   -72.0000    87.0000   -51.0000    10.0000 
  -34.0000    17.0000   100.0000    85.0000    26.0000 
   25.0000   -28.0000     7.0000    -4.0000   -59.0000 

Scale A on device: 1.0000
Matrix multiplication completed successfully.

**Running with Scale A = 2.0000**

Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000     0.0000    64.0000    64.0000   200.0000 
    0.0000    76.0000     0.0000   204.0000   200.0000 
  192.0000    76.0000   200.0000    64.0000   192.0000 
  204.0000    64.0000    76.0000    76.0000   192.0000 
  200.0000     0.0000   204.0000   204.0000    64.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
  200.0000   192.0000    72.0000   192.0000   192.0000 
   64.0000   192.0000    72.0000   192.0000   200.0000 
   76.0000   192.0000    64.0000    64.0000    76.0000 
   76.0000     0.0000   192.0000   204.0000   192.0000 
   72.0000    64.0000   192.0000   192.0000    76.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
 -146.0000   100.0000    28.0000    48.0000  -144.0000 
   -4.0000    30.0000   -84.0000    12.0000    64.0000 
  -64.0000  -144.0000   174.0000  -102.0000    20.0000 
  -68.0000    34.0000   200.0000   170.0000    52.0000 
   50.0000   -56.0000    14.0000    -8.0000  -118.0000

Scale A on device: 2.0000
Matrix multiplication completed successfully.`


### Validation on Matrix B
- matrix B will take effect of scale B.
- the validation result is as below.
- `root@bfb46c6707f5:/Workspace/briachou/hipBLASLt/build/release# ./clients/staging/sample_hipblaslt_scale_b

**Running with Scale B = 0.5**

Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000   192.0000   200.0000    72.0000   192.0000 
  200.0000   192.0000   200.0000   204.0000    64.0000 
   72.0000    76.0000    64.0000     0.0000   204.0000 
   76.0000    72.0000     0.0000   192.0000     0.0000 
   64.0000    64.0000     0.0000   204.0000    72.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
   64.0000    64.0000    64.0000   204.0000   192.0000 
   72.0000   200.0000   204.0000    76.0000   204.0000 
  192.0000    76.0000    64.0000    72.0000    72.0000 
  192.0000    76.0000     0.0000   192.0000     0.0000 
   76.0000   204.0000    76.0000    64.0000     0.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
    5.0000     3.0000   -21.0000    -7.0000    -1.0000 
   20.0000    29.5000   -10.5000     9.0000   -10.0000 
   11.5000    25.0000    39.0000   -15.5000   -10.0000 
  -18.0000    13.5000     4.0000    -5.0000    13.5000 
   -9.5000    11.5000    31.5000   -35.0000     0.0000 

Scale B on device: 0.5000
Matrix multiplication completed successfully.

**Running with Scale B = 1.0000**

Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000   192.0000   200.0000    72.0000   192.0000 
  200.0000   192.0000   200.0000   204.0000    64.0000 
   72.0000    76.0000    64.0000     0.0000   204.0000 
   76.0000    72.0000     0.0000   192.0000     0.0000 
   64.0000    64.0000     0.0000   204.0000    72.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
   64.0000    64.0000    64.0000   204.0000   192.0000 
   72.0000   200.0000   204.0000    76.0000   204.0000 
  192.0000    76.0000    64.0000    72.0000    72.0000 
  192.0000    76.0000     0.0000   192.0000     0.0000 
   76.0000   204.0000    76.0000    64.0000     0.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
   10.0000     6.0000   -42.0000   -14.0000    -2.0000 
   40.0000    59.0000   -21.0000    18.0000   -20.0000 
   23.0000    50.0000    78.0000   -31.0000   -20.0000 
  -36.0000    27.0000     8.0000   -10.0000    27.0000 
  -19.0000    23.0000    63.0000   -70.0000     0.0000 

Scale B on device: 1.0000
Matrix multiplication completed successfully.

**Running with Scale B = 2.0000**

Running with Scale B = 2.0000
Returned Algorithm Count: 2
Using workspace size: 33554432
Solution 0: state=SUCCESS
Solution 1: state=SUCCESS
Matrix A before multiplication (128x128), showing top-left 5x5:
   64.0000   192.0000   200.0000    72.0000   192.0000 
  200.0000   192.0000   200.0000   204.0000    64.0000 
   72.0000    76.0000    64.0000     0.0000   204.0000 
   76.0000    72.0000     0.0000   192.0000     0.0000 
   64.0000    64.0000     0.0000   204.0000    72.0000 

Matrix B before multiplication (128x128), showing top-left 5x5:
   64.0000    64.0000    64.0000   204.0000   192.0000 
   72.0000   200.0000   204.0000    76.0000   204.0000 
  192.0000    76.0000    64.0000    72.0000    72.0000 
  192.0000    76.0000     0.0000   192.0000     0.0000 
   76.0000   204.0000    76.0000    64.0000     0.0000 

Matrix D after multiplication (128x128), showing top-left 5x5:
   20.0000    12.0000   -84.0000   -28.0000    -4.0000 
   80.0000   118.0000   -42.0000    36.0000   -40.0000 
   46.0000   100.0000   156.0000   -62.0000   -40.0000 
  -72.0000    54.0000    16.0000   -20.0000    54.0000 
  -38.0000    46.0000   126.0000  -140.0000     0.0000 

Scale B on device: 2.0000
Matrix multiplication completed successfully.`