### PR TITLE
Use different getFile function that doesn't trigger segfault

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/llvm/Loading.cpp
+++ b/tensilelite/Tensile/Source/lib/source/llvm/Loading.cpp
@@ -44,7 +44,7 @@ namespace Tensile
 
         try
         {
-            auto inputFile = llvm::MemoryBuffer::getFile(filename);
+            auto inputFile = llvm::MemoryBuffer::getFileAsStream(filename);
 
             LibraryIOContext<MySolution> context{filename, preloaded, nullptr};
             llvm::yaml::Input            yin((*inputFile)->getMemBufferRef(), &context);


### PR DESCRIPTION
The previously used `getFile` function uses `boost::optional` and the manner in which it is used in the context of the function is triggering a segfault on SLES. This PR replaces the function with another function from the llvm library.