### PR TITLE
Revised output logic YAML to use efficiency instead of gflops.

### DIFF
--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -35,6 +35,7 @@ import array
 import csv
 import os
 import time
+import math
 
 ################################################################################
 # Analyze Problem Type
@@ -454,6 +455,7 @@ class LogicAnalyzer:
 
     # iterate over rows
     rowIdx = 0
+    columnOfFreqIdx = -1
     for row in csvFile:
       rowIdx+=1
       if rowIdx == 1:
@@ -466,7 +468,13 @@ class LogicAnalyzer:
         else:
           printWarning("Performance unit %s in %s is unrecognized: assuming GFlops (device efficiency)" % (perfUnit, dataFileName))
           self.perfMetric = "DeviceEfficiency"
-
+        
+        # get the index of "WinnerFreq"
+        try:
+          columnOfFreqIdx = row.index(" WinnerFreq")
+        except ValueError as e:
+          print(f"Error: {e}")
+            
         # get the length of each row, and derive the first column of the solution instead of using wrong "solutionStartIdx = totalSizeIdx + 1"
         rowLength = len(row)
         solutionStartIdx = rowLength - numSolutions
@@ -482,7 +490,6 @@ class LogicAnalyzer:
         for i in range(problemSizeStartIdx, totalSizeIdx):
           problemSize.append(int(row[i]))
         problemSize = tuple(problemSize)
-
         # Exact Problem Size
         if problemSize in self.exactProblemSizes:
 
@@ -503,15 +510,28 @@ class LogicAnalyzer:
                 winnerGFlops = gflops
               solutionIdx += 1
 
+          # calculate effLike
+          # effLike = winnerGFlops / Frequency(MHz)
+          try:
+            frequency = float(row[columnOfFreqIdx])
+            if frequency != 0 and not math.isnan(frequency):
+              effLike = round(float(winnerGFlops) / frequency, 2)
+            else:
+              effLike = float(winnerGFlops)
+              print1("Warning: Frequency is Nan or 0, using GFlops as the efficiency metric")
+          except(ValueError, TypeError):
+            effLike = float(winnerGFlops)
+            print1("Warning: Could not convert frequency value to float, using GFlops as the efficiency metric")
+        
           if winnerIdx != -1:
             if problemSize in self.exactWinners:
               if winnerGFlops > self.exactWinners[problemSize][1]:
                 #print "update exact", problemSize, "CSV index=", winnerIdx, self.exactWinners[problemSize], "->", solutionMap[winnerIdx], winnerGFlops
-                self.exactWinners[problemSize] = [solutionMap[winnerIdx], winnerGFlops]
+                self.exactWinners[problemSize] = [solutionMap[winnerIdx], effLike]
             else:
-              self.exactWinners[problemSize] = [solutionMap[winnerIdx], winnerGFlops]
+              self.exactWinners[problemSize] = [solutionMap[winnerIdx], effLike]
               #print "new exact", problemSize, "CSV index=", winnerIdx, self.exactWinners[problemSize]
-
+            
         # Range Problem Size
         elif problemSize in self.rangeProblemSizes:
           problemIndices = []

--- a/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
+++ b/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
@@ -75,13 +75,21 @@ namespace Tensile
                                   rsmi_temperature_metric_t metric      = RSMI_TEMP_CURRENT);
             double getAverageClock(rsmi_clk_type_t clockType);
             double getAverageFanSpeed(uint32_t sensorIndex = 0);
-            int    getDeviceIndex()
+            double getAverageGfxFreqPowerTemperature(std::vector<uint16_t>& dataValues);
+            double getMedianGfxFreqPowerTemperature(std::vector<uint16_t>& dataValues);
+
+            int getDeviceIndex()
             {
                 return m_hipDeviceIndex;
             }
             size_t getSamples()
             {
                 return m_dataPoints;
+            }
+
+            std::vector<uint16_t>& getAllGfxFreqValues()
+            {
+                return m_freqValues;
             }
 
             /// Begins monitoring until stop() is called.
@@ -147,6 +155,9 @@ namespace Tensile
 
             std::vector<uint32_t> m_fanMetrics;
             std::vector<int64_t>  m_fanValues;
+
+            std::vector<uint16_t> m_freqValues;
+            bool                  m_hasInvalidGpuMetricStatus = false;
 
             // Reserved for further performance check.
             std::vector<uint64_t>              m_SYSCLK_sum;

--- a/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
@@ -128,6 +128,7 @@ namespace Tensile
             const std::string DeviceIndex         = "device-idx";
             const std::string FanSpeedRPMs        = "fan-rpm";
             const std::string HardwareSampleCount = "hardware-samples";
+            const std::string GfxFrequency        = "gfx-frequency(median)"; // GPU clock in Mhz
         }; // namespace ResultKey
 
         class ResultReporter : public RunListener

--- a/tensilelite/Tensile/Source/client/source/HardwareMonitorListener.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitorListener.cpp
@@ -101,6 +101,14 @@ namespace Tensile
 
             m_reporter->report(ResultKey::FanSpeedRPMs, m_monitor->getAverageFanSpeed());
             m_reporter->report(ResultKey::HardwareSampleCount, m_monitor->getSamples());
+
+            // Report the median frequency during kernel execution.
+            // 20+ GEMM kernel problem runs (DGEMM, HPA-HGEMM) and frequency data points reveals to consider
+            // the median frequency for efficiency calculation over average, especially for auto clock runs.
+            // if we need to consider the average frequency then need to erase first few data points.
+            m_reporter->report(
+                ResultKey::GfxFrequency,
+                m_monitor->getMedianGfxFreqPowerTemperature(m_monitor->getAllGfxFreqValues()));
         }
     } // namespace Client
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/tensilelite/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -159,6 +159,7 @@ namespace Tensile
                 m_output.setHeaderForKey(ResultKey::LDA, "LDA");
                 m_output.setHeaderForKey(ResultKey::LDB, "LDB");
                 m_output.setHeaderForKey(ResultKey::TotalFlops, "TotalFlops");
+                m_output.setHeaderForKey(ResultKey::GfxFrequency, "WinnerFreq");
                 if(m_extraCol)
                 {
                     m_output.setHeaderForKey(ResultKey::TilesPerCu, "TilesPerCu");


### PR DESCRIPTION
* Main modifications:
 1. Replacement of winnerGflops with effLike
 2. Addition of Frequency Monitor in TensileLite

* Notice: If Frequency is Nan or 0, original WinnerGflops will be used as the performance metric. The console will output warning to notify users WinnerGflops is in used instead of efficiency. 


![image](https://github.com/user-attachments/assets/db3d615d-7896-46f4-9dc7-1e5c076dfd49)

Please refer to the comments in [link](https://ontrack-internal.amd.com/browse/SWDEV-474557) for further details.