### PR TITLE
Used lazy initialization for the static variable to workaround the double-free symptom.

### DIFF
--- a/tensilelite/Tensile/Source/lib/include/Tensile/ArithmeticUnitTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ArithmeticUnitTypes.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -84,8 +84,8 @@ namespace Tensile
 
         static void addInfoObject(ArithmeticUnitTypeInfo const& info);
 
-        static std::map<ArithmeticUnit, ArithmeticUnitTypeInfo> data;
-        static std::map<std::string, ArithmeticUnit>            typeNames;
+        static std::map<ArithmeticUnit, ArithmeticUnitTypeInfo>* getData();
+        static std::map<std::string, ArithmeticUnit>*            getTypeNames();
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -116,8 +116,8 @@ namespace Tensile
 
         static void addInfoObject(DataTypeInfo const& info);
 
-        static std::map<DataType, DataTypeInfo> data;
-        static std::map<std::string, DataType>  typeNames;
+        static std::map<DataType, DataTypeInfo>* getData();
+        static std::map<std::string, DataType>*  getTypeNames();
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/include/Tensile/KernelLanguageTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/KernelLanguageTypes.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -85,8 +85,8 @@ namespace Tensile
 
         static void addInfoObject(KernelLanguageTypeInfo const& info);
 
-        static std::map<KernelLanguage, KernelLanguageTypeInfo> data;
-        static std::map<std::string, KernelLanguage>            typeNames;
+        static std::map<KernelLanguage, KernelLanguageTypeInfo>* getData();
+        static std::map<std::string, KernelLanguage>*            getTypeNames();
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/PerformanceMetricTypes.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,8 +86,8 @@ namespace Tensile
 
         static void addInfoObject(PerformanceMetricTypeInfo const& info);
 
-        static std::map<PerformanceMetric, PerformanceMetricTypeInfo> data;
-        static std::map<std::string, PerformanceMetric>               typeNames;
+        static std::map<PerformanceMetric, PerformanceMetricTypeInfo>* getData();
+        static std::map<std::string, PerformanceMetric>*               getTypeNames();
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ScalarValueTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ScalarValueTypes.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -86,8 +86,8 @@ namespace Tensile
 
         static void addInfoObject(ScalarValueTypeInfo const& info);
 
-        static std::map<ScalarValue, ScalarValueTypeInfo> data;
-        static std::map<std::string, ScalarValue>         typeNames;
+        static std::map<ScalarValue, ScalarValueTypeInfo>* getData();
+        static std::map<std::string, ScalarValue>*         getTypeNames();
     };
 
     /**


### PR DESCRIPTION
[SWDEV-482261](https://ontrack-internal.amd.com/browse/SWDEV-482261)