### PR TITLE
Fix write yaml for sparse tuning

### DIFF
--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -145,6 +145,9 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
                     solutionState["ProblemType"]["ActivationType"].value
             solutionState["ProblemType"]["F32XdlMathOp"] = \
                 solutionState["ProblemType"]["F32XdlMathOp"].value
+            if "DataTypeMetadata" in solutionState["ProblemType"]:
+                solutionState["ProblemType"]["DataTypeMetadata"] = \
+                    solutionState["ProblemType"]["DataTypeMetadata"].value
             solutionStates.append(solutionState)
     # write dictionaries
     with open(filename, "w") as f:
@@ -419,6 +422,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
             problemTypeState["ActivationType"].value
     problemTypeState["F32XdlMathOp"] = \
             problemTypeState["F32XdlMathOp"].value
+    if "DataTypeMetadata" in problemTypeState:
+        problemTypeState["DataTypeMetadata"] = \
+                problemTypeState["DataTypeMetadata"].value
     data.append(problemTypeState)
     # solutions
     solutionList = []
@@ -447,6 +453,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
                 solutionState["ProblemType"]["ActivationType"].value
         solutionState["ProblemType"]["F32XdlMathOp"] = \
                 solutionState["ProblemType"]["F32XdlMathOp"].value
+        if "DataTypeMetadata" in solutionState["ProblemType"]:
+            solutionState["ProblemType"]["DataTypeMetadata"] = \
+                    solutionState["ProblemType"]["DataTypeMetadata"].value
         solutionList.append(solutionState)
 
     if tileSelection:
@@ -476,6 +485,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
                     solutionState["ProblemType"]["ActivationType"].value
             solutionState["ProblemType"]["F32XdlMathOp"] = \
                 solutionState["ProblemType"]["F32XdlMathOp"].value
+            if "DataTypeMetadata" in solutionState["ProblemType"]:
+                solutionState["ProblemType"]["DataTypeMetadata"] = \
+                    solutionState["ProblemType"]["DataTypeMetadata"].value
             solutionList.append(solutionState)
 
     data.append(solutionList)

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1192,6 +1192,8 @@ def WriteClientLibraryFromSolutions(solutionList, libraryWorkingPath, tensileSou
   problemType["DestDataType"] = problemType["DestDataType"].value
   problemType["ComputeDataType"] = problemType["ComputeDataType"].value
   problemType["F32XdlMathOp"] = problemType["F32XdlMathOp"].value
+  if "DataTypeMetadata" in problemType:
+    problemType["DataTypeMetadata"] = problemType["DataTypeMetadata"].value
   cxxCompiler = globalParameters["CxxCompiler"]
 
   effectiveWorkingPath = os.path.join(libraryWorkingPath, "library")

--- a/tensilelite/Tensile/TensileUpdateLibrary.py
+++ b/tensilelite/Tensile/TensileUpdateLibrary.py
@@ -54,6 +54,8 @@ def UpdateLogic(filename, logicPath, outputPath):
     problemTypeState["ActivationComputeDataType"] = problemTypeState["ActivationComputeDataType"].value
     problemTypeState["ActivationType"] = problemTypeState["ActivationType"].value
     problemTypeState["F32XdlMathOp"] = problemTypeState["F32XdlMathOp"].value
+    if "DataTypeMetadata" in problemTypeState:
+        problemTypeState["DataTypeMetadata"] = problemTypeState["DataTypeMetadata"].value
 
     # solution objects to state
     solutionList = []
@@ -82,6 +84,9 @@ def UpdateLogic(filename, logicPath, outputPath):
                 solutionState["ProblemType"]["ActivationType"].value
         solutionState["ProblemType"]["F32XdlMathOp"] = \
             solutionState["ProblemType"]["F32XdlMathOp"].value
+        if "DataTypeMetadata" in solutionState["ProblemType"]:
+            solutionState["ProblemType"]["DataTypeMetadata"] = \
+                solutionState["ProblemType"]["DataTypeMetadata"].value
 
         solutionState["ISA"] = list(solutionState["ISA"])
         solutionList.append(solutionState)

--- a/tensilelite/Tensile/Tests/common/sparse/libray_logic.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/libray_logic.yaml
@@ -1,0 +1,81 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  KernelTime: True
+  NewClient: 2
+  BoundsCheck: False
+  # PrintSolutionRejectionReason: True
+  PrintWinnersOnly: True
+  ValidationMaxToPrint: 4      # maximum number of mismatches to print
+  ValidationPrintValids: False # print matches too
+  DataInitValueActivationArgs: [0.5, -1]
+  PruneSparseMode: 0
+  MinKForGSU: 1
+
+BenchmarkProblems:
+  #######################################
+  # NN - standard
+  #######################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: s
+      HighPrecisionAccumulate:  True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Sparse: 1
+      Batched: True
+      Activation: True
+      UseBias: 3
+      UseScaleAlphaVec: 3
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1,  1, 1,  1, 1 ]
+        - GlobalReadVectorWidthA: [-1]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - DepthU: [32,64]
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - StaggerU: [0,4]
+        - ScheduleIterAlg: [3]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - PrefetchGlobalRead: [2]
+        - StoreRemapVectorWidth: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: [MultipleBuffer]
+        - 1LDSBuffer: [-1]
+        - DirectToVgprSparseMetadata: [0,1]
+        - WorkGroupMapping: [18]
+        - StoreVectorWidth: [-1]
+        - AssertFree0ElementMultiple: [1,8]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [256, 256, 1, 256] # classic format
+          - Exact: [512, 512, 1, 512] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - FactorDimArgs: [0, 1]
+        - ActivationArgs:
+          - [Enum: none]
+          
+LibraryLogic:
+    ScheduleName: "aquavanjaram"
+    DeviceNames: ["Device 0049", "Device 0050"]
+    ArchitectureName: "gfx942"


### PR DESCRIPTION
Fix write yaml for sparse tuning.
Currently it will write entire data structure in winner yaml and logic yaml.

![10534440-501f-4508-b0fe-1fc207140be5](https://github.com/user-attachments/assets/f3f2d916-f4f2-42b5-872f-34f68692174e)
