### PR TITLE
[Enhance client's build time] Remove template type for testing_matmul_with_bias

### DIFF
--- a/clients/common/cblas_interface.cpp
+++ b/clients/common/cblas_interface.cpp
@@ -24,6 +24,7 @@
  *
  *******************************************************************************/
 #include "cblas_interface.hpp"
+#include "datatype_interface.hpp"
 #include "hipblaslt_vector.hpp"
 #include "utility.hpp"
 #include <bitset>
@@ -77,190 +78,704 @@ private:
     void*          m_pointer = nullptr;
 };
 
-template <typename TiA, typename TiB, typename To, typename Tc, typename TciA, typename TciB>
-void cblas_gemm(hipblasOperation_t     transA,
-                hipblasOperation_t     transB,
-                int64_t                m,
-                int64_t                n,
-                int64_t                k,
-                Tc                     alpha,
-                const TiA*             A,
-                int64_t                lda,
-                const TiB*             B,
-                int64_t                ldb,
-                Tc                     beta,
-                std::add_pointer_t<To> C,
-                int64_t                ldc,
-                const Tc*              AlphaVec,
-                const Tc*              scaleAVec,
-                const Tc*              scaleBVec,
-                Tc                     scaleD,
-                bool                   isScaleAVec,
-                bool                   isScaleBVec,
-                bool                   alt)
+template <typename TD, typename TcCast, typename Tc>
+void sat_cast_mul(TD* dst, customVector<TcCast>& src, Tc scale, size_t size)
 {
-    using TcCast  = std::conditional_t<std::is_same<Tc, int32_t>::value, double, Tc>;
-    using TciACast = std::conditional_t<std::is_same<TciA, int32_t>::value, double, TciA>;
-    using TciBCast = std::conditional_t<std::is_same<TciB, int32_t>::value, double, TciB>;
+    if constexpr(std::is_same<TcCast, float>::value
+                 || (!std::is_same<TD, hipblaslt_bf8_fnuz>::value
+                     && !std::is_same<TD, hipblaslt_f8_fnuz>::value))
+    {
+        if(scale != 1)
+        {
+            for(size_t i = 0; i < size; i++)
+                dst[i] = saturate_cast<TD>(src[i] * scale);
+        }
+        else
+        {
+            for(size_t i = 0; i < size; i++)
+                dst[i] = saturate_cast<TD>(src[i]);
+        }
+    }
+}
+
+template <typename TcCast, typename Tc>
+void sat_cast_mul(void* dst, hipDataType typeD, customVector<TcCast>& src, Tc scale, size_t size)
+{
+    switch(typeD)
+    {
+    case HIP_R_32F:
+        sat_cast_mul<float, TcCast, Tc>(static_cast<float*>(dst), src, scale, size);
+        break;
+    case HIP_R_64F:
+        sat_cast_mul<double, TcCast, Tc>(static_cast<double*>(dst), src, scale, size);
+        break;
+    case HIP_R_16F:
+        sat_cast_mul<hipblasLtHalf, TcCast, Tc>(static_cast<hipblasLtHalf*>(dst), src, scale, size);
+        break;
+    case HIP_R_16BF:
+        sat_cast_mul<hip_bfloat16, TcCast, Tc>(static_cast<hip_bfloat16*>(dst), src, scale, size);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        sat_cast_mul<hipblaslt_f8_fnuz, TcCast, Tc>(
+            static_cast<hipblaslt_f8_fnuz*>(dst), src, scale, size);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        sat_cast_mul<hipblaslt_bf8_fnuz, TcCast, Tc>(
+            static_cast<hipblaslt_bf8_fnuz*>(dst), src, scale, size);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        sat_cast_mul<hipblaslt_f8_ocp, TcCast, Tc>(
+            static_cast<hipblaslt_f8_ocp*>(dst), src, scale, size);
+        break;
+    case HIP_R_8F_E5M2:
+        sat_cast_mul<hipblaslt_bf8_ocp, TcCast, Tc>(
+            static_cast<hipblaslt_bf8_ocp*>(dst), src, scale, size);
+        break;
+#endif
+    case HIP_R_32I:
+        sat_cast_mul<int32_t, TcCast, Tc>(static_cast<int32_t*>(dst), src, scale, size);
+        break;
+    case HIP_R_8I:
+        sat_cast_mul<hipblasLtInt8, TcCast, Tc>(static_cast<hipblasLtInt8*>(dst), src, scale, size);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in sat_cast_mul" << std::endl;
+        break;
+    }
+}
+
+template <typename TcCast, typename TiA>
+void cast_mul(customVector<TcCast>& dst, const TiA* src, size_t size)
+{
+    if constexpr(std::is_same<TcCast, float>::value
+                 || (!std::is_same<TiA, hipblaslt_bf8_fnuz>::value
+                     && !std::is_same<TiA, hipblaslt_f8_fnuz>::value))
+    {
+#ifdef ROCM_USE_FLOAT8
+        if constexpr(std::is_same<TcCast, float>::value
+                     || !(std::is_same<TiA, hipblaslt_bf8_ocp>::value
+                          || std::is_same<TiA, hipblaslt_f8_ocp>::value))
+#endif
+            for(size_t i = 0; i < size; i++)
+            {
+                dst[i] = static_cast<TcCast>(src[i]);
+            }
+    }
+}
+
+template <typename TcCast>
+void cast_mul(customVector<TcCast>& dst, const void* src, hipDataType TiA, size_t size)
+{
+    switch(TiA)
+    {
+    case HIP_R_32F:
+        cast_mul<TcCast, float>(dst, static_cast<const float*>(src), size);
+        break;
+    case HIP_R_64F:
+        cast_mul<TcCast, double>(dst, static_cast<const double*>(src), size);
+        break;
+    case HIP_R_16F:
+        cast_mul<TcCast, hipblasLtHalf>(dst, static_cast<const hipblasLtHalf*>(src), size);
+        break;
+    case HIP_R_16BF:
+        cast_mul<TcCast, hip_bfloat16>(dst, static_cast<const hip_bfloat16*>(src), size);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        cast_mul<TcCast, hipblaslt_f8_fnuz>(dst, static_cast<const hipblaslt_f8_fnuz*>(src), size);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        cast_mul<TcCast, hipblaslt_bf8_fnuz>(
+            dst, static_cast<const hipblaslt_bf8_fnuz*>(src), size);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        cast_mul<TcCast, hipblaslt_f8_ocp>(dst, static_cast<const hipblaslt_f8_ocp*>(src), size);
+        break;
+    case HIP_R_8F_E5M2:
+        cast_mul<TcCast, hipblaslt_bf8_ocp>(dst, static_cast<const hipblaslt_bf8_ocp*>(src), size);
+        break;
+#endif
+    case HIP_R_32I:
+        cast_mul<TcCast, int32_t>(dst, static_cast<const int32_t*>(src), size);
+        break;
+    case HIP_R_8I:
+        cast_mul<TcCast, hipblasLtInt8>(dst, static_cast<const hipblasLtInt8*>(src), size);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in cast_mul" << std::endl;
+        break;
+    }
+}
+
+template <typename TcCast, typename Tc, typename TiA>
+void cast_mul(customVector<TcCast>& dst,
+              const TiA*            A,
+              bool                  isScaleAVec,
+              const Tc*             scaleAVec,
+              const Tc*             AlphaVec,
+              bool                  transA,
+              int64_t               m,
+              int64_t               k,
+              size_t                size)
+{
+    if constexpr((std::is_same<TcCast, float>::value)
+                 || (!std::is_same<TiA, hipblaslt_bf8_fnuz>::value
+                     && !std::is_same<TiA, hipblaslt_f8_fnuz>::value))
+    {
+#ifdef ROCM_USE_FLOAT8
+        if constexpr(std::is_same<TcCast, float>::value
+                     || !(std::is_same<TiA, hipblaslt_bf8_ocp>::value
+                          || std::is_same<TiA, hipblaslt_f8_ocp>::value))
+        {
+#endif
+            if(AlphaVec != nullptr)
+            {
+                if(transA)
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(A[i]) * scaleA * AlphaVec[i % m];
+                    }
+                }
+                else
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(A[i]) * scaleA * AlphaVec[i / k];
+                    }
+                }
+            }
+            else
+            {
+                if(transA)
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(A[i] * scaleA);
+                    }
+                }
+                else
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(A[i] * scaleA);
+                    }
+                }
+            }
+#ifdef ROCM_USE_FLOAT8
+        }
+#endif
+    }
+}
+
+template <typename TcCast, typename Tc>
+void cast_mul(customVector<TcCast>& dst,
+              const void*           src,
+              hipDataType           TiA,
+              bool                  isScaleAVec,
+              const Tc*             scaleAVec,
+              const Tc*             AlphaVec,
+              bool                  transA,
+              int64_t               m,
+              int64_t               k,
+              size_t                size)
+{
+    switch(TiA)
+    {
+    case HIP_R_32F:
+        cast_mul<TcCast, Tc, float>(dst,
+                                    static_cast<const float*>(src),
+                                    isScaleAVec,
+                                    scaleAVec,
+                                    AlphaVec,
+                                    transA,
+                                    m,
+                                    k,
+                                    size);
+        break;
+    case HIP_R_64F:
+        cast_mul<TcCast, Tc, double>(dst,
+                                     static_cast<const double*>(src),
+                                     isScaleAVec,
+                                     scaleAVec,
+                                     AlphaVec,
+                                     transA,
+                                     m,
+                                     k,
+                                     size);
+        break;
+    case HIP_R_16F:
+        cast_mul<TcCast, Tc, hipblasLtHalf>(dst,
+                                            static_cast<const hipblasLtHalf*>(src),
+                                            isScaleAVec,
+                                            scaleAVec,
+                                            AlphaVec,
+                                            transA,
+                                            m,
+                                            k,
+                                            size);
+        break;
+    case HIP_R_16BF:
+        cast_mul<TcCast, Tc, hip_bfloat16>(dst,
+                                           static_cast<const hip_bfloat16*>(src),
+                                           isScaleAVec,
+                                           scaleAVec,
+                                           AlphaVec,
+                                           transA,
+                                           m,
+                                           k,
+                                           size);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        cast_mul<TcCast, Tc, hipblaslt_f8_fnuz>(dst,
+                                                static_cast<const hipblaslt_f8_fnuz*>(src),
+                                                isScaleAVec,
+                                                scaleAVec,
+                                                AlphaVec,
+                                                transA,
+                                                m,
+                                                k,
+                                                size);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        cast_mul<TcCast, Tc, hipblaslt_bf8_fnuz>(dst,
+                                                 static_cast<const hipblaslt_bf8_fnuz*>(src),
+                                                 isScaleAVec,
+                                                 scaleAVec,
+                                                 AlphaVec,
+                                                 transA,
+                                                 m,
+                                                 k,
+                                                 size);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        cast_mul<TcCast, Tc, hipblaslt_f8_ocp>(dst,
+                                               static_cast<const hipblaslt_f8_ocp*>(src),
+                                               isScaleAVec,
+                                               scaleAVec,
+                                               AlphaVec,
+                                               transA,
+                                               m,
+                                               k,
+                                               size);
+        break;
+    case HIP_R_8F_E5M2:
+        cast_mul<TcCast, Tc, hipblaslt_bf8_ocp>(dst,
+                                                static_cast<const hipblaslt_bf8_ocp*>(src),
+                                                isScaleAVec,
+                                                scaleAVec,
+                                                AlphaVec,
+                                                transA,
+                                                m,
+                                                k,
+                                                size);
+        break;
+#endif
+    case HIP_R_32I:
+        cast_mul<TcCast, Tc, int32_t>(dst,
+                                      static_cast<const int32_t*>(src),
+                                      isScaleAVec,
+                                      scaleAVec,
+                                      AlphaVec,
+                                      transA,
+                                      m,
+                                      k,
+                                      size);
+        break;
+    case HIP_R_8I:
+        cast_mul<TcCast, Tc, hipblasLtInt8>(dst,
+                                            static_cast<const hipblasLtInt8*>(src),
+                                            isScaleAVec,
+                                            scaleAVec,
+                                            AlphaVec,
+                                            transA,
+                                            m,
+                                            k,
+                                            size);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in cast_mul" << std::endl;
+        break;
+    }
+}
+
+template <typename TcCast, typename Tc, typename TciACast, typename TiA>
+void cast_mul_with_Tci(customVector<TcCast>& dst,
+                       const TiA*            A,
+                       bool                  isScaleAVec,
+                       const Tc*             scaleAVec,
+                       const Tc*             AlphaVec,
+                       bool                  transA,
+                       int64_t               m,
+                       int64_t               k,
+                       size_t                size)
+{
+    if constexpr(std::is_same<TcCast, float>::value
+                 || (!std::is_same<TciACast, hipblaslt_bf8_fnuz>::value
+                     && !std::is_same<TciACast, hipblaslt_f8_fnuz>::value)
+                        && (!std::is_same<TiA, hipblaslt_bf8_fnuz>::value
+                            && !std::is_same<TiA, hipblaslt_f8_fnuz>::value))
+    {
+#ifdef ROCM_USE_FLOAT8
+        if constexpr(std::is_same<TcCast, float>::value
+                     || (!std::is_same<TciACast, hipblaslt_bf8_ocp>::value
+                         && !std::is_same<TciACast, hipblaslt_f8_ocp>::value)
+                            && (!std::is_same<TiA, hipblaslt_bf8_ocp>::value
+                                && !std::is_same<TiA, hipblaslt_f8_ocp>::value))
+        {
+#endif
+            if(AlphaVec != nullptr)
+            {
+                if(transA)
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA))
+                                 * AlphaVec[i % m];
+                    }
+                }
+                else
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA))
+                                 * AlphaVec[i / k];
+                    }
+                }
+            }
+            else
+            {
+                if(transA)
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA));
+                    }
+                }
+                else
+                {
+#pragma omp for
+                    for(size_t i = 0; i < size; i++)
+                    {
+                        auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
+                        dst[i]      = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA));
+                    }
+                }
+            }
+#ifdef ROCM_USE_FLOAT8
+        }
+#endif
+    }
+}
+
+template <typename TcCast, typename Tc, typename TciACast>
+void cast_mul_with_Tci(customVector<TcCast>& dst,
+                       const void*           src,
+                       hipDataType           TiA,
+                       bool                  isScaleAVec,
+                       const Tc*             scaleAVec,
+                       const Tc*             AlphaVec,
+                       bool                  transA,
+                       int64_t               m,
+                       int64_t               k,
+                       size_t                size)
+{
+    switch(TiA)
+    {
+    case HIP_R_32F:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, float>(dst,
+                                                       static_cast<const float*>(src),
+                                                       isScaleAVec,
+                                                       scaleAVec,
+                                                       AlphaVec,
+                                                       transA,
+                                                       m,
+                                                       k,
+                                                       size);
+        break;
+    case HIP_R_64F:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, double>(dst,
+                                                        static_cast<const double*>(src),
+                                                        isScaleAVec,
+                                                        scaleAVec,
+                                                        AlphaVec,
+                                                        transA,
+                                                        m,
+                                                        k,
+                                                        size);
+        break;
+    case HIP_R_16F:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblasLtHalf>(
+            dst,
+            static_cast<const hipblasLtHalf*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+    case HIP_R_16BF:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hip_bfloat16>(dst,
+                                                              static_cast<const hip_bfloat16*>(src),
+                                                              isScaleAVec,
+                                                              scaleAVec,
+                                                              AlphaVec,
+                                                              transA,
+                                                              m,
+                                                              k,
+                                                              size);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblaslt_f8_fnuz>(
+            dst,
+            static_cast<const hipblaslt_f8_fnuz*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblaslt_bf8_fnuz>(
+            dst,
+            static_cast<const hipblaslt_bf8_fnuz*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblaslt_f8_ocp>(
+            dst,
+            static_cast<const hipblaslt_f8_ocp*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+    case HIP_R_8F_E5M2:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblaslt_bf8_ocp>(
+            dst,
+            static_cast<const hipblaslt_bf8_ocp*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+#endif
+    case HIP_R_32I:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, int32_t>(dst,
+                                                         static_cast<const int32_t*>(src),
+                                                         isScaleAVec,
+                                                         scaleAVec,
+                                                         AlphaVec,
+                                                         transA,
+                                                         m,
+                                                         k,
+                                                         size);
+        break;
+    case HIP_R_8I:
+        cast_mul_with_Tci<TcCast, Tc, TciACast, hipblasLtInt8>(
+            dst,
+            static_cast<const hipblasLtInt8*>(src),
+            isScaleAVec,
+            scaleAVec,
+            AlphaVec,
+            transA,
+            m,
+            k,
+            size);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in cast_mul_with_Tci" << std::endl;
+        break;
+    }
+}
+
+template <typename TcCast, typename Tc>
+void cast_mul_with_Tci(customVector<TcCast>& dst,
+                       const void*           src,
+                       hipDataType           TiA,
+                       bool                  isScaleAVec,
+                       const Tc*             scaleAVec,
+                       const Tc*             AlphaVec,
+                       bool                  transA,
+                       int64_t               m,
+                       int64_t               k,
+                       hipDataType           TciACast,
+                       size_t                size)
+{
+    switch(TciACast)
+    {
+    case HIP_R_32F:
+        cast_mul_with_Tci<TcCast, Tc, float>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_64F:
+        cast_mul_with_Tci<TcCast, Tc, double>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_16F:
+        cast_mul_with_Tci<TcCast, Tc, hipblasLtHalf>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_16BF:
+        cast_mul_with_Tci<TcCast, Tc, hip_bfloat16>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        cast_mul_with_Tci<TcCast, Tc, hipblaslt_f8_fnuz>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        cast_mul_with_Tci<TcCast, Tc, hipblaslt_bf8_fnuz>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        cast_mul_with_Tci<TcCast, Tc, hipblaslt_f8_ocp>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_8F_E5M2:
+        cast_mul_with_Tci<TcCast, Tc, hipblaslt_bf8_ocp>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+#endif
+    case HIP_R_32I:
+        cast_mul_with_Tci<TcCast, Tc, int32_t>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    case HIP_R_8I:
+        cast_mul_with_Tci<TcCast, Tc, hipblasLtInt8>(
+            dst, src, TiA, isScaleAVec, scaleAVec, AlphaVec, transA, m, k, size);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in cast_mul_with_Tci" << std::endl;
+        break;
+    }
+}
+
+template <typename Tc>
+void cblas_gemm(hipblasOperation_t       transA,
+                hipblasOperation_t       transB,
+                int64_t                  m,
+                int64_t                  n,
+                int64_t                  k,
+                Tc                       alpha,
+                const void*              A,
+                int64_t                  lda,
+                const void*              B,
+                int64_t                  ldb,
+                Tc                       beta,
+                std::add_pointer_t<void> C,
+                int64_t                  ldc,
+                const Tc*                AlphaVec,
+                const Tc*                scaleAVec,
+                const Tc*                scaleBVec,
+                Tc                       scaleD,
+                bool                     isScaleAVec,
+                bool                     isScaleBVec,
+                hipDataType              TiA,
+                hipDataType              TiB,
+                hipDataType              To,
+                hipDataType              Tc_enum,
+                hipDataType              TciA,
+                hipDataType              TciB,
+                bool                     alt)
+{
+    using TcCast         = std::conditional_t<std::is_same<Tc, int32_t>::value, double, Tc>;
+    Tc_enum              = (Tc_enum == HIP_R_32I) ? HIP_R_64F : Tc_enum;
+    hipDataType TciACast = (TciA == HIP_R_32I) ? HIP_R_64F : TciA;
+    hipDataType TciBCast = (TciB == HIP_R_32I) ? HIP_R_64F : TciB;
 
     // cblas does not support hipblasLtHalf, so convert to higher precision float
     // This will give more precise result which is acceptable for testing
-
     size_t sizeA = (transA == HIPBLAS_OP_N ? k : m) * size_t(lda);
     size_t sizeB = (transB == HIPBLAS_OP_N ? n : k) * size_t(ldb);
     size_t sizeC = n * size_t(ldc);
 
     customVector<TcCast> A_Tc, B_Tc, C_Tc;
-    if(AlphaVec != nullptr)
+
+    A_Tc.initialize(sizeA);
+    if(realDataTypeSize(TiA) > realDataTypeSize(TciACast))
     {
-        A_Tc.initialize(sizeA);
-        if constexpr(sizeof(TiA) > sizeof(TciACast))
-        {
-            if(transA == HIPBLAS_OP_N)
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA))
-                              * AlphaVec[i % m];
-                }
-            }
-            else
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA))
-                              * AlphaVec[i / k];
-                }
-            }
-        }
-        else
-        {
-            if(transA == HIPBLAS_OP_N)
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(A[i]) * scaleA * AlphaVec[i % m];
-                }
-            }
-            else
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i  / k] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(A[i]) * scaleA * AlphaVec[i / k];
-                }
-            }
-        }
+        cast_mul_with_Tci<TcCast, Tc>(A_Tc,
+                                      A,
+                                      TiA,
+                                      isScaleAVec,
+                                      scaleAVec,
+                                      AlphaVec,
+                                      transA == HIPBLAS_OP_N,
+                                      m,
+                                      k,
+                                      TciACast,
+                                      sizeA);
     }
     else
     {
-        A_Tc.initialize(sizeA);
-        if constexpr(sizeof(TiA) > sizeof(TciACast))
-        {
-            if(transA == HIPBLAS_OP_N)
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA));
-                }
-            }
-            else
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(static_cast<TciACast>(A[i] * scaleA));
-                }
-            }
-        }
-        else
-        {
-            if(transA == HIPBLAS_OP_N)
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i % m] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(A[i] * scaleA);
-                }
-            }
-            else
-            {
-                #pragma omp for
-                for(size_t i = 0; i < sizeA; i++)
-                {
-                    auto scaleA = isScaleAVec ? scaleAVec[i / k] : scaleAVec[0];
-                    A_Tc[i] = static_cast<TcCast>(A[i] * scaleA);
-                }
-            }
-        }
+        cast_mul<TcCast, Tc>(
+            A_Tc, A, TiA, isScaleAVec, scaleAVec, AlphaVec, transA == HIPBLAS_OP_N, m, k, sizeA);
     }
 
     B_Tc.initialize(sizeB);
-    if constexpr(sizeof(TiB) > sizeof(TciBCast))
+    if(realDataTypeSize(TiB) > realDataTypeSize(TciBCast))
     {
-        if(transB == HIPBLAS_OP_N)
-        {
-            #pragma omp for
-            for(size_t i = 0; i < sizeB; i++)
-            {
-                auto scaleB = isScaleBVec ? scaleBVec[i / k] : scaleBVec[0];
-                B_Tc[i] = static_cast<TcCast>(static_cast<TciBCast>(B[i] * scaleB));
-            }
-        }
-        else
-        {
-            #pragma omp for
-            for(size_t i = 0; i < sizeB; i++)
-            {
-                auto scaleB = isScaleBVec ? scaleBVec[i % n] : scaleBVec[0];
-                B_Tc[i] = static_cast<TcCast>(static_cast<TciBCast>(B[i] * scaleB));
-            }
-        }
+        cast_mul_with_Tci<TcCast, Tc>(B_Tc,
+                                      B,
+                                      TiB,
+                                      isScaleBVec,
+                                      scaleBVec,
+                                      nullptr,
+                                      transB != HIPBLAS_OP_N,
+                                      n,
+                                      k,
+                                      TciBCast,
+                                      sizeB);
     }
     else
     {
-        if(transB == HIPBLAS_OP_N)
-        {
-            #pragma omp for
-            for(size_t i = 0; i < sizeB; i++)
-            {
-                auto scaleB = isScaleBVec ? scaleBVec[i / k] : scaleBVec[0];
-                B_Tc[i] = static_cast<TcCast>(B[i] * scaleB);
-            }
-        }
-        else
-        {
-            #pragma omp for
-            for(size_t i = 0; i < sizeB; i++)
-            {
-                auto scaleB = isScaleBVec ? scaleBVec[i % n] : scaleBVec[0];
-                B_Tc[i] = static_cast<TcCast>(B[i] * scaleB);
-            }
-        }
+        cast_mul<TcCast, Tc>(
+            B_Tc, B, TiB, isScaleBVec, scaleBVec, nullptr, transB != HIPBLAS_OP_N, n, k, sizeB);
     }
 
-    if constexpr(std::is_same<To, TcCast>::value)
+    if(To == Tc_enum)
     {
         C_Tc.initialize(C);
     }
     else
     {
         C_Tc.initialize(sizeC);
-        for(size_t i = 0; i < sizeC; i++)
-        {
-            C_Tc[i] = static_cast<TcCast>(C[i]);
-        }
+        cast_mul<TcCast>(C_Tc, C, To, sizeC);
     }
 
     TcCast alphaCast = (TcCast)alpha;
@@ -305,123 +820,45 @@ void cblas_gemm(hipblasOperation_t     transA,
 
     if(scaleD != 1)
     {
-        for(size_t i = 0; i < sizeC; i++)
-            C[i] = saturate_cast<To>(C_Tc[i] * scaleD);
+        sat_cast_mul<TcCast, Tc>(C, To, C_Tc, scaleD, sizeC);
     }
     else
     {
-        if constexpr(!std::is_same<To, TcCast>::value)
+        if(To != Tc_enum)
         {
-            for(size_t i = 0; i < sizeC; i++)
-                C[i] = saturate_cast<To>(C_Tc[i]);
+            sat_cast_mul<TcCast, Tc>(C, To, C_Tc, scaleD, sizeC);
         }
     }
 }
 
