### PR TITLE
Fix scaleAB addresses no freed in MBSK and free more sgprs

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3775,10 +3775,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.nonPostLoopSgpr.remove("OrigLoopCounter")
     self.states.nonPostLoopSgpr.remove("AddressA")
     self.states.nonPostLoopSgpr.remove("AddressB")
-    if not kernel["ForceDisableShadowInit"] and kernel["ActivationFuncCall"]:
-      if kernel["PrefetchGlobalRead"]:
-        self.states.nonPostLoopSgpr.remove("AddressC")
-        self.states.nonPostLoopSgpr.remove("AddressD")
     self.states.nonPostLoopSgpr.remove("StridesA")
     self.states.nonPostLoopSgpr.remove("StridesB")
 


### PR DESCRIPTION
Local tests
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-- generated xml file: /data0/yangwen/hipBLASLt/tensilelite/python_tests.xml ---
[33m========== [32m68 passed[0m, [33m[1m26 skipped[0m, [33m[1m38 warnings[0m[33m in 10855.95s (3:00:55)[0m[33m ===========[0m
py3: exit 0 (10856.20 seconds) /data0/yangwen/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tensile-tox/py3/tmp --junit-xml=/data0/yangwen/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tensile-tox/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=4163859
  py3: OK (10987.67=setup[8.81]+cmd[122.65,10856.20] seconds)
  congratulations :) (10987.71 seconds)

[----------] Global test environment tear-down
[==========] 37294 tests from 13 test suites ran. (2451348 ms total)
[  PASSED  ] 37294 tests.
hipBLASLt version: 1000

command line: ./clients/staging/hipblaslt-test