### PR TITLE
Library logic filter for developer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ function display_help()
   echo "    [--codecoverage] build with code coverage profiling enabled"
   echo "    [--gprof] enable profiling functionality with GNU gprof"
   echo "    [--keep-build-tmp] do not remove the temporary build artifacts or build_tmp"
+  echo "    [--dev-logic-filter] logic filter for developer, example: gfx942/Equality/* for building equality of gfx942 only"
 }
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root

--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ function display_help()
   echo "    [--codecoverage] build with code coverage profiling enabled"
   echo "    [--gprof] enable profiling functionality with GNU gprof"
   echo "    [--keep-build-tmp] do not remove the temporary build artifacts or build_tmp"
-  echo "    [--dev-logic-filter] logic filter for developer, example: gfx942/Equality/* for building equality of gfx942 only"
+  echo "    [--logic-yaml-filter] logic filter for developer, example: gfx942/Equality/* for building equality of gfx942 only"
 }
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
@@ -410,7 +410,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,disable-hipblaslt-marker,enable-tensile-marker,dev-logic-filter: --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,disable-hipblaslt-marker,enable-tensile-marker,logic-yaml-filter: --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -527,7 +527,7 @@ while true; do
         --enable-tensile-marker)
             enable_tensile_marker=true
             shift;;
-        --dev_logic_filter|--dev-logic-filter)
+        --logic_yaml_filter|--logic-yaml-filter)
             logic_filter=${2}
             shift 2;;
         --) shift ; break ;;

--- a/install.sh
+++ b/install.sh
@@ -394,6 +394,7 @@ enable_gprof=false
 keep_build_tmp=false
 disable_hipblaslt_marker=false
 enable_tensile_marker=false
+logic_filter=
 
 
 rocm_path=/opt/rocm
@@ -408,7 +409,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,disable-hipblaslt-marker,enable-tensile-marker --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,disable-hipblaslt-marker,enable-tensile-marker,dev-logic-filter: --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -525,6 +526,9 @@ while true; do
         --enable-tensile-marker)
             enable_tensile_marker=true
             shift;;
+        --dev_logic_filter|--dev-logic-filter)
+            logic_filter=${2}
+            shift 2;;
         --) shift ; break ;;
         *)  echo "Unexpected command line parameter received: '${1}'; aborting";
             exit 1
@@ -754,6 +758,10 @@ pushd .
 
   if [[ "${build_release}" == false ]]; then
     tensile_opt="${tensile_opt} -DTensile_ASM_DEBUG=ON"
+  fi
+
+  if ! [[ "${logic_filter}" == "" ]]; then
+    tensile_opt="${tensile_opt} -DTensile_LOGIC_FILTER=${logic_filter}"
   fi
 
   if [[ "${enable_gprof}" == true ]]; then

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -284,6 +284,7 @@ globalParameters["RotatingMode"] = 0 # Default is 0, allocated in order A0B0C0D0
 
 globalParameters["BuildIdKind"] = "sha1"
 globalParameters["ValidateLibrary"] = False
+globalParameters["AsmDebug"] = False # Set to True to keep debug information for compiled code objects
 
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1307,7 +1307,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--validate-library", dest="ValidateLibrary", action="store_true", default=False)
   argParser.add_argument("--logic-filter", dest="LogicFilter", action="store", default="*", type=str,
                         help="Cutomsized logic filter, default is *, i.e. all logics."
-                        " Example: gfx942/GridBased/* for building equality of gfx942 only")
+                        " Example: gfx942/Equality/* for building equality of gfx942 only")
 
   args = argParser.parse_args()
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1395,17 +1395,12 @@ def TensileCreateLibrary():
   def validLogicFile(p: Path):
     return p.suffix == logicExtFormat and ("all" in archs or archMatch(load_logic_gfx_arch(p), archs))
 
-  logicFiles = []
   globPattern = os.path.join(logicPath, f"**/{args.LogicFilter}{logicExtFormat}")
   print1(f"# LogicFilter: {globPattern}")
+  logicFiles = (os.path.join(logicPath, file) for file in glob.iglob(globPattern, recursive=True))
+  logicFiles = [file for file in logicFiles if validLogicFile(Path(file))]
 
-  for file in glob.iglob(f"**/{args.LogicFilter}{logicExtFormat}", recursive=True):
-    logic = os.path.join(logicPath, file)
-
-    if validLogicFile(Path(logic)):
-      logicFiles.append(logic)
-
-  print1("# LibraryLogicFiles:")
+  print1(f"# LibraryLogicFiles({len(logicFiles)}):")
   for logicFile in logicFiles:
     print1("#   %s" % logicFile)
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -44,6 +44,7 @@ from .CustomYamlLoader import load_logic_gfx_arch
 
 import argparse
 import collections
