### PR TITLE
pytest: speedup test, avoid building unused archs code objects.

### DIFF
--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -175,6 +175,10 @@ def argUpdatedGlobalParameters(args):
     for key, value in args.global_parameters:
         rv[key] = value
 
+    PyTestBuildArchNames = os.environ.get("PyTestBuildArchNames")
+    if PyTestBuildArchNames != None and len(PyTestBuildArchNames) > 0:
+        rv["Architecture"] = PyTestBuildArchNames
+
     return rv
 
 

--- a/tensilelite/Tensile/Tests/common/amaxd/8r_amaxd.yaml
+++ b/tensilelite/Tensile/Tests/common/amaxd/8r_amaxd.yaml
@@ -4,14 +4,11 @@ TestParameters:
 GlobalParameters:
   NumElementsToValidate: -1
   MinimumRequiredVersion: 4.14.0
-  PrintLevel: 1
-  PrintSolutionRejectionReason: True
   Device: 0
-  CMakeBuildType: Release
   MergeFiles: False
-  KernelTime: True
   CSVExportWinner: 1
   MaxWorkspaceSize: 13421772800
+  SleepPercent: 50
   DataInitTypeBias: 3
   DataInitTypeA: 12
   DataInitTypeB: 12
@@ -24,17 +21,16 @@ GlobalParameters:
   DataInitTypeScaleC: 1
   DataInitTypeScaleD: 2
   DataInitTypeScaleAlphaVec: 3
-  BoundsCheck: 2
 
 BenchmarkProblems:
   ########################################
-  # TN - standard B8_B8_S
+  # TN - B8_F8_S
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
       DataType: B8
-      DestDataType: B8
+      DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
       TransposeA: 1
@@ -55,12 +51,8 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
           - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
           - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
           - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
         - DepthU: [ 32, 64 ]
         - AssertFree0ElementMultiple: [1]
@@ -92,8 +84,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
           - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
           - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
           - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
@@ -104,13 +94,13 @@ BenchmarkProblems:
           - [Enum: relu]
 
   ########################################
-  # NT - standard B8_B8_S
+  # NT - B8_F8_S
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
       DataType: B8
-      DestDataType: B8
+      DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
       TransposeA: 0
@@ -131,12 +121,8 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
           - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
           - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
           - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
         - DepthU: [ 32, 64 ]
         - AssertFree0ElementMultiple: [1]
@@ -167,8 +153,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
           - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
           - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
           - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
@@ -179,13 +163,13 @@ BenchmarkProblems:
           - [Enum: relu]
 
   ########################################
-  # NN - standard B8_B8_S
+  # NN - B8_F8_S
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
       DataType: B8
-      DestDataType: B8
+      DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
       TransposeA: 0
@@ -206,12 +190,8 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
           - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
           - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
           - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
         - DepthU: [ 32, 64 ]
         - AssertFree0ElementMultiple: [1]
@@ -243,8 +223,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
           - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
           - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
           - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
@@ -255,315 +233,12 @@ BenchmarkProblems:
           - [Enum: relu]
 
   ########################################
-  # TT - standard B8_B8_S
+  # TT - B8_F8_S
   ########################################
   -
     - # ProblemType
       OperationType: GEMM
       DataType: B8
