### PR TITLE
Reduce peak memory usage of TensileCreateLibrary

### DIFF
--- a/tensilelite/Tensile/CustomYamlLoader.py
+++ b/tensilelite/Tensile/CustomYamlLoader.py
@@ -50,15 +50,17 @@ def is_float(value):
 
 def parse_scalar(loader: yaml.Loader):
     assert loader.check_event(yaml.ScalarEvent)
-    value: str = loader.get_event().value
+    evt = loader.get_event()
+    value: str = evt.value
     value_lower: str = value.lower()
 
     if value_lower in ('true', 'yes',):
         return True
     elif value_lower in ('false', 'no',):
         return False
-    elif value_lower in ('null',):
-        return None
+    elif value_lower in ('null', '', '~'):
+        if not evt.style:
+            return None
     elif value_lower.lstrip('+-').isnumeric():
         return int(value_lower)
     elif is_float(value_lower):

--- a/tensilelite/Tensile/CustomYamlLoader.py
+++ b/tensilelite/Tensile/CustomYamlLoader.py
@@ -1,6 +1,11 @@
 import yaml
 from pathlib import Path
 
+try:
+    DEFAULT_YAML_LOADER = yaml.CSafeLoader
+finally:
+    DEFAULT_YAML_LOADER = yaml.SafeLoader
+
 def parse_general(loader: yaml.Loader):
     if loader.check_event(yaml.MappingStartEvent):
         return parse_mapping(loader)
@@ -129,7 +134,7 @@ def load_yaml_dict_item(yaml_path: Path, loader_type: yaml.Loader, key: str):
 
         return v
 
-def load_logic_gfx_arch(yaml_path: Path, loader_type: yaml.Loader = yaml.CSafeLoader):
+def load_logic_gfx_arch(yaml_path: Path, loader_type: yaml.Loader = DEFAULT_YAML_LOADER):
     try:
         GFX_ARCH_IDX = 2
         arch = load_yaml_sequence_item(yaml_path, loader_type, GFX_ARCH_IDX)

--- a/tensilelite/Tensile/CustomYamlLoader.py
+++ b/tensilelite/Tensile/CustomYamlLoader.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 try:
     DEFAULT_YAML_LOADER = yaml.CSafeLoader
-finally:
+except:
+    print('CSafeLoader is not installed.')
     DEFAULT_YAML_LOADER = yaml.SafeLoader
 
 def parse_general(loader: yaml.Loader):

--- a/tensilelite/Tensile/CustomYamlLoader.py
+++ b/tensilelite/Tensile/CustomYamlLoader.py
@@ -1,0 +1,86 @@
+import yaml
+from pathlib import Path
+
+def parse_general(loader: yaml.Loader):
+    if loader.check_event(yaml.MappingStartEvent):
+        return parse_mapping(loader)
+    elif loader.check_event(yaml.SequenceStartEvent):
+        return parse_sequence(loader)
+    elif loader.check_event(yaml.ScalarEvent):
+        return parse_scalar(loader)
+
+def parse_sequence(loader: yaml.Loader):
+    ret = []
+    #pop sequence start event
+    loader.get_event()
+    while not loader.check_event(yaml.SequenceEndEvent):
+        ret.append(parse_general(loader))
+    #pop sequence end event
+    loader.get_event()
+    return ret
+
+def parse_mapping(loader: yaml.Loader):
+    ret = {}
+    k, v = None, None
+    #pop mapping start event
+    loader.get_event()
+    while not loader.check_event(yaml.MappingEndEvent):
+        if k is None:
+            k = parse_scalar(loader)
+        elif v is None:
+            v = parse_general(loader)
+            ret[k] = v
+            k, v = None, None
+
+    #pop mapping end event
+    loader.get_event()
+    return ret
+
+def is_float(value):
+    try:
+        float(value)
+        return True
+    except ValueError:
+        return False
+
+def parse_scalar(loader: yaml.Loader):
+    assert loader.check_event(yaml.ScalarEvent)
+    value: str = loader.get_event().value
+    value_lower: str = value.lower()
+
+    if value_lower in ('true', 'yes',):
+        return True
+    elif value_lower in ('false', 'no',):
+        return False
+    elif value_lower in ('null',):
+        return None
+    elif value_lower.lstrip('+-').isnumeric():
+        return int(value_lower)
+    elif is_float(value_lower):
+        return float(value_lower)
+
+    return value
+
+def load_yaml_stream(yaml_path: Path, loader_type):
+    with open(yaml_path, 'r') as f:
+        loader = loader_type(f)
+        assert loader.check_event(yaml.StreamStartEvent)
+        loader.get_event()
+        assert loader.check_event(yaml.DocumentStartEvent)
+        loader.get_event()
+
+        # assume the root element is a sequence
+        assert loader.check_event(yaml.SequenceStartEvent)
+        loader.get_event()
+        logic = []
+
+        # now while the next event does not end the sequence, process each item
+        while not loader.check_event(yaml.SequenceEndEvent):
+            logic.append(parse_general(loader))
+
+        # assume document ends and no further documents are in stream
+        loader.get_event()
+        assert loader.check_event(yaml.DocumentEndEvent)
+        loader.get_event()
+        assert loader.check_event(yaml.StreamEndEvent)
+        return logic

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -2554,8 +2554,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     version = tuple(kernel["ISA"])
     if self.ti == None:
       self.ti = TensileInstructions()
