### PR TITLE
Enable HardwareMonitor for gfx94x.

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -1611,11 +1611,6 @@ def assignGlobalParameters( config ):
       globalParameters["CurrentISA"] = (9,0,6)
       printWarning("Failed to detect ISA so forcing (gfx906) on windows")
 
-  # TODO Remove this when rocm-smi supports gfx940
-  if globalParameters["CurrentISA"] in [(9,4,0), (9,4,1), (9,4,2)]:
-    printWarning("HardwareMonitor currently disabled for gfx940")
-    globalParameters["HardwareMonitor"] = False
-
   globalParameters["AsmCaps"] = {}
   globalParameters["ArchCaps"] = {}
   globalParameters["AsmBugs"] = {}

--- a/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
+++ b/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
@@ -35,6 +35,7 @@
 
 #include <hip/hip_runtime.h>
 #include <rocm_smi/rocm_smi.h>
+#include <rocm_smi/rocm_smi64Config.h>
 
 namespace Tensile
 {
@@ -135,6 +136,8 @@ namespace Tensile
 
             size_t m_dataPoints;
 
+            uint16_t m_XCDCount;
+
             std::vector<std::tuple<rsmi_temperature_type_t, rsmi_temperature_metric_t>>
                                  m_tempMetrics;
             std::vector<int64_t> m_tempValues;
@@ -144,6 +147,10 @@ namespace Tensile
 
             std::vector<uint32_t> m_fanMetrics;
             std::vector<int64_t>  m_fanValues;
+
+            // Reserved for further performance check.
+            std::vector<uint64_t>              m_SYSCLK_sum;
+            std::vector<std::vector<uint64_t>> m_SYSCLK_array;
         };
     } // namespace Client
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -76,9 +76,13 @@ namespace Tensile
 #endif
 
             uint64_t hipPCIID = 0;
-            hipPCIID |= props.pciDeviceID & 0xFF;
-            hipPCIID |= ((props.pciBusID & 0xFF) << 8);
-            hipPCIID |= (props.pciDomainID) << 16;
+            // hipPCIID |= props.pciDeviceID & 0xFF;
+            // hipPCIID |= ((props.pciBusID & 0xFF) << 8);
+            // hipPCIID |= (props.pciDomainID) << 16;
+
+            hipPCIID |= (((uint64_t)props.pciDomainID & 0xffffffff) << 32);
+            hipPCIID |= ((props.pciBusID & 0xff) << 8);
+            hipPCIID |= ((props.pciDeviceID & 0x1f) << 3);
 
             uint32_t smiCount = 0;
 
@@ -125,23 +129,41 @@ namespace Tensile
         HardwareMonitor::HardwareMonitor(int hipDeviceIndex, clock::duration minPeriod)
             : m_minPeriod(minPeriod)
             , m_hipDeviceIndex(hipDeviceIndex)
-            , m_smiDeviceIndex(GetROCmSMIIndex(hipDeviceIndex))
             , m_dataPoints(0)
+            , m_XCDCount(1)
         {
             InitROCmSMI();
-
+            m_smiDeviceIndex = GetROCmSMIIndex(hipDeviceIndex);
             initThread();
+
+#if rocm_smi_VERSION_MAJOR >= 7
+            auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
+
+            if(status2 != RSMI_STATUS_SUCCESS)
+            {
+                m_XCDCount = 1;
+            }
+#endif
         }
 
         HardwareMonitor::HardwareMonitor(int hipDeviceIndex)
             : m_minPeriod(clock::duration::zero())
             , m_hipDeviceIndex(hipDeviceIndex)
-            , m_smiDeviceIndex(GetROCmSMIIndex(hipDeviceIndex))
             , m_dataPoints(0)