-      DestDataType: B8
-      ComputeDataType: S
-      HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 1
-      UseBeta: True
-      Batched: True
-      UseBias: 1
-      OutputAmaxD: True
-      UseScaleAB: "Scalar" # scale is available only for fp8 type
-      UseScaleCD: True # scale is available only for fp8 type
-      UseScaleAlphaVec: 1
-      Activation: True # must be true if there is any of bias scale
-      BiasDataTypeList: ['h'] #
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-          - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
-        - DepthU: [ 32, 64 ]
-        - AssertFree0ElementMultiple: [1]
-        - PrefetchGlobalRead: [2]
-        - PrefetchLocalRead: [1]
-        - ClusterLocalRead: [1]
-        - VectorWidthA: [1]
-        - VectorWidthB: [1]
-        - GlobalReadVectorWidthA: [-1,1]
-        - GlobalReadVectorWidthB: [-1,1]
-        - LocalReadVectorWidth: [8]
-        - ScheduleIterAlg: [3]
-        - InnerUnroll: [1]
-        - ExpandPointerSwap: [1]
-        - TransposeLDS: [1]
-        - LdsBlockSizePerPadA: [0]
-        - LdsBlockSizePerPadB: [0]
-        - LdsPadA: [0]
-        - LdsPadB: [0]
-        - WaveSeparateGlobalReadB: [1]
-        - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
-        - GlobalReadPerMfma: [1]
-        - LocalWritePerMfma: [-1]
-        - StoreVectorWidth: [-1]
-        - SourceSwap: [1]
-        - NumElementsPerBatchStore: [0]
-        - StorePriorityOpt: [0]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
-          - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
-          - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
-          - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
-          - Exact: [129, 129, 1, 128, 129, 129, 129, 129]
-        - BiasTypeArgs: ['h']
-        - ActivationArgs:
-          - [Enum: none]
-          - [Enum: relu]
-
-  ########################################
-  # TN - standard F8_F8_S
-  ########################################
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: F8
-      DestDataType: F8
-      ComputeDataType: S
-      HighPrecisionAccumulate: True
-      TransposeA: 1
-      TransposeB: 0
-      UseBeta: True
-      Batched: True
-      UseBias: 1
-      OutputAmaxD: True
-      UseScaleAB: "Scalar" # scale is available only for fp8 type
-      UseScaleCD: True # scale is available only for fp8 type
-      UseScaleAlphaVec: 1
-      Activation: True # must be true if there is any of bias scale
-      BiasDataTypeList: ['h'] #
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-          - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
-        - DepthU: [ 32, 64 ]
-        - AssertFree0ElementMultiple: [1]
-        - PrefetchGlobalRead: [2]
-        - PrefetchLocalRead: [1]
-        - ClusterLocalRead: [1]
-        - VectorWidthA: [1]
-        - VectorWidthB: [1]
-        - GlobalReadVectorWidthA: [-1,1]
-        - GlobalReadVectorWidthB: [-1,1]
-        - LocalReadVectorWidth: [8]
-        - ScheduleIterAlg: [3]
-        - InnerUnroll: [1]
-        - ExpandPointerSwap: [1]
-        - TransposeLDS: [1]
-        - LdsBlockSizePerPadA: [0]
-        - LdsBlockSizePerPadB: [0]
-        - LdsPadA: [0]
-        - LdsPadB: [0]
-        - WaveSeparateGlobalReadB: [1]
-        - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
-        - GlobalReadPerMfma: [1]
-        - LocalWritePerMfma: [-1]
-        - StoreVectorWidth: [-1]
-        - SourceSwap: [1]
-        - NumElementsPerBatchStore: [0]
-        - StorePriorityOpt: [0]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
-          - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
-          - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
-          - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
-          - Exact: [129, 129, 1, 128, 129, 129, 129, 129]
-        - BiasTypeArgs: ['h']
-        - ActivationArgs:
-          - [Enum: none]
-          - [Enum: relu]
-
-  ########################################
-  # NT - standard F8_F8_S
-  ########################################
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: F8
-      DestDataType: F8
-      ComputeDataType: S
-      HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 1
-      UseBeta: True
-      Batched: True
-      UseBias: 1
-      OutputAmaxD: True
-      UseScaleAB: "Scalar" # scale is available only for fp8 type
-      UseScaleCD: True # scale is available only for fp8 type
-      UseScaleAlphaVec: 1
-      Activation: True # must be true if there is any of bias scale
-      BiasDataTypeList: ['h'] #
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-          - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
-        - DepthU: [ 32, 64 ]
-        - AssertFree0ElementMultiple: [1]
-        - PrefetchGlobalRead: [2]
-        - PrefetchLocalRead: [1]
-        - ClusterLocalRead: [1]
-        - VectorWidthA: [1]
-        - VectorWidthB: [1]
-        - GlobalReadVectorWidthA: [-1,1]
-        - GlobalReadVectorWidthB: [-1,1]
-        - ScheduleIterAlg: [3]
-        - InnerUnroll: [1]
-        - ExpandPointerSwap: [1]
-        - TransposeLDS: [0]
-        - LdsBlockSizePerPadA: [0]
-        - LdsBlockSizePerPadB: [0]
-        - LdsPadA: [0]
-        - LdsPadB: [0]
-        - WaveSeparateGlobalReadB: [1]
-        - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
-        - GlobalReadPerMfma: [1]
-        - LocalWritePerMfma: [-1]
-        - StoreVectorWidth: [-1]
-        - SourceSwap: [1]
-        - NumElementsPerBatchStore: [0]
-        - StorePriorityOpt: [0]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
-          - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
-          - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
-          - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
-          - Exact: [129, 129, 1, 128, 129, 129, 129, 129]
-        - BiasTypeArgs: ['h']
-        - ActivationArgs:
-          - [Enum: none]
-          - [Enum: relu]
-
-  ########################################
-  # NN - standard F8_F8_S
-  ########################################
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: F8
-      DestDataType: F8
-      ComputeDataType: S
-      HighPrecisionAccumulate: True
-      TransposeA: 0
-      TransposeB: 0
-      UseBeta: True
-      Batched: True
-      UseBias: 1
-      OutputAmaxD: True
-      UseScaleAB: "Scalar" # scale is available only for fp8 type
-      UseScaleCD: True # scale is available only for fp8 type
-      UseScaleAlphaVec: 1
-      Activation: True # must be true if there is any of bias scale
-      BiasDataTypeList: ['h'] #
-    - # BenchmarkProblemSizeGroup - Standard
-      InitialSolutionParameters:
-      BenchmarkCommonParameters:
-        - KernelLanguage: ["Assembly"]
-      ForkParameters:
-        - MatrixInstruction:
-          - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
-        - DepthU: [ 32, 64 ]
-        - AssertFree0ElementMultiple: [1]
-        - PrefetchGlobalRead: [2]
-        - PrefetchLocalRead: [1]
-        - ClusterLocalRead: [1]
-        - VectorWidthA: [1]
-        - VectorWidthB: [1]
-        - GlobalReadVectorWidthA: [-1,1]
-        - GlobalReadVectorWidthB: [-1,1]
-        - LocalReadVectorWidth: [8]
-        - ScheduleIterAlg: [3]
-        - InnerUnroll: [1]
-        - ExpandPointerSwap: [1]
-        - TransposeLDS: [1]
-        - LdsBlockSizePerPadA: [0]
-        - LdsBlockSizePerPadB: [0]
-        - LdsPadA: [0]
-        - LdsPadB: [0]
-        - WaveSeparateGlobalReadB: [1]
-        - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
-        - GlobalReadPerMfma: [1]
-        - LocalWritePerMfma: [-1]
-        - StoreVectorWidth: [-1]
-        - SourceSwap: [1]
-        - NumElementsPerBatchStore: [0]
-        - StorePriorityOpt: [0]
-      BenchmarkJoinParameters:
-      BenchmarkFinalParameters:
-        - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
-          - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
-          - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
-          - Exact: [127, 127, 1, 128, 127, 127, 127, 127]
-          - Exact: [129, 129, 1, 128, 129, 129, 129, 129]
-        - BiasTypeArgs: ['h']
-        - ActivationArgs:
-          - [Enum: none]
-          - [Enum: relu]
-
-  ########################################
-  # TT - standard F8_F8_S
-  ########################################
-  -
-    - # ProblemType
-      OperationType: GEMM
-      DataType: F8
       DestDataType: F8
       ComputeDataType: S
       HighPrecisionAccumulate: True