-    if not self.ti.isInit():
-      self.ti.init(version, globalParameters["AssemblerPath"])
+    self.ti.init(version, globalParameters["AssemblerPath"])
     self.ti.setKernelInfo(version, kernel["WavefrontSize"])
 
     self.consts = ConstValues()

--- a/tensilelite/Tensile/KernelWriterActivationFunction.py
+++ b/tensilelite/Tensile/KernelWriterActivationFunction.py
@@ -132,6 +132,8 @@ class KernelWriterActivationFunction(KernelWriterBase):
       return fileString
 
     activationCDataType = self.state["ProblemType"]["ActivationComputeDataType"]
+    if not self._tf.isInit():
+      self._tf.init(tuple(self.state["Kernel"]["ISA"]), globalParameters["AssemblerPath"])
     self._tf.setKernelInfo(tuple(self.state["Kernel"]["ISA"]), self.state["Kernel"]["WavefrontSize"])
     activation = ActivationInline(activationCDataType, not self.state["ProblemType"]["ActivationNoGuard"])
 

--- a/tensilelite/Tensile/KernelWriterActivationFunction.py
+++ b/tensilelite/Tensile/KernelWriterActivationFunction.py
@@ -140,8 +140,7 @@ class KernelWriterActivationFunction(KernelWriterBase):
 
     activationCDataType = self.state["ProblemType"]["ActivationComputeDataType"]
     isa = tuple(self.state["Kernel"]["ISA"])
-    if not self._tf.isInit():
-      self._tf.init(isa, globalParameters["AssemblerPath"])
+    self._tf.init(isa, globalParameters["AssemblerPath"])
     self._tf.setKernelInfo(isa, self.state["Kernel"]["WavefrontSize"])
     activation = ActivationInline(activationCDataType, not self.state["ProblemType"]["ActivationNoGuard"])
 

--- a/tensilelite/Tensile/KernelWriterActivationFunction.py
+++ b/tensilelite/Tensile/KernelWriterActivationFunction.py
@@ -91,8 +91,15 @@ class KernelWriterActivationFunction(KernelWriterBase):
 
   def getInlineAsm(self, activation: ActivationInline, spaces: int, activationType: str):
     activationStrList = []
+
+    isa = tuple(self.state["Kernel"]["ISA"])
+    if not self._tf.isInit():
+      self._tf.init(isa, globalParameters["AssemblerPath"])
+    self._tf.setKernelInfo(isa, self.state["Kernel"]["WavefrontSize"])
+
     for arch in self.supportedArchs:
-      self._tf.setKernelInfo(tuple(arch), self.state["Kernel"]["WavefrontSize"])
+      self._tf.init(arch, globalParameters["AssemblerPath"])
+      self._tf.setKernelInfo(arch, self.state["Kernel"]["WavefrontSize"])
       activationStrList.append(activation.generateInlineAssemblyBody(spaces, activationType))
 
     activationStrSetList = list(set(activationStrList))
@@ -132,9 +139,10 @@ class KernelWriterActivationFunction(KernelWriterBase):
       return fileString
 
     activationCDataType = self.state["ProblemType"]["ActivationComputeDataType"]
+    isa = tuple(self.state["Kernel"]["ISA"])
     if not self._tf.isInit():