+            , m_XCDCount(1)
         {
             InitROCmSMI();
-
+            m_smiDeviceIndex = GetROCmSMIIndex(hipDeviceIndex);
             initThread();
+
+#if rocm_smi_VERSION_MAJOR >= 7
+            auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
+
+            if(status2 != RSMI_STATUS_SUCCESS)
+            {
+                m_XCDCount = 1;
+            }
+#endif
         }
 
         HardwareMonitor::~HardwareMonitor()
@@ -224,7 +246,14 @@ namespace Tensile
                     if(rawValue == std::numeric_limits<uint64_t>::max())
                         return std::numeric_limits<double>::quiet_NaN();
 
-                    return static_cast<double>(rawValue) / (1e6 * m_dataPoints);
+                    if(m_clockMetrics[i] == RSMI_CLK_TYPE_SYS)
+                    {
+                        return static_cast<double>(rawValue) / (1e6 * m_dataPoints * m_XCDCount);
+                    }
+                    else
+                    {
+                        return static_cast<double>(rawValue) / (1e6 * m_dataPoints);
+                    }
                 }
             }
 
@@ -303,10 +332,15 @@ namespace Tensile
 
             m_lastCollection = clock::time_point();
             m_nextCollection = clock::time_point();
+
+            m_SYSCLK_sum   = std::vector<uint64_t>(m_XCDCount, 0);
+            m_SYSCLK_array = std::vector<std::vector<uint64_t>>(m_XCDCount, std::vector<uint64_t>{});
         }
 
         void HardwareMonitor::collectOnce()
         {
+            const double cMhzToHz = 1000000;
+
             for(int i = 0; i < m_tempMetrics.size(); i++)
             {
                 // if an error occurred previously, don't overwrite it.
@@ -334,15 +368,49 @@ namespace Tensile
 
                 rsmi_frequencies_t freq;
 
-                auto status = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, m_clockMetrics[i], &freq);
-                if(status != RSMI_STATUS_SUCCESS)
+                if(m_clockMetrics[i] == RSMI_CLK_TYPE_SYS)
                 {
-                    m_clockValues[i] = std::numeric_limits<uint64_t>::max();
+#if rocm_smi_VERSION_MAJOR >= 7
+                    rsmi_gpu_metrics_t gpuMetrics;
+                    // multi_XCD
+                    auto status1 = rsmi_dev_gpu_metrics_info_get(m_smiDeviceIndex, &gpuMetrics);
+                    if(status1 == RSMI_STATUS_SUCCESS)
+                    {
+                        uint64_t sysclkSum = 0;
+                        for(uint32_t xcd = 0; xcd < m_XCDCount; xcd++)
+                        {
+                            m_SYSCLK_sum[xcd] += gpuMetrics.current_gfxclks[xcd] * cMhzToHz;
+                            m_SYSCLK_array[xcd].push_back(gpuMetrics.current_gfxclks[xcd] * cMhzToHz);
+                            sysclkSum += gpuMetrics.current_gfxclks[xcd] * cMhzToHz;
+                        }
+                        m_clockValues[i] += sysclkSum;
+                    }
+#else
+                    // XCD0
+                    auto status = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, m_clockMetrics[i], &freq);
+                    if(status != RSMI_STATUS_SUCCESS)
+                    {
+                        m_clockValues[i] = std::numeric_limits<uint64_t>::max();
+                    }
+                    else
+                    {
+                        m_clockValues[i] += freq.frequency[freq.current];
+                    }
+#endif
                 }
                 else
                 {
-                    m_clockValues[i] += freq.frequency[freq.current];
+                    auto status = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, m_clockMetrics[i], &freq);
+                    if(status != RSMI_STATUS_SUCCESS)
+                    {
+                        m_clockValues[i] = std::numeric_limits<uint64_t>::max();
+                    }
+                    else
+                    {
+                        m_clockValues[i] += freq.frequency[freq.current];
+                    }
                 }
+
             }
 
             for(int i = 0; i < m_fanMetrics.size(); i++)


### PR DESCRIPTION
1. Enable HardwareMonitor
2. Return average clock rate for all XCDs.