-#define CREATEFUNCTION(TiA, TiB, To, Tc, TciA, TciB)                                        \
-    template void cblas_gemm<TiA, TiB, To, Tc, TciA, TciB>(hipblasOperation_t     transA,   \
-                                                    hipblasOperation_t     transB,     \
-                                                    int64_t                m,          \
-                                                    int64_t                n,          \
-                                                    int64_t                k,          \
-                                                    Tc                     alpha,      \
-                                                    const TiA*             A,          \
-                                                    int64_t                lda,        \
-                                                    const TiB*             B,          \
-                                                    int64_t                ldb,        \
-                                                    Tc                     beta,       \
-                                                    std::add_pointer_t<To> C,          \
-                                                    int64_t                ldc,        \
-                                                    const Tc*              AlphaVec,   \
-                                                    const Tc*              scaleAVec,  \
-                                                    const Tc*              scaleBVec,  \
-                                                    Tc                     scaleD,     \
-                                                    bool                   isScaleAVec,\
-                                                    bool                   isScaleBVec,\
-                                                    bool                   alt);
+#define CREATEFUNCTION(Tc)                                             \
+    template void cblas_gemm<Tc>(hipblasOperation_t       transA,      \
+                                 hipblasOperation_t       transB,      \
+                                 int64_t                  m,           \
+                                 int64_t                  n,           \
+                                 int64_t                  k,           \
+                                 Tc                       alpha,       \
+                                 const void*              A,           \
+                                 int64_t                  lda,         \
+                                 const void*              B,           \
+                                 int64_t                  ldb,         \
+                                 Tc                       beta,        \
+                                 std::add_pointer_t<void> C,           \
+                                 int64_t                  ldc,         \
+                                 const Tc*                AlphaVec,    \
+                                 const Tc*                scaleAVec,   \
+                                 const Tc*                scaleBVec,   \
+                                 Tc                       scaleD,      \
+                                 bool                     isScaleAVec, \
+                                 bool                     isScaleBVec, \
+                                 hipDataType              TiA,         \
+                                 hipDataType              TiB,         \
+                                 hipDataType              To,          \
+                                 hipDataType              Tc_enum,     \
+                                 hipDataType              TciA,        \
+                                 hipDataType              TciB,        \
+                                 bool                     alt);
 
-CREATEFUNCTION(hip_bfloat16, hip_bfloat16, hip_bfloat16, float, hip_bfloat16, hip_bfloat16)
-CREATEFUNCTION(hip_bfloat16, hip_bfloat16, float, float, hip_bfloat16, hip_bfloat16)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, float, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, float, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, float, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, float, float, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-//
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, float, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, float, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz)
-//
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, hip_bfloat16, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, hipblasLtHalf, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz, hip_bfloat16, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, hipblasLtHalf, float, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz, hip_bfloat16, float, hipblaslt_bf8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz, hip_bfloat16, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-#ifdef ROCM_USE_FLOAT8
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_f8_ocp, float, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_f8_ocp, float, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_bf8_ocp, float, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, float, float, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_f8_ocp, hipblasLtHalf, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-//
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_f8_ocp, hipblaslt_f8_ocp, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_f8_ocp, hipblaslt_bf8_ocp, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_bf8_ocp, hipblaslt_f8_ocp, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_f8_ocp, hipblaslt_f8_ocp, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_f8_ocp, hipblaslt_bf8_ocp, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, hipblaslt_f8_ocp, float, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, float, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp)
-//
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_f8_ocp, hip_bfloat16, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_f8_ocp, hipblasLtHalf, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_bf8_ocp, hipblasLtHalf, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_f8_ocp, hipblaslt_bf8_ocp, hip_bfloat16, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, hipblasLtHalf, float, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_bf8_ocp, hip_bfloat16, float, hipblaslt_bf8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblaslt_bf8_ocp, hipblaslt_f8_ocp, hip_bfloat16, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_f8_ocp, hipblaslt_f8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_f8_ocp, hipblaslt_bf8_ocp)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_bf8_ocp, hipblaslt_f8_ocp)
-
-#endif
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hip_bfloat16, hip_bfloat16)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_bf8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_bf8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hip_bfloat16, hip_bfloat16)
-CREATEFUNCTION(hipblasLtHalf, hipblasLtHalf, float, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(float, float, float, float, float, float)
-CREATEFUNCTION(double, double, double, double, double, double)
-CREATEFUNCTION(int8_t, int8_t, int32_t, int32_t, int8_t, int8_t)
-CREATEFUNCTION(int8_t, int8_t, int8_t, int32_t, int8_t, int8_t)
-// Mix precision
-// FP16FP8 mix FP16 in MFMA
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, hipblaslt_f8_fnuz, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, hipblasLtHalf, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, hipblasLtHalf, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, float, float, hipblasLtHalf, hipblasLtHalf)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, float, float, hipblasLtHalf, hipblasLtHalf)
-// Mix precision
-// FP16FP8 mix FP8 in MFMA
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, hipblaslt_f8_fnuz, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, hipblasLtHalf, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblasLtHalf, hipblaslt_f8_fnuz, float, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
-CREATEFUNCTION(hipblaslt_f8_fnuz, hipblasLtHalf, float, float, hipblaslt_f8_fnuz, hipblaslt_f8_fnuz)
+CREATEFUNCTION(float)
+CREATEFUNCTION(double)
+CREATEFUNCTION(int32_t)

--- a/clients/common/d_vector.cpp
+++ b/clients/common/d_vector.cpp
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "d_vector.hpp"
+
+#define MEM_MAX_GUARD_PAD 8192
+#define MAX_DTYPE_SIZE sizeof(double)
+
+char d_vector_type::m_guard_type[MEM_MAX_GUARD_PAD * MAX_DTYPE_SIZE] = {};
+
+bool d_vector_type::m_init_guard_type = false;
+
+#undef MEM_MAX_GUARD_PAD
+#undef MAX_DTYPE_SIZE

--- a/clients/include/allclose.hpp
+++ b/clients/include/allclose.hpp
@@ -28,6 +28,7 @@
 
 #include "allclose.hpp"
 #include "cblas.h"
+#include "hipblaslt_ostream.hpp"
 #include "hipblaslt_vector.hpp"
 #include "utility.hpp"
 #include <cstdio>
@@ -72,8 +73,7 @@ template <typename T,
                 || std::is_same<T, hipblaslt_f8_ocp>{} || std::is_same<T, hipblaslt_bf8_ocp>{}
 #endif
                 ),
-              int>
-          = 0>
+              int> = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -129,8 +129,7 @@ bool allclose_check_general(char    allclose_type,
 template <typename T,
           std::enable_if_t<(std::is_same<T, hipblaslt_f8_fnuz>{}
                             || std::is_same<T, hipblaslt_bf8_fnuz>{}),
-                           int>
-          = 0>
+                           int> = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -187,8 +186,7 @@ bool allclose_check_general(char    allclose_type,
 template <
     typename T,
     std::enable_if_t<(std::is_same<T, hipblaslt_f8_ocp>{} || std::is_same<T, hipblaslt_bf8_ocp>{}),
-                     int>
-    = 0>
+                     int> = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -242,10 +240,10 @@ bool allclose_check_general(char    allclose_type,
 }
 #endif
 // For BF16 and half, we convert the results to double first
-template <typename T,
-          typename VEC,
-          std::enable_if_t<std::is_same<T, hipblasLtHalf>{} || std::is_same<T, hip_bfloat16>{}, int>
-          = 0>
+template <
+    typename T,
+    typename VEC,
+    std::enable_if_t<std::is_same<T, hipblasLtHalf>{} || std::is_same<T, hip_bfloat16>{}, int> = 0>
 bool allclose_check_general(char    allclose_type,
                             int64_t M,
                             int64_t N,
@@ -307,17 +305,17 @@ bool allclose_check_general(char    allclose_type,
 }
 
 /* ============== allclose check for strided_batched case ============= */
-template <typename T, template <typename> class VEC, typename T_hpa>
-bool allclose_check_general(char        allclose_type,
-                            int64_t     M,
-                            int64_t     N,
-                            int64_t     lda,
-                            int64_t     stride_a,
-                            VEC<T_hpa>& hCPU,
-                            T*          hGPU,
-                            int64_t     batch_count,
-                            double&     hipblaslt_atol,
-                            double&     hipblaslt_rtol)
+template <typename T, typename T_hpa>
+bool allclose_check_general(char    allclose_type,
+                            int64_t M,
+                            int64_t N,
+                            int64_t lda,
+                            int64_t stride_a,
+                            T_hpa*  hCPU,
+                            T*      hGPU,
+                            int64_t batch_count,
+                            double& hipblaslt_atol,
+                            double& hipblaslt_rtol)
 {
     if(M * N == 0)
         return 0;
@@ -325,14 +323,8 @@ bool allclose_check_general(char        allclose_type,
     for(size_t i = 0; i < batch_count; i++)
     {
         auto index = i * stride_a;
-        bool close = allclose_check_general(allclose_type,
-                                            M,
-                                            N,
-                                            lda,
-                                            (T_hpa*)hCPU + index,
-                                            hGPU + index,
-                                            hipblaslt_atol,
-                                            hipblaslt_rtol);
+        bool close = allclose_check_general(
+            allclose_type, M, N, lda, hCPU + index, hGPU + index, hipblaslt_atol, hipblaslt_rtol);
         if(!close)
             return false;
     }
@@ -365,4 +357,136 @@ bool allclose_check_general(char    allclose_type,
     }
 
     return true;
+}
+
+bool allclose_check_general(char        allclose_type,
+                            int64_t     M,
+                            int64_t     N,
+                            int64_t     lda,
+                            int64_t     stride_a,
+                            void*       hCPU,
+                            void*       hGPU,
+                            int64_t     batch_count,
+                            double&     hipblaslt_atol,
+                            double&     hipblaslt_rtol,
+                            hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return allclose_check_general<float>(allclose_type,
+                                             M,
+                                             N,
+                                             lda,
+                                             stride_a,
+                                             static_cast<float*>(hCPU),
+                                             static_cast<float*>(hGPU),
+                                             batch_count,
+                                             hipblaslt_atol,
+                                             hipblaslt_rtol);
+    case HIP_R_64F:
+        return allclose_check_general<double>(allclose_type,
+                                              M,
+                                              N,
+                                              lda,
+                                              stride_a,
+                                              static_cast<double*>(hCPU),
+                                              static_cast<double*>(hGPU),
+                                              batch_count,
+                                              hipblaslt_atol,
+                                              hipblaslt_rtol);
+    case HIP_R_16F:
+        return allclose_check_general<hipblasLtHalf>(allclose_type,
+                                                     M,
+                                                     N,
+                                                     lda,
+                                                     stride_a,
+                                                     static_cast<hipblasLtHalf*>(hCPU),
+                                                     static_cast<hipblasLtHalf*>(hGPU),
+                                                     batch_count,
+                                                     hipblaslt_atol,
+                                                     hipblaslt_rtol);
+    case HIP_R_16BF:
+        return allclose_check_general<hip_bfloat16>(allclose_type,
+                                                    M,
+                                                    N,
+                                                    lda,
+                                                    stride_a,
+                                                    static_cast<hip_bfloat16*>(hCPU),
+                                                    static_cast<hip_bfloat16*>(hGPU),
+                                                    batch_count,
+                                                    hipblaslt_atol,
+                                                    hipblaslt_rtol);
+    case HIP_R_8F_E4M3_FNUZ:
+        return allclose_check_general<hipblaslt_f8_fnuz>(allclose_type,
+                                                         M,
+                                                         N,
+                                                         lda,
+                                                         stride_a,
+                                                         static_cast<hipblaslt_f8_fnuz*>(hCPU),
+                                                         static_cast<hipblaslt_f8_fnuz*>(hGPU),
+                                                         batch_count,
+                                                         hipblaslt_atol,
+                                                         hipblaslt_rtol);
+    case HIP_R_8F_E5M2_FNUZ:
+        return allclose_check_general<hipblaslt_bf8_fnuz>(allclose_type,
+                                                          M,
+                                                          N,
+                                                          lda,
+                                                          stride_a,
+                                                          static_cast<hipblaslt_bf8_fnuz*>(hCPU),
+                                                          static_cast<hipblaslt_bf8_fnuz*>(hGPU),
+                                                          batch_count,
+                                                          hipblaslt_atol,
+                                                          hipblaslt_rtol);
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        return allclose_check_general<hipblaslt_f8_ocp>(allclose_type,
+                                                        M,
+                                                        N,
+                                                        lda,
+                                                        stride_a,
+                                                        static_cast<hipblaslt_f8_ocp*>(hCPU),
+                                                        static_cast<hipblaslt_f8_ocp*>(hGPU),
+                                                        batch_count,
+                                                        hipblaslt_atol,
+                                                        hipblaslt_rtol);
+    case HIP_R_8F_E5M2:
+        return allclose_check_general<hipblaslt_bf8_ocp>(allclose_type,
+                                                         M,
+                                                         N,
+                                                         lda,
+                                                         stride_a,
+                                                         static_cast<hipblaslt_bf8_ocp*>(hCPU),
+                                                         static_cast<hipblaslt_bf8_ocp*>(hGPU),
+                                                         batch_count,
+                                                         hipblaslt_atol,
+                                                         hipblaslt_rtol);
+#endif
+    case HIP_R_32I:
+        return allclose_check_general<int32_t>(allclose_type,
+                                               M,
+                                               N,
+                                               lda,
+                                               stride_a,
+                                               static_cast<int32_t*>(hCPU),
+                                               static_cast<int32_t*>(hGPU),
+                                               batch_count,
+                                               hipblaslt_atol,
+                                               hipblaslt_rtol);
+    case HIP_R_8I:
+        return allclose_check_general<hipblasLtInt8>(allclose_type,
+                                                     M,
+                                                     N,
+                                                     lda,
+                                                     stride_a,
+                                                     static_cast<hipblasLtInt8*>(hCPU),
+                                                     static_cast<hipblasLtInt8*>(hGPU),
+                                                     batch_count,
+                                                     hipblaslt_atol,
+                                                     hipblaslt_rtol);
+    default:
+        hipblaslt_cerr << "Error type in allclose_check_general" << std::endl;
+        return false;
+    }
 }

--- a/clients/include/argument_model.hpp
+++ b/clients/include/argument_model.hpp
@@ -131,7 +131,8 @@ public:
                 {
                     name_line << ",atol";
                     if(atol == 1) // atol == init value
-                        val_line << "," << "failed";
+                        val_line << ","
+                                 << "failed";
                     else
                         val_line << "," << atol;
                 }
@@ -139,7 +140,8 @@ public:
                 {
                     name_line << ",rtol";
                     if(rtol == 1) // rtol == init value
-                        val_line << "," << "failed";
+                        val_line << ","
+                                 << "failed";
                     else
                         val_line << "," << rtol;
                 }
@@ -147,8 +149,8 @@ public:
         }
     }
 
-    template <typename T>
-    void log_args(hipblaslt_internal_ostream& str,
+    void log_args(hipDataType                 Tc,
+                  hipblaslt_internal_ostream& str,
                   size_t                      index,
                   int32_t                     solution_index,
                   std::string&                solution_name,
@@ -187,10 +189,48 @@ public:
 
 #if __cplusplus >= 201703L
         // C++17
-        (ArgumentsHelper::apply<Args>(print, arg, T{}), ...);
+        //(ArgumentsHelper::apply<Args>(print, arg, T{}), ...);
+        switch(Tc)
+        {
+        case HIP_R_32F:
+            (ArgumentsHelper::apply<Args>(print, arg, float{}), ...);
+            break;
+        case HIP_R_64F:
+            (ArgumentsHelper::apply<Args>(print, arg, double{}), ...);
+            break;
+        case HIP_R_16F:
+            (ArgumentsHelper::apply<Args>(print, arg, hipblasLtHalf{}), ...);
+            break;
+        case HIP_R_32I:
+            (ArgumentsHelper::apply<Args>(print, arg, int32_t{}), ...);
+            break;
+        default:
+            hipblaslt_cerr << "Error type in log_args" << std::endl;
+            (ArgumentsHelper::apply<Args>(print, arg, float{}), ...);
+            break;
+        }
 #else
         // C++14. TODO: Remove when C++17 is used
-        (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, T{}), 0)...};
+        //(void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, T{}), 0)...};
+        switch(Tc)
+        {
+        case HIP_R_32F:
+            (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, float{}), 0)...};
+            break;
+        case HIP_R_64F:
+            (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, double{}), 0)...};
+            break;
+        case HIP_R_16F:
+            (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, hipblasLtHalf{}), 0)...};
+            break;
+        case HIP_R_32I:
+            (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, int32_t{}), 0)...};
+            break;
+        default:
+            hipblaslt_cerr << "Error type in log_args" << std::endl;
+            (void)(int[]){(ArgumentsHelper::apply<Args>{}()(print, arg, float{}), 0)...};
+            break;
+        }
 #endif
 
         // Additional name and value list

--- a/clients/include/cblas_interface.hpp
+++ b/clients/include/cblas_interface.hpp
@@ -27,6 +27,8 @@
 #pragma once
 
 #include "cblas.h"
+#include "datatype_interface.hpp"
+#include "hipblaslt_ostream.hpp"
 #include <hipblaslt/hipblaslt.h>
 #include <type_traits>
 
@@ -36,24 +38,149 @@
  */
 
 // gemm
-template <typename TiA, typename TiB, typename To, typename Tc, typename TciA=TiA, typename TciB=TiB>
-void cblas_gemm(hipblasOperation_t     transA,
-                hipblasOperation_t     transB,
-                int64_t                m,
-                int64_t                n,
-                int64_t                k,
-                Tc                     alpha,
-                const TiA*             A,
-                int64_t                lda,
-                const TiB*             B,
-                int64_t                ldb,
-                Tc                     beta,
-                std::add_pointer_t<To> C,
-                int64_t                ldc,
-                const Tc*              AlphaVec,
-                const Tc*              scaleA,
-                const Tc*              scaleB,
-                Tc                     scaleD,
-                bool                   isScaleAVec,
-                bool                   isScaleBVec,
-                bool                   alt = false);
+template <typename Tc>
+void cblas_gemm(hipblasOperation_t       transA,
+                hipblasOperation_t       transB,
+                int64_t                  m,
+                int64_t                  n,
+                int64_t                  k,
+                Tc                       alpha,
+                const void*              A,
+                int64_t                  lda,
+                const void*              B,
+                int64_t                  ldb,
+                Tc                       beta,
+                std::add_pointer_t<void> C,
+                int64_t                  ldc,
+                const Tc*                AlphaVec,
+                const Tc*                scaleA,
+                const Tc*                scaleB,
+                Tc                       scaleD,
+                bool                     isScaleAVec,
+                bool                     isScaleBVec,
+                hipDataType              tiA,
+                hipDataType              tiB,
+                hipDataType              to,
+                hipDataType              tc,
+                hipDataType              tciA,
+                hipDataType              tciB,
+                bool                     alt = false);
+
+inline void cblas_gemm(hipblasOperation_t       transA,
+                       hipblasOperation_t       transB,
+                       int64_t                  m,
+                       int64_t                  n,
+                       int64_t                  k,
+                       computeTypeInterface     alpha,
+                       const void*              A,
+                       int64_t                  lda,
+                       const void*              B,
+                       int64_t                  ldb,
+                       computeTypeInterface     beta,
+                       std::add_pointer_t<void> C,
+                       int64_t                  ldc,
+                       const void*              AlphaVec,
+                       const void*              scaleA,
+                       const void*              scaleB,
+                       void*                    scaleD,
+                       bool                     isScaleAVec,
+                       bool                     isScaleBVec,
+                       hipDataType              tiA,
+                       hipDataType              tiB,
+                       hipDataType              to,
+                       hipDataType              tc,
+                       hipDataType              tciA,
+                       hipDataType              tciB,
+                       bool                     alt = false)
+{
+    switch(tc)
+    {
+    case HIP_R_32F:
+        cblas_gemm<float>(transA,
+                          transB,
+                          m,
+                          n,
+                          k,
+                          alpha.f32,
+                          A,
+                          lda,
+                          B,
+                          ldb,
+                          beta.f32,
+                          C,
+                          ldc,
+                          (const float*)AlphaVec,
+                          (const float*)scaleA,
+                          (const float*)scaleB,
+                          *(float*)scaleD,
+                          isScaleAVec,
+                          isScaleBVec,
+                          tiA,
+                          tiB,
+                          to,
+                          tc,
+                          tciA,
+                          tciB,
+                          alt);
+        return;
+    case HIP_R_64F:
+        cblas_gemm<double>(transA,
+                           transB,
+                           m,
+                           n,
+                           k,
+                           alpha.f64,
+                           A,
+                           lda,
+                           B,
+                           ldb,
+                           beta.f64,
+                           C,
+                           ldc,
+                           (const double*)AlphaVec,
+                           (const double*)scaleA,
+                           (const double*)scaleB,
+                           *(double*)scaleD,
+                           isScaleAVec,
+                           isScaleBVec,
+                           tiA,
+                           tiB,
+                           to,
+                           tc,
+                           tciA,
+                           tciB,
+                           alt);
+        return;
+    case HIP_R_32I:
+        cblas_gemm<int32_t>(transA,
+                            transB,
+                            m,
+                            n,
+                            k,
+                            alpha.i32,
+                            A,
+                            lda,
+                            B,
+                            ldb,
+                            beta.i32,
+                            C,
+                            ldc,
+                            (const int32_t*)AlphaVec,
+                            (const int32_t*)scaleA,
+                            (const int32_t*)scaleB,
+                            *(int32_t*)scaleD,
+                            isScaleAVec,
+                            isScaleBVec,
+                            tiA,
+                            tiB,
+                            to,
+                            tc,
+                            tciA,
+                            tciB,
+                            alt);
+        return;
+    default:
+        hipblaslt_cerr << "Error type in cblas_gemm()" << std::endl;
+        return;
+    }
+}

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "datatype_interface.hpp"
 #include "hipblaslt_arguments.hpp"
 #include "hipblaslt_init.hpp"
 #include "hipblaslt_test.hpp"
@@ -34,6 +35,7 @@
 #include <hipblaslt/hipblaslt.h>
 
 #define MEM_MAX_GUARD_PAD 8192
+#define MAX_DTYPE_SIZE sizeof(double)
 
 /* ============================================================================================ */
 /*! \brief  base-class to allocate/deallocate device memory */
