### PR TITLE
Remove deepcopies in TensileCreateLibrary

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1044,7 +1044,7 @@ class Solution(collections.abc.Mapping):
   ########################################
   def __init__(self, config):
     self._name = None
-    config = deepcopy(config)
+    config = config
 
     self._state = {}
     # problem type
@@ -1107,7 +1107,7 @@ class Solution(collections.abc.Mapping):
   ########################################
   # get a list of kernel parameters for this solution
   def getKernels(self):
-    kernel = deepcopy(self)
+    kernel = self
     kernel._state.update({"Kernel": True})
     kernels = []
     kernels.append(kernel)
@@ -4026,7 +4026,7 @@ class Solution(collections.abc.Mapping):
     return self.__str__()
 
   def getAttributes(self):
-    return deepcopy(self._state)
+    return self._state
 
   def __hash__(self):
     return hash(str(self) + self._state.get("codeObjectFile", ""))

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -52,7 +52,6 @@ import shutil
 import subprocess
 import sys
 from timeit import default_timer as timer
-from copy import deepcopy
 
 def timing(func):
   def wrapper(*args, **kwargs):
@@ -1094,17 +1093,17 @@ def generateLogicDataAndSolutions(logicFiles, args):
       if architectureName in masterLibraries:
         masterLibraries[architectureName].merge(newLibrary)
       else:
-        masterLibraries[architectureName] = deepcopy(newLibrary)
+        masterLibraries[architectureName] = newLibrary
         masterLibraries[architectureName].version = args.version
     elif globalParameters["SeparateArchitectures"] or globalParameters["LazyLibraryLoading"]:
       if architectureName in masterLibraries:
         nextSolIndex = masterLibraries[architectureName].merge(newLibrary, nextSolIndex)
       else:
-        masterLibraries[architectureName] = deepcopy(newLibrary)
+        masterLibraries[architectureName] = newLibrary
         masterLibraries[architectureName].version = args.version
     else:
       if fullMasterLibrary is None:
-        fullMasterLibrary = deepcopy(newLibrary)
+        fullMasterLibrary = newLibrary
         fullMasterLibrary.version = args.version
       else:
         fullMasterLibrary.merge(newLibrary)
@@ -1118,7 +1117,7 @@ def generateLogicDataAndSolutions(logicFiles, args):
     if "fallback" in masterLibraries.keys():
       for key, value in masterLibraries.items():
         if key != "fallback":
-          value.merge(deepcopy(masterLibraries["fallback"]))
+          value.merge(masterLibraries["fallback"])
 
       masterLibraries.pop("fallback")
 
@@ -1182,7 +1181,7 @@ def WriteClientLibraryFromSolutions(solutionList, libraryWorkingPath, tensileSou
 
   if tensileSourcePath == None:
     tensileSourcePath = os.path.dirname(os.path.realpath(__file__))
-  firstSolution = deepcopy(solutionList[0])
+  firstSolution = solutionList[0]
   problemType = firstSolution["ProblemType"].state
   problemType["DataType"] = problemType["DataType"].value
   problemType["DataTypeA"] = problemType["DataTypeA"].value


### PR DESCRIPTION
This [PR](https://github.com/ROCm/Tensile/pull/1973) from the Tensile project is the reference implementation for this work. 

We recently diagnosed an out of memory error when running:

```
./install.sh -c
```

which was causing several CI jobs to fail. The develop branch was memory profiled using python mprof which showed that peak memory consumption reaches ~5 TB when building for all targets using the install command above. One of the contributors to the excessive memory consumption is a number of deepcopy calls in `TensileCreateLibrary.py` and `SolutionStructs.py`. Targeted removal of deepcopies in tensilelt leads to reduced memory consumption and improved turnaround time (results will follow). 

Ran the following on gfx90a:

```
./install.sh -c
./build/release/clients/staging/hipblaslt-tests
```

with the following output:

```
[----------] Global test environment tear-down
[==========] 13061 tests from 13 test suites ran. (1713905 ms total)
[  PASSED  ] 13061 tests.
hipBLASLt version: 1000
```