+import glob
 import itertools
 import math
 import os
@@ -1304,6 +1305,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--keep-build-tmp", dest="KeepBuildTmp", action="store_true",
                           default=False, help="Do not remove the temporary build directory (may required hundreds of GBs of space)"),
   argParser.add_argument("--validate-library", dest="ValidateLibrary", action="store_true", default=False)
+  argParser.add_argument("--logic-filter", dest="LogicFilter", action="store", default="*", type=str)
 
   args = argParser.parse_args()
 
@@ -1395,11 +1397,15 @@ def TensileCreateLibrary():
 
   logicFiles = []
 
-  for root, _, files in os.walk(logicPath):
-    logics = (os.path.join(root, f) for f in files)
-    logicFiles += [file for file in logics if validLogicFile(Path(file))]
+  for file in glob.glob(f"**/{args.LogicFilter}{logicExtFormat}", root_dir=logicPath, recursive=True):
+    logic = os.path.join(logicPath, file)
 
-  print1("# LibraryLogicFiles:" % logicFiles)
+    if validLogicFile(Path(logic)):
+      logicFiles.append(logic)
+
+  print1(f"# LogicFilter: {args.LogicFilter}")
+
+  print1("# LibraryLogicFiles:")
   for logicFile in logicFiles:
     print1("#   %s" % logicFile)
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1396,14 +1396,14 @@ def TensileCreateLibrary():
     return p.suffix == logicExtFormat and ("all" in archs or archMatch(load_logic_gfx_arch(p), archs))
 
   logicFiles = []
+  globPattern = os.path.join(logicPath, f"**/{args.LogicFilter}{logicExtFormat}")
+  print1(f"# LogicFilter: {globPattern}")
 
-  for file in glob.glob(f"**/{args.LogicFilter}{logicExtFormat}", root_dir=logicPath, recursive=True):
+  for file in glob.iglob(f"**/{args.LogicFilter}{logicExtFormat}", recursive=True):
     logic = os.path.join(logicPath, file)
 
     if validLogicFile(Path(logic)):
       logicFiles.append(logic)
-
-  print1(f"# LogicFilter: {args.LogicFilter}")
 
   print1("# LibraryLogicFiles:")
   for logicFile in logicFiles:

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1305,7 +1305,9 @@ def TensileCreateLibrary():
   argParser.add_argument("--keep-build-tmp", dest="KeepBuildTmp", action="store_true",
                           default=False, help="Do not remove the temporary build directory (may required hundreds of GBs of space)"),
   argParser.add_argument("--validate-library", dest="ValidateLibrary", action="store_true", default=False)
-  argParser.add_argument("--logic-filter", dest="LogicFilter", action="store", default="*", type=str)
+  argParser.add_argument("--logic-filter", dest="LogicFilter", action="store", default="*", type=str,
+                        help="Cutomsized logic filter, default is *, i.e. all logics."
+                        " Example: gfx942/GridBased/* for building equality of gfx942 only")
 
   args = argParser.parse_args()
 

--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -197,6 +197,10 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--asm-debug")
   endif()
 
+  if(Tensile_LOGIC_FILTER)
+    set(Options ${Options} "--logic-filter=${Tensile_LOGIC_FILTER}")
+  endif()
+
   if(Tensile_LIBRARY_FORMAT)
     set(Options ${Options} "--library-format=${Tensile_LIBRARY_FORMAT}")
     if(Tensile_LIBRARY_FORMAT MATCHES "yaml")


### PR DESCRIPTION
## Brief ##
Added ~~`--dev-logic-filter`~~ `--logic-yaml-filter` to `install.sh` for developer. It's equivalent to the following glob pattern for logic searching:

```bash
<logic-root>/**/<logic-yaml-filter>.yaml
```
E.g.
```bash
bash ./install.sh -a gfx90a --logic-yaml-filter *BBS*
```
then only the following logics will be built

```bash   library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/Equality/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bljk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Ailk_Bjlk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bjlk_BBS_BH_Bias_AH_SAV.yaml
library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/104CU/GridBased/aldebaran_Cijk_Alik_Bljk_BBS_BH_Bias_AH_SAV.yaml
```

## Implementation ##
 - [x] Added ~~`--dev-logic-filter`~~ `--logic-yaml-filter` option to `install.sh`
 - [x] Added `--logic-filter` option to `TensileCreateLibrary.py`
 - [x] CMake integration