### PR TITLE
Fix dim == 3 not working properly when bias is off

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3429,6 +3429,13 @@ class Solution(collections.abc.Mapping):
     state["LdsOffsetBias"] = 0  # TODO: ldsBiasOffset = ldsNumBytesAB
     state["LdsOffsetBiasNonGSU"] = 0
     state["LdsOffsetBiasGSU"] = 0
+
+    # TODO: Should change name to LdsOffsetEpilogue or something.
+    if state["StoreRemapVectorWidth"]:
+      state["LdsOffsetBiasNonGSU"] = ldsNumBytesRemapCNonGSU
+      state["LdsOffsetBiasGSU"] = ldsNumBytesRemapCGSU
+      state["LdsOffsetBias"] = ldsNumBytesRemapC
+
     epilogueSize = 0
     # Bias
     if state["ProblemType"]["UseBias"]:
@@ -3448,10 +3455,6 @@ class Solution(collections.abc.Mapping):
           for dataType in state["ProblemType"]["BiasDataTypeList"]:
             epilogueSize = max(epilogueSize, state["MacroTile%d"%tile01] * maxKId * dataType.numBytes())
       else:
-        if state["StoreRemapVectorWidth"]:
-          state["LdsOffsetBiasNonGSU"] = ldsNumBytesRemapCNonGSU
-          state["LdsOffsetBiasGSU"] = ldsNumBytesRemapCGSU
-          state["LdsOffsetBias"] = ldsNumBytesRemapC
         epilogueSize = state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes()
     # Calculate max ldsNumBytes for other epilogues
     if state["ProblemType"]["UseScaleAlphaVec"]:

--- a/tensilelite/Tensile/Tests/common/sparse/spmm_fp16.yaml
+++ b/tensilelite/Tensile/Tests/common/sparse/spmm_fp16.yaml
@@ -171,6 +171,84 @@ BenchmarkProblems:
         - ActivationArgs:
           - [Enum: none]
 
+  #########################################
+  ## TN - standard (No Bias)
+  #########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: H
+      DestDataType: H
+      ComputeDataType: s
+      HighPrecisionAccumulate:  True
+      TransposeA: True
+      TransposeB: False
+      UseBeta: True
+      Sparse: 1
+      Batched: True
+      Activation: True
+      UseBias: 0
+      UseScaleAlphaVec: 3
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        #- EdgeType: ["ShiftPtr"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [32, 32, 16, 1,  1,  1, 1,  1, 1 ]
+          - [32, 32, 16, 1,  1,  2, 2,  2, 2 ]
+          - [32, 32, 16, 1,  1,  2, 4,  4, 2 ]
+          - [32, 32, 16, 1,  1,  7, 2,  1, 4 ]
+          - [32, 32, 16, 1,  1,  4, 4,  2, 2 ]
+          - [32, 32, 16, 1,  1,  4, 2,  2, 4 ]
+        - GlobalReadVectorWidthA: [4,8]
+        - VectorWidthA: [1,2,4]
+        - VectorWidthB: [1,2,4]
+        - DepthU: [32,64]
+        - TransposeLDS: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - LdsPadMetadata: [-1]
+        - StaggerU: [0,4]
+        - ScheduleIterAlg: [3]
+        - PrefetchLocalRead: [1,2,3]
+        - ClusterLocalRead: [1]
+        - PrefetchGlobalRead: [2]
+        - StoreRemapVectorWidth: [-1]
+        - GlobalSplitU: [1,2]
+        - GlobalSplitUAlgorithm: [MultipleBuffer]
+        - 1LDSBuffer: [-1]
+        - DirectToVgprSparseMetadata: [0,1]
+        - WorkGroupMapping: [18]
+        - StoreVectorWidth: [-1]
+        - AssertFree0ElementMultiple: [1,8]
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [16, 16, 1, 16] # classic format
+          - Exact: [16, 16, 1, 32] # classic format
+          - Exact: [16, 16, 1, 64] # classic format
+          - Exact: [16, 16, 1, 96] # classic format
+          - Exact: [16, 16, 1, 128] # classic format
+          - Exact: [256, 256, 1, 16] # classic format
+          - Exact: [256, 256, 1, 32] # classic format
+          - Exact: [256, 256, 1, 64] # classic format
+          - Exact: [256, 256, 1, 96] # classic format
+          - Exact: [256, 256, 1, 128] # classic format
+          - Exact: [384, 384, 1, 16] # classic format
+          - Exact: [384, 384, 1, 32] # classic format
+          - Exact: [384, 384, 1, 64] # classic format
+          - Exact: [384, 384, 1, 96] # classic format
+          - Exact: [384, 384, 1, 128] # classic format
+        - BiasTypeArgs: ['s', 'h']
+        - FactorDimArgs: [0, 1]
+        - ActivationArgs:
+          - [Enum: none]
+
   #######################################
   # NT - standard
   #######################################


### PR DESCRIPTION
```
[----------] Global test environment tear-down
[==========] 48206 tests from 13 test suites ran. (2678244 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1000

command line: ./clients/staging/hipblaslt-test 
```

```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-- generated xml file: /data0/yangwen/hipBLASLt/tensilelite/python_tests.xml ---
[33m=========== [32m70 passed[0m, [33m[1m26 skipped[0m, [33m[1m39 warnings[0m[33m in 8209.67s (2:16:49)[0m[33m ===========[0m
py3: exit 0 (8209.94 seconds) /data0/yangwen/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tox-tflite/py3/tmp --junit-xml=/data0/yangwen/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tox-tflite/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=1597844
  py3: OK (8346.73=setup[12.27]+cmd[0.39,124.13,8209.94] seconds)
  congratulations :) (8346.76 seconds)
```