-      self._tf.init(tuple(self.state["Kernel"]["ISA"]), globalParameters["AssemblerPath"])
-    self._tf.setKernelInfo(tuple(self.state["Kernel"]["ISA"]), self.state["Kernel"]["WavefrontSize"])
+      self._tf.init(isa, globalParameters["AssemblerPath"])
+    self._tf.setKernelInfo(isa, self.state["Kernel"]["WavefrontSize"])
     activation = ActivationInline(activationCDataType, not self.state["ProblemType"]["ActivationNoGuard"])
 
     fileString = "" # CHeader

--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -28,6 +28,7 @@ from .SolutionStructs import Solution, ProblemSizes, ProblemType
 from . import __version__
 from . import Common
 from . import SolutionLibrary
+from .CustomYamlLoader import load_yaml_stream
 
 from typing import NamedTuple, List
 import os
@@ -175,6 +176,7 @@ def read(filename):
     name, extension = os.path.splitext(filename)
     if extension == ".yaml":
         return readYAML(filename)
+        # return load_yaml_stream(filename, yamlLoader)
     if extension == ".json":
         return readJson(filename)
     else:

--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -172,10 +172,10 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
 ###############################
 # Reading and parsing functions
 ###############################
-def read(filename):
+def read(filename, customizedLoader=False):
     name, extension = os.path.splitext(filename)
     if extension == ".yaml":
-        return load_yaml_stream(filename, yamlLoader)
+        return load_yaml_stream(filename, yamlLoader) if customizedLoader else readYAML(filename)
     if extension == ".json":
         return readJson(filename)
     else:
@@ -245,7 +245,7 @@ class LibraryLogic(NamedTuple):
 
 def parseLibraryLogicFile(filename, archs=None):
     """Wrapper function to read and parse a library logic file."""
-    return parseLibraryLogicData(read(filename), filename, archs)
+    return parseLibraryLogicData(read(filename, True), filename, archs)
 
 
 def parseLibraryLogicData(data, srcFile="?", archs=None):

