### PR TITLE
Reduce sgpr usage in globalWriteBatch

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8971,6 +8971,9 @@ class KernelWriterAssembly(KernelWriter):
             module.add(self.setSgprToInUseState("AddressScaleB"))
             if (kernel["ProblemType"]["UseScaleAB"] == "Vector"):
               module.add(self.setSgprToInUseState("SrdScaleB"))
+        if kernel["ProblemType"]["UseScaleAlphaVec"]:
+          module.add(self.setSgprToInUseState("AddressScaleAlphaVec"))
+          module.add(self.setSgprToInUseState("SrdScaleAlphaVec"))
 
       # Issue read scale A/B value for later use
       if kernel["ProblemType"]["UseScaleAB"] == "Scalar" and ((kernel["GlobalSplitU"] == 1) or kernel["_GlobalAccumulation"] == 'MultipleBufferSingleKernel') and \
@@ -9199,6 +9202,9 @@ class KernelWriterAssembly(KernelWriter):
             module.add(self.setSgprToFreeState("AddressScaleB"))
             if (kernel["ProblemType"]["UseScaleAB"] == "Vector"):
               module.add(self.setSgprToFreeState("SrdScaleB"))
+        if kernel["ProblemType"]["UseScaleAlphaVec"]:
+          module.add(self.setSgprToFreeState("AddressScaleAlphaVec"))
+          module.add(self.setSgprToFreeState("SrdScaleAlphaVec"))
       else:
         if kernel["ProblemType"]["UseScaleAB"]:
           if not self.states.preloadScaleA:
@@ -9209,6 +9215,9 @@ class KernelWriterAssembly(KernelWriter):
             module.add(self.undefineSgpr("AddressScaleB"))
             if (kernel["ProblemType"]["UseScaleAB"] == "Vector"):
               module.add(self.undefineSgpr("SrdScaleB"))
+        if kernel["ProblemType"]["UseScaleAlphaVec"]:
+          module.add(self.undefineSgpr("AddressScaleAlphaVec"))
+          module.add(self.undefineSgpr("SrdScaleAlphaVec"))
 
       if kernel["ProblemType"]["UseScaleAB"] == "Scalar" and ((kernel["GlobalSplitU"] == 1) or kernel["_GlobalAccumulation"] == 'MultipleBufferSingleKernel') and \
         ((kernel["ProblemType"]["DataTypeA"].numRegisters() <= kernel["ProblemType"]["DataType"].numRegisters()) or \


### PR DESCRIPTION
```
[----------] Global test environment tear-down
[==========] 48206 tests from 13 test suites ran. (4894328 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1000

command line: ./clients/staging/hipblaslt-test 
```

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-- generated xml file: /data0/yangwen/hipBLASLt/tensilelite/python_tests.xml ---
[33m========== [32m70 passed[0m, [33m[1m26 skipped[0m, [33m[1m36 warnings[0m[33m in 10625.47s (2:57:05)[0m[33m ===========[0m
py3: exit 0 (10625.65 seconds) /data0/yangwen/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tox-tflite/py3/tmp --junit-xml=/data0/yangwen/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tox-tflite/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=1816591
  py3: OK (10759.99=setup[8.99]+cmd[0.38,124.97,10625.65] seconds)
  congratulations :) (10760.03 seconds)
```