### PR TITLE
Fixed empty MatchTable.yaml if lazy loading enabled

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1299,8 +1299,8 @@ def TensileCreateLibrary():
   argParser.add_argument("--client-config", dest="ClientConfig", action="store_true",
                          help="Create client config for setting the library and code object files")
   argParser.add_argument("--global-parameters", nargs="+", type=splitExtraParameters, default=[])
-  argParser.add_argument("--generate-solution-table", dest="GenSolTable", action="store_true", default=True,
-                         help="Generate solution-yaml matching table")
+  argParser.add_argument("--no-generate-solution-table", dest="GenSolTable", action="store_false", default=True,
+                         help="Skip generating solution-yaml matching table")
   argParser.add_argument("--asm-debug", dest="AsmDebug", action="store_true", default=False,
                          help="Keep debug information for built code objects")
   argParser.add_argument("--build-id", dest="BuildIdKind", action="store", default="sha1")

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1139,16 +1139,19 @@ def generateLogicDataAndSolutions(logicFiles, args):
 
   # Match yaml file solutions to solution index
   if args.GenSolTable:
+    def libraryIter(lib: MasterSolutionLibrary):
+      if len(lib.solutions):
+        for i, s in enumerate(lib.solutions.items()):
+          yield i, *s
+      else:
+        for _, lazyLib in lib.lazyLibraries.items():
+          yield from libraryIter(lazyLib)
+
     matchTable = {}
-    counter = 0
     for logic in filter(lambda i: i[1] != "", Utils.tqdm(libraries, "Match yaml file solutions to solution index")):
       (_, architectureName, _, _, _, newLibrary, srcFile) = logic
-      fileCounter = 0
-      for _, s in newLibrary.solutions.items():
-        assert counter == s.index
-        matchTable[s.index] = [srcFile, fileCounter]
-        fileCounter += 1
-        counter += 1
+      for localIdx, _, s in libraryIter(newLibrary):
+        matchTable[s.index] = [srcFile, localIdx]
     LibraryIO.write("MatchTable", matchTable)
 
   return solutions, masterLibraries, fullMasterLibrary


### PR DESCRIPTION
## Brief ##
 - Fixed empty match table if lazy library loading enabled.
 - Fixed `find_exact.py` with minor tweaks.
 - Added `--no-generate-solution-table` to disable match table generating.