@@ -120,7 +122,7 @@ public:
 #ifdef GOOGLE_TEST
         if(m_guard_len > 0)
         {
-            T *host = new T[m_pad];
+            T* host = new T[m_pad];
 
             // Copy device memory after allocated memory to host
             EXPECT_EQ(hipMemcpy(host, d + this->m_size, m_guard_len, hipMemcpyDeviceToHost),
@@ -150,7 +152,7 @@ public:
 #ifdef GOOGLE_TEST
             if(m_pad > 0)
             {
-                T *host = new T[m_pad];
+                T* host = new T[m_pad];
 
                 // Copy device memory after allocated memory to host
                 EXPECT_EQ(hipMemcpy(host, d + this->m_size, m_guard_len, hipMemcpyDeviceToHost),
@@ -180,6 +182,163 @@ public:
     }
 };
 
+/* ============================================================================================ */
+/*! \brief  base-class to allocate/deallocate device memory */
+class d_vector_type
+{
+private:
+    size_t      m_size;
+    hipDataType m_dtype;
+    size_t      m_pad, m_guard_len;
+    size_t      m_bytes;
+
+    inline static bool m_init_guard_type;
+
+protected:
+    inline size_t nmemb() const noexcept
+    {
+        return m_size;
+    }
+
+public:
+    bool use_HMM = false;
+
+public:
+    inline static char m_guard_type[MEM_MAX_GUARD_PAD * MAX_DTYPE_SIZE];
+
+#ifdef GOOGLE_TEST
+    d_vector_type(hipDataType dtype, size_t s, bool HMM = false)
+        : m_size(s)
+        , m_dtype(dtype)
+        , m_pad(std::min(g_DVEC_PAD, size_t(MEM_MAX_GUARD_PAD)))
+        , m_guard_len(m_pad * realDataTypeSize(dtype))
+        , m_bytes((s + m_pad * 2) * realDataTypeSize(dtype))
+        , use_HMM(HMM)
+    {
+        // Initialize m_guard with random data
+        if(!m_init_guard_type)
+        {
+            hipblaslt_init_nan(m_guard_type, MEM_MAX_GUARD_PAD);
+            m_init_guard_type = true;
+        }
+    }
+#else
+    d_vector_type(hipDataType dtype, size_t s, bool HMM = false)
+        : m_size(s)
+        , m_dtype(dtype)
+        , m_pad(0) // save current pad length
+        , m_guard_len(0 * realDataTypeSize(dtype))
+        , m_bytes(s ? s * realDataTypeSize(dtype) : realDataTypeSize(dtype))
+        , use_HMM(HMM)
+    {
+    }
+#endif
+
+    char* device_vector_setup()
+    {
+        char* d = nullptr;
+        if(use_HMM ? hipMallocManaged(&d, m_bytes) : (hipMalloc)(&d, m_bytes) != hipSuccess)
+        {
+            hipblaslt_cerr << "Error allocating " << m_bytes << " m_bytes (" << (m_bytes >> 30)
+                           << " GB)" << std::endl;
+
+            d = nullptr;
+        }
+#ifdef GOOGLE_TEST
+        else
+        {
+            if(m_guard_len > 0)
+            {
+                // Copy m_guard to device memory before allocated memory
+                EXPECT_EQ(hipMemcpy(d, m_guard_type, m_guard_len, hipMemcpyHostToDevice),
+                          hipSuccess);
+
+                // Point to allocated block
+                d += m_pad * realDataTypeSize(m_dtype);
+
+                // Copy m_guard to device memory after allocated memory
+                EXPECT_EQ(hipMemcpy(d + this->m_size * realDataTypeSize(m_dtype),
+                                    m_guard_type,
+                                    m_guard_len,
+                                    hipMemcpyHostToDevice),
+                          hipSuccess);
+            }
+        }
+#endif
+        return d;
+    }
+
+    void device_vector_check(char* d)
+    {
+#ifdef GOOGLE_TEST
+        if(m_guard_len > 0)
+        {
+            char* host = new char[m_pad * realDataTypeSize(m_dtype)];
+
+            // Copy device memory after allocated memory to host
+            EXPECT_EQ(hipMemcpy(host,
+                                d + this->m_size * realDataTypeSize(m_dtype),
+                                m_guard_len,
+                                hipMemcpyDeviceToHost),
+                      hipSuccess);
+
+            // Make sure no corruption has occurred
+            EXPECT_EQ(memcmp(host, m_guard_type, m_guard_len), 0);
+
+            // Point to m_guard before allocated memory
+            d -= m_pad * realDataTypeSize(m_dtype);
+
+            // Copy device memory after allocated memory to host
+            EXPECT_EQ(hipMemcpy(host, d, m_guard_len, hipMemcpyDeviceToHost), hipSuccess);
+
+            // Make sure no corruption has occurred
+            EXPECT_EQ(memcmp(host, m_guard_type, m_guard_len), 0);
+
+            delete[] host;
+        }
+#endif
+    }
+
+    void device_vector_teardown(char* d)
+    {
+        if(d != nullptr)
+        {
+#ifdef GOOGLE_TEST
+            if(m_pad > 0)
+            {
+                char* host = new char[m_pad * realDataTypeSize(m_dtype)];
+
+                // Copy device memory after allocated memory to host
+                EXPECT_EQ(hipMemcpy(host,
+                                    d + this->m_size * realDataTypeSize(m_dtype),
+                                    m_guard_len,
+                                    hipMemcpyDeviceToHost),
+                          hipSuccess);
+
+                // Make sure no corruption has occurred
+                EXPECT_EQ(memcmp(host, m_guard_type, m_guard_len), 0);
+
+                // Point to m_guard before allocated memory
+                d -= m_pad * realDataTypeSize(m_dtype);
+
+                // Copy device memory after allocated memory to host
+                EXPECT_EQ(hipMemcpy(host, d, m_guard_len, hipMemcpyDeviceToHost), hipSuccess);
+
+                // Make sure no corruption has occurred
+                EXPECT_EQ(memcmp(host, m_guard_type, m_guard_len), 0);
+
+                delete[] host;
+            }
+#endif
+            // Free device memory
+            if((hipFree)(d) != hipSuccess)
+            {
+                hipblaslt_cerr << "free device memory failed" << std::endl;
+            }
+        }
+    }
+};
+
 template <typename T>
 T d_vector<T>::m_guard[MEM_MAX_GUARD_PAD] = {};
 
@@ -187,3 +346,4 @@ template <typename T>
 bool d_vector<T>::m_init_guard = false;
 
 #undef MEM_MAX_GUARD_PAD
+#undef MAX_DTYPE_SIZE

--- a/clients/include/datatype_interface.hpp
+++ b/clients/include/datatype_interface.hpp
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include <hipblaslt/hipblaslt.h>
+
+union computeTypeInterface
+{
+    float         f32;
+    double        f64;
+    hipblasLtHalf f16;
+    int32_t       i32;
+};
+
+template <typename T>
+constexpr auto hipblaslt_type2datatype()
+{
+    if(std::is_same<T, hipblasLtHalf>{})
+        return HIP_R_16F;
+    if(std::is_same<T, hip_bfloat16>{})
+        return HIP_R_16BF;
+    if(std::is_same<T, float>{})
+        return HIP_R_32F;
+    if(std::is_same<T, double>{})
+        return HIP_R_64F;
+    if(std::is_same<T, hipblaslt_f8_fnuz>{})
+        return HIP_R_8F_E4M3_FNUZ;
+    if(std::is_same<T, hipblaslt_bf8_fnuz>{})
+        return HIP_R_8F_E5M2_FNUZ;
+#ifdef ROCM_USE_FLOAT8
+    if(std::is_same<T, hipblaslt_f8_ocp>{})
+        return HIP_R_8F_E4M3;
+    if(std::is_same<T, hipblaslt_bf8_ocp>{})
+        return HIP_R_8F_E5M2;
+#endif
+    if(std::is_same<T, int32_t>{})
+        return HIP_R_32I;
+    if(std::is_same<T, hipblasLtInt8>{})
+        return HIP_R_8I;
+
+    return HIP_R_16F; // testing purposes we default to f32 ex
+}
+
+inline hipDataType computeTypeToRealDataType(hipblasComputeType_t ctype)
+{
+    static const std::map<hipblasComputeType_t, hipDataType> ctypeMap{
+        {HIPBLAS_COMPUTE_16F, HIP_R_16F},
+        {HIPBLAS_COMPUTE_16F_PEDANTIC, HIP_R_16F},
+        {HIPBLAS_COMPUTE_32F, HIP_R_32F},
+        {HIPBLAS_COMPUTE_32F_PEDANTIC, HIP_R_32F},
+        {HIPBLAS_COMPUTE_32F_FAST_16F, HIP_R_32F},
+        {HIPBLAS_COMPUTE_32F_FAST_16BF, HIP_R_32F},
+        {HIPBLAS_COMPUTE_32F_FAST_TF32, HIP_R_32F},
+        {HIPBLAS_COMPUTE_64F, HIP_R_64F},
+        {HIPBLAS_COMPUTE_64F_PEDANTIC, HIP_R_64F},
+        {HIPBLAS_COMPUTE_32I, HIP_R_32I},
+        {HIPBLAS_COMPUTE_32I_PEDANTIC, HIP_R_32I}};
+
+    return ctypeMap.at(ctype);
+}
+
+inline std::size_t realDataTypeSize(hipDataType dtype)
+{
+    static const std::map<hipDataType, std::size_t> dtypeMap{
+        {HIP_R_32F, 4},
+        {HIP_R_64F, 8},
+        {HIP_R_16F, 2},
+        {HIP_R_8I, 1},
+        {HIP_R_8U, 1},
+        {HIP_R_32I, 4},
+        {HIP_R_32U, 4},
+        {HIP_R_16BF, 2},
+        {HIP_R_4I, 1},
+        {HIP_R_4U, 1},
+        {HIP_R_16I, 2},
+        {HIP_R_16U, 2},
+        {HIP_R_64I, 8},
+        {HIP_R_64U, 8},
+        {HIP_R_8F_E4M3_FNUZ, 1},
+        {HIP_R_8F_E5M2_FNUZ, 1},
+#ifdef ROCM_USE_FLOAT8
+        {HIP_R_8F_E4M3, 1},
+        {HIP_R_8F_E5M2, 1},
+#endif
+    };
+
+    return dtypeMap.at(dtype);
+}

--- a/clients/include/flops.hpp
+++ b/clients/include/flops.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,14 +39,68 @@ constexpr double gemm_gflop_count(int64_t m, int64_t n, int64_t k)
     return (2.0 * m * n * k) / 1e9;
 }
 
+constexpr double gemm_gflop_count(int64_t m, int64_t n, int64_t k, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return gemm_gflop_count<float>(m, n, k);
+    case HIP_R_64F:
+        return gemm_gflop_count<double>(m, n, k);
+    case HIP_R_16F:
+        return gemm_gflop_count<hipblasLtHalf>(m, n, k);
+    case HIP_R_32I:
+        return gemm_gflop_count<int32_t>(m, n, k);
+    default:
+        hipblaslt_cerr << "Error type in gemm_gflop_count()" << std::endl;
+        return gemm_gflop_count<float>(m, n, k);
+    }
+}
+
 template <typename T>
 constexpr double relu_gflop_count(int64_t m, int64_t n)
 {
     return (m * n) / 1e9;
 }
 
+constexpr double relu_gflop_count(int64_t m, int64_t n, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return relu_gflop_count<float>(m, n);
+    case HIP_R_64F:
+        return relu_gflop_count<double>(m, n);
+    case HIP_R_16F:
+        return relu_gflop_count<hipblasLtHalf>(m, n);
+    case HIP_R_32I:
+        return relu_gflop_count<int32_t>(m, n);
+    default:
+        hipblaslt_cerr << "Error type in relu_gflop_count()" << std::endl;
+        return relu_gflop_count<float>(m, n);
+    }
+}
+
 template <typename T>
 constexpr double gelu_gflop_count(int64_t m, int64_t n)
 {
     return (9.0 * m * n) / 1e9;
+}
+
+constexpr double gelu_gflop_count(int64_t m, int64_t n, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return gelu_gflop_count<float>(m, n);
+    case HIP_R_64F:
+        return gelu_gflop_count<double>(m, n);
+    case HIP_R_16F:
+        return gelu_gflop_count<hipblasLtHalf>(m, n);
+    case HIP_R_32I:
+        return gelu_gflop_count<int32_t>(m, n);
+    default:
+        hipblaslt_cerr << "Error type in gelu_gflop_count()" << std::endl;
+        return gelu_gflop_count<float>(m, n);
+    }
 }

--- a/clients/include/hipBuffer.hpp
+++ b/clients/include/hipBuffer.hpp
@@ -1,0 +1,314 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#pragma once
+
+#include "d_vector.hpp"
+#include "datatype_interface.hpp"
+#include "hipblaslt_ostream.hpp"
+
+class HipDeviceBuffer : public d_vector_type
+{
+public:
+    HipDeviceBuffer(hipDataType dtype, std::size_t numElements, bool HMM = false)
+        : d_vector_type(dtype, numElements, HMM)
+        , numBytes(realDataTypeSize(dtype) * numElements)
+        , buffer{this->device_vector_setup(), &hipFree}
+    {
+    }
+
+    ~HipDeviceBuffer()
+    {
+        this->device_vector_teardown(static_cast<char*>(buffer.get()));
+        buffer = nullptr;
+    }
+
+    HipDeviceBuffer(const HipDeviceBuffer&)            = delete;
+    HipDeviceBuffer(HipDeviceBuffer&&)                 = default;
+    HipDeviceBuffer& operator=(const HipDeviceBuffer&) = delete;
+    HipDeviceBuffer& operator=(HipDeviceBuffer&&)      = default;
+
+    void* buf()
+    {
+        return buffer.get();
+    }
+
+    const void* buf() const
+    {
+        return buffer.get();
+    }
+
+    std::size_t getNumBytes() const
+    {
+        return numBytes;
+    }
+
+    template <typename T>
+    T* as()
+    {
+        return reinterpret_cast<T*>(buf());
+    }
+
+    template <typename T>
+    const T* as() const
+    {
+        return reinterpret_cast<const T*>(buf());
+    }
+
+private:
+    std::size_t                               numBytes;
+    std::unique_ptr<void, decltype(&hipFree)> buffer;
+};
+
+class HipHostBuffer
+{
+public:
+    HipHostBuffer(hipDataType dtype, std::size_t numElements)
+        : numBytes(realDataTypeSize(dtype) * numElements ? realDataTypeSize(dtype) * numElements
+                                                         : realDataTypeSize(dtype))
+        , buffer(createBuffer(numBytes))
+    {
+    }
+
+    ~HipHostBuffer()                               = default;
+    HipHostBuffer(const HipHostBuffer&)            = delete;
+    HipHostBuffer(HipHostBuffer&&)                 = default;
+    HipHostBuffer& operator=(const HipHostBuffer&) = delete;
+    HipHostBuffer& operator=(HipHostBuffer&&)      = default;
+
+    void* end()
+    {
+        return (void*)((char*)buffer.get() + getNumBytes());
+    }
+
+    const void* end() const
+    {
+        return (void*)((const char*)buffer.get() + getNumBytes());
+    }
+
+    void* buf()
+    {
+        return buffer.get();
+    }
+
+    const void* buf() const
+    {
+        return buffer.get();
+    }
+
+    std::size_t getNumBytes() const
+    {
+        return numBytes;
+    }
+
+    template <typename T>
+    T* as()
+    {
+        return reinterpret_cast<T*>(buf());
+    }
+
+    template <typename T>
+    const T* as() const
+    {
+        return reinterpret_cast<const T*>(buf());
+    }
+
+private:
+    std::size_t                                      numBytes;
+    std::unique_ptr<void, decltype(&hipFree)>        buffer;
+    static std::unique_ptr<void, decltype(&hipFree)> createBuffer(std::size_t numBytes)
+    {
+        void* rawBuf{};
+        (void)hipHostMalloc(&rawBuf, numBytes);
+        if(!rawBuf)
+        {
+            hipblaslt_cerr << "Error to allocate memory in HipHostBuffer" << std::endl;
+        }
+        return std::unique_ptr<void, decltype(&hipFree)>(rawBuf, &hipFree);
+    }
+};
+
+inline hipError_t
+    synchronize(HipDeviceBuffer& dBuf, const HipHostBuffer& hBuf, std::size_t repeats = 1)
+{
+    hipError_t hip_err;
+    for(size_t i = 0; i < repeats; ++i)
+    {
+        hip_err = hipMemcpy(dBuf.as<char>() + i * dBuf.getNumBytes() / repeats,
+                            hBuf.as<char>(),
+                            dBuf.getNumBytes() / repeats,
+                            dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
+
+        if(hip_err != hipSuccess)
+        {
+            return hip_err;
+        }
+    }
+    return hip_err;
+}
+
+inline hipError_t synchronize(HipHostBuffer& hBuf, const HipDeviceBuffer& dBuf)
+{
+    hipError_t hip_err;
+    if(hipSuccess != (hip_err = hipDeviceSynchronize()))
+        return hip_err;
+
+    return hipMemcpy(hBuf.as<char>(), dBuf.as<char>(), hBuf.getNumBytes(), hipMemcpyDeviceToHost);
+}
+
+template <typename T1>
+inline void copy_buf(HipHostBuffer& src, HipHostBuffer& dst)
+{
+    std::copy(
+        static_cast<T1*>(src.buf()), static_cast<T1*>(src.end()), static_cast<T1*>(dst.buf()));
+}
+
+inline void copy_buf(HipHostBuffer& src, HipHostBuffer& dst, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        copy_buf<float>(src, dst);
+        break;
+    case HIP_R_64F:
+        copy_buf<double>(src, dst);
+        break;
+    case HIP_R_16F:
+        copy_buf<hipblasLtHalf>(src, dst);
+        break;
+    case HIP_R_16BF:
+        copy_buf<hip_bfloat16>(src, dst);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        copy_buf<hipblaslt_f8_fnuz>(src, dst);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        copy_buf<hipblaslt_bf8_fnuz>(src, dst);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        copy_buf<hipblaslt_f8_ocp>(src, dst);
+        break;
+    case HIP_R_8F_E5M2:
+        copy_buf<hipblaslt_bf8_ocp>(src, dst);
+        break;
+#endif
+    case HIP_R_32I:
+        copy_buf<int32_t>(src, dst);
+        break;
+    case HIP_R_8I:
+        copy_buf<hipblasLtInt8>(src, dst);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in copy_buf" << std::endl;
+        break;
+    }
+}
+
+template <typename T1, typename Tc>
+inline void transform_buf(HipHostBuffer& src, HipHostBuffer& dst)
+{
+    if constexpr(std::is_same<Tc, float>::value
+                 || !(std::is_same<T1, hipblaslt_bf8_fnuz>::value
+                      || std::is_same<T1, hipblaslt_f8_fnuz>::value))
+    {
+#ifdef ROCM_USE_FLOAT8
+        if constexpr(std::is_same<Tc, float>::value
+                     || !(std::is_same<T1, hipblaslt_bf8_ocp>::value
+                          || std::is_same<T1, hipblaslt_f8_ocp>::value))
+#endif
+            std::transform(static_cast<T1*>(src.buf()),
+                           static_cast<T1*>(src.end()),
+                           static_cast<Tc*>(dst.buf()),
+                           [](T1 c) -> Tc { return static_cast<Tc>(c); });
+    }
+}
+
+template <typename T1>
+inline void _transform_buf(HipHostBuffer& src, HipHostBuffer& dst, hipDataType typeTc)
+{
+    switch(typeTc)
+    {
+    case HIP_R_32F:
+        transform_buf<T1, float>(src, dst);
+        break;
+    case HIP_R_64F:
+        transform_buf<T1, double>(src, dst);
+        break;
+    case HIP_R_16F:
+        transform_buf<T1, hipblasLtHalf>(src, dst);
+        break;
+    case HIP_R_32I:
+        transform_buf<T1, int32_t>(src, dst);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in transform_buf" << std::endl;
+        break;
+    }
+}
+
+inline void
+    transform_buf(HipHostBuffer& src, HipHostBuffer& dst, hipDataType type, hipDataType typeTc)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        _transform_buf<float>(src, dst, typeTc);
+        break;
+    case HIP_R_64F:
+        _transform_buf<double>(src, dst, typeTc);
+        break;
+    case HIP_R_16F:
+        _transform_buf<hipblasLtHalf>(src, dst, typeTc);
+        break;
+    case HIP_R_16BF:
+        _transform_buf<hip_bfloat16>(src, dst, typeTc);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        _transform_buf<hipblaslt_f8_fnuz>(src, dst, typeTc);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        _transform_buf<hipblaslt_bf8_fnuz>(src, dst, typeTc);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        _transform_buf<hipblaslt_f8_ocp>(src, dst, typeTc);
+        break;
+    case HIP_R_8F_E5M2:
+        _transform_buf<hipblaslt_bf8_ocp>(src, dst, typeTc);
+        break;
+#endif
+    case HIP_R_32I:
+        _transform_buf<int32_t>(src, dst, typeTc);
+        break;
+    case HIP_R_8I:
+        _transform_buf<hipblasLtInt8>(src, dst, typeTc);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in transform_buf" << std::endl;
+        break;
+    }
+}

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "datatype_interface.hpp"
 #include "hipblaslt_datatype2string.hpp"
 #include "hipblaslt_math.hpp"
 #include "hipblaslt_ostream.hpp"
@@ -328,6 +329,171 @@ private:
         return T(r);
     }
 };
+
+inline bool alpha_isnan_type(const Arguments& arg, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return arg.alpha_isnan<float>();
+    case HIP_R_64F:
+        return arg.alpha_isnan<double>();
+    case HIP_R_16F:
+        return arg.alpha_isnan<hipblasLtHalf>();
+    case HIP_R_32I:
+        return arg.alpha_isnan<int32_t>();
+    default:
+        hipblaslt_cerr << "Error type in alpha_isnan_type()" << std::endl;
+        return arg.alpha_isnan<float>();
+    }
+}
+
+inline bool beta_isnan_type(const Arguments& arg, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return arg.beta_isnan<float>();
+    case HIP_R_64F:
+        return arg.beta_isnan<double>();
+    case HIP_R_16F:
+        return arg.beta_isnan<hipblasLtHalf>();
+    case HIP_R_32I:
+        return arg.beta_isnan<int32_t>();
+    default:
+        hipblaslt_cerr << "Error type in beta_isnan_type()" << std::endl;
+        return arg.beta_isnan<float>();
+    }
+}
+
+inline void set_alpha_type(computeTypeInterface& h_alpha, const Arguments& arg, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        h_alpha.f32 = arg.get_alpha<float>();
+        return;
+    case HIP_R_64F:
+        h_alpha.f64 = arg.get_alpha<double>();
+        return;
+    case HIP_R_16F:
+        h_alpha.f16 = arg.get_alpha<hipblasLtHalf>();
+        return;
+    case HIP_R_32I:
+        h_alpha.i32 = arg.get_alpha<int32_t>();
+        return;
+    default:
+        hipblaslt_cerr << "Error type in set_alpha_type()" << std::endl;
+        return;
+    }
+}
+
+inline void set_beta_type(computeTypeInterface& h_beta, const Arguments& arg, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        h_beta.f32 = arg.get_beta<float>();
+        return;
+    case HIP_R_64F:
+        h_beta.f64 = arg.get_beta<double>();
+        return;
+    case HIP_R_16F:
+        h_beta.f16 = arg.get_beta<hipblasLtHalf>();
+        return;
+    case HIP_R_32I:
+        h_beta.i32 = arg.get_beta<int32_t>();
+        return;
+    default:
+        hipblaslt_cerr << "Error type in set_beta_type()" << std::endl;
+        return;
+    }
+}
+
+inline void set_computeInterface(computeTypeInterface& src, void* ptr, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        src.f32 = *(float*)ptr;
+        return;
+    case HIP_R_64F:
+        src.f64 = *(double*)ptr;
+        return;
+    case HIP_R_16F:
+        src.f16 = *(hipblasLtHalf*)ptr;
+        return;
+    case HIP_R_32I:
+        src.i32 = *(int32_t*)ptr;
+        return;
+    default:
+        hipblaslt_cerr << "Error type in set_computeInterface()" << std::endl;
+        return;
+    }
+}
+
+inline void set_computeInterface(computeTypeInterface& src, double value, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        src.f32 = static_cast<float>(value);
+        return;
+    case HIP_R_64F:
+        src.f64 = static_cast<double>(value);
+        return;
+    case HIP_R_16F:
+        src.f16 = static_cast<hipblasLtHalf>(value);
+        return;
+    case HIP_R_32I:
+        src.i32 = static_cast<int32_t>(value);
+        return;
+    default:
+        hipblaslt_cerr << "Error type in set_computeInterface()" << std::endl;
+        return;
+    }
+}
+
+inline void
+    mul_computeInterface(computeTypeInterface& dst, computeTypeInterface& src, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        dst.f32 *= src.f32;
+        return;
+    case HIP_R_64F:
+        dst.f64 *= src.f64;
+        return;
+    case HIP_R_16F:
+        dst.f16 *= src.f16;
+        return;
+    case HIP_R_32I:
+        dst.i32 *= src.i32;
+        return;
+    default:
+        hipblaslt_cerr << "Error type in mul_computeInterface()" << std::endl;
+        return;
+    }
+}
+
+inline double get_computeInterface(const computeTypeInterface src, hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return (double)src.f32;
+    case HIP_R_64F:
+        return (double)src.f64;
+    case HIP_R_16F:
+        return (double)src.f16;
+    case HIP_R_32I:
+        return (double)src.i32;
+    default:
+        hipblaslt_cerr << "Error type in get_computeInterface()" << std::endl;
+        return 0;
+    }
+}
 
 // We make sure that the Arguments struct is C-compatible
 static_assert(std::is_standard_layout<Arguments>{},
@@ -687,7 +853,7 @@ namespace ArgumentsHelper
                 func("rotating_buffer", arg.rotating);
         };
 };
-// clang-format on
+    // clang-format on
 
 #else
 #error "Unsupported C++ version"

--- a/clients/include/hipblaslt_random.hpp
+++ b/clients/include/hipblaslt_random.hpp
@@ -189,8 +189,9 @@ public:
     template <typename T, std::enable_if_t<std::is_integral<T>{}, int> = 0>
     explicit operator T()
     {
-        return rand2() ? std::numeric_limits<T>::min : std::numeric_limits<T>::max;
+        return rand2() ? std::numeric_limits<T>::min() : std::numeric_limits<T>::max();
     }
+
     // Random float
     template <typename T, std::enable_if_t<!std::is_integral<T>{}, int> = 0>
     explicit operator T()