@@ -585,12 +260,8 @@ BenchmarkProblems:
       ForkParameters:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 1,1, 1,1]  # 16x16
-          - [16,16,32, 1, 1, 1,1, 2,2]  # 32x32
-          - [16,16,32, 1, 1, 2,2, 1,1]  # 32x32
           - [16,16,32, 1, 1, 2,2, 2,2]  # 64x64
           - [32,32, 16, 1, 1, 1,1, 1,1]  # 32x32
-          - [32,32, 16, 1, 1, 1,1, 2,2]  # 64x64
-          - [32,32, 16, 1, 1, 2,2, 1,1]  # 64x64
           - [32,32, 16, 1, 1, 2,2, 2,2]  # 128x128
         - DepthU: [ 32, 64 ]
         - AssertFree0ElementMultiple: [1]
@@ -622,8 +293,6 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Exact: [128, 1, 1, 128, 128, 128, 128, 1]
-          - Exact: [1, 128, 1, 128, 1, 1, 1, 128]
           - Exact: [1, 1, 1, 128, 1, 1, 1, 1]
           - Exact: [128, 128, 1, 128, 128, 128, 128, 128]
           - Exact: [127, 127, 1, 128, 127, 127, 127, 127]

--- a/tensilelite/Tensile/Tests/common/test_config.py
+++ b/tensilelite/Tensile/Tests/common/test_config.py
@@ -167,7 +167,7 @@ def findAvailableArchs():
     lines = output.decode().splitlines()
     for line in lines:
         line = line.strip()
-        if not line in availableArchs:
+        if (not line in availableArchs) and (not "gfx000" in line):
             availableArchs.append(line)
     return availableArchs
 
@@ -183,6 +183,8 @@ def findConfigs(rootDir=None):
         printRoot = rootDir
 
     availableArchs = findAvailableArchs()
+    globaParamArchsStr = ';'.join(availableArchs)
+    os.environ["PyTestBuildArchNames"] = globaParamArchsStr
 
     params = []
     for (dirpath, dirnames, filenames) in os.walk(rootDir):


### PR DESCRIPTION
SWDEV-482444

For those helper kernels, we can know what archs are not needed.
So we reduce the time and space both, which shortens the pytest process.

A quick test by running only Tensile/Tests **-m 'amaxd or client or gradient'**
Before:
  py310: OK (527.67=setup[11.39]+cmd[126.00,390.27] seconds)
  congratulations :) (**527.74 seconds**)  

This PR:
  py310: OK (256.99=setup[8.71]+cmd[127.09,121.18] seconds)
  congratulations :) (**257.06 seconds**)

And the used disk space is reduced, too:
Before:
```
root@ae2448c09a4f:~/repos/hipBLASLt/tensilelite/.tensile-tox2/py310/tmp
$ du -sh
795M
```

This PR:
```
root@ae2448c09a4f:~/repos/hipBLASLt/tensilelite/.tensile-tox/py310/tmp
$ du -sh
465M
```