### PR TITLE
Fixed inconsistent # of kernels in some cases

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -281,6 +281,7 @@ globalParameters["RotatingMode"] = 0 # Default is 0, allocated in order A0B0C0D0
                                      # Mode 0 requires memcpy everytime when the problem changes to reset the data, but mode 1 doesn't.
 
 globalParameters["BuildIdKind"] = "sha1"
+globalParameters["ValidateLibrary"] = False
 
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3879,6 +3879,15 @@ class Solution(collections.abc.Mapping):
       requiredParameters["GlobalSplitUCoalesced"] = False
       requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
 
+    useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
+
+    if 'MatrixInstM' in state:
+      requiredParameters["MIWaveTile"] = True
+      requiredParameters["ThreadTile"] = False
+    else:
+      requiredParameters["MIWaveTile"] = False
+      requiredParameters["ThreadTile"] = True
+
     components.append('SN')
     for key in sorted(state.keys()):
       if key in requiredParameters and key[0] != '_':
@@ -3893,6 +3902,8 @@ class Solution(collections.abc.Mapping):
     requiredParameters["StaggerUMapping"] = True
     requiredParameters["GlobalSplitUCoalesced"] = True
     requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
+    requiredParameters["MIWaveTile"] = useWaveTile
+    requiredParameters["ThreadTile"] = useThreadTile
 
     return '_'.join(components)
 


### PR DESCRIPTION
## Brief ##
For [SWDEV-480537](https://ontrack-internal.amd.com/browse/SWDEV-480537) and [SWDEV-476834](https://ontrack-internal.amd.com/browse/SWDEV-476834).

## Details ##
In some special situations, one or more of the built kernel libraries and their code object have inconsistent kernel names.
It happened only if the the kernel list in `TensileCreateLibrary` has the following properties
 - the first non-custom kernel in the list is MAC kernel
 - there're kernels in same arch have exact same configs except "ThreadTile".

## Implementation ##
 - [x] Use MIWaveTile and ThreadTile in naming of MI-kernel and MAC-kernel respectively
 - [x] Added `--validate-library` to `TensileCreateLibrary.py` for disable/enable the library validation mechanism. 

## Local Test Results ##
### gfx90a ###
```bash
[----------] Global test environment tear-down
[==========] 13059 tests from 13 test suites ran. (1866511 ms total)
[  PASSED  ] 13059 tests.
hipBLASLt version: 1000
```

### gfx942 ###
```bash
[----------] Global test environment tear-down
[==========] 35372 tests from 13 test suites ran. (2352490 ms total)
[  PASSED  ] 35372 tests.
hipBLASLt version: 1000
```