### PR TITLE
remove xfail from i8 test since complier has fixed the llvm error

### DIFF
--- a/tensilelite/Tensile/Tests/common/gemm/gfx11/i8_gsu_gfx11.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx11/i8_gsu_gfx11.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1200, skip-gfx1201] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1200, skip-gfx1201] # not supported by arch
 GlobalParameters:
   NumElementsToValidate: -1
   KernelTime: True

--- a/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx12/i8_gsu_gfx12.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102] # not supported by arch
 GlobalParameters:
   NumElementsToValidate: -1
   KernelTime: True

--- a/tensilelite/Tensile/Tests/common/gemm/i8_gsu.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/i8_gsu.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+  marks: [skip-gfx940, skip-gfx941, skip-gfx942, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/tensilelite/Tensile/Tests/common/gemm/i8_gsu_gfx940.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/i8_gsu_gfx940.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [xfail, skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1


### PR DESCRIPTION
revert #728  and part of #746