--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -175,8 +175,7 @@ def writeSolutions(filename, problemSizes, biasTypeArgs, activationArgs, solutio
 def read(filename):
     name, extension = os.path.splitext(filename)
     if extension == ".yaml":
-        return readYAML(filename)
-        # return load_yaml_stream(filename, yamlLoader)
+        return load_yaml_stream(filename, yamlLoader)
     if extension == ".json":
         return readJson(filename)
     else:

--- a/tensilelite/Tensile/Parallel.py
+++ b/tensilelite/Tensile/Parallel.py
@@ -152,7 +152,7 @@ def ParallelMap(function, objects, message="", enable=True, method=None, maxTask
   pool.close()
   return rv
 
-def ParallelMap2(function, objects, message="", enable=True, multiArg=True):
+def ParallelMap2(function, objects, message="", enable=True, multiArg=True, return_as="list"):
   """
   Generally equivalent to list(map(function, objects)), possibly executing in parallel.
 
@@ -182,7 +182,7 @@ def ParallelMap2(function, objects, message="", enable=True, multiArg=True):
 
   pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
   pargs = zip(objects, itertools.repeat(globalParameters))
-  rv = Parallel(n_jobs=threadCount,timeout=99999)(delayed(pcall)(function, a, params) for a, params in pargs)
+  rv = Parallel(n_jobs=threadCount,timeout=99999, return_as=return_as)(delayed(pcall)(function, a, params) for a, params in pargs)
 
   totalTime = time.time() - currentTime
   print("{0}Done. ({1:.1f} secs elapsed)".format(message, totalTime))

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -3957,10 +3957,9 @@ class Solution(collections.abc.Mapping):
   @staticmethod
   def getSerialNaming(objs):
     data = {}
-    for objIdx in range(0, len(objs)):
-      obj = objs[objIdx]
+    for obj in objs:
       for paramName in sorted(obj.keys()):
-        if paramName in list(validParameters.keys()):
+        if paramName in validParameters.keys():
           paramValue = obj[paramName]
           if paramName in data:
             if paramValue not in data[paramName]:
@@ -3969,7 +3968,7 @@ class Solution(collections.abc.Mapping):
             data[paramName] = [ paramValue ]
     maxObjs = 1
     for paramName in data:
-      if not isinstance(data[paramName][0],dict):
+      if not isinstance(data[paramName][0], dict):
         data[paramName] = sorted(data[paramName])
       maxObjs *= len(data[paramName])
     numDigits = len(str(maxObjs))

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -40,6 +40,7 @@ from .Common import globalParameters, HR, print1, print2, printExit, ensurePath,
 from .KernelWriterAssembly import KernelWriterAssembly
 from .SolutionLibrary import MasterSolutionLibrary
 from .SolutionStructs import Solution
+from .CustomYamlLoader import load_logic_gfx_arch
 
 import argparse
 import collections
@@ -53,7 +54,6 @@ import subprocess
 import sys
 from timeit import default_timer as timer
 from pathlib import Path
-from copy import deepcopy
 from typing import Sequence
 
 def timing(func):
@@ -1389,12 +1389,14 @@ def TensileCreateLibrary():
   else:
     printExit("Unrecognized LogicFormat", args.LogicFormat)
 
+  def validLogicFile(p: Path):
+    return p.suffix == logicExtFormat and load_logic_gfx_arch(p) in arch
+
   logicFiles = []
-  for root, dirs, files in os.walk(logicPath):
-    logicFiles += [os.path.join(root, f) for f in files
-                       if os.path.splitext(f)[1]==logicExtFormat \
-                       and (any(logicArch in os.path.splitext(f)[0] for logicArch in logicArchs) \
-                       or "hip" in os.path.splitext(f)[0]) ]
+
+  for root, _, files in os.walk(logicPath):
+    logics = (os.path.join(root, f) for f in files)
+    logicFiles += [file for file in logics if validLogicFile(Path(file))]
 
   print1("# LibraryLogicFiles:" % logicFiles)
   for logicFile in logicFiles:

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1384,8 +1384,11 @@ def TensileCreateLibrary():
   else:
     printExit("Unrecognized LogicFormat", args.LogicFormat)
 
+  def archMatch(arch: str, archs: list[str]):
+    return (arch in archs) or any(a.startswith(arch) for a in archs)
+
   def validLogicFile(p: Path):
-    return p.suffix == logicExtFormat and ("all" in archs or load_logic_gfx_arch(p) in archs)
+    return p.suffix == logicExtFormat and ("all" in archs or archMatch(load_logic_gfx_arch(p), archs))
 
   logicFiles = []
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1041,26 +1041,6 @@ def writeCMake(outputPath, solutionFiles, kernelFiles, libraryStaticFiles, maste
 
   generatedFile.close()
 
-def toKernelObjects(solutions):
-  kernelNames = set()
-  for solution in solutions:
-    solutionKernels = solution.getKernels()
-    for kernel in solutionKernels:
-        kName = Solution.getKeyNoInternalArgs(kernel)
-        if kName not in kernelNames:
-            kernelNames.add(kName)
-            yield kernel
-
-def getKernelHelpObjects(solutions):
-  kernelNames = set()
-  for solution in solutions:
-    solutionHelperKernels = solution.getHelperKernelObjects()
-    for ko in solutionHelperKernels:
-      kName = ko.getKernelName()
-      if kName not in kernelNames:
-        kernelNames.add(kName)
-        yield ko
-
 ################################################################################
 # Generate Kernel Objects From Solutions
 ################################################################################

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1416,7 +1416,7 @@ def TensileCreateLibrary():
     printExit("Unrecognized LogicFormat", args.LogicFormat)
 
   def validLogicFile(p: Path):
-    return p.suffix == logicExtFormat and load_logic_gfx_arch(p) in arch
+    return p.suffix == logicExtFormat and ("all" in archs or load_logic_gfx_arch(p) in archs)
 
   logicFiles = []
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1437,7 +1437,7 @@ def TensileCreateLibrary():
 
   # kernels, kernelHelperObjs, _ = generateKernelObjectsFromSolutions(solutions)
   kernels = list(toKernelObjects(solutions))
-  kernelHelperObjs = getKernelHelpObjects(solutions)
+  kernelHelperObjs = list(getKernelHelpObjects(solutions))
 
   # if any kernels are assembly, append every ISA supported
   kernelWriterAssembly, kernelMinNaming, _ = getSolutionAndKernelWriters(solutions, kernels)

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1115,7 +1115,7 @@ def generateLogicDataAndSolutions(logicFiles, args):
       for _, lazyLib in lib.lazyLibraries.items():
         yield from libraryIter(lazyLib)
 
-  for library in Common.ParallelMap2(LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator"):
+  for library in Common.ParallelMap2(LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator_unordered"):
     _, architectureName, _, _, _, newLibrary, srcFile = library
 
     if architectureName == "":

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -349,7 +349,7 @@ def buildSourceCodeObjectFile(CxxCompiler, outputPath, kernelFile):
 
 def buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath):
     args    = zip(itertools.repeat(CxxCompiler), itertools.repeat(outputPath), kernelFiles)
-    coFiles = Common.ParallelMap(buildSourceCodeObjectFile, args, "Compiling source kernels", method=lambda x: x.starmap)
+    coFiles = Common.ParallelMap2(buildSourceCodeObjectFile, args, "Compiling source kernels")
 
     return itertools.chain.from_iterable(coFiles)
 

--- a/tensilelite/Tensile/TensileInstructions/Base.py
+++ b/tensilelite/Tensile/TensileInstructions/Base.py
@@ -77,7 +77,8 @@ class TensileInstructions:
 
     def setKernelInfo(self, isaVersion: Tuple[int, int, int], wavefrontSize: int) -> None:
         if isaVersion not in self._isaInfo: # type: ignore
-            printExit("Current isa %s not initialized. Initialized isas are %s"%(str(isaVersion), str(self._isaInfo.keys())))
+            import traceback
+            printExit(f"Current isa {str(isaVersion)} not initialized. Initialized isas are {str(self._isaInfo.keys())}, traceback: {traceback.format_stack()}")
         with self._lock:
             if len(self._kernelInfo) > 1000:
                 self._kernelInfo = _removeIdent(self._kernelInfo)

--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -210,11 +210,7 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--build-id=${Tensile_BUILD_ID}")
   endif()
 
-  if (WIN32)
-    set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
-  else()
-    set(CommandLine ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
-  endif()
+  set(CommandLine ${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME} ${Script} ${Options} ${Tensile_LOGIC_PATH} ${Tensile_OUTPUT_PATH} HIP)
   message(STATUS "Tensile_CREATE_COMMAND: ${CommandLine}")
 
   if(Tensile_EMBED_LIBRARY)

--- a/tensilelite/requirements.txt
+++ b/tensilelite/requirements.txt
@@ -1,7 +1,8 @@
 dataclasses; python_version == '3.6'
 pyyaml
 msgpack
-joblib>=1.4.0
+joblib>=1.4.0; python_version >= '3.8'
+joblib>=1.1.1; python_version < '3.8'
 simplejson
 ujson
 orjson

--- a/tensilelite/requirements.txt
+++ b/tensilelite/requirements.txt
@@ -1,7 +1,7 @@
 dataclasses; python_version == '3.6'
 pyyaml
 msgpack
-joblib
+joblib>=1.4.0
 simplejson
 ujson
 orjson


### PR DESCRIPTION
## Brief ##
This PR reduces the peak memory usage of `TensileCreateLibrary` via customized YAML loader and tweaks on logic loading flow.

## Implementation
 - [x] Customized YAML loader(with pyyaml's event mechanism) for improvement on speed and memory usage.
 - [x] Add faster path to get child of root element in YAML file.
 - [x] Use above to properly filter out mismatched archs durling logic listing.
 - [x] Allow `ParallelMap2` to return generator instead of list for overlapping logic reading and library merging.

## Comparison
### TensileCreateLibrary
Tested on building gfx942 with 64 workers:
#### Before
![mprof_gfx942_org](https://github.com/user-attachments/assets/b97b745b-b8a8-4bb8-86f8-77d2f4470abd)
Peak memory usage: 
```bash
mprofile_20240904190006.dat     108930.523 MiB
```
#### After
![mprof_gfx942_0907](https://github.com/user-attachments/assets/346e9646-aadc-4db8-8e2f-6159544a2f77)
```bash
mprofile_20240906183806.dat     70725.227 MiB
```
Peak memory usage reduces to ~65% with ~9% build time increase. 

### For Building with All Archs
Here's the memory footprint for building all archs with 32 workers:
![mprof_all_0907](https://github.com/user-attachments/assets/7fc00a5c-cfaa-448d-9092-63cea72c7c1a)
peak memory usage:
```bash
mprofile_20240907151401.dat     71030.605 MiB
```
### Customized YAML Loader
Here's the data for loading `aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_AH_SAV.yaml` logic in repo:
| |file size|peak memory|time(sec)
|-|----|------|--|
|Customized|14 MiB|111 MiB|5.06|
|pyyaml built-in|14 MiB|1039 MiB|9.65|

