### PR TITLE
Remove vgpr and use ds_offset instead in epilogue read

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -10399,12 +10399,12 @@ class KernelWriterAssembly(KernelWriter):
       elif kernel["ProblemType"]["ComputeDataType"].isInt32():
         maskConst = 1
 
+    turnOffset = 0
     for i in range(turn):
       if i != 0:
-        module.add(VAddU32(dst=vgpr(offsetVgpr), src0=offset, src1=vgpr(offsetVgpr), comment="add subgroup offset"))
-        subGroupOffset[0] = subGroupOffset[0] + offset
+        turnOffset += offset
       bps = kernel["ProblemType"]["ComputeDataType"].numBytes() * gwvw
-      ds  = DSModifiers(offset=0)
+      ds  = DSModifiers(offset=(subGroupOffset[0] + turnOffset))
       dst = vgpr(offsetVgpr)
       for vi in range(gwvw):
         # Does not support hi/lo yet
@@ -10589,38 +10589,19 @@ class KernelWriterAssembly(KernelWriter):
 
     # Get all local stores
     storeModules = Module("Store")
-    dstOffset = 0
+    subGroupOffset = [0]
     if biasDataType:
-      subGroupOffset = [0]
       storeModules.add(self.addVectorLocalStore(kernel, "Bias", offsetVgpr, biasShiftOffset, biasDataType, gwvw, tmpVgpr1Res, biasDstVgpr, subGroupOffset, dim, comment="store bias"))
-      dstOffset = kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.bias.turn - subGroupOffset[0]
+      subGroupOffset[0] += kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.bias.turn
     if scaleAlphaDataType:
-      if dstOffset > 0:
-        storeModules.add(VAddU32(dst=vgpr(offsetVgpr), \
-                                src0=(dstOffset), \
-                                src1=vgpr(offsetVgpr), \
-                                comment="add lds offset"))
-      subGroupOffset = [0]
       storeModules.add(self.addVectorLocalStore(kernel, "ScaleAlphaVec", offsetVgpr, scaleAlphaShiftOffset, scaleAlphaDataType, gwvw, tmpVgpr1Res, scaleAlphaDstVgpr, subGroupOffset, dim, setToOne=True, comment="store scaleAlpha"))
-      dstOffset = kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleAlpha.turn - subGroupOffset[0]
+      subGroupOffset[0] += kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleAlpha.turn
     if scaleADataType:
-      if dstOffset > 0:
-        storeModules.add(VAddU32(dst=vgpr(offsetVgpr), \
-                                src0=(dstOffset), \
-                                src1=vgpr(offsetVgpr), \
-                                comment="add lds offset"))
-      subGroupOffset = [0]
       storeModules.add(self.addVectorLocalStore(kernel, "ScaleA", offsetVgpr, scaleAShiftOffset, scaleADataType, gwvw, tmpVgpr1Res, scaleADstVgpr, subGroupOffset, 0, setToOne=True, comment="store scaleA"))
-      dstOffset = kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleA.turn - subGroupOffset[0]
+      subGroupOffset[0] += kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleA.turn
     if scaleBDataType:
-      if dstOffset > 0:
-        storeModules.add(VAddU32(dst=vgpr(offsetVgpr), \
-                                src0=(dstOffset), \
-                                src1=vgpr(offsetVgpr), \
-                                comment="add lds offset"))
-      subGroupOffset = [0]
       storeModules.add(self.addVectorLocalStore(kernel, "ScaleB", offsetVgpr, scaleBShiftOffset, scaleBDataType, gwvw, tmpVgpr1Res, scaleBDstVgpr, subGroupOffset, 1, setToOne=True, comment="store scaleB"))
-      dstOffset = kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleB.turn - subGroupOffset[0]
+      subGroupOffset[0] += kernel["NumThreads"] * kernel["ProblemType"]["ComputeDataType"].numBytes() * vectorDataTypes.scaleB.turn
     # We move s_barrier before local load. Add barrier here to avoid race condition if lds offset starts from 0
     if kernel["LdsOffsetBias"] == 0:
       module.add(SBarrier(comment="wait for all global loads."))


### PR DESCRIPTION
```
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-- generated xml file: /data0/yangwen/hipBLASLt/tensilelite/python_tests.xml ---
[33m=========== [32m70 passed[0m, [33m[1m26 skipped[0m, [33m[1m38 warnings[0m[33m in 8380.40s (2:19:40)[0m[33m ===========[0m
py3: exit 0 (8380.71 seconds) /data0/yangwen/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tflite/py3/tmp --junit-xml=/data0/yangwen/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tflite/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=1203387
  py3: OK (8522.56=setup[10.94]+cmd[0.38,130.54,8380.71] seconds)
  congratulations :) (8522.63 seconds)
  ```
  
  ```
[----------] Global test environment tear-down
[==========] 48206 tests from 13 test suites ran. (1979089 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1000

command line: ./clients/staging/hipblaslt-test 
  ```