### PR TITLE
Upgrade pip when running tox

### DIFF
--- a/tensilelite/tox.ini
+++ b/tensilelite/tox.ini
@@ -12,6 +12,8 @@ deps =
     pytest-xdist>=1.32.0
     filelock
 commands =
+    pip install --upgrade pip
+    pip install ../pytest-memory_usage
     python3 ./Tensile/bin/Tensile Tensile/Tests/build_client.yaml {envdir}/client
     py.test -v --basetemp={envtmpdir} --junit-xml={toxinidir}/python_tests.xml --junit-prefix={envname} --color=yes -n 4 --prebuilt-client={envdir}/client/0_Build/client/tensile_client {posargs}
 


### PR DESCRIPTION
Current default pip in Ubuntu 22.04 has bug that when installing wheels from folders will result in UNKNOWN 0.0.0.