### PR TITLE
Add option to build logics in sub-folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,7 @@ else()
     set( Tensile_COMPILER "amdclang++" CACHE STRING "Tensile compiler")
     set( Tensile_LIBRARY_FORMAT "msgpack" CACHE STRING "Tensile library format")
     set( Tensile_CPU_THREADS "" CACHE STRING "Number of threads for Tensile parallel build")
+    set( Tensile_BUILD_SUB_FOLDER "" CACHE STRING "Build only the logic files in the sub-folder" )
 
     option( Tensile_MERGE_FILES "Tensile to merge kernels and solutions files?" ON )
     option( Tensile_SHORT_FILENAMES "Tensile to use short file names? Use if compiler complains they're too long." OFF )

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ function display_help()
   echo "    [--codecoverage] build with code coverage profiling enabled"
   echo "    [--gprof] enable profiling functionality with GNU gprof"
   echo "    [--keep-build-tmp] do not remove the temporary build artifacts or build_tmp"
+  echo "    [--logic-sub-folder] specify a sub-path to build logics under the sub-path (default is empty which does nothing)"
 }
 
 # This function is helpful for dockerfiles that do not have sudo installed, but the default user is root
@@ -392,7 +393,7 @@ tensile_msgpack_backend=true
 update_cmake=true
 enable_gprof=false
 keep_build_tmp=false
-
+logic_sub_folder=
 
 rocm_path=/opt/rocm
 if ! [ -z ${ROCM_PATH+x} ]; then
@@ -406,7 +407,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,logic-sub-folder: --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -517,6 +518,9 @@ while true; do
         --legacy_hipblas_direct)
             legacy_hipblas_direct=true
             shift ;;
+        --logic-sub-folder)
+            logic_sub_folder=${2}
+            shift 2 ;;
         --) shift ; break ;;
         *)  echo "Unexpected command line parameter received: '${1}'; aborting";
             exit 1
@@ -726,6 +730,10 @@ pushd .
 
   if [[ -n "${tensile_version}" ]]; then
     cmake_common_options="${cmake_common_options} -DTENSILE_VERSION=${tensile_version}"
+  fi
+
+  if [[ -n "${logic_sub_folder}" ]]; then
+    cmake_common_options="${cmake_common_options} -DTensile_BUILD_SUB_FOLDER=${logic_sub_folder}"
   fi
 
   tensile_opt=""

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1307,6 +1307,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--keep-build-tmp", dest="KeepBuildTmp", action="store_true",
                           default=False, help="Do not remove the temporary build directory (may required hundreds of GBs of space)"),
   argParser.add_argument("--validate-library", dest="ValidateLibrary", action="store_true", default=False)
+  argParser.add_argument("--logic-sub-folder", dest="LogicSubFolder", type=str, action="store", default="")
 
   args = argParser.parse_args()
 
@@ -1352,6 +1353,7 @@ def TensileCreateLibrary():
   arguments["BuildIdKind"] = args.BuildIdKind
   arguments["KeepBuildTmp"] = args.KeepBuildTmp
   arguments["ValidateLibrary"] = args.ValidateLibrary
+  arguments["LogicSubFolder"] = args.LogicSubFolder
 
   for key, value in args.global_parameters:
     arguments[key] = value
@@ -1389,12 +1391,18 @@ def TensileCreateLibrary():
   else:
     printExit("Unrecognized LogicFormat", args.LogicFormat)
 
+  logicSubFolder = None
+  if arguments["LogicSubFolder"] is not "":
+    logicSubFolder = arguments["LogicSubFolder"]
+    print1("Build logic files only in sub-folder: %s" % logicSubFolder)
+
   logicFiles = []
   for root, dirs, files in os.walk(logicPath):
     logicFiles += [os.path.join(root, f) for f in files
                        if os.path.splitext(f)[1]==logicExtFormat \
                        and (any(logicArch in os.path.splitext(f)[0] for logicArch in logicArchs) \
-                       or "hip" in os.path.splitext(f)[0]) ]
+                       or "hip" in os.path.splitext(f)[0]) \
+                       and ((logicSubFolder is None) or (logicSubFolder in os.path.join(root, f)))]
 
   print1("# LibraryLogicFiles:" % logicFiles)
   for logicFile in logicFiles:

--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -173,6 +173,10 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--embed-library-key=${Tensile_EMBED_KEY}")
   endif()
 
+  if(Tensile_BUILD_SUB_FOLDER)
+    set(Options ${Options} "--logic-sub-folder=${Tensile_BUILD_SUB_FOLDER}")
+  endif()
+
   if(Tensile_CODE_OBJECT_VERSION)
     set(Options ${Options} "--code-object-version=${Tensile_CODE_OBJECT_VERSION}")
   endif()


### PR DESCRIPTION
## Descriptions:
In order to shorten our build time when working in our local side, we always add **-a** to build for specific arch. 
But we can do a further filter to pick a sub-path from arch and build only from the sub-path. 

This PR adds an new option `--local-sub-folder` as a handy option so that we don't need to manually remove those unwanted folder. ( Such as now we still need to remove gfx940, gfx941...even we already put -a gfx942. )

## A few examples:
- **`./install.sh -c -a gfx942 --logic-sub-folder gfx941`**
  * -a gfx942 will build from aquavanjaram folder, and `--logic-sub-folder gfx941` filters logics only if the path contains "gfx941"

- **`./install.sh -c -a gfx942 --logic-sub-folder gfx942`**
  * -a gfx942 will build from aquavanjaram folder, and `--logic-sub-folder gfx942` filters logics only if the path contains "gfx942"
  * This will still build gfx942_cuXX
  
- **`./install.sh -c -a gfx942 --logic-sub-folder gfx942/`**
  * -a gfx942 will build from aquavanjaram folder, and `--logic-sub-folder gfx942/` filters logics only if the path contains "gfx942/"
  * This can filter the folder gfx942_cuXX, only gfx942/ itself will be built
  
- **`./install.sh -c -a gfx942 --logic-sub-folder gfx942/Equality`**
  * -a gfx942 will build from aquavanjaram folder, and `--logic-sub-folder gfx942/Equality` filters logics only if the path contains "gfx942/Equality"
  * You don't even manually remove FreeSize, GridBased folder. Which might be a good way for us when developing.