--- a/clients/include/hipblaslt_vector.hpp
+++ b/clients/include/hipblaslt_vector.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -121,7 +121,7 @@ inline void hipblaslt_init(std::vector<T>& that, bool seedReset = false)
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init(that, that.size(), 1, 1);
+    hipblaslt_init(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -129,7 +129,7 @@ inline void hipblaslt_init_alternating_sign(std::vector<T>& that, bool seedReset
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_alternating_sign(that, that.size(), 1, 1);
+    hipblaslt_init_alternating_sign(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -137,7 +137,7 @@ inline void hipblaslt_init_sin(std::vector<T>& that, bool seedReset = false)
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_sin(that, that.size(), 1, 1);
+    hipblaslt_init_sin(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -145,7 +145,7 @@ inline void hipblaslt_init_cos(std::vector<T>& that, bool seedReset = false)
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_cos(that, that.size(), 1, 1);
+    hipblaslt_init_cos<T>(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -153,7 +153,7 @@ inline void hipblaslt_init_hpl(std::vector<T>& that, bool seedReset = false)
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_hpl(that, that.size(), 1, 1);
+    hipblaslt_init_hpl(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -161,7 +161,7 @@ inline void hipblaslt_init_alt_impl_big(std::vector<T>& that, bool seedReset = f
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_alt_impl_big(that, that.size(), 1, 1);
+    hipblaslt_init_alt_impl_big(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -169,7 +169,7 @@ inline void hipblaslt_init_alt_impl_small(std::vector<T>& that, bool seedReset =
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_alt_impl_small(that, that.size(), 1, 1);
+    hipblaslt_init_alt_impl_small(that.data(), that.size(), 1, 1);
 }
 
 template <typename T>
@@ -177,7 +177,7 @@ inline void hipblaslt_init_zero(std::vector<T>& that, bool seedReset = false)
 {
     if(seedReset)
         hipblaslt_seedrand();
-    hipblaslt_init_zero(that, that.size(), 1, 1);
+    hipblaslt_init_zero(that.data(), that.size(), 1, 1);
 }
 
 //!
@@ -231,9 +231,9 @@ inline void hipblaslt_init_vector(host_vector<T>&          hx,
     else if(arg.initialization == hipblaslt_initialization::trig_float)
     {
         if(seedReset)
-            hipblaslt_init_cos(hx, 1, N, incx, stride_x, batch_count);
+            hipblaslt_init_cos(hx.data(), 1, N, incx, stride_x, batch_count);
         else
-            hipblaslt_init_sin(hx, 1, N, incx, stride_x, batch_count);
+            hipblaslt_init_sin(hx.data(), 1, N, incx, stride_x, batch_count);
     }
     else if(arg.initialization == hipblaslt_initialization::zero)
     {
@@ -294,9 +294,9 @@ inline void hipblaslt_init_matrix(host_vector<T>&          hA,
     else if(arg.initialization == hipblaslt_initialization::trig_float)
     {
         if(seedReset)
-            hipblaslt_init_cos(hA, M, N, lda, stride_A, batch_count);
+            hipblaslt_init_cos<T>(hA.data(), M, N, lda, stride_A, batch_count);
         else
-            hipblaslt_init_sin(hA, M, N, lda, stride_A, batch_count);
+            hipblaslt_init_sin<T>(hA.data(), M, N, lda, stride_A, batch_count);
     }
     else if(arg.initialization == hipblaslt_initialization::zero)
     {

--- a/clients/include/near.hpp
+++ b/clients/include/near.hpp
@@ -34,7 +34,9 @@
 
 #pragma once
 
+#include "hipBuffer.hpp"
 #include "hipblaslt_math.hpp"
+#include "hipblaslt_ostream.hpp"
 #include "hipblaslt_test.hpp"
 #include "hipblaslt_vector.hpp"
 #include <hipblaslt/hipblaslt.h>
@@ -52,12 +54,39 @@ template <>
 static constexpr double sum_error_tolerance_for_gfx11<float, hipblasLtHalf, float> = 1 / 100.0;
 
 template <>
-static constexpr double sum_error_tolerance_for_gfx11<float, hipblasLtHalf, hipblasLtHalf>
-    = 1 / 100.0;
+static constexpr double
+    sum_error_tolerance_for_gfx11<float, hipblasLtHalf, hipblasLtHalf> = 1 / 100.0;
 
 template <>
-static constexpr double sum_error_tolerance_for_gfx11<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf>
-    = 1 / 100.0;
+static constexpr double
+    sum_error_tolerance_for_gfx11<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf> = 1 / 100.0;
+
+double sum_error_tolerance_for_gfx11_type(hipDataType Tc, hipDataType Ti, hipDataType To)
+{
+    if(Tc == HIP_R_32F && Ti == HIP_R_16BF && (To == HIP_R_32F || To == HIP_R_16BF))
+        return 1 / 10.0;
+    else if(Tc == HIP_R_32F && Ti == HIP_R_16F && (To == HIP_R_32F || To == HIP_R_16F))
+        return 1 / 100.0;
+    else if(Tc == HIP_R_16F && Ti == HIP_R_16F && To == HIP_R_16F)
+        return 1 / 100.0;
+    else
+    {
+        switch(Tc)
+        {
+        case HIP_R_32F:
+            return std::numeric_limits<float>::epsilon();
+        case HIP_R_64F:
+            return std::numeric_limits<double>::epsilon();
+        case HIP_R_16F:
+            return std::numeric_limits<hipblasLtHalf>::epsilon();
+        case HIP_R_32I:
+            return std::numeric_limits<int32_t>::epsilon();
+        default:
+            hipblaslt_cerr << "Error type in sum_error_tolerance_for_gfx11_type" << std::endl;
+            return 0.0;
+        }
+    }
+};
 
 #ifndef GOOGLE_TEST
 #define NEAR_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, err, NEAR_ASSERT)
@@ -144,46 +173,46 @@ inline void near_check_general<hip_bfloat16, float>(int64_t             M,
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
+inline void near_check_general(int64_t                  M,
+                               int64_t                  N,
+                               int64_t                  lda,
                                const hipblaslt_f8_fnuz* hCPU,
                                const hipblaslt_f8_fnuz* hGPU,
-                               double              abs_error)
+                               double                   abs_error)
 {
     NEAR_CHECK(M, N, lda, 0, hCPU, hGPU, 1, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
+inline void near_check_general(int64_t                   M,
+                               int64_t                   N,
+                               int64_t                   lda,
                                const hipblaslt_bf8_fnuz* hCPU,
                                const hipblaslt_bf8_fnuz* hGPU,
-                               double              abs_error)
+                               double                    abs_error)
 {
     NEAR_CHECK(M, N, lda, 0, hCPU, hGPU, 1, abs_error, NEAR_ASSERT_FP8);
 }
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
+inline void near_check_general(int64_t                 M,
+                               int64_t                 N,
+                               int64_t                 lda,
                                const hipblaslt_f8_ocp* hCPU,
                                const hipblaslt_f8_ocp* hGPU,
-                               double              abs_error)
+                               double                  abs_error)
 {
     NEAR_CHECK(M, N, lda, 0, hCPU, hGPU, 1, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
+inline void near_check_general(int64_t                  M,
+                               int64_t                  N,
+                               int64_t                  lda,
                                const hipblaslt_bf8_ocp* hCPU,
                                const hipblaslt_bf8_ocp* hGPU,
-                               double              abs_error)
+                               double                   abs_error)
 {
     NEAR_CHECK(M, N, lda, 0, hCPU, hGPU, 1, abs_error, NEAR_ASSERT_FP8);
 }
@@ -229,54 +258,54 @@ inline void near_check_general<hip_bfloat16, float>(int64_t             M,
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
-                               int64_t             strideA,
+inline void near_check_general(int64_t                  M,
+                               int64_t                  N,
+                               int64_t                  lda,
+                               int64_t                  strideA,
                                const hipblaslt_f8_fnuz* hCPU,
                                const hipblaslt_f8_fnuz* hGPU,
-                               int64_t             batch_count,
-                               double              abs_error)
+                               int64_t                  batch_count,
+                               double                   abs_error)
 {
     NEAR_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
-                               int64_t             strideA,
+inline void near_check_general(int64_t                   M,
+                               int64_t                   N,
+                               int64_t                   lda,
+                               int64_t                   strideA,
                                const hipblaslt_bf8_fnuz* hCPU,
                                const hipblaslt_bf8_fnuz* hGPU,
-                               int64_t             batch_count,
-                               double              abs_error)
+                               int64_t                   batch_count,
+                               double                    abs_error)
 {
     NEAR_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
-                               int64_t             strideA,
+inline void near_check_general(int64_t                 M,
+                               int64_t                 N,
+                               int64_t                 lda,
+                               int64_t                 strideA,
                                const hipblaslt_f8_ocp* hCPU,
                                const hipblaslt_f8_ocp* hGPU,
-                               int64_t             batch_count,
-                               double              abs_error)
+                               int64_t                 batch_count,
+                               double                  abs_error)
 {
     NEAR_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t             M,
-                               int64_t             N,
-                               int64_t             lda,
-                               int64_t             strideA,
+inline void near_check_general(int64_t                  M,
+                               int64_t                  N,
+                               int64_t                  lda,
+                               int64_t                  strideA,
                                const hipblaslt_bf8_ocp* hCPU,
                                const hipblaslt_bf8_ocp* hGPU,
-                               int64_t             batch_count,
-                               double              abs_error)
+                               int64_t                  batch_count,
+                               double                   abs_error)
 {
     NEAR_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
@@ -318,50 +347,50 @@ inline void near_check_general<hip_bfloat16, float>(int64_t                     
 }
 
 template <>
-inline void near_check_general(int64_t                         M,
-                               int64_t                         N,
-                               int64_t                         lda,
+inline void near_check_general(int64_t                              M,
+                               int64_t                              N,
+                               int64_t                              lda,
                                const host_vector<hipblaslt_f8_fnuz> hCPU[],
                                const host_vector<hipblaslt_f8_fnuz> hGPU[],
-                               int64_t                         batch_count,
-                               double                          abs_error)
+                               int64_t                              batch_count,
+                               double                               abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t                         M,
-                               int64_t                         N,
-                               int64_t                         lda,
+inline void near_check_general(int64_t                               M,
+                               int64_t                               N,
+                               int64_t                               lda,
                                const host_vector<hipblaslt_bf8_fnuz> hCPU[],
                                const host_vector<hipblaslt_bf8_fnuz> hGPU[],
-                               int64_t                         batch_count,
-                               double                          abs_error)
+                               int64_t                               batch_count,
+                               double                                abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline void near_check_general(int64_t                         M,
-                               int64_t                         N,
-                               int64_t                         lda,
+inline void near_check_general(int64_t                             M,
+                               int64_t                             N,
+                               int64_t                             lda,
                                const host_vector<hipblaslt_f8_ocp> hCPU[],
                                const host_vector<hipblaslt_f8_ocp> hGPU[],
-                               int64_t                         batch_count,
-                               double                          abs_error)
+                               int64_t                             batch_count,
+                               double                              abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t                         M,
-                               int64_t                         N,
-                               int64_t                         lda,
+inline void near_check_general(int64_t                              M,
+                               int64_t                              N,
+                               int64_t                              lda,
                                const host_vector<hipblaslt_bf8_ocp> hCPU[],
                                const host_vector<hipblaslt_bf8_ocp> hGPU[],
-                               int64_t                         batch_count,
-                               double                          abs_error)
+                               int64_t                              batch_count,
+                               double                               abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
@@ -404,51 +433,171 @@ inline void near_check_general<hip_bfloat16, float>(int64_t                   M,
 }
 
 template <>
-inline void near_check_general(int64_t                   M,
-                               int64_t                   N,
-                               int64_t                   lda,
+inline void near_check_general(int64_t                        M,
+                               int64_t                        N,
+                               int64_t                        lda,
                                const hipblaslt_f8_fnuz* const hCPU[],
                                const hipblaslt_f8_fnuz* const hGPU[],
-                               int64_t                   batch_count,
-                               double                    abs_error)
+                               int64_t                        batch_count,
+                               double                         abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t                   M,
-                               int64_t                   N,
-                               int64_t                   lda,
+inline void near_check_general(int64_t                         M,
+                               int64_t                         N,
+                               int64_t                         lda,
                                const hipblaslt_bf8_fnuz* const hCPU[],
                                const hipblaslt_bf8_fnuz* const hGPU[],
-                               int64_t                   batch_count,
-                               double                    abs_error)
+                               int64_t                         batch_count,
+                               double                          abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline void near_check_general(int64_t                   M,
-                               int64_t                   N,
-                               int64_t                   lda,
+inline void near_check_general(int64_t                       M,
+                               int64_t                       N,
+                               int64_t                       lda,
                                const hipblaslt_f8_ocp* const hCPU[],
                                const hipblaslt_f8_ocp* const hGPU[],
-                               int64_t                   batch_count,
-                               double                    abs_error)
+                               int64_t                       batch_count,
+                               double                        abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 
 template <>
-inline void near_check_general(int64_t                   M,
-                               int64_t                   N,
-                               int64_t                   lda,
+inline void near_check_general(int64_t                        M,
+                               int64_t                        N,
+                               int64_t                        lda,
                                const hipblaslt_bf8_ocp* const hCPU[],
                                const hipblaslt_bf8_ocp* const hGPU[],
-                               int64_t                   batch_count,
-                               double                    abs_error)
+                               int64_t                        batch_count,
+                               double                         abs_error)
 {
     NEAR_CHECK_B(M, N, lda, hCPU, hGPU, batch_count, abs_error, NEAR_ASSERT_FP8);
 }
 #endif
+
+inline void near_check_general(int64_t     M,
+                               int64_t     N,
+                               int64_t     lda,
+                               int64_t     strideA,
+                               void*       hCPU,
+                               void*       hGPU,
+                               int64_t     batch_count,
+                               double      abs_error,
+                               hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<float*>(hCPU),
+                           static_cast<float*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_64F:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<double*>(hCPU),
+                           static_cast<double*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_16F:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblasLtHalf*>(hCPU),
+                           static_cast<hipblasLtHalf*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_16BF:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hip_bfloat16*>(hCPU),
+                           static_cast<hip_bfloat16*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_f8_fnuz*>(hCPU),
+                           static_cast<hipblaslt_f8_fnuz*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_bf8_fnuz*>(hCPU),
+                           static_cast<hipblaslt_bf8_fnuz*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_f8_ocp*>(hCPU),
+                           static_cast<hipblaslt_f8_ocp*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_8F_E5M2:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_bf8_ocp*>(hCPU),
+                           static_cast<hipblaslt_bf8_ocp*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+#endif
+    case HIP_R_32I:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<int32_t*>(hCPU),
+                           static_cast<int32_t*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    case HIP_R_8I:
+        near_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblasLtInt8*>(hCPU),
+                           static_cast<hipblasLtInt8*>(hGPU),
+                           batch_count,
+                           abs_error);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in near_check_general" << std::endl;
+        break;
+    }
+}

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -30,6 +30,7 @@
 #include "cblas_interface.hpp"
 #include "flops.hpp"
 #include "frequency_monitor.hpp"
+#include "hipBuffer.hpp"
 #include "hipblaslt_datatype2string.hpp"
 #include "hipblaslt_init.hpp"
 #include "hipblaslt_math.hpp"
@@ -38,9 +39,11 @@
 #include "hipblaslt_vector.hpp"
 #include "near.hpp"
 #include "norm.hpp"
+#include "type_dispatch.hpp"
 #include "unit.hpp"
 #include "utility.hpp"
 #include <cstddef>
+#include <functional>
 #include <hipblaslt/hipblaslt-ext-op.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <hipblaslt/hipblaslt.h>
@@ -70,39 +73,126 @@ extern "C" __global__ void flush_icache()
                          :);
 }
 
-template <typename Ti, typename Tc, typename To, typename Tbias, typename Tact, typename F>
-void epilogue_func(int64_t m,
-                   int64_t n,
-                   int64_t ld,
-                   Ti*     in,
-                   To*     out,
-                   Tc*     out_raw,
-                   Tc*     amaxD,
-                   To*     e,
-                   Tc      scaleD,
-                   Tc      scaleE,
-                   bool    enable_bias,
-                   Tbias*  bias,
-                   Tact    arg1,
-                   Tact    arg2,
-                   F&      act_func,
-                   bool    gradient)
+template <typename Tout>
+Tout cast_from_type(void* in, hipDataType type, size_t index)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        return static_cast<Tout>((static_cast<float*>(in))[index]);
+    case HIP_R_64F:
+        return static_cast<Tout>((static_cast<double*>(in))[index]);
+    case HIP_R_16F:
+        return static_cast<Tout>((static_cast<hipblasLtHalf*>(in))[index]);
+    case HIP_R_16BF:
+        return static_cast<Tout>((static_cast<hip_bfloat16*>(in))[index]);
+    case HIP_R_8F_E4M3_FNUZ:
+        if constexpr(std::is_same<Tout, float>::value)
+            return static_cast<Tout>((static_cast<hipblaslt_f8_fnuz*>(in))[index]);
+        return 0;
+    case HIP_R_8F_E5M2_FNUZ:
+        if constexpr(std::is_same<Tout, float>::value)
+            return static_cast<Tout>((static_cast<hipblaslt_bf8_fnuz*>(in))[index]);
+        return 0;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        if constexpr(std::is_same<Tout, float>::value)
+            return static_cast<Tout>((static_cast<hipblaslt_f8_ocp*>(in))[index]);
+        return 0;
+    case HIP_R_8F_E5M2:
+        if constexpr(std::is_same<Tout, float>::value)
+            return static_cast<Tout>((static_cast<hipblaslt_bf8_ocp*>(in))[index]);
+        return 0;
+#endif
+    case HIP_R_32I:
+        return static_cast<Tout>((static_cast<int32_t*>(in))[index]);
+    case HIP_R_8I:
+        return static_cast<Tout>((static_cast<hipblasLtInt8*>(in))[index]);
+    default:
+        hipblaslt_cerr << "Error type in cast_from_type()" << std::endl;
+        return 0;
+    }
+}
+
+template <typename Tin>
+void saturate_cast_to_type(void* dst, Tin src, hipDataType typeD, size_t indexD)
+{
+    switch(typeD)
+    {
+    case HIP_R_32F:
+        static_cast<float*>(dst)[indexD] = saturate_cast<float>(src);
+        return;
+    case HIP_R_64F:
+        static_cast<double*>(dst)[indexD] = saturate_cast<double>(src);
+        return;
+    case HIP_R_16F:
+        static_cast<hipblasLtHalf*>(dst)[indexD] = saturate_cast<hipblasLtHalf>(src);
+        return;
+    case HIP_R_16BF:
+        static_cast<hip_bfloat16*>(dst)[indexD] = saturate_cast<hip_bfloat16>(src);
+        return;
+    case HIP_R_8F_E4M3_FNUZ:
+        static_cast<hipblaslt_f8_fnuz*>(dst)[indexD] = saturate_cast<hipblaslt_f8_fnuz>(src);
+        return;
+    case HIP_R_8F_E5M2_FNUZ:
+        static_cast<hipblaslt_bf8_fnuz*>(dst)[indexD] = saturate_cast<hipblaslt_bf8_fnuz>(src);
+        return;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        static_cast<hipblaslt_f8_ocp*>(dst)[indexD] = saturate_cast<hipblaslt_f8_ocp>(src);
+        return;
+    case HIP_R_8F_E5M2:
+        static_cast<hipblaslt_bf8_ocp*>(dst)[indexD] = saturate_cast<hipblaslt_bf8_ocp>(src);
+        return;
+#endif
+    case HIP_R_32I:
+        static_cast<int32_t*>(dst)[indexD] = saturate_cast<int32_t>(src);
+        return;
+    case HIP_R_8I:
+        static_cast<hipblasLtInt8*>(dst)[indexD] = saturate_cast<hipblasLtInt8>(src);
+        return;
+    default:
+        hipblaslt_cerr << "Error type in cast_from_type()" << std::endl;
+    }
+}
+
+template <typename Ti, typename Tc, typename Tact, typename F>
+void epilogue_func(int64_t     m,
+                   int64_t     n,
+                   int64_t     ld,
+                   Ti*         in,
+                   void*       out,
+                   Tc*         out_raw,
+                   Tc*         amaxD,
+                   void*       e,
+                   Tc          scaleD,
+                   Tc          scaleE,
+                   bool        enable_bias,
+                   void*       bias,
+                   hipDataType bias_type,
+                   Tact        arg1,
+                   Tact        arg2,
+                   F&          act_func,
+                   bool        gradient,
+                   hipDataType To)
 {
     for(int i = 0; i < m; i++)
     {
-        Ti bias_data = enable_bias ? static_cast<Ti>(*(bias + i)) : 0;
+        Ti bias_data = enable_bias ? cast_from_type<Ti>(bias, bias_type, i) : 0;
 
-#define CALCULATE_EPILOGUE_ACT                                                       \
-    auto pos     = j * ld + i;                                                       \
-    auto in_Tact = static_cast<Tact>(*(in + pos)) + bias_data;                       \
-    if(e && !gradient)                                                               \
-    {                                                                                \
-        *(e + pos) = saturate_cast<To>(in_Tact * scaleE);                            \
-    }                                                                                \
-    Tact in_Tact_act = 0;                                                            \
-    if(gradient)                                                                     \
-        in_Tact_act = act_func(static_cast<Tact>(*(e + pos)), arg1, arg2) * in_Tact; \
-    else                                                                             \
+#define CALCULATE_EPILOGUE_ACT                                                          \
+    auto pos     = j * ld + i;                                                          \
+    auto in_Tact = static_cast<Tact>(in[pos]) + bias_data;                              \
+    if(e && !gradient)                                                                  \
+    {                                                                                   \
+        saturate_cast_to_type(e, in_Tact* scaleE, To, pos);                             \
+    }                                                                                   \
+    Tact in_Tact_act = 0;                                                               \
+    if(gradient)                                                                        \
+    {                                                                                   \
+        in_Tact_act = act_func(cast_from_type<Tact>(e, To, pos), arg1, arg2) * in_Tact; \
+    }                                                                                   \
+    else                                                                                \
         in_Tact_act = act_func(in_Tact, arg1, arg2);
 
         if(amaxD == nullptr)
@@ -111,7 +201,7 @@ void epilogue_func(int64_t m,
             for(int j = 0; j < n; j++)
             {
                 CALCULATE_EPILOGUE_ACT;
-                *(out + pos)     = saturate_cast<To>(in_Tact_act * scaleD);
+                saturate_cast_to_type(out, in_Tact_act * scaleD, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(in_Tact_act * scaleD);
             }
         }
@@ -120,41 +210,133 @@ void epilogue_func(int64_t m,
             for(int j = 0; j < n; j++)
             {
                 CALCULATE_EPILOGUE_ACT;
-                *amaxD           = *amaxD > fabs(static_cast<Tc>(in_Tact_act))
-                                       ? *amaxD
-                                       : fabs(static_cast<Tc>(in_Tact_act));
-                *(out + pos)     = saturate_cast<To>(in_Tact_act * scaleD);
+                *amaxD = *amaxD > fabs(static_cast<Tc>(in_Tact_act))
+                             ? *amaxD
+                             : fabs(static_cast<Tc>(in_Tact_act));
+                saturate_cast_to_type(out, in_Tact_act * scaleD, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(in_Tact_act * scaleD);
             }
         }
     }
 }
-template <typename Ti, typename Tc, typename To, typename Tbias>
-void epilogue_func(int64_t m,
-                   int64_t n,
-                   int64_t ld,
-                   Ti*     in,
-                   To*     out,
-                   Tc*     out_raw,
-                   Tc*     amaxD,
-                   To*     e,
-                   Tc      scaleD,
-                   Tc      scaleE,
-                   bool    enable_bias,
-                   Tbias*  bias,
-                   bool    gradient)
+
+template <typename Tact, typename F>
+void epilogue_func(int64_t     m,
+                   int64_t     n,
+                   int64_t     ld,
+                   void*       in,
+                   void*       out,
+                   void*       out_raw,
+                   void*       amaxD,
+                   void*       e,
+                   void*       scaleD,
+                   void*       scaleE,
+                   bool        enable_bias,
+                   void*       bias,
+                   hipDataType bias_type,
+                   Tact        arg1,
+                   Tact        arg2,
+                   F&          act_func,
+                   bool        gradient,
+                   hipDataType To,
+                   hipDataType Tc)
+{
+    switch(Tc)
+    {
+    case HIP_R_32F:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (float*)in,
+                      out,
+                      (float*)out_raw,
+                      (float*)amaxD,
+                      e,
+                      *(float*)scaleD,
+                      *(float*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      arg1,
+                      arg2,
+                      act_func,
+                      gradient,
+                      To);
+        return;
+    case HIP_R_64F:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (double*)in,
+                      out,
+                      (double*)out_raw,
+                      (double*)amaxD,
+                      e,
+                      *(double*)scaleD,
+                      *(double*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      arg1,
+                      arg2,
+                      act_func,
+                      gradient,
+                      To);
+        return;
+    case HIP_R_32I:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (int32_t*)in,
+                      out,
+                      (int32_t*)out_raw,
+                      (int32_t*)amaxD,
+                      e,
+                      *(int32_t*)scaleD,
+                      *(int32_t*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      arg1,
+                      arg2,
+                      act_func,
+                      gradient,
+                      To);
+        return;
+    default:
+        hipblaslt_cerr << "Error type in epilogue_func()" << std::endl;
+        return;
+    }
+}
+
+template <typename Ti, typename Tc>
+void epilogue_func(int64_t     m,
+                   int64_t     n,
+                   int64_t     ld,
+                   Ti*         in,
+                   void*       out,
+                   Tc*         out_raw,
+                   Tc*         amaxD,
+                   void*       e,
+                   Tc          scaleD,
+                   Tc          scaleE,
+                   bool        enable_bias,
+                   void*       bias,
+                   hipDataType bias_type,
+                   bool        gradient,
+                   hipDataType To)
 {
 #define CALCULATE_EPILOGUE_BASIC                          \
     auto pos  = j * ld + i;                               \
     Tc   temp = static_cast<Ti>(*(in + pos)) + bias_data; \
     if(e)                                                 \
     {                                                     \
-        *(e + pos) = saturate_cast<To>(temp * scaleE);    \
+        saturate_cast_to_type(e, temp* scaleE, To, pos);  \
     }
 
     for(int i = 0; i < m; i++)
     {
-        Ti bias_data = enable_bias ? static_cast<Ti>(*(bias + i)) : 0;
+        Ti bias_data = enable_bias ? cast_from_type<Ti>(bias, bias_type, i) : 0;
 
         if(amaxD == nullptr)
         {
@@ -163,7 +345,7 @@ void epilogue_func(int64_t m,
             {
                 CALCULATE_EPILOGUE_BASIC;
                 temp *= scaleD;
-                *(out + pos)     = saturate_cast<To>(temp);
+                saturate_cast_to_type(out, temp, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(temp);
             }
         }
@@ -175,16 +357,100 @@ void epilogue_func(int64_t m,
                 *amaxD
                     = *amaxD > fabs(static_cast<Tc>(temp)) ? *amaxD : fabs(static_cast<Tc>(temp));
                 temp *= scaleD;
-                *(out + pos)     = saturate_cast<To>(temp);
+                saturate_cast_to_type(out, temp, To, pos);
                 *(out_raw + pos) = static_cast<Tc>(temp);
             }
         }
     }
 }
 
-template <bool SumLd, typename Tc, typename Ti, typename To>
-void reduction_func(
-    Ti* workspace, To* bias, int length, int k, int s1, int s2, int s3, int batch_count)
+void epilogue_func(int64_t     m,
+                   int64_t     n,
+                   int64_t     ld,
+                   void*       in,
+                   void*       out,
+                   void*       out_raw,
+                   void*       amaxD,
+                   void*       e,
+                   void*       scaleD,
+                   void*       scaleE,
+                   bool        enable_bias,
+                   void*       bias,
+                   hipDataType bias_type,
+                   bool        gradient,
+                   hipDataType To,
+                   hipDataType Tc)
+{
+    switch(Tc)
+    {
+    case HIP_R_32F:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (float*)in,
+                      out,
+                      (float*)out_raw,
+                      (float*)amaxD,
+                      e,
+                      *(float*)scaleD,
+                      *(float*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      gradient,
+                      To);
+        return;
+    case HIP_R_64F:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (double*)in,
+                      out,
+                      (double*)out_raw,
+                      (double*)amaxD,
+                      e,
+                      *(double*)scaleD,
+                      *(double*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      gradient,
+                      To);
+        return;
+    case HIP_R_32I:
+        epilogue_func(m,
+                      n,
+                      ld,
+                      (int32_t*)in,
+                      out,
+                      (int32_t*)out_raw,
+                      (int32_t*)amaxD,
+                      e,
+                      *(int32_t*)scaleD,
+                      *(int32_t*)scaleE,
+                      enable_bias,
+                      bias,
+                      bias_type,
+                      gradient,
+                      To);
+        return;
+    default:
+        hipblaslt_cerr << "Error type in epilogue_func()" << std::endl;
+        return;
+    }
+}
+
+template <bool SumLd, typename Tc>
+void reduction_func(void*       workspace,
+                    hipDataType ti,
+                    void*       bias,
+                    hipDataType bias_type,
+                    int         length,
+                    int         k,
+                    int         s1,
+                    int         s2,
+                    int         s3,
+                    int         batch_count)
 {
     assert(batch_count == 1);
     for(int batch = 0; batch < batch_count; batch++)
@@ -196,14 +462,14 @@ void reduction_func(
             {
                 if constexpr(SumLd)
                 {
-                    sum += static_cast<Tc>(workspace[i1 * s2 + i2 * s1 + batch * s3]);
+                    sum += cast_from_type<Tc>(workspace, ti, i1 * s2 + i2 * s1 + batch * s3);
                 }
                 else
                 {
-                    sum += static_cast<Tc>(workspace[i1 * s1 + i2 * s2 + batch * s3]);
+                    sum += cast_from_type<Tc>(workspace, ti, i1 * s1 + i2 * s2 + batch * s3);
                 }
             }
-            bias[i1] = saturate_cast<To>(sum);
+            saturate_cast_to_type(bias, sum, bias_type, i1);
         }
     }
 }
@@ -292,48 +558,49 @@ void testing_matmul_bad_arg(const Arguments& arg)
     hipStream_t stream = nullptr;
 }
 
-template <typename T>
-void copy_gemm_to_host(hipStream_t                     stream,
-                       const uint32_t&                 gemm_count,
-                       std::vector<host_vector<T>*>&   hDst,
-                       std::vector<device_vector<T>*>& dSrc)
+void copy_gemm_to_host(hipStream_t                   stream,
+                       const uint32_t&               gemm_count,
+                       std::vector<HipHostBuffer>&   hDst,
+                       std::vector<HipDeviceBuffer>& dSrc)
 {
 
     CHECK_HIP_ERROR(hipStreamSynchronize(stream));
     for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
     {
-        CHECK_HIP_ERROR(hDst[gemmIdx]->transfer_from(*(dSrc[gemmIdx])));
+        CHECK_HIP_ERROR(synchronize(hDst[gemmIdx], dSrc[gemmIdx]));
     }
 }
 
-template <typename To, typename Tc, typename Tbias>
-void check(hipStream_t                         stream,
-           const Arguments&                    arg,
-           const uint32_t&                     gemm_count,
-           const std::vector<int64_t>&         M,
-           const std::vector<int64_t>&         N,
-           const std::vector<int64_t>&         ldd,
-           const std::vector<int64_t>&         lde,
-           const std::vector<int64_t>&         stride_d,
-           const std::vector<int64_t>&         stride_e,
-           const std::vector<int>&             num_batches,
-           const std::vector<size_t>&          size_bias,
-           std::vector<host_vector<To>*>&      hD_gold,
-           std::vector<host_vector<To>*>&      hD_1,
-           std::vector<device_vector<To>*>&    dD,
-           std::vector<host_vector<Tc>*>&      hAmaxD_gold,
-           std::vector<host_vector<Tc>*>&      hAmaxD,
-           std::vector<device_vector<Tc>*>&    dAmaxD,
-           std::vector<host_vector<To>*>&      hE_gold,
-           std::vector<host_vector<To>*>&      hE,
-           std::vector<device_vector<To>*>&    dE,
-           std::vector<host_vector<Tbias>*>&   hBias_gold,
-           std::vector<host_vector<Tbias>*>&   hBias,
-           std::vector<device_vector<Tbias>*>& dBias,
-           std::vector<double>&                tol,
-           double&                             hipblaslt_error,
-           double&                             hipblaslt_atol,
-           double&                             hipblaslt_rtol)
+void check(hipStream_t                   stream,
+           const Arguments&              arg,
+           const uint32_t&               gemm_count,
+           const std::vector<int64_t>&   M,
+           const std::vector<int64_t>&   N,
+           const std::vector<int64_t>&   ldd,
+           const std::vector<int64_t>&   lde,
+           const std::vector<int64_t>&   stride_d,
+           const std::vector<int64_t>&   stride_e,
+           const std::vector<int>&       num_batches,
+           const std::vector<size_t>&    size_bias,
+           std::vector<HipHostBuffer>&   hD_gold,
+           std::vector<HipHostBuffer>&   hD_1,
+           std::vector<HipDeviceBuffer>& dD,
+           std::vector<HipHostBuffer>&   hAmaxD_gold,
+           std::vector<HipHostBuffer>&   hAmaxD,
+           std::vector<HipDeviceBuffer>& dAmaxD,
+           std::vector<HipHostBuffer>&   hE_gold,
+           std::vector<HipHostBuffer>&   hE,
+           std::vector<HipDeviceBuffer>& dE,
+           std::vector<HipHostBuffer>&   hBias_gold,
+           std::vector<HipHostBuffer>&   hBias,
+           std::vector<HipDeviceBuffer>& dBias,
+           std::vector<double>&          tol,
+           double&                       hipblaslt_error,
+           double&                       hipblaslt_atol,
+           double&                       hipblaslt_rtol,
+           hipDataType                   To,
+           hipDataType                   Tbias,
+           hipDataType                   Tc)
 {
     // fetch GPU
     CHECK_HIP_ERROR(hipStreamSynchronize(stream));
@@ -341,182 +608,207 @@ void check(hipStream_t                         stream,
     for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
     {
         if(!arg.gradient && arg.use_e)
-            CHECK_HIP_ERROR(hE[gemmIdx]->transfer_from(*(dE[gemmIdx])));
+        {
+            CHECK_HIP_ERROR(synchronize(hE[gemmIdx], dE[gemmIdx]));
+        }
+
         if(arg.amaxD)
         {
-            CHECK_HIP_ERROR(hAmaxD[gemmIdx]->transfer_from(*(dAmaxD[gemmIdx])));
+            CHECK_HIP_ERROR(synchronize(hAmaxD[gemmIdx], dAmaxD[gemmIdx]));
         }
         if(arg.gradient && arg.bias_vector)
         {
-            CHECK_HIP_ERROR(hBias[gemmIdx]->transfer_from(*(dBias[gemmIdx])));
+            CHECK_HIP_ERROR(synchronize(hBias[gemmIdx], dBias[gemmIdx]));
         }
         if(arg.unit_check)
         {
             if(tol[gemmIdx] != 0)
             {
-                near_check_general<To>(M[gemmIdx],
-                                       N[gemmIdx],
-                                       ldd[gemmIdx],
-                                       stride_d[gemmIdx],
-                                       *(hD_gold[gemmIdx]),
-                                       *(hD_1[gemmIdx]),
-                                       num_batches[gemmIdx],
-                                       tol[gemmIdx]);
+                near_check_general(M[gemmIdx],
+                                   N[gemmIdx],
+                                   ldd[gemmIdx],
+                                   stride_d[gemmIdx],
+                                   hD_gold[gemmIdx].buf(),
+                                   hD_1[gemmIdx].buf(),
+                                   num_batches[gemmIdx],
+                                   tol[gemmIdx],
+                                   To);
             }
             else
             {
-                unit_check_general<To>(M[gemmIdx],
-                                       N[gemmIdx],
-                                       ldd[gemmIdx],
-                                       stride_d[gemmIdx],
-                                       *(hD_gold[gemmIdx]),
-                                       *(hD_1[gemmIdx]),
-                                       num_batches[gemmIdx]);
+                unit_check_general(M[gemmIdx],
+                                   N[gemmIdx],
+                                   ldd[gemmIdx],
+                                   stride_d[gemmIdx],
+                                   hD_gold[gemmIdx].buf(),
+                                   hD_1[gemmIdx].buf(),
+                                   num_batches[gemmIdx],
+                                   To);
             }
             if(arg.amaxD)
             {
                 if(tol[gemmIdx] != 0)
                 {
-                    near_check_general<Tc>(1,
-                                           1,
-                                           1,
-                                           1,
-                                           *(hAmaxD_gold[gemmIdx]),
-                                           *(hAmaxD[gemmIdx]),
-                                           num_batches[gemmIdx],
-                                           tol[gemmIdx]);
+                    near_check_general(1,
+                                       1,
+                                       1,
+                                       1,
+                                       hAmaxD_gold[gemmIdx].buf(),
+                                       hAmaxD[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       tol[gemmIdx],
+                                       Tc);
                 }
                 else
                 {
-                    unit_check_general<Tc>(1,
-                                           1,
-                                           1,
-                                           1,
-                                           *(hAmaxD_gold[gemmIdx]),
-                                           *(hAmaxD[gemmIdx]),
-                                           num_batches[gemmIdx]);
+                    unit_check_general(1,
+                                       1,
+                                       1,
+                                       1,
+                                       hAmaxD_gold[gemmIdx].buf(),
+                                       hAmaxD[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       Tc);
                 }
             }
             if(!arg.gradient && arg.use_e)
             {
                 if(tol[gemmIdx] != 0)
                 {
-                    near_check_general<To>(M[gemmIdx],
-                                           N[gemmIdx],
-                                           lde[gemmIdx],
-                                           stride_e[gemmIdx],
-                                           *(hE_gold[gemmIdx]),
-                                           *(hE[gemmIdx]),
-                                           num_batches[gemmIdx],
-                                           tol[gemmIdx]);
+                    near_check_general(M[gemmIdx],
+                                       N[gemmIdx],
+                                       lde[gemmIdx],
+                                       stride_e[gemmIdx],
+                                       hE_gold[gemmIdx].buf(),
+                                       hE[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       tol[gemmIdx],
+                                       To);
                 }
                 else
                 {
-                    unit_check_general<To>(M[gemmIdx],
-                                           N[gemmIdx],
-                                           lde[gemmIdx],
-                                           stride_e[gemmIdx],
-                                           *(hE_gold[gemmIdx]),
-                                           *(hE[gemmIdx]),
-                                           num_batches[gemmIdx]);
+                    unit_check_general(M[gemmIdx],
+                                       N[gemmIdx],
+                                       lde[gemmIdx],
+                                       stride_e[gemmIdx],
+                                       hE_gold[gemmIdx].buf(),
+                                       hE[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       To);
                 }
             }
             if(arg.gradient && arg.bias_vector)
             {
                 if(tol[gemmIdx] != 0)
                 {
-                    near_check_general<Tbias>(size_bias[gemmIdx],
-                                              1,
-                                              size_bias[gemmIdx],
-                                              size_bias[gemmIdx],
-                                              *(hBias_gold[gemmIdx]),
-                                              *(hBias[gemmIdx]),
-                                              num_batches[gemmIdx],
-                                              tol[gemmIdx]);
+                    near_check_general(size_bias[gemmIdx],
+                                       1,
+                                       size_bias[gemmIdx],
+                                       size_bias[gemmIdx],
+                                       hBias_gold[gemmIdx].buf(),
+                                       hBias[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       tol[gemmIdx],
+                                       Tbias);
                 }
                 else
                 {
-                    unit_check_general<Tbias>(size_bias[gemmIdx],
-                                              1,
-                                              size_bias[gemmIdx],
-                                              size_bias[gemmIdx],
-                                              *(hBias_gold[gemmIdx]),
-                                              *(hBias[gemmIdx]),
-                                              num_batches[gemmIdx]);
+                    unit_check_general(size_bias[gemmIdx],
+                                       1,
+                                       size_bias[gemmIdx],
+                                       size_bias[gemmIdx],
+                                       hBias_gold[gemmIdx].buf(),
+                                       hBias[gemmIdx].buf(),
+                                       num_batches[gemmIdx],
+                                       Tbias);
                 }
             }
         }
 
         if(arg.norm_check)
         {
-            double norm_error = std::abs(norm_check_general<To>('F',
-                                                                M[gemmIdx],
-                                                                N[gemmIdx],
-                                                                ldd[gemmIdx],
-                                                                stride_d[gemmIdx],
-                                                                *(hD_gold[gemmIdx]),
-                                                                *(hD_1[gemmIdx]),
-                                                                num_batches[gemmIdx]));
+            double norm_error = 0.0;
+            norm_error        = std::abs(norm_check_general('F',
+                                                     M[gemmIdx],
+                                                     N[gemmIdx],
+                                                     ldd[gemmIdx],
+                                                     stride_d[gemmIdx],
+                                                     hD_gold[gemmIdx].buf(),
+                                                     hD_1[gemmIdx].buf(),
+                                                     num_batches[gemmIdx],
+                                                     To));
             hipblaslt_error += norm_error;
             if(arg.norm_check_assert)
-                CHECK_SUCCESS(norm_check<To>(norm_error));
+            {
+                CHECK_SUCCESS(norm_check(norm_error, To));
+            }
 
             if(arg.amaxD)
             {
-                double norm_error = std::abs(norm_check_general<Tc>('F',
-                                                                    1,
-                                                                    1,
-                                                                    1,
-                                                                    1,
-                                                                    *(hAmaxD_gold[gemmIdx]),
-                                                                    *(hAmaxD[gemmIdx]),
-                                                                    num_batches[gemmIdx]));
+                double norm_error = std::abs(norm_check_general('F',
+                                                                1,
+                                                                1,
+                                                                1,
+                                                                1,
+                                                                hAmaxD_gold[gemmIdx].buf(),
+                                                                hAmaxD[gemmIdx].buf(),
+                                                                num_batches[gemmIdx],
+                                                                Tc));
                 hipblaslt_error += norm_error;
                 if(arg.norm_check_assert)
-                    CHECK_SUCCESS(norm_check<Tc>(norm_error));
+                    CHECK_SUCCESS(norm_check(norm_error, Tc));
             }
             if(!arg.gradient && arg.use_e)
             {
-                double norm_error = std::abs(norm_check_general<To>('F',
-                                                                    M[gemmIdx],
-                                                                    N[gemmIdx],
-                                                                    lde[gemmIdx],
-                                                                    stride_e[gemmIdx],
-                                                                    *(hE_gold[gemmIdx]),
-                                                                    *(hE[gemmIdx]),
-                                                                    num_batches[gemmIdx]));
+                double norm_error = 0.0;
+                norm_error        = std::abs(norm_check_general('F',
+                                                         M[gemmIdx],
+                                                         N[gemmIdx],
+                                                         lde[gemmIdx],
+                                                         stride_e[gemmIdx],
+                                                         hE_gold[gemmIdx].buf(),
+                                                         hE[gemmIdx].buf(),
+                                                         num_batches[gemmIdx],
+                                                         To));
                 hipblaslt_error += norm_error;
                 if(arg.norm_check_assert)
-                    CHECK_SUCCESS(norm_check<To>(norm_error));
+                {
+                    CHECK_SUCCESS(norm_check(norm_error, To));
+                }
             }
             if(arg.gradient && arg.bias_vector)
             {
-                double norm_error = std::abs(norm_check_general<Tbias>('F',
-                                                                       M[gemmIdx],
-                                                                       1,
-                                                                       M[gemmIdx],
-                                                                       M[gemmIdx],
-                                                                       *(hBias_gold[gemmIdx]),
-                                                                       *(hBias[gemmIdx]),
-                                                                       num_batches[gemmIdx]));
+                double norm_error = 0.0;
+                norm_error        = std::abs(norm_check_general('F',
+                                                         M[gemmIdx],
+                                                         1,
+                                                         M[gemmIdx],
+                                                         M[gemmIdx],
+                                                         hBias_gold[gemmIdx].buf(),
+                                                         hBias[gemmIdx].buf(),
+                                                         num_batches[gemmIdx],
+                                                         Tbias));
                 hipblaslt_error += norm_error;
                 if(arg.norm_check_assert)
-                    CHECK_SUCCESS(norm_check<Tbias>(norm_error));
+                {
+                    CHECK_SUCCESS(norm_check(norm_error, Tbias));
+                }
             }
         }
 
         if(arg.allclose_check)
         {
-            bool is_allclose = allclose_check_general<To>('F',
-                                                          M[gemmIdx],
-                                                          N[gemmIdx],
-                                                          ldd[gemmIdx],
-                                                          stride_d[gemmIdx],
-                                                          *(hD_gold[gemmIdx]),
-                                                          *(hD_1[gemmIdx]),
-                                                          num_batches[gemmIdx],
-                                                          hipblaslt_atol,
-                                                          hipblaslt_rtol);
+            bool is_allclose = allclose_check_general('F',
+                                                      M[gemmIdx],
+                                                      N[gemmIdx],
+                                                      ldd[gemmIdx],
+                                                      stride_d[gemmIdx],
+                                                      hD_gold[gemmIdx].buf(),
+                                                      hD_1[gemmIdx].buf(),
+                                                      num_batches[gemmIdx],
+                                                      hipblaslt_atol,
+                                                      hipblaslt_rtol,
+                                                      To);
             //TODO: confirm if allclose_check_assert is neccessary
         }
     }
@@ -577,14 +869,14 @@ hipDataType derive_unset_bias_type(const Arguments& arg)
     return real_bias_type;
 }
 
-template <typename TiA,
-          typename TiB,
-          typename To,
-          typename Tc,
-          typename TciA,
-          typename TciB,
-          typename Tbias>
-void testing_matmul_with_bias(const Arguments&);
+void testing_matmul_with_bias(const Arguments& arg,
+                              hipDataType      TiA,
+                              hipDataType      TiB,
+                              hipDataType      To,
+                              hipDataType      Tc,
+                              hipDataType      TciA,
+                              hipDataType      TciB,
+                              hipDataType      Tbias);
 
 template <typename TiA,
           typename TiB,
@@ -594,86 +886,83 @@ template <typename TiA,
           typename TciB = TiB>
 void testing_matmul(const Arguments& arg)
 {
+    hipDataType tiA  = hipblaslt_type2datatype<TiA>();
+    hipDataType tiB  = hipblaslt_type2datatype<TiB>();
+    hipDataType to   = hipblaslt_type2datatype<To>();
+    hipDataType tc   = hipblaslt_type2datatype<Tc>();
+    hipDataType tciA = hipblaslt_type2datatype<TciA>();
+    hipDataType tciB = hipblaslt_type2datatype<TciB>();
+
     // after this, real bias type should not be invalid
     hipDataType real_bias_type = derive_unset_bias_type(arg);
 
     // for all f8/bf8 cases including mix mode
-    if constexpr((sizeof(TiA) == 1 || sizeof(TiB) == 1) && !std::is_same<Tc, int32_t>::value)
+    if((realDataTypeSize(tiA) == 1 || realDataTypeSize(tiB) == 1)
+       && !std::is_same<Tc, int32_t>::value) //Tc!=HIPBLAS_COMPUTE_32I
     {
-        if constexpr(std::is_same<To, hip_bfloat16>::value || std::is_same<To, float>::value)
+        if(to == HIP_R_16BF || to == HIP_R_32F)
         {
             if(real_bias_type == HIP_R_16BF)
             {
-                return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, hip_bfloat16>(arg);
+                return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_16BF);
             }
             else
             {
-                return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, float>(arg);
+                return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_32F);
             }
         }
         else
         {
             if(real_bias_type == HIP_R_16F)
             {
-                return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, hipblasLtHalf>(arg);
+                return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_16F);
             }
             else
             {
-                return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, float>(arg);
+                return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_32F);
             }
         }
     }
-    else if constexpr(std::is_same<To, hipblasLtHalf>::value)
+    else if(to == HIP_R_16F)
     {
         if(real_bias_type == HIP_R_16F)
         {
-            return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, hipblasLtHalf>(arg);
+            return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_16F);
         }
         else
         {
-            return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, float>(arg);
+            return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_32F);
         }
     }
-    else if constexpr(std::is_same<To, hip_bfloat16>::value)
+    else if(to == HIP_R_16BF)
     {
         if(real_bias_type == HIP_R_16BF)
         {
-            return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, hip_bfloat16>(arg);
+            return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_16BF);
         }
         else
         {
-            return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, float>(arg);
+            return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, HIP_R_32F);
         }
     }
-    else if constexpr(std::is_same<To, float>::value)
+    else if(to == HIP_R_32F || to == HIP_R_32I || to == HIP_R_8I || to == HIP_R_64F)
     {
-        return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, float>(arg);
-    }
-    else if constexpr(std::is_same<To, int32_t>::value)
-    {
-        return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, int32_t>(arg);
-    }
-    else if constexpr(std::is_same<To, int8_t>::value)
-    {
-        return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, int8_t>(arg);
-    }
-    else if constexpr(std::is_same<To, double>::value)
-    {
-        return testing_matmul_with_bias<TiA, TiB, To, Tc, TciA, TciB, double>(arg);
+        //set Tbias to To
+        return testing_matmul_with_bias(arg, tiA, tiB, to, tc, tciA, tciB, to);
     }
     // shouldn't arrive here
     CHECK_SUCCESS(false);
     return;
 }
 
-template <typename TiA,
-          typename TiB,
-          typename To,
-          typename Tc,
-          typename TciA,
-          typename TciB,
-          typename Tbias>
-void testing_matmul_with_bias(const Arguments& arg)
+void testing_matmul_with_bias(const Arguments& arg,
+                              hipDataType      TiA,
+                              hipDataType      TiB,
+                              hipDataType      To,
+                              hipDataType      Tc,
+                              hipDataType      TciA,
+                              hipDataType      TciB,
+                              hipDataType      Tbias)
 {
     double gpu_time_used, cpu_time_used;
     gpu_time_used = cpu_time_used = 0.0;
@@ -689,10 +978,7 @@ void testing_matmul_with_bias(const Arguments& arg)
     hipblasOperation_t transA(char_to_hipblas_operation(arg.transA));
     hipblasOperation_t transB(char_to_hipblas_operation(arg.transB));
 
-    hipDataType tciA = arg.compute_input_typeA;
-    hipDataType tciB = arg.compute_input_typeB;
-
-    using Talpha = Tc;
+    hipDataType Talpha = Tc;
 
     bool    do_grouped_gemm = arg.grouped_gemm > 0;
     int32_t gemm_count      = std::max(1, arg.grouped_gemm);
@@ -700,7 +986,7 @@ void testing_matmul_with_bias(const Arguments& arg)
 
     std::vector<int64_t> M(gemm_count), N(gemm_count), K(gemm_count), lda(gemm_count),
         ldb(gemm_count), ldc(gemm_count), ldd(gemm_count), lde(gemm_count);
-    std::vector<Talpha>  h_alpha(gemm_count), h_beta(gemm_count);
+    std::vector<computeTypeInterface> h_alpha(gemm_count), h_beta(gemm_count);
     std::vector<int64_t> A_row(gemm_count), A_col(gemm_count), B_row(gemm_count), B_col(gemm_count);
     std::vector<int64_t> stride_a(gemm_count), stride_b(gemm_count), stride_c(gemm_count),
         stride_d(gemm_count), stride_e(gemm_count);
@@ -715,40 +1001,32 @@ void testing_matmul_with_bias(const Arguments& arg)
     std::vector<std::vector<hipblasLtMatmulDesc_t>> matmul;
     std::vector<hipblasLtEpilogue_t> epilogue(gemm_count, HIPBLASLT_EPILOGUE_DEFAULT);
 
-    std::vector<device_vector<TiA>*>    dA(gemm_count);
-    std::vector<device_vector<TiB>*>    dB(gemm_count);
-    std::vector<device_vector<To>*>     dC(gemm_count), dD(gemm_count);
-    std::vector<device_vector<Talpha>*> dScaleAlphaVec(gemm_count), dScaleA(gemm_count),
-        dScaleB(gemm_count), dScaleC(gemm_count), dScaleD(gemm_count), dScaleE(gemm_count),
-        dAmaxD(gemm_count);
-    std::vector<device_vector<To>*>    dE(gemm_count);
-    std::vector<device_vector<Tbias>*> dBias(gemm_count);
+    std::vector<HipDeviceBuffer>  dA, dB, dC, dD, dE, dBias;
+    std::vector<HipDeviceBuffer>* dDp;
+    std::vector<HipDeviceBuffer>  dScaleAlphaVec, dScaleA, dScaleB, dScaleC, dScaleD, dScaleE,
+        dAmaxD;
 
-    std::vector<host_vector<TiA>*>    hA(gemm_count);
-    std::vector<host_vector<TiB>*>    hB(gemm_count);
-    std::vector<host_vector<To>*>     hC(gemm_count), hD_gold(gemm_count), hD_1(gemm_count);
-    std::vector<host_vector<Talpha>*> hD_gold_epl(gemm_count), hScaleAlphaVec(gemm_count),
-        hD_gold_ScaleAlpha(gemm_count), hBias_gold_epl(gemm_count), hScaleA(gemm_count),
-        hScaleB(gemm_count), hScaleC(gemm_count), hScaleD(gemm_count), hScaleE(gemm_count),
-        hAmaxD_gold(gemm_count), hAmaxD(gemm_count);
-    std::vector<host_vector<To>*>    hE(gemm_count, nullptr), hE_gold(gemm_count, nullptr);
-    std::vector<void*>               alpha_in(gemm_count);
-    std::vector<host_vector<Tbias>*> hBias(gemm_count), hBias_gold(gemm_count);
+    std::vector<HipHostBuffer> hE, hE_gold, hBias, hBias_gold;
+    std::vector<HipHostBuffer> hA, hB, hC, hD_gold, hD_1;
+    std::vector<HipHostBuffer> hScaleAlphaVec, hScaleA, hScaleB, hScaleC, hScaleD, hScaleE,
+        hAmaxD_gold, hAmaxD, hD_gold_epl, hD_gold_ScaleAlpha, hBias_gold_epl;
+
+    std::vector<void*> alpha_in(gemm_count);
 
     // Need to split into two for loop to calculate the rotating buffer
     int64_t totalRotatingSizeNeeded = 0;
     for(int i = 0; i < gemm_count; i++)
     {
-        M[i]       = arg.M[i];
-        N[i]       = arg.N[i];
-        K[i]       = arg.K[i];
-        h_alpha[i] = arg.get_alpha<Talpha>();
-        h_beta[i]  = arg.get_beta<Talpha>();
-        lda[i]     = arg.lda[i];
-        ldb[i]     = arg.ldb[i];
-        ldc[i]     = arg.ldc[i];
-        ldd[i]     = arg.ldd[i];
-        lde[i]     = arg.lde[i];
+        M[i] = arg.M[i];
+        N[i] = arg.N[i];
+        K[i] = arg.K[i];
+        set_alpha_type(h_alpha[i], arg, Tc);
+        set_beta_type(h_beta[i], arg, Tc);
+        lda[i] = arg.lda[i];
+        ldb[i] = arg.ldb[i];
+        ldc[i] = arg.ldc[i];
+        ldd[i] = arg.ldd[i];
+        lde[i] = arg.lde[i];
 
         A_row[i] = transA == HIPBLAS_OP_N ? M[i] : K[i];
         A_col[i] = transA == HIPBLAS_OP_N ? K[i] : M[i];
@@ -809,12 +1087,14 @@ void testing_matmul_with_bias(const Arguments& arg)
         {
             size_bias[i] = 0;
         }
-        auto    biasSize = size_bias[i] * sizeof(Tbias);
-        int64_t sizeC    = h_beta[i] == 0 ? 0 : size_C[i] * sizeof(To);
+        auto    biasSize = size_bias[i] * realDataTypeSize(Tbias);
+        int64_t sizeC    = get_computeInterface(h_beta[i], Tc) == 0 ? 0 : size_C[i] * sizeof(To);
         totalRotatingSizeNeeded
-            += size_A[i] * sizeof(TiA) + size_B[i] * sizeof(TiB) + sizeC + size_D[i] * sizeof(To)
-               + size_E[i] * sizeof(To) + biasSize + size_scaleAlphaVec[i] * sizeof(Talpha)
-               + size_scaleAVec[i] * sizeof(Talpha) + size_scaleBVec[i] * sizeof(Talpha);
+            += size_A[i] * realDataTypeSize(TiA) + size_B[i] * realDataTypeSize(TiB) + sizeC
+               + size_D[i] * realDataTypeSize(To) + size_E[i] * realDataTypeSize(To) + biasSize
+               + size_scaleAlphaVec[i] * realDataTypeSize(Talpha)
+               + size_scaleAVec[i] * realDataTypeSize(Talpha)
+               + size_scaleBVec[i] * realDataTypeSize(Talpha);
     }
 
     // Calculating block count
@@ -891,12 +1171,12 @@ void testing_matmul_with_bias(const Arguments& arg)
 
         EXPECT_HIPBLAS_STATUS(
             hipblasLtMatmulDescSetAttribute(
-                matmul[0][i], HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_A_EXT, &tciA, sizeof(void*)),
+                matmul[0][i], HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_A_EXT, &TciA, sizeof(void*)),
             HIPBLAS_STATUS_SUCCESS);
 
         EXPECT_HIPBLAS_STATUS(
             hipblasLtMatmulDescSetAttribute(
-                matmul[0][i], HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_B_EXT, &tciB, sizeof(void*)),
+                matmul[0][i], HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_B_EXT, &TciB, sizeof(void*)),
             HIPBLAS_STATUS_SUCCESS);
 
         CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
@@ -988,251 +1268,239 @@ void testing_matmul_with_bias(const Arguments& arg)
         }
 
         // allocate memory on device
-        dA[i] = new device_vector<TiA>(size_A[i] * block_count, 1, HMM);
-        dB[i] = new device_vector<TiB>(size_B[i] * block_count, 1, HMM);
-        dC[i] = new device_vector<To>(size_C[i] * block_count, 1, HMM);
-        if(!arg.c_equal_d)
-            dD[i] = new device_vector<To>(size_D[i] * block_count, 1, HMM);
-        else
-            dD[i] = dC[i];
-        dBias[i]          = new device_vector<Tbias>(size_bias[i] * block_count, 1, HMM);
-        dScaleAlphaVec[i] = new device_vector<Talpha>(size_scaleAlphaVec[i] * block_count, 1, HMM);
+        dA.emplace_back(TiA, size_A[i] * block_count, HMM);
+        dB.emplace_back(TiB, size_B[i] * block_count, HMM);
+        dC.emplace_back(To, size_C[i] * block_count, HMM);
 
-        CHECK_DEVICE_ALLOCATION(dA[i]->memcheck());
-        CHECK_DEVICE_ALLOCATION(dB[i]->memcheck());
-        CHECK_DEVICE_ALLOCATION(dC[i]->memcheck());
         if(!arg.c_equal_d)
-            CHECK_DEVICE_ALLOCATION(dD[i]->memcheck());
-        CHECK_DEVICE_ALLOCATION(dBias[i]->memcheck());
-        CHECK_DEVICE_ALLOCATION(dScaleAlphaVec[i]->memcheck());
-        if(arg.use_e)
         {
-            dE[i] = new device_vector<To>(size_E[i] * block_count, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dE[i]->memcheck());
+            dD.emplace_back(To, size_D[i] * block_count, HMM);
+            dDp = &dD;
         }
         else
+            dDp = &dC;
+
+        if(size_bias[i] * block_count != 0)
+            dBias.emplace_back(Tbias, size_bias[i] * block_count, HMM);
+
+        if(arg.scaleAlpha_vector)
         {
-            dE[i] = nullptr;
+            dScaleAlphaVec.emplace_back(Talpha, size_scaleAlphaVec[i] * block_count, HMM);
+        }
+
+        if(arg.use_e)
+        {
+            dE.emplace_back(To, size_E[i] * block_count, HMM);
         }
 
         if(arg.scaleA)
         {
-            dScaleA[i] = new device_vector<Talpha>(size_scaleAVec[i] * block_count, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dScaleA[i]->memcheck());
+            dScaleA.emplace_back(Talpha, size_scaleAVec[i] * block_count, HMM);
         }
         if(arg.scaleB)
         {
-            dScaleB[i] = new device_vector<Talpha>(size_scaleBVec[i] * block_count, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dScaleB[i]->memcheck());
+            dScaleB.emplace_back(Talpha, size_scaleBVec[i] * block_count, HMM);
         }
         if(arg.scaleC)
         {
-            dScaleC[i] = new device_vector<Talpha>(1, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dScaleC[i]->memcheck());
+            dScaleC.emplace_back(Talpha, 1, HMM);
         }
         if(arg.scaleD)
         {
-            dScaleD[i] = new device_vector<Talpha>(1, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dScaleD[i]->memcheck());
+            dScaleD.emplace_back(Talpha, 1, HMM);
         }
         if(arg.amaxD)
         {
             epilogue_on[i] = true;
-            dAmaxD[i]      = new device_vector<Talpha>(1, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dAmaxD[i]->memcheck());
+            dAmaxD.emplace_back(Talpha, 1, HMM);
         }
         if(arg.scaleE)
         {
-            dScaleE[i] = new device_vector<Talpha>(1, 1, HMM);
-            CHECK_DEVICE_ALLOCATION(dScaleE[i]->memcheck());
+            dScaleE.emplace_back(Talpha, 1, HMM);
         }
 
         // Naming: dX is in GPU (device) memory. hK is in CPU (host) memory
-        hA[i]                 = new host_vector<TiA>(size_A[i]);
-        hB[i]                 = new host_vector<TiB>(size_B[i]);
-        hC[i]                 = new host_vector<To>(size_C[i]);
-        hD_gold[i]            = new host_vector<To>(size_D_copy[i]);
-        hD_gold_epl[i]        = new host_vector<Talpha>(size_D_copy[i]);
-        hD_gold_ScaleAlpha[i] = new host_vector<Talpha>(size_D_copy[i]);
-        hD_1[i]               = new host_vector<To>(size_D_copy[i]);
-        hBias[i]              = new host_vector<Tbias>(size_bias[i]);
-        hBias_gold[i]         = new host_vector<Tbias>(size_bias[i]);
-        hBias_gold_epl[i]     = new host_vector<Talpha>(size_D_copy[i]); // Reduction for matrix D
-        hScaleAlphaVec[i]     = new host_vector<Talpha>(size_scaleAlphaVec[i]);
+        hA.emplace_back(TiA, size_A[i]);
+        hB.emplace_back(TiB, size_B[i]);
+        hC.emplace_back(To, size_C[i]);
+        hD_gold.emplace_back(To, size_D_copy[i]);
+        hD_1.emplace_back(To, size_D_copy[i]);
+        if(size_bias[i] * block_count != 0)
+        {
+            hBias.emplace_back(Tbias, size_bias[i]);
+            hBias_gold.emplace_back(Tbias, size_bias[i]);
+        }
+
+        hD_gold_epl.emplace_back(Talpha, size_D_copy[i]);
+        hD_gold_ScaleAlpha.emplace_back(Talpha, size_D_copy[i]);
+        hBias_gold_epl.emplace_back(Talpha, size_D_copy[i]); // Reduction for matrix D
+
+        if(arg.scaleAlpha_vector)
+            hScaleAlphaVec.emplace_back(Talpha, size_scaleAlphaVec[i]);
 
         if(arg.scaleA)
-            hScaleA[i] = new host_vector<Talpha>(size_scaleAVec[i]);
+            hScaleA.emplace_back(Talpha, size_scaleAVec[i]);
         if(arg.scaleB)
-            hScaleB[i] = new host_vector<Talpha>(size_scaleBVec[i]);
+            hScaleB.emplace_back(Talpha, size_scaleBVec[i]);
         if(arg.scaleC)
-            hScaleC[i] = new host_vector<Talpha>(1);
+            hScaleC.emplace_back(Talpha, 1);
         if(arg.scaleD)
-            hScaleD[i] = new host_vector<Talpha>(1);
+            hScaleD.emplace_back(Talpha, 1);
         if(arg.amaxD)
         {
-            hAmaxD_gold[i] = new host_vector<Talpha>(1);
-            hAmaxD[i]      = new host_vector<Talpha>(1);
+            hAmaxD_gold.emplace_back(Talpha, 1);
+            hAmaxD.emplace_back(Talpha, 1);
         }
         if(arg.scaleE)
-            hScaleE[i] = new host_vector<Talpha>(1);
+            hScaleE.emplace_back(Talpha, 1);
 
         if(arg.use_e)
         {
-            hE[i] = new host_vector<To>(size_E[i]);
+            hE.emplace_back(To, size_E[i]);
             if(!arg.gradient)
-                hE_gold[i] = new host_vector<To>(size_E[i]);
+            {
+                hE_gold.emplace_back(To, size_E[i]);
+            }
         }
 
         hipblaslt_seedrand();
 
         // Initial Data on CPU
-        if(arg.alpha_isnan<Tc>())
+        if(alpha_isnan_type(arg, Talpha))
         {
-            hipblaslt_init_nan<TiA>(
-                *hA[i], A_row[i], A_col[i], lda[i], stride_a[i], num_batches[i]);
-            hipblaslt_init_nan<TiB>(
-                *hB[i], B_row[i], B_col[i], ldb[i], stride_b[i], num_batches[i]);
+            hipblaslt_init_nan(
+                hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
+            hipblaslt_init_nan(
+                hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
         }
         else
         {
             if(arg.initialization == hipblaslt_initialization::rand_int)
             {
-                hipblaslt_init<TiA>(
-                    *hA[i], A_row[i], A_col[i], lda[i], stride_a[i], num_batches[i]);
-                hipblaslt_init_alternating_sign<TiB>(
-                    *hB[i], B_row[i], B_col[i], ldb[i], stride_b[i], num_batches[i]);
+                hipblaslt_init(
+                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
+                hipblaslt_init_alternating_sign(
+                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
             }
             else if(arg.initialization == hipblaslt_initialization::trig_float)
             {
-                hipblaslt_init_sin<TiA>(
-                    *hA[i], A_row[i], A_col[i], lda[i], stride_a[i], num_batches[i]);
-                hipblaslt_init_cos<TiB>(
-                    *hB[i], B_row[i], B_col[i], ldb[i], stride_b[i], num_batches[i]);
+                hipblaslt_init_sin(
+                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
+                hipblaslt_init_cos(
+                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
             }
             else if(arg.initialization == hipblaslt_initialization::hpl)
             {
-                hipblaslt_init_hpl<TiA>(
-                    *hA[i], A_row[i], A_col[i], lda[i], stride_a[i], num_batches[i]);
-                hipblaslt_init_hpl<TiB>(
-                    *hB[i], B_row[i], B_col[i], ldb[i], stride_b[i], num_batches[i]);
+                hipblaslt_init_hpl(
+                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
+                hipblaslt_init_hpl(
+                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
             }
             else if(arg.initialization == hipblaslt_initialization::special)
             {
-                hipblaslt_init_alt_impl_big<TiA>(
-                    *hA[i], A_row[i], A_col[i], lda[i], num_batches[i]);
-                hipblaslt_init_alt_impl_small<TiB>(
-                    *hB[i], B_row[i], B_col[i], ldb[i], num_batches[i]);
+                hipblaslt_init_alt_impl_big(
+                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, num_batches[i]);
+                hipblaslt_init_alt_impl_small(
+                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, num_batches[i]);
             }
             else if(arg.initialization == hipblaslt_initialization::zero)
             {
-                hipblaslt_init_zero<TiA>(
-                    *hA[i], A_row[i], A_col[i], lda[i], stride_a[i], num_batches[i]);
-                hipblaslt_init_zero<TiB>(
-                    *hB[i], B_row[i], B_col[i], ldb[i], stride_b[i], num_batches[i]);
+                hipblaslt_init_zero(
+                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
+                hipblaslt_init_zero(
+                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
             }
         }
 
-        if(arg.beta_isnan<Tc>())
+        if(beta_isnan_type(arg, Talpha))
         {
-            hipblaslt_init_nan<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+            hipblaslt_init_nan(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
         }
         else
         {
             if(arg.initialization == hipblaslt_initialization::rand_int)
-                hipblaslt_init<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+                hipblaslt_init(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
             else if(arg.initialization == hipblaslt_initialization::trig_float)
-                hipblaslt_init_sin<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+                hipblaslt_init_sin(
+                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
             else if(arg.initialization == hipblaslt_initialization::hpl)
-                hipblaslt_init_hpl<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+                hipblaslt_init_hpl(
+                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
             else if(arg.initialization == hipblaslt_initialization::special)
-                hipblaslt_init<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+                hipblaslt_init(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
             else if(arg.initialization == hipblaslt_initialization::zero)
-                hipblaslt_init_zero<To>(*hC[i], M[i], N[i], ldc[i], stride_c[i], num_batches[i]);
+                hipblaslt_init_zero(
+                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
         }
 
         if(arg.gradient && arg.use_e)
         {
-            hipblaslt_init<To>(*hE[i], M[i], N[i], lde[i], stride_e[i], num_batches[i]);
+            hipblaslt_init(hE[i].buf(), M[i], N[i], lde[i], To, stride_e[i], num_batches[i]);
         }
 
         if(arg.bias_vector)
         {
-            hipblaslt_init<Tbias>(*hBias[i], size_bias[i], 1, size_bias[i]);
+            hipblaslt_init(hBias[i].buf(), size_bias[i], 1, size_bias[i], Tbias);
         }
 
         if(arg.scaleA)
-            hipblaslt_init<Talpha>(*hScaleA[i], size_scaleAVec[i], 1, size_scaleAVec[i]);
+            hipblaslt_init(hScaleA[i].buf(), size_scaleAVec[i], 1, size_scaleAVec[i], Talpha);
 
         if(arg.scaleB)
-            hipblaslt_init<Talpha>(*hScaleB[i], size_scaleBVec[i], 1, size_scaleBVec[i]);
+            hipblaslt_init(hScaleB[i].buf(), size_scaleBVec[i], 1, size_scaleBVec[i], Talpha);
 
         if(arg.scaleC)
         {
-            if constexpr(std::is_same<To, hipblaslt_f8_fnuz>::value
-                         || std::is_same<To, hipblaslt_bf8_fnuz>::value)
+            if(To == HIP_R_8F_E4M3_FNUZ || To == HIP_R_8F_E5M2_FNUZ)
             {
-                hipblaslt_init_small<Talpha>(*hScaleC[i], 1, 1, 1);
+                hipblaslt_init_small(hScaleC[i].buf(), 1, 1, 1, Talpha);
             }
-#ifdef ROCM_USE_FLOAT8
-            else if constexpr(std::is_same<To, hipblaslt_f8_ocp>::value
-                         || std::is_same<To, hipblaslt_bf8_ocp>::value)
-            {
-                hipblaslt_init_small<Talpha>(*hScaleC[i], 1, 1, 1);
-            }
-#endif
             else
             {
-                hipblaslt_init<Talpha>(*hScaleC[i], 1, 1, 1);
+                hipblaslt_init(hScaleC[i].buf(), 1, 1, 1, Talpha);
             }
         }
 
         if(arg.scaleD)
         {
-            if constexpr(std::is_same<To, hipblaslt_f8_fnuz>::value
-                         || std::is_same<To, hipblaslt_bf8_fnuz>::value)
+            if(To == HIP_R_8F_E4M3_FNUZ || To == HIP_R_8F_E5M2_FNUZ)
             {
-                hipblaslt_init_small<Talpha>(*hScaleD[i], 1, 1, 1);
+                hipblaslt_init_small(hScaleD[i].buf(), 1, 1, 1, Talpha);
             }
-#ifdef ROCM_USE_FLOAT8
-            else if constexpr(std::is_same<To, hipblaslt_f8_ocp>::value
-                         || std::is_same<To, hipblaslt_bf8_ocp>::value)
-            {
-                hipblaslt_init_small<Talpha>(*hScaleD[i], 1, 1, 1);
-            }
-#endif
             else
             {
-                hipblaslt_init<Talpha>(*hScaleD[i], 1, 1, 1);
+                hipblaslt_init(hScaleD[i].buf(), 1, 1, 1, Talpha);
             }
         }
 
         if(arg.amaxD)
-            hipblaslt_init_zero<Talpha>(*hAmaxD_gold[i], 1, 1, 1);
+            hipblaslt_init_zero(hAmaxD_gold[i].buf(), 1, 1, 1, Talpha);
 
         if(arg.scaleE)
-            hipblaslt_init<Talpha>(*hScaleE[i], 1, 1, 1);
+            hipblaslt_init(hScaleE[i].buf(), 1, 1, 1, Talpha);
 
         if(arg.scaleAlpha_vector)
-            hipblaslt_init<Talpha>(*hScaleAlphaVec[i], M[i], 1, M[i]);
+            hipblaslt_init(hScaleAlphaVec[i].buf(), M[i], 1, M[i], Talpha);
 
         // copy data from CPU to device
-        CHECK_HIP_ERROR(dA[i]->transfer_from(*hA[i], block_count));
-        CHECK_HIP_ERROR(dB[i]->transfer_from(*hB[i], block_count));
-        CHECK_HIP_ERROR(dC[i]->transfer_from(*hC[i], block_count));
+        CHECK_HIP_ERROR(synchronize(dA[i], hA[i], block_count));
+        CHECK_HIP_ERROR(synchronize(dB[i], hB[i], block_count));
+        CHECK_HIP_ERROR(synchronize(dC[i], hC[i], block_count));
         if(arg.gradient && arg.use_e)
         {
-            CHECK_HIP_ERROR(dE[i]->transfer_from(*hE[i], block_count));
+            CHECK_HIP_ERROR(synchronize(dE[i], hE[i], block_count));
         }
         if(!arg.gradient && arg.bias_vector)
         {
-            CHECK_HIP_ERROR(dBias[i]->transfer_from(*hBias[i], block_count));
+            CHECK_HIP_ERROR(synchronize(dBias[i], hBias[i], block_count));
         }
 
         if(arg.scaleAlpha_vector)
         {
-            CHECK_HIP_ERROR(dScaleAlphaVec[i]->transfer_from(*hScaleAlphaVec[i], block_count));
-            alpha_in[i] = *(dScaleAlphaVec[i]);
-            h_alpha[i]  = 1.0; // use dScaleAlphaVec instead, original alpha = 1.0 for verify
+            CHECK_HIP_ERROR(synchronize(dScaleAlphaVec[i], hScaleAlphaVec[i], block_count));
+            alpha_in[i] = dScaleAlphaVec[i].buf();
+            set_computeInterface(
+                h_alpha[i], 1.0, Tc); // use dScaleAlphaVec instead, original alpha = 1.0 for verify
         }
         else
             alpha_in[i] = &(h_alpha[i]);
@@ -1241,48 +1509,56 @@ void testing_matmul_with_bias(const Arguments& arg)
         {
             if(arg.amaxScaleA && (arg.a_type == HIP_R_32F || arg.a_type == HIP_R_16F))
             {
-                CHECK_HIPBLASLT_ERROR(hipblasltExtAMax(
-                    arg.a_type, HIP_R_32F, *dScaleA[i], *dA[i], A_row[i], A_col[i], stream));
-                CHECK_HIP_ERROR(hScaleA[i]->transfer_from(*dScaleA[i]));
+                CHECK_HIPBLASLT_ERROR(hipblasltExtAMax(arg.a_type,
+                                                       HIP_R_32F,
+                                                       dScaleA[i].buf(),
+                                                       dA[i].buf(),
+                                                       A_row[i],
+                                                       A_col[i],
+                                                       stream));
+
+                CHECK_HIP_ERROR(synchronize(hScaleA[i], dScaleA[i]));
             }
             else
-                CHECK_HIP_ERROR(dScaleA[i]->transfer_from(*hScaleA[i]));
+                CHECK_HIP_ERROR(synchronize(dScaleA[i], hScaleA[i]));
         }
 
         if(arg.scaleB)
         {
             if(arg.amaxScaleB && (arg.b_type == HIP_R_32F || arg.b_type == HIP_R_16F))
             {
-                CHECK_HIPBLASLT_ERROR(hipblasltExtAMax(
-                    arg.b_type, HIP_R_32F, *dScaleB[i], *dB[i], B_row[i], B_col[i], stream));
-                CHECK_HIP_ERROR(hScaleB[i]->transfer_from(*dScaleB[i]));
+                CHECK_HIPBLASLT_ERROR(hipblasltExtAMax(arg.b_type,
+                                                       HIP_R_32F,
+                                                       dScaleB[i].buf(),
+                                                       dB[i].buf(),
+                                                       B_row[i],
+                                                       B_col[i],
+                                                       stream));
+                CHECK_HIP_ERROR(synchronize(hScaleB[i], dScaleB[i]));
             }
             else
-                CHECK_HIP_ERROR(dScaleB[i]->transfer_from(*hScaleB[i]));
+                CHECK_HIP_ERROR(synchronize(dScaleB[i], hScaleB[i]));
         }
 
         if(arg.scaleC)
-            CHECK_HIP_ERROR(dScaleC[i]->transfer_from(*hScaleC[i]));
+            CHECK_HIP_ERROR(synchronize(dScaleC[i], hScaleC[i]));
 
         if(arg.scaleD)
-            CHECK_HIP_ERROR(dScaleD[i]->transfer_from(*hScaleD[i]));
+            CHECK_HIP_ERROR(synchronize(dScaleD[i], hScaleD[i]));
 
         if(arg.scaleE)
-            CHECK_HIP_ERROR(dScaleE[i]->transfer_from(*hScaleE[i]));
-        //// copy data from CPU to device end
+            CHECK_HIP_ERROR(synchronize(dScaleE[i], hScaleE[i]));
 
+        //// copy data from CPU to device end
         if(size_D_copy[i])
         {
             if(epilogue_on[i])
             {
-                std::transform(hC[i]->begin(),
-                               hC[i]->end(),
-                               hD_gold_epl[i]->begin(),
-                               [](To c) -> Talpha { return static_cast<Talpha>(c); });
+                transform_buf(hC[i], hD_gold_epl[i], To, Talpha);
             }
             else
             {
-                std::copy(hC[i]->begin(), hC[i]->end(), hD_gold[i]->begin());
+                copy_buf(hC[i], hD_gold[i], To);
             }
         }
 
@@ -1295,7 +1571,7 @@ void testing_matmul_with_bias(const Arguments& arg)
 
         if(arg.use_e)
         {
-            void* e_addr = *dE[i];
+            void* e_addr = dE[i].buf();
             CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                 matmul[0][i], HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_POINTER, &e_addr, sizeof(void*)));
             CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
@@ -1316,7 +1592,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                                                 &arg.bias_type,
                                                 sizeof(hipDataType)),
                 HIPBLAS_STATUS_SUCCESS);
-            bias_addr = *dBias[i];
+            bias_addr = dBias[i].buf();
 
             EXPECT_HIPBLAS_STATUS(
                 hipblasLtMatmulDescSetAttribute(
@@ -1330,7 +1606,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                 = arg.scaleA == Arguments::ScalingFormat::Vector
                       ? HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT
                       : HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER;
-            void* scaleA_addr = (void*)(*dScaleA[i]);
+            void* scaleA_addr = (void*)(dScaleA[i].buf());
             CHECK_HIPBLASLT_ERROR(
                 hipblasLtMatmulDescSetAttribute(matmul[0][i], attr, &scaleA_addr, sizeof(void*)));
         }
@@ -1341,35 +1617,35 @@ void testing_matmul_with_bias(const Arguments& arg)
                 = arg.scaleB == Arguments::ScalingFormat::Vector
                       ? HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT
                       : HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER;
-            void* scaleB_addr = (void*)(*dScaleB[i]);
+            void* scaleB_addr = (void*)(dScaleB[i].buf());
             CHECK_HIPBLASLT_ERROR(
                 hipblasLtMatmulDescSetAttribute(matmul[0][i], attr, &scaleB_addr, sizeof(void*)));
         }
 
         if(arg.scaleC)
         {
-            void* scaleC_addr = *dScaleC[i];
+            void* scaleC_addr = dScaleC[i].buf();
             CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                 matmul[0][i], HIPBLASLT_MATMUL_DESC_C_SCALE_POINTER, &scaleC_addr, sizeof(void*)));
         }
 
         if(arg.scaleD)
         {
-            void* scaleD_addr = *dScaleD[i];
+            void* scaleD_addr = dScaleD[i].buf();
             CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                 matmul[0][i], HIPBLASLT_MATMUL_DESC_D_SCALE_POINTER, &scaleD_addr, sizeof(void*)));
         }
 
         if(arg.amaxD)
         {
-            void* amaxD_addr = *dAmaxD[i];
+            void* amaxD_addr = dAmaxD[i].buf();
             CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                 matmul[0][i], HIPBLASLT_MATMUL_DESC_AMAX_D_POINTER, &amaxD_addr, sizeof(void*)));
         }
 
         if(arg.scaleE)
         {
-            void* scaleE_addr = *dScaleE[i];
+            void* scaleE_addr = dScaleE[i].buf();
             CHECK_HIPBLASLT_ERROR(
                 hipblasLtMatmulDescSetAttribute(matmul[0][i],
                                                 HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_SCALE_POINTER,
@@ -1398,21 +1674,22 @@ void testing_matmul_with_bias(const Arguments& arg)
             EXPECT_HIPBLAS_STATUS(
                 hipblasLtMatmulDescSetAttribute(matmul[b][i],
                                                 HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_A_EXT,
-                                                &tciA,
+                                                &TciA,
                                                 sizeof(void*)),
                 HIPBLAS_STATUS_SUCCESS);
 
             EXPECT_HIPBLAS_STATUS(
                 hipblasLtMatmulDescSetAttribute(matmul[b][i],
                                                 HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_B_EXT,
-                                                &tciB,
+                                                &TciB,
                                                 sizeof(void*)),
                 HIPBLAS_STATUS_SUCCESS);
 
             // Update bias, E
             if(arg.bias_vector)
             {
-                const void* bias_addr = (const void*)((*dBias[i]) + b * size_bias[i]);
+                const void* bias_addr = (const void*)(dBias[i].as<char>()
+                                                      + b * size_bias[i] * realDataTypeSize(Tbias));
                 EXPECT_HIPBLAS_STATUS(
                     hipblasLtMatmulDescSetAttribute(matmul[b][i],
                                                     HIPBLASLT_MATMUL_DESC_BIAS_POINTER,
@@ -1422,7 +1699,7 @@ void testing_matmul_with_bias(const Arguments& arg)
             }
             if(arg.use_e)
             {
-                void* e_addr = (*dE[i]) + b * size_E[i];
+                void* e_addr = (void*)(dE[i].as<char>() + b * size_E[i] * realDataTypeSize(To));
                 CHECK_HIPBLASLT_ERROR(
                     hipblasLtMatmulDescSetAttribute(matmul[b][i],
                                                     HIPBLASLT_MATMUL_DESC_EPILOGUE_AUX_POINTER,
@@ -1435,7 +1712,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                     = arg.scaleA == Arguments::ScalingFormat::Vector
                           ? HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT
                           : HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER;
-                void* scaleA_addr = (void*)(*dScaleA[i] + b * size_scaleAVec[i]);
+                void* scaleA_addr = (void*)(dScaleA[i].as<char>() + b * size_scaleAVec[i]);
                 CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                     matmul[b][i], attr, &scaleA_addr, sizeof(void*)));
             }
@@ -1446,7 +1723,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                     = arg.scaleB == Arguments::ScalingFormat::Vector
                           ? HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT
                           : HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER;
-                void* scaleB_addr = (void*)(*dScaleB[i] + b * size_scaleBVec[i]);
+                void* scaleB_addr = (void*)(dScaleB[i].as<char>() + b * size_scaleBVec[i]);
                 CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
                     matmul[b][i], attr, &scaleB_addr, sizeof(void*)));
             }
@@ -1527,7 +1804,8 @@ void testing_matmul_with_bias(const Arguments& arg)
                 if(arg.bias_vector)
                 {
                     bias_type = arg.bias_type;
-                    bias_addr = (void*)((*dBias[gemmIdx]) + b * size_bias[gemmIdx]);
+                    bias_addr = (void*)(dBias[gemmIdx].as<char>()
+                                        + b * size_bias[gemmIdx] * realDataTypeSize(bias_type));
                 }
                 if(b == 0)
                 {
@@ -1540,29 +1818,36 @@ void testing_matmul_with_bias(const Arguments& arg)
                     extepilogue[gemmIdx].setScalingBType(
                         arg.scaleB == Arguments::ScalingFormat::Vector ? 1 : 0);
                 }
-
-                extinputs[b][gemmIdx].setA((void*)((*dA[gemmIdx]) + b * size_A[gemmIdx]));
-                extinputs[b][gemmIdx].setB((void*)((*dB[gemmIdx]) + b * size_B[gemmIdx]));
-                extinputs[b][gemmIdx].setC((void*)((*dC[gemmIdx]) + b * size_C[gemmIdx]));
-                extinputs[b][gemmIdx].setD((void*)((*dD[gemmIdx]) + b * size_D[gemmIdx]));
+                extinputs[b][gemmIdx].setA((void*)((dA[gemmIdx].as<char>())
+                                                   + b * size_A[gemmIdx] * realDataTypeSize(TiA)));
+                extinputs[b][gemmIdx].setB((void*)((dB[gemmIdx].as<char>())
+                                                   + b * size_B[gemmIdx] * realDataTypeSize(TiB)));
+                extinputs[b][gemmIdx].setC(
+                    (void*)((dC[gemmIdx].as<char>()) + b * size_C[gemmIdx] * realDataTypeSize(To)));
+                extinputs[b][gemmIdx].setD((void*)(((*dDp)[gemmIdx].as<char>())
+                                                   + b * size_D[gemmIdx] * realDataTypeSize(To)));
                 extinputs[b][gemmIdx].setAlpha(&h_alpha[gemmIdx]);
                 extinputs[b][gemmIdx].setBeta(&h_beta[gemmIdx]);
                 extinputs[b][gemmIdx].setBias(bias_addr);
-                extinputs[b][gemmIdx].setScaleA(
-                    arg.scaleA ? (void*)((*dScaleA[gemmIdx]) + b * size_scaleAVec[gemmIdx])
-                               : nullptr);
-                extinputs[b][gemmIdx].setScaleB(
-                    arg.scaleB ? (void*)((*dScaleB[gemmIdx]) + b * size_scaleBVec[gemmIdx])
-                               : nullptr);
-                extinputs[b][gemmIdx].setScaleC(arg.scaleC ? *dScaleC[gemmIdx] : nullptr);
-                extinputs[b][gemmIdx].setScaleD(arg.scaleD ? *dScaleD[gemmIdx] : nullptr);
-                extinputs[b][gemmIdx].setScaleAux(arg.scaleE ? *dScaleE[gemmIdx] : nullptr);
-                extinputs[b][gemmIdx].setAmaxD(arg.amaxD ? *dAmaxD[gemmIdx] : nullptr);
+                extinputs[b][gemmIdx].setScaleA(arg.scaleA ? (void*)((dScaleA[gemmIdx].as<char>())
+                                                                     + b * size_scaleAVec[gemmIdx])
+                                                           : nullptr);
+                extinputs[b][gemmIdx].setScaleB(arg.scaleB ? (void*)((dScaleB[gemmIdx].as<char>())
+                                                                     + b * size_scaleBVec[gemmIdx])
+                                                           : nullptr);
+                extinputs[b][gemmIdx].setScaleC(arg.scaleC ? dScaleC[gemmIdx].as<char>() : nullptr);
+                extinputs[b][gemmIdx].setScaleD(arg.scaleD ? dScaleD[gemmIdx].as<char>() : nullptr);
+                extinputs[b][gemmIdx].setScaleAux(arg.scaleE ? dScaleE[gemmIdx].as<char>()
+                                                             : nullptr);
+                extinputs[b][gemmIdx].setAmaxD(arg.amaxD ? dAmaxD[gemmIdx].as<char>() : nullptr);
                 if(arg.use_e)
-                    extinputs[b][gemmIdx].setAux((void*)((*dE[gemmIdx]) + b * size_E[gemmIdx]));
+                    extinputs[b][gemmIdx].setAux(
+                        (void*)((dE[gemmIdx].as<char>())
+                                + b * size_E[gemmIdx] * realDataTypeSize(To)));
                 if(arg.scaleAlpha_vector)
                     extinputs[b][gemmIdx].setScaleAlphaVec(
-                        (void*)((*dScaleAlphaVec[gemmIdx]) + b * size_scaleAlphaVec[gemmIdx]));
+                        (void*)((dScaleAlphaVec[gemmIdx].as<char>())
+                                + b * size_scaleAlphaVec[gemmIdx] * realDataTypeSize(Talpha)));
             }
         }
         extproblemtype.setOpA(transA);
@@ -1579,10 +1864,14 @@ void testing_matmul_with_bias(const Arguments& arg)
         {
             for(int32_t b = 0; b < block_count; b++)
             {
-                da[b][gemmIdx] = (void*)((*dA[gemmIdx]) + b * size_A[gemmIdx]);
-                db[b][gemmIdx] = (void*)((*dB[gemmIdx]) + b * size_B[gemmIdx]);
-                dc[b][gemmIdx] = (void*)((*dC[gemmIdx]) + b * size_C[gemmIdx]);
-                dd[b][gemmIdx] = (void*)((*dD[gemmIdx]) + b * size_D[gemmIdx]);
+                da[b][gemmIdx] = (void*)((dA[gemmIdx].as<char>())
+                                         + b * size_A[gemmIdx] * realDataTypeSize(TiA));
+                db[b][gemmIdx] = (void*)((dB[gemmIdx].as<char>())
+                                         + b * size_B[gemmIdx] * realDataTypeSize(TiB));
+                dc[b][gemmIdx] = (void*)((dC[gemmIdx].as<char>())
+                                         + b * size_C[gemmIdx] * realDataTypeSize(To));
+                dd[b][gemmIdx] = (void*)(((*dDp)[gemmIdx].as<char>())
+                                         + b * size_D[gemmIdx] * realDataTypeSize(To));
             }
         }
     }
@@ -1689,17 +1978,18 @@ void testing_matmul_with_bias(const Arguments& arg)
                     else
                     {
                         for(int32_t b = 0; b < block_count; b++)
-                            CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(matmul[b][0],
-                                                                        alpha_in[0],
-                                                                        *(dA[0]) + b * size_A[0],
-                                                                        matA[0],
-                                                                        *(dB[0]) + b * size_B[0],
-                                                                        matB[0],
-                                                                        &h_beta[0],
-                                                                        *(dC[0]) + b * size_C[0],
-                                                                        matC[0],
-                                                                        *(dD[0]) + b * size_D[0],
-                                                                        matD[0]));
+                            CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(
+                                matmul[b][0],
+                                alpha_in[0],
+                                (dA[0].as<char>()) + b * size_A[0] * realDataTypeSize(TiA),
+                                matA[0],
+                                (dB[0].as<char>()) + b * size_B[0] * realDataTypeSize(TiB),
+                                matB[0],
+                                &h_beta[0],
+                                (dC[0].as<char>()) + b * size_C[0] * realDataTypeSize(To),
+                                matC[0],
+                                ((*dDp)[0].as<char>()) + b * size_D[0] * realDataTypeSize(To),
+                                matD[0]));
                     }
                     for(int j = 0; j < returnedAlgoCount; j++)
                     {
@@ -1869,17 +2159,18 @@ void testing_matmul_with_bias(const Arguments& arg)
                 else
                 {
                     for(int32_t b = 0; b < block_count; b++)
-                        CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(matmul[b][0],
-                                                                    alpha_in[0],
-                                                                    *(dA[0]) + b * size_A[0],
-                                                                    matA[0],
-                                                                    *(dB[0]) + b * size_B[0],
-                                                                    matB[0],
-                                                                    &h_beta[0],
-                                                                    *(dC[0]) + b * size_C[0],
-                                                                    matC[0],
-                                                                    *(dD[0]) + b * size_D[0],
-                                                                    matD[0]));
+                        CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(
+                            matmul[b][0],
+                            alpha_in[0],
+                            (dA[0].as<char>()) + b * size_A[0] * realDataTypeSize(TiA),
+                            matA[0],
+                            (dB[0].as<char>()) + b * size_B[0] * realDataTypeSize(TiB),
+                            matB[0],
+                            &h_beta[0],
+                            (dC[0].as<char>()) + b * size_C[0] * realDataTypeSize(To),
+                            matC[0],
+                            ((*dDp)[0].as<char>()) + b * size_D[0] * realDataTypeSize(To),
+                            matD[0]));
                 }
                 for(int j = 0; j < returnedAlgoCount; j++)
                 {
@@ -2037,17 +2328,18 @@ void testing_matmul_with_bias(const Arguments& arg)
                 else
                 {
                     for(int32_t b = 0; b < block_count; b++)
-                        CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(matmul[b][0],
-                                                                    alpha_in[0],
-                                                                    *(dA[0]) + b * size_A[0],
-                                                                    matA[0],
-                                                                    *(dB[0]) + b * size_B[0],
-                                                                    matB[0],
-                                                                    &h_beta[0],
-                                                                    *(dC[0]) + b * size_C[0],
-                                                                    matC[0],
-                                                                    *(dD[0]) + b * size_D[0],
-                                                                    matD[0]));
+                        CHECK_HIPBLASLT_ERROR(gemmVec[b].setProblem(
+                            matmul[b][0],
+                            alpha_in[0],
+                            (dA[0].as<char>()) + b * size_A[0] * realDataTypeSize(TiA),
+                            matA[0],
+                            (dB[0].as<char>()) + b * size_B[0] * realDataTypeSize(TiB),
+                            matB[0],
+                            &h_beta[0],
+                            (dC[0].as<char>()) + b * size_C[0] * realDataTypeSize(To),
+                            matC[0],
+                            ((*dDp)[0].as<char>()) + b * size_D[0] * realDataTypeSize(To),
+                            matD[0]));
                 }
                 CHECK_HIPBLASLT_ERROR(
                     gemmVec[0].algoGetHeuristic(requestAlgoCount, gemmPref, tmpAlgo));
@@ -2165,63 +2457,6 @@ void testing_matmul_with_bias(const Arguments& arg)
 
     if(returnedAlgoCount == 0)
     {
-        for(int i = 0; i < gemm_count; i++)
-        {
-            delete hA[i];
-            delete hB[i];
-            delete hC[i];
-            delete hD_gold[i];
-            delete hD_gold_epl[i];
-            delete hD_gold_ScaleAlpha[i];
-            delete hD_1[i];
-            delete hBias[i];
-            delete hBias_gold_epl[i];
-            delete hBias_gold[i];
-            delete hScaleAlphaVec[i];
-            delete dA[i];
-            delete dB[i];
-            delete dC[i];
-            if(!arg.c_equal_d)
-                delete dD[i];
-            delete dBias[i];
-            delete dScaleAlphaVec[i];
-            if(arg.scaleA)
-            {
-                delete hScaleA[i];
-                delete dScaleA[i];
-            }
-            if(arg.scaleB)
-            {
-                delete hScaleB[i];
-                delete dScaleB[i];
-            }
-            if(arg.scaleC)
-            {
-                delete hScaleC[i];
-                delete dScaleC[i];
-            }
-            if(arg.scaleD)
-            {
-                delete hScaleD[i];
-                delete dScaleD[i];
-            }
-            if(arg.amaxD)
-            {
-                delete hAmaxD_gold[i];
-                delete hAmaxD[i];
-                delete dAmaxD[i];
-            }
-            if(arg.scaleE)
-            {
-                delete hScaleE[i];
-                delete dScaleE[i];
-            }
-            if(arg.use_e)
-            {
-                delete dE[i];
-                delete hE[i];
-            }
-        }
         int             deviceId;
         hipDeviceProp_t deviceProperties;
         static_cast<void>(hipGetDevice(&deviceId));
@@ -2273,100 +2508,134 @@ void testing_matmul_with_bias(const Arguments& arg)
         }
 
         // For the xf32 xdl math op, cast type of A/B from float to xfloat32 .
-        if constexpr(std::is_same<TiA, float>{} && std::is_same<TiB, float>{}
-                     && std::is_same<To, float>{} && std::is_same<Tc, float>{})
+        if(TiA == HIP_R_32F && TiB == HIP_R_32F && To == HIP_R_32F && Talpha == HIP_R_32F)
             if(arg.compute_type == HIPBLAS_COMPUTE_32F_FAST_TF32)
-            {
                 for(int i = 0; i < gemm_count; i++)
                 {
-                    type_to_xdl_math_op_type<hipblasLtXfloat32, float>(hA[i]->data(), size_A[i]);
-                    type_to_xdl_math_op_type<hipblasLtXfloat32, float>(hB[i]->data(), size_B[i]);
+                    type_to_xdl_math_op_type<hipblasLtXfloat32, float, float>(
+                        static_cast<float*>(hA[i].buf()), size_A[i]);
+                    type_to_xdl_math_op_type<hipblasLtXfloat32, float, float>(
+                        static_cast<float*>(hB[i].buf()), size_B[i]);
                 }
-            }
 
-#define epilogue_param                                                                     \
-    M[gemmIdx], N[gemmIdx], ldd[gemmIdx], *(hD_gold_epl[gemmIdx]) + pos,                   \
-        *(hD_gold[gemmIdx]) + pos, *(hBias_gold_epl[gemmIdx]) + pos,                       \
-        arg.amaxD ? *(hAmaxD_gold[gemmIdx]) + 0 : nullptr, ePos, scaleDValue, scaleEValue, \
+#define epilogue_param                                                                             \
+    M[gemmIdx], N[gemmIdx], ldd[gemmIdx],                                                          \
+        (hD_gold_epl[gemmIdx].as<char>() + pos * realDataTypeSize(Talpha)),                        \
+        (hD_gold[gemmIdx].as<char>() + pos * realDataTypeSize(To)),                                \
+        (hBias_gold_epl[gemmIdx].as<char>() + pos * realDataTypeSize(Talpha)),                     \
+        arg.amaxD ? hAmaxD_gold[gemmIdx].as<char>() + 0 : nullptr, ePos, scaleDValue, scaleEValue, \
         applyBias
         for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
         {
-            auto alpha    = h_alpha[gemmIdx];
-            auto betaTemp = h_beta[gemmIdx];
+            auto                 alpha    = h_alpha[gemmIdx];
+            auto                 betaTemp = h_beta[gemmIdx];
+            computeTypeInterface tempSC;
             if(arg.scaleC)
-                betaTemp *= (*hScaleC[gemmIdx])[0];
-            Talpha scale       = 1;
-            auto   scaleAVec   = arg.scaleA ? (*hScaleA[gemmIdx]) : &scale;
-            auto   scaleBVec   = arg.scaleB ? (*hScaleB[gemmIdx]) : &scale;
-            auto   scaleDValue = arg.scaleD ? (*hScaleD[gemmIdx])[0] : 1;
-            auto   scaleEValue = arg.scaleE ? (*hScaleE[gemmIdx])[0] : 1;
+            {
+                // betaTemp *= hScaleC[gemmIdx][0];
+                set_computeInterface(tempSC, hScaleC[gemmIdx].buf(), Tc);
+                mul_computeInterface(betaTemp, tempSC, Tc);
+            }
+
+            computeTypeInterface scale;
+            set_computeInterface(scale, 1, Talpha);
+            void* scaleAVec   = arg.scaleA ? hScaleA[gemmIdx].buf() : (void*)(&scale);
+            void* scaleBVec   = arg.scaleB ? hScaleB[gemmIdx].buf() : (void*)(&scale);
+            void* scaleDValue = arg.scaleD ? hScaleD[gemmIdx].buf() : (void*)(&scale);
+            void* scaleEValue = arg.scaleE ? hScaleE[gemmIdx].buf() : (void*)(&scale);
 
             for(int batchIdx = 0; batchIdx < num_batches[gemmIdx]; batchIdx++)
             {
                 if(epilogue_on[gemmIdx])
                 {
-                    cblas_gemm<TiA, TiB, Talpha, Talpha, TciA, TciB>(
-                        transA,
-                        transB,
-                        M[gemmIdx],
-                        N[gemmIdx],
-                        K[gemmIdx],
-                        alpha,
-                        *(hA[gemmIdx]) + stride_a[gemmIdx] * batchIdx,
-                        lda[gemmIdx],
-                        *(hB[gemmIdx]) + stride_b[gemmIdx] * batchIdx,
-                        ldb[gemmIdx],
-                        betaTemp,
-                        *(hD_gold_epl[gemmIdx]) + stride_d[gemmIdx] * batchIdx,
-                        ldd[gemmIdx],
-                        arg.scaleAlpha_vector ? *(hScaleAlphaVec[gemmIdx]) + 0 : nullptr,
-                        scaleAVec,
-                        scaleBVec,
-                        1,
-                        (arg.scaleA == Arguments::ScalingFormat::Vector),
-                        (arg.scaleB == Arguments::ScalingFormat::Vector),
-                        false);
-                    auto pos    = stride_d[gemmIdx] * batchIdx;
-                    auto hEInst = arg.gradient ? hE : hE_gold;
-                    auto ePos = (hEInst[gemmIdx] == nullptr) ? nullptr : (*(hEInst[gemmIdx]) + pos);
-                    auto applyBias = arg.gradient ? false : arg.bias_vector;
+                    cblas_gemm(transA,
+                               transB,
+                               M[gemmIdx],
+                               N[gemmIdx],
+                               K[gemmIdx],
+                               alpha,
+                               hA[gemmIdx].as<char>()
+                                   + stride_a[gemmIdx] * batchIdx * realDataTypeSize(TiA),
+                               lda[gemmIdx],
+                               hB[gemmIdx].as<char>()
+                                   + stride_b[gemmIdx] * batchIdx * realDataTypeSize(TiB),
+                               ldb[gemmIdx],
+                               betaTemp,
+                               hD_gold_epl[gemmIdx].as<char>()
+                                   + stride_d[gemmIdx] * batchIdx * realDataTypeSize(Talpha),
+                               ldd[gemmIdx],
+                               arg.scaleAlpha_vector ? hScaleAlphaVec[gemmIdx].as<char>() + 0
+                                                     : nullptr,
+                               scaleAVec,
+                               scaleBVec,
+                               (void*)(&scale),
+                               (arg.scaleA == Arguments::ScalingFormat::Vector),
+                               (arg.scaleB == Arguments::ScalingFormat::Vector),
+                               TiA,
+                               TiB,
+                               Tc,
+                               Tc,
+                               TciA,
+                               TciB,
+                               false);
+                    auto                        pos       = stride_d[gemmIdx] * batchIdx;
+                    std::vector<HipHostBuffer>* hEInst    = arg.gradient ? &hE : &hE_gold;
+                    void*                       ePos      = ((*hEInst).size() <= gemmIdx)
+                                                                ? nullptr
+                                                                : ((*hEInst)[gemmIdx].as<char>() + pos * realDataTypeSize(To));
+                    auto                        applyBias = arg.gradient ? false : arg.bias_vector;
+                    void* hBias_buf = ((hBias).size() <= gemmIdx) ? nullptr : hBias[gemmIdx].buf();
 
                     switch(arg.activation_type)
                     {
                     case hipblaslt_activation_type::gelu:
                         if(arg.gradient)
                             epilogue_func(epilogue_param,
-                                          *(hBias[gemmIdx]) + 0,
+                                          hBias_buf,
+                                          Tbias,
                                           arg.activation_arg1,
                                           arg.activation_arg2,
                                           ::_dgelu,
-                                          true);
+                                          true,
+                                          To,
+                                          Talpha);
                         else
+                        {
                             epilogue_func(epilogue_param,
-                                          *(hBias[gemmIdx]) + 0,
+                                          hBias_buf,
+                                          Tbias,
                                           arg.activation_arg1,
                                           arg.activation_arg2,
                                           ::_gelu,
-                                          false);
+                                          false,
+                                          To,
+                                          Talpha);
+                        }
                         break;
                     case hipblaslt_activation_type::relu:
                         epilogue_func(epilogue_param,
-                                      *(hBias[gemmIdx]) + 0,
+                                      hBias_buf,
+                                      Tbias,
                                       arg.activation_arg1,
                                       arg.activation_arg2,
                                       ::_relu,
-                                      arg.gradient);
+                                      arg.gradient,
+                                      To,
+                                      Talpha);
                         break;
                     default:
-                        epilogue_func(epilogue_param, *(hBias[gemmIdx]) + 0, false);
+                        epilogue_func(epilogue_param, hBias_buf, Tbias, false, To, Talpha);
                         break;
                     }
                     if(arg.gradient && arg.bias_vector && batchIdx == num_batches[gemmIdx] - 1)
                     {
                         if(arg.bias_source == hipblaslt_bias_source::d)
                         {
-                            reduction_func<false, float>(*(hBias_gold_epl[gemmIdx]) + pos,
-                                                         *(hBias_gold[gemmIdx]) + 0,
+                            reduction_func<false, float>(hBias_gold_epl[gemmIdx].as<char>()
+                                                             + pos * realDataTypeSize(Talpha),
+                                                         Talpha,
+                                                         hBias_gold[gemmIdx].buf(),
+                                                         Tbias,
                                                          M[gemmIdx],
                                                          N[gemmIdx],
                                                          1,
@@ -2376,24 +2645,25 @@ void testing_matmul_with_bias(const Arguments& arg)
                         }
                         else
                         {
-                            // *(hA[gemmIdx]) + stride_a[gemmIdx] * batchIdx
                             bool sumLd = false;
                             int  s1 = 1, s2 = 1, s3 = 1;
-
                             auto reduc = [&sumLd,
                                           &s1,
                                           &s2,
                                           &s3,
                                           &hBias_gold,
+                                          &Tbias,
                                           &size_bias,
                                           &K,
                                           &num_batches,
                                           &gemmIdx,
-                                          &arg](auto* ptr) {
+                                          &arg](void* ptr, hipDataType Ti) {
                                 if(sumLd)
                                 {
                                     reduction_func<true, float>(ptr,
-                                                                *(hBias_gold[gemmIdx]) + 0,
+                                                                Ti,
+                                                                hBias_gold[gemmIdx].buf(),
+                                                                Tbias,
                                                                 size_bias[gemmIdx],
                                                                 K[gemmIdx],
                                                                 s1,
@@ -2404,7 +2674,9 @@ void testing_matmul_with_bias(const Arguments& arg)
                                 else
                                 {
                                     reduction_func<false, float>(ptr,
-                                                                 *(hBias_gold[gemmIdx]) + 0,
+                                                                 Ti,
+                                                                 hBias_gold[gemmIdx].buf(),
+                                                                 Tbias,
                                                                  size_bias[gemmIdx],
                                                                  K[gemmIdx],
                                                                  s1,
@@ -2413,49 +2685,56 @@ void testing_matmul_with_bias(const Arguments& arg)
                                                                  num_batches[gemmIdx]);
                                 }
                             };
-
                             if(arg.bias_source == hipblaslt_bias_source::a)
                             {
-                                TiA* ptr = *(hA[gemmIdx]);
-                                s2       = lda[gemmIdx];
-                                s3       = stride_a[gemmIdx];
-                                sumLd    = transA == HIPBLAS_OP_N ? false : true;
-                                reduc(ptr);
+                                void* ptr = hA[gemmIdx].buf();
+                                s2        = lda[gemmIdx];
+                                s3        = stride_a[gemmIdx];
+                                sumLd     = transA == HIPBLAS_OP_N ? false : true;
+                                reduc(ptr, TiA);
                             }
                             else if(arg.bias_source == hipblaslt_bias_source::b)
                             {
-                                TiB* ptr = *(hB[gemmIdx]);
-                                s2       = ldb[gemmIdx];
-                                s3       = stride_b[gemmIdx];
-                                sumLd    = transB == HIPBLAS_OP_N ? true : false;
-                                reduc(ptr);
+                                void* ptr = hB[gemmIdx].buf();
+                                s2        = ldb[gemmIdx];
+                                s3        = stride_b[gemmIdx];
+                                sumLd     = transB == HIPBLAS_OP_N ? true : false;
+                                reduc(ptr, TiB);
                             }
                         }
                     }
                 }
                 else
                 {
-                    cblas_gemm<TiA, TiB, To, Talpha, TciA, TciB>(
-                        transA,
-                        transB,
-                        M[gemmIdx],
-                        N[gemmIdx],
-                        K[gemmIdx],
-                        alpha,
-                        *(hA[gemmIdx]) + stride_a[gemmIdx] * batchIdx,
-                        lda[gemmIdx],
-                        *(hB[gemmIdx]) + stride_b[gemmIdx] * batchIdx,
-                        ldb[gemmIdx],
-                        betaTemp,
-                        *(hD_gold[gemmIdx]) + stride_d[gemmIdx] * batchIdx,
-                        ldd[gemmIdx],
-                        nullptr,
-                        scaleAVec,
-                        scaleBVec,
-                        scaleDValue,
-                        (arg.scaleA == Arguments::ScalingFormat::Vector),
-                        (arg.scaleB == Arguments::ScalingFormat::Vector),
-                        false);
+                    cblas_gemm(transA,
+                               transB,
+                               M[gemmIdx],
+                               N[gemmIdx],
+                               K[gemmIdx],
+                               alpha,
+                               hA[gemmIdx].as<char>()
+                                   + stride_a[gemmIdx] * batchIdx * realDataTypeSize(TiA),
+                               lda[gemmIdx],
+                               hB[gemmIdx].as<char>()
+                                   + stride_b[gemmIdx] * batchIdx * realDataTypeSize(TiB),
+                               ldb[gemmIdx],
+                               betaTemp,
+                               hD_gold[gemmIdx].as<char>()
+                                   + stride_d[gemmIdx] * batchIdx * realDataTypeSize(To),
+                               ldd[gemmIdx],
+                               nullptr,
+                               scaleAVec,
+                               scaleBVec,
+                               scaleDValue,
+                               (arg.scaleA == Arguments::ScalingFormat::Vector),
+                               (arg.scaleB == Arguments::ScalingFormat::Vector),
+                               TiA,
+                               TiB,
+                               To,
+                               Tc,
+                               TciA,
+                               TciB,
+                               false);
                 }
             }
         }
@@ -2486,14 +2765,14 @@ void testing_matmul_with_bias(const Arguments& arg)
                     EXPECT_HIPBLAS_STATUS(hipblasLtMatmul(handle,
                                                           matmul[0][0],
                                                           alpha_in[0],
-                                                          *(dA[0]),
+                                                          dA[0].buf(),
                                                           matA[0],
-                                                          *(dB[0]),
+                                                          dB[0].buf(),
                                                           matB[0],
                                                           &(h_beta[0]),
-                                                          *(dC[0]),
+                                                          dC[0].buf(),
                                                           matC[0],
-                                                          *(dD[0]),
+                                                          (*dDp)[0].buf(),
                                                           matD[0],
                                                           &heuristicResult[sol].algo,
                                                           *dWorkspace,
@@ -2539,16 +2818,16 @@ void testing_matmul_with_bias(const Arguments& arg)
             std::vector<double> tol(gemm_count);
             if(arg.unit_check
                && (hipblaslt_get_arch_major() == 11 || hipblaslt_get_arch_major() == 12)
-               && sizeof(TiA) == 2 && sizeof(TiB) == 2)
+               && realDataTypeSize(TiA) == 2 && realDataTypeSize(TiB) == 2)
             {
                 for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
                 {
-                    tol[gemmIdx] = K[gemmIdx] * sum_error_tolerance_for_gfx11<Tc, TiA, To>;
+                    tol[gemmIdx] = K[gemmIdx] * sum_error_tolerance_for_gfx11_type(Tc, TiA, To);
                 }
             }
             if(arg.unit_check || arg.norm_check || arg.allclose_check)
             {
-                copy_gemm_to_host(stream, gemm_count, hD_1, dD);
+                copy_gemm_to_host(stream, gemm_count, hD_1, (*dDp));
                 check(stream,
                       arg,
                       gemm_count,
@@ -2562,7 +2841,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                       size_bias,
                       hD_gold,
                       hD_1,
-                      dD,
+                      (*dDp),
                       hAmaxD_gold,
                       hAmaxD,
                       dAmaxD,
@@ -2575,7 +2854,10 @@ void testing_matmul_with_bias(const Arguments& arg)
                       tol,
                       hipblaslt_error,
                       hipblaslt_atol,
-                      hipblaslt_rtol);
+                      hipblaslt_rtol,
+                      To,
+                      Tbias,
+                      Talpha);
             }
         }
     }
@@ -2647,7 +2929,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                     {
                         CHECK_HIPBLASLT_ERROR(gemmVec[i % block_count].run(stream));
                         if(i == 0 && (arg.unit_check || arg.norm_check || arg.allclose_check))
-                            copy_gemm_to_host(stream, gemm_count, hD_1, dD);
+                            copy_gemm_to_host(stream, gemm_count, hD_1, (*dDp));
                     }
                     freq_monitor.start();
                     if(arg.use_gpu_timer)
@@ -2668,34 +2950,36 @@ void testing_matmul_with_bias(const Arguments& arg)
                 {
                     for(int i = 0; i < number_cold_calls; i++)
                     {
-                        TiA* ptr_dA     = *(dA[0]) + (i % block_count) * size_A[0];
-                        TiB* ptr_dB     = *(dB[0]) + (i % block_count) * size_B[0];
-                        To*  ptr_dC     = *(dC[0]) + (i % block_count) * size_C[0];
-                        To*  ptr_dD     = *(dD[0]) + (i % block_count) * size_D[0];
                         auto ptr_matmul = matmul[i % block_count][0];
-                        auto ptr_alpha
-                            = arg.scaleAlpha_vector
-                                  ? *(dScaleAlphaVec[0]) + (i % block_count) * size_scaleAlphaVec[0]
-                                  : alpha_in[0];
-                        EXPECT_HIPBLAS_STATUS(hipblasLtMatmul(handle,
-                                                              ptr_matmul,
-                                                              ptr_alpha,
-                                                              ptr_dA,
-                                                              matA[0],
-                                                              ptr_dB,
-                                                              matB[0],
-                                                              &(h_beta[0]),
-                                                              ptr_dC,
-                                                              matC[0],
-                                                              ptr_dD,
-                                                              matD[0],
-                                                              &heuristicResult[sol].algo,
-                                                              *dWorkspace,
-                                                              workspace_size,
-                                                              stream),
-                                              HIPBLAS_STATUS_SUCCESS);
+                        auto ptr_alpha  = arg.scaleAlpha_vector
+                                              ? (dScaleAlphaVec[0].as<char>())
+                                                   + (i % block_count) * size_scaleAlphaVec[0]
+                                              : alpha_in[0];
+                        EXPECT_HIPBLAS_STATUS(
+                            hipblasLtMatmul(
+                                handle,
+                                ptr_matmul,
+                                ptr_alpha,
+                                dA[0].as<char>()
+                                    + (i % block_count) * size_A[0] * realDataTypeSize(TiA),
+                                matA[0],
+                                dB[0].as<char>()
+                                    + (i % block_count) * size_B[0] * realDataTypeSize(TiB),
+                                matB[0],
+                                &(h_beta[0]),
+                                dC[0].as<char>()
+                                    + (i % block_count) * size_C[0] * realDataTypeSize(To),
+                                matC[0],
+                                (*dDp)[0].as<char>()
+                                    + (i % block_count) * size_D[0] * realDataTypeSize(To),
+                                matD[0],
+                                &heuristicResult[sol].algo,
+                                *dWorkspace,
+                                workspace_size,
+                                stream),
+                            HIPBLAS_STATUS_SUCCESS);
                         if(i == 0 && (arg.unit_check || arg.norm_check || arg.allclose_check))
-                            copy_gemm_to_host(stream, gemm_count, hD_1, dD);
+                            copy_gemm_to_host(stream, gemm_count, hD_1, (*dDp));
                     }
                     freq_monitor.start();
                     if(arg.use_gpu_timer)
@@ -2706,32 +2990,34 @@ void testing_matmul_with_bias(const Arguments& arg)
                     }
                     for(int i = 0; i < number_hot_calls; i++)
                     {
-                        TiA* ptr_dA     = *(dA[0]) + (i % block_count) * size_A[0];
-                        TiB* ptr_dB     = *(dB[0]) + (i % block_count) * size_B[0];
-                        To*  ptr_dC     = *(dC[0]) + (i % block_count) * size_C[0];
-                        To*  ptr_dD     = *(dD[0]) + (i % block_count) * size_D[0];
                         auto ptr_matmul = matmul[i % block_count][0];
-                        auto ptr_alpha
-                            = arg.scaleAlpha_vector
-                                  ? *(dScaleAlphaVec[0]) + (i % block_count) * size_scaleAlphaVec[0]
-                                  : alpha_in[0];
-                        EXPECT_HIPBLAS_STATUS(hipblasLtMatmul(handle,
-                                                              ptr_matmul,
-                                                              ptr_alpha,
-                                                              ptr_dA,
-                                                              matA[0],
-                                                              ptr_dB,
-                                                              matB[0],
-                                                              &(h_beta[0]),
-                                                              ptr_dC,
-                                                              matC[0],
-                                                              ptr_dD,
-                                                              matD[0],
-                                                              &heuristicResult[sol].algo,
-                                                              *dWorkspace,
-                                                              workspace_size,
-                                                              stream),
-                                              HIPBLAS_STATUS_SUCCESS);
+                        auto ptr_alpha  = arg.scaleAlpha_vector
+                                              ? (dScaleAlphaVec[0].as<char>())
+                                                   + (i % block_count) * size_scaleAlphaVec[0]
+                                              : alpha_in[0];
+                        EXPECT_HIPBLAS_STATUS(
+                            hipblasLtMatmul(
+                                handle,
+                                ptr_matmul,
+                                ptr_alpha,
+                                dA[0].as<char>()
+                                    + (i % block_count) * size_A[0] * realDataTypeSize(TiA),
+                                matA[0],
+                                dB[0].as<char>()
+                                    + (i % block_count) * size_B[0] * realDataTypeSize(TiB),
+                                matB[0],
+                                &(h_beta[0]),
+                                dC[0].as<char>()
+                                    + (i % block_count) * size_C[0] * realDataTypeSize(To),
+                                matC[0],
+                                (*dDp)[0].as<char>()
+                                    + (i % block_count) * size_D[0] * realDataTypeSize(To),
+                                matD[0],
+                                &heuristicResult[sol].algo,
+                                *dWorkspace,
+                                workspace_size,
+                                stream),
+                            HIPBLAS_STATUS_SUCCESS);
                         if(arg.flush)
                             hipLaunchKernelGGL(flush_icache, dim3(gpu_block3), dim3(64), 0, stream);
                     }
@@ -2780,7 +3066,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                         CHECK_HIPBLASLT_ERROR(groupedGemmVec[i % block_count].run(
                             d_userArgsVec[i % block_count], stream));
                         if(i == 0 && (arg.unit_check || arg.norm_check || arg.allclose_check))
-                            copy_gemm_to_host(stream, gemm_count, hD_1, dD);
+                            copy_gemm_to_host(stream, gemm_count, hD_1, (*dDp));
                     }
                     freq_monitor.start();
                     if(arg.use_gpu_timer)
@@ -2824,7 +3110,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                     {
                         CHECK_HIPBLASLT_ERROR(groupedGemmVec[i % block_count].run(stream));
                         if(i == 0 && (arg.unit_check || arg.norm_check || arg.allclose_check))
-                            copy_gemm_to_host(stream, gemm_count, hD_1, dD);
+                            copy_gemm_to_host(stream, gemm_count, hD_1, (*dDp));
                     }
                     if(arg.use_gpu_timer)
                         CHECK_HIP_ERROR(hipEventRecord(event_gpu_time_start, stream));
@@ -2857,14 +3143,14 @@ void testing_matmul_with_bias(const Arguments& arg)
             double flops = 0;
             for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
             {
-                flops += gemm_gflop_count<Tc>(M[gemmIdx], N[gemmIdx], K[gemmIdx]);
+                flops += gemm_gflop_count(M[gemmIdx], N[gemmIdx], K[gemmIdx], Talpha);
                 switch(arg.activation_type)
                 {
                 case hipblaslt_activation_type::relu:
-                    flops += relu_gflop_count<Tc>(M[gemmIdx], N[gemmIdx]);
+                    flops += relu_gflop_count(M[gemmIdx], N[gemmIdx], Talpha);
                     break;
                 case hipblaslt_activation_type::gelu:
-                    flops += gelu_gflop_count<Tc>(M[gemmIdx], N[gemmIdx]);
+                    flops += gelu_gflop_count(M[gemmIdx], N[gemmIdx], Talpha);
                     break;
                 default:
                     break;
@@ -2877,14 +3163,15 @@ void testing_matmul_with_bias(const Arguments& arg)
             std::vector<double> tol(gemm_count);
             if(arg.unit_check
                && (hipblaslt_get_arch_major() == 11 || hipblaslt_get_arch_major() == 12)
-               && sizeof(TiA) == 2 && sizeof(TiB) == 2)
+               && realDataTypeSize(TiA) == 2 && realDataTypeSize(TiB) == 2)
             {
                 for(int gemmIdx = 0; gemmIdx < gemm_count; gemmIdx++)
                 {
-                    tol[gemmIdx] = K[gemmIdx] * sum_error_tolerance_for_gfx11<Tc, TiA, To>;
+                    tol[gemmIdx] = K[gemmIdx] * sum_error_tolerance_for_gfx11_type(Tc, TiA, To);
                 }
             }
             if(arg.unit_check || arg.norm_check || arg.allclose_check)
+            {
                 check(stream,
                       arg,
                       gemm_count,
@@ -2898,7 +3185,7 @@ void testing_matmul_with_bias(const Arguments& arg)
                       size_bias,
                       hD_gold,
                       hD_1,
-                      dD,
+                      (*dDp),
                       hAmaxD_gold,
                       hAmaxD,
                       dAmaxD,
@@ -2911,7 +3198,11 @@ void testing_matmul_with_bias(const Arguments& arg)
                       tol,
                       hipblaslt_error,
                       hipblaslt_atol,
-                      hipblaslt_rtol);
+                      hipblaslt_rtol,
+                      To,
+                      Tbias,
+                      Talpha);
+            }
 
 #define argument_param                                                                            \
     e_transA, e_transB, e_grouped_gemm, e_batch_count, e_M, e_N, e_K, e_alpha, e_lda, e_stride_a, \
@@ -2948,7 +3239,8 @@ void testing_matmul_with_bias(const Arguments& arg)
                     }
                     solutionIndex = hipblaslt_ext::getIndexFromAlgo(heuristicResult[sol].algo);
                 }
-                ArgumentModel<argument_param>{}.log_args<Tc>(
+                ArgumentModel<argument_param>{}.log_args(
+                    Talpha,
                     hipblaslt_cout,
                     sol,
                     solutionIndex,
@@ -2992,7 +3284,8 @@ void testing_matmul_with_bias(const Arguments& arg)
             }
 
             hipblaslt_cout << "Winner: " << std::endl;
-            ArgumentModel<argument_param>{}.log_args<Tc>(
+            ArgumentModel<argument_param>{}.log_args(
+                Talpha,
                 hipblaslt_cout,
                 best_sol,
                 solutionIndex,
@@ -3023,64 +3316,6 @@ void testing_matmul_with_bias(const Arguments& arg)
         CHECK_HIP_ERROR(hipFree(userArgs));
     if(d_userArgs != nullptr)
         CHECK_HIP_ERROR(hipFree(d_userArgs));
-
-    for(int i = 0; i < gemm_count; i++)
-    {
-        delete hA[i];
-        delete hB[i];
-        delete hC[i];
-        delete hD_gold[i];
-        delete hD_gold_epl[i];
-        delete hD_gold_ScaleAlpha[i];
-        delete hD_1[i];
-        delete hBias[i];
-        delete hBias_gold_epl[i];
-        delete hBias_gold[i];
-        delete hScaleAlphaVec[i];
-        delete dA[i];
-        delete dB[i];
-        delete dC[i];
-        if(!arg.c_equal_d)
-            delete dD[i];
-        delete dBias[i];
-        delete dScaleAlphaVec[i];
-        if(arg.scaleA)
-        {
-            delete hScaleA[i];
-            delete dScaleA[i];
-        }
-        if(arg.scaleB)
-        {
-            delete hScaleB[i];
-            delete dScaleB[i];
-        }
-        if(arg.scaleC)
-        {
-            delete hScaleC[i];
-            delete dScaleC[i];
-        }
-        if(arg.scaleD)
-        {
-            delete hScaleD[i];
-            delete dScaleD[i];
-        }
-        if(arg.amaxD)
-        {
-            delete hAmaxD_gold[i];
-            delete hAmaxD[i];
-            delete dAmaxD[i];
-        }
-        if(arg.scaleE)
-        {
-            delete hScaleE[i];
-            delete dScaleE[i];
-        }
-        if(arg.use_e)
-        {
-            delete dE[i];
-            delete hE[i];
-        }
-    }
 
     CHECK_HIP_ERROR(hipStreamDestroy(stream));
     CHECK_HIP_ERROR(hipEventDestroy(event_gpu_time_start));

--- a/clients/include/type_dispatch.hpp
+++ b/clients/include/type_dispatch.hpp
@@ -26,35 +26,9 @@
 
 #pragma once
 
+#include "datatype_interface.hpp"
 #include "hipblaslt_arguments.hpp"
 #include <hipblaslt/hipblaslt.h>
-
-template <typename T>
-constexpr auto hipblaslt_type2datatype()
-{
-    if(std::is_same<T, hipblasLtHalf>{})
-        return HIP_R_16F;
-    if(std::is_same<T, hip_bfloat16>{})
-        return HIP_R_16BF;
-    if(std::is_same<T, float>{})
-        return HIP_R_32F;
-    if(std::is_same<T, hipblaslt_f8_fnuz>{})
-        return HIP_R_8F_E4M3_FNUZ;
-    if(std::is_same<T, hipblaslt_bf8_fnuz>{})
-        return HIP_R_8F_E5M2_FNUZ;
-#ifdef ROCM_USE_FLOAT8
-    if(std::is_same<T, hipblaslt_f8_ocp>{})
-        return HIP_R_8F_E4M3;
-    if(std::is_same<T, hipblaslt_bf8_ocp>{})
-        return HIP_R_8F_E5M2;
-#endif
-    if(std::is_same<T, int32_t>{})
-        return HIP_R_32I;
-    if(std::is_same<T, hipblasLtInt8>{})
-        return HIP_R_8I;
-
-    return HIP_R_16F; // testing purposes we default to f32 ex
-}
 
 // ----------------------------------------------------------------------------
 // Calls TEST template based on the argument types. TEST<> is expected to

--- a/clients/include/unit.hpp
+++ b/clients/include/unit.hpp
@@ -32,6 +32,7 @@
 #pragma once
 
 #include "hipblaslt_math.hpp"
+#include "hipblaslt_ostream.hpp"
 #include "hipblaslt_test.hpp"
 #include "hipblaslt_vector.hpp"
 #include <hipblaslt/hipblaslt.h>
@@ -113,7 +114,7 @@
 // TODO: Replace std::remove_cv_t with std::type_identity_t in C++20
 // It is only used to make T_hpa non-deduced
 template <typename T, typename T_hpa = T>
-void unit_check_general(
+inline void unit_check_general(
     int64_t M, int64_t N, int64_t lda, const std::remove_cv_t<T_hpa>* hCPU, const T* hGPU);
 
 template <>
@@ -124,8 +125,11 @@ inline void unit_check_general(
 }
 
 template <>
-inline void unit_check_general(
-    int64_t M, int64_t N, int64_t lda, const hipblaslt_bf8_fnuz* hCPU, const hipblaslt_bf8_fnuz* hGPU)
+inline void unit_check_general(int64_t                   M,
+                               int64_t                   N,
+                               int64_t                   lda,
+                               const hipblaslt_bf8_fnuz* hCPU,
+                               const hipblaslt_bf8_fnuz* hGPU)
 {
     UNIT_CHECK(M, N, lda, 0, hCPU, hGPU, 1, ASSERT_BF8_EQ);
 }
@@ -196,13 +200,13 @@ inline void
 }
 
 template <typename T, typename T_hpa = T>
-void unit_check_general(int64_t                        M,
-                        int64_t                        N,
-                        int64_t                        lda,
-                        int64_t                        strideA,
-                        const std::remove_cv_t<T_hpa>* hCPU,
-                        const T*                       hGPU,
-                        int64_t                        batch_count);
+inline void unit_check_general(int64_t                        M,
+                               int64_t                        N,
+                               int64_t                        lda,
+                               int64_t                        strideA,
+                               const std::remove_cv_t<T_hpa>* hCPU,
+                               const T*                       hGPU,
+                               int64_t                        batch_count);
 
 template <>
 inline void unit_check_general(int64_t             M,
@@ -242,25 +246,25 @@ inline void unit_check_general(int64_t                   M,
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline void unit_check_general(int64_t                  M,
-                               int64_t                  N,
-                               int64_t                  lda,
-                               int64_t                  strideA,
+inline void unit_check_general(int64_t                 M,
+                               int64_t                 N,
+                               int64_t                 lda,
+                               int64_t                 strideA,
                                const hipblaslt_f8_ocp* hCPU,
                                const hipblaslt_f8_ocp* hGPU,
-                               int64_t                  batch_count)
+                               int64_t                 batch_count)
 {
     UNIT_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, ASSERT_F8_EQ);
 }
 
 template <>
-inline void unit_check_general(int64_t                   M,
-                               int64_t                   N,
-                               int64_t                   lda,
-                               int64_t                   strideA,
+inline void unit_check_general(int64_t                  M,
+                               int64_t                  N,
+                               int64_t                  lda,
+                               int64_t                  strideA,
                                const hipblaslt_bf8_ocp* hCPU,
                                const hipblaslt_bf8_ocp* hGPU,
-                               int64_t                   batch_count)
+                               int64_t                  batch_count)
 {
     UNIT_CHECK(M, N, lda, strideA, hCPU, hGPU, batch_count, ASSERT_BF8_EQ);
 }
@@ -351,12 +355,12 @@ inline void unit_check_general(int64_t        M,
 }
 
 template <typename T, typename T_hpa = T>
-void unit_check_general(int64_t                                    M,
-                        int64_t                                    N,
-                        int64_t                                    lda,
-                        const host_vector<std::remove_cv_t<T_hpa>> hCPU[],
-                        const host_vector<T>                       hGPU[],
-                        int64_t                                    batch_count);
+inline void unit_check_general(int64_t                                    M,
+                               int64_t                                    N,
+                               int64_t                                    lda,
+                               const host_vector<std::remove_cv_t<T_hpa>> hCPU[],
+                               const host_vector<T>                       hGPU[],
+                               int64_t                                    batch_count);
 
 template <>
 inline void unit_check_general(int64_t                         M,
@@ -436,12 +440,12 @@ inline void unit_check_general(int64_t                   M,
 }
 
 template <typename T, typename T_hpa = T>
-void unit_check_general(int64_t                              M,
-                        int64_t                              N,
-                        int64_t                              lda,
-                        const std::remove_cv_t<T_hpa>* const hCPU[],
-                        const T* const                       hGPU[],
-                        int64_t                              batch_count);
+inline void unit_check_general(int64_t                              M,
+                               int64_t                              N,
+                               int64_t                              lda,
+                               const std::remove_cv_t<T_hpa>* const hCPU[],
+                               const T* const                       hGPU[],
+                               int64_t                              batch_count);
 
 template <>
 inline void unit_check_general(int64_t                   M,
@@ -551,4 +555,108 @@ inline int64_t unit_check_diff(
                     }
     } while(0);
     return error;
+}
+
+inline void unit_check_general(int64_t     M,
+                               int64_t     N,
+                               int64_t     lda,
+                               int64_t     strideA,
+                               void*       hCPU,
+                               void*       hGPU,
+                               int64_t     batch_count,
+                               hipDataType type)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        unit_check_general(
+            M, N, lda, strideA, static_cast<float*>(hCPU), static_cast<float*>(hGPU), batch_count);
+        break;
+    case HIP_R_64F:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<double*>(hCPU),
+                           static_cast<double*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_16F:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblasLtHalf*>(hCPU),
+                           static_cast<hipblasLtHalf*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_16BF:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hip_bfloat16*>(hCPU),
+                           static_cast<hip_bfloat16*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_f8_fnuz*>(hCPU),
+                           static_cast<hipblaslt_f8_fnuz*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_bf8_fnuz*>(hCPU),
+                           static_cast<hipblaslt_bf8_fnuz*>(hGPU),
+                           batch_count);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_f8_ocp*>(hCPU),
+                           static_cast<hipblaslt_f8_ocp*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_8F_E5M2:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblaslt_bf8_ocp*>(hCPU),
+                           static_cast<hipblaslt_bf8_ocp*>(hGPU),
+                           batch_count);
+        break;
+#endif
+    case HIP_R_32I:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<int32_t*>(hCPU),
+                           static_cast<int32_t*>(hGPU),
+                           batch_count);
+        break;
+    case HIP_R_8I:
+        unit_check_general(M,
+                           N,
+                           lda,
+                           strideA,
+                           static_cast<hipblasLtInt8*>(hCPU),
+                           static_cast<hipblasLtInt8*>(hGPU),
+                           batch_count);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in unit_check_general" << std::endl;
+        break;
+    }
 }


### PR DESCRIPTION
This PR reduces the building time for hipblaslt-bench and hipblaslt-test from 14m44s to 0m48s.

at directory ..../hipBLASLt/build/release/clients
make clean
at directory ..../hipBLASLt/build/release
time make -j : real 14m44s (develop)
time make -j : real   0m48s (PR-1025)


Updated: conflict is fixed and types hipblaslt_f8/bf8_ocp are supported 

local test on gfx942:
[----------] Global test environment tear-down
[======] 48206 tests from 13 test suites ran. (2982608 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1000