### PR TITLE
Using ref link to replace absoulte link

### DIFF
--- a/docs/ext-ops.rst
+++ b/docs/ext-ops.rst
@@ -12,22 +12,22 @@ These extensions support:
 
 1. ``hipblasltExtSoftmax``
     Softmax for 2D-tensor. Currently, it performs softmax on the second dimension of input tensor and assumes the input to be contigious on the second dimension.
-    For sample code, refer to `client_extop_softmax.cpp <https://github.com/ROCm/hipBLASLt/blob/develop/clients/benchmarks/client_extop_softmax.cpp>`_.
+    For sample code, refer to :ref:`client_extop_softmax`.
 
 2. ``hipblasltExtLayerNorm``
     Converts a 2D tensor using LayerNorm to generate a new 2D normalized tensor.
     it is an independent function used to just call and get result.
-    For sample code, refer to `sample_hipblaslt_ext_op_layernorm.cpp <https://github.com/ROCm/hipBLASLt/blob/develop/clients/samples/22_layernorm_ext/sample_hipblaslt_ext_op_layernorm.cpp>`_.
+    For sample code, refer to :ref:`sample_hipblaslt_ext_op_layernorm`.
 
 3. ``hipblasltExtAMax``
     Abs maximum value of a 2D tensor.
     it is an independent function used to just call and get result.
-    For sample code, refer to `sample_hipblaslt_ext_op_amax.cpp <https://github.com/ROCm/hipBLASLt/blob/develop/clients/samples/23_amax_ext/sample_hipblaslt_ext_op_amax.cpp>`_.
+    For sample code, refer to :ref:`sample_hipblaslt_ext_op_amax`.
 
 4. ``hipblasltExtAMaxWithScale``
     Abs maximum value and scaled output of a 2D tensor.
     it is an independent function used to just call and get result.
-    For sample code, refer to `sample_hipblaslt_ext_op_amax_with_scale.cpp <https://github.com/ROCm/hipBLASLt/blob/develop/clients/samples/24_amax_with_scale_ext/sample_hipblaslt_ext_op_amax_with_scale.cpp>`_.
+    For sample code, refer to :ref:`sample_hipblaslt_ext_op_amax_with_scale`.
 
 These APIs are explained in detail below.
 

--- a/docs/samples/client_extop_softmax.rst
+++ b/docs/samples/client_extop_softmax.rst
@@ -1,0 +1,7 @@
+.. _client_extop_softmax:
+
+client_extop_softmax.cpp
+========================
+
+.. literalinclude:: ../../clients/benchmarks/client_extop_softmax.cpp
+   :language: c++    

--- a/docs/samples/sample_hipblaslt_ext_op_amax.rst
+++ b/docs/samples/sample_hipblaslt_ext_op_amax.rst
@@ -1,0 +1,7 @@
+.. _sample_hipblaslt_ext_op_amax:
+
+sample_hipblaslt_ext_op_amax.cpp
+================================
+
+.. literalinclude:: ../../clients/samples/23_amax_ext/sample_hipblaslt_ext_op_amax.cpp
+   :language: c++    

--- a/docs/samples/sample_hipblaslt_ext_op_amax_with_scale.rst
+++ b/docs/samples/sample_hipblaslt_ext_op_amax_with_scale.rst
@@ -1,0 +1,7 @@
+.. _sample_hipblaslt_ext_op_amax_with_scale:
+
+sample_hipblaslt_ext_op_amax_with_scale.cpp
+===========================================
+
+.. literalinclude:: ../../clients/samples/24_amax_with_scale_ext/sample_hipblaslt_ext_op_amax_with_scale.cpp
+   :language: c++    

--- a/docs/samples/sample_hipblaslt_ext_op_layernorm.rst
+++ b/docs/samples/sample_hipblaslt_ext_op_layernorm.rst
@@ -1,0 +1,7 @@
+.. _sample_hipblaslt_ext_op_layernorm:
+
+sample_hipblaslt_ext_op_layernorm.cpp
+=====================================
+
+.. literalinclude:: ../../clients/samples/22_layernorm_ext/sample_hipblaslt_ext_op_layernorm.cpp
+   :language: c++


### PR DESCRIPTION
In the [ext-ops.rst](https://github.com/ROCm/hipBLASLt/blob/develop/docs/ext-ops.rst). we use absolute url to link to cpp files that are listed in this file.

But when we fork a new branch from this original branch and modify file paths for those cpp files. the absolute link inside the generated document from the new branch will be invalid.

This PR will translate those cpp files to html files and place them inside the generated document, this can help to avoid the external changes impacting the document with the specific version.
for example, https://advanced-micro-devices-demo--1075.com.readthedocs.build/projects/hipBLASLt/en/1075/samples/sample_hipblaslt_ext_op_layernorm.html#sample-hipblaslt-ext-op-layernorm

However, this change will let the link on the github page be invalid. Because we changed the absolute url to a reference link that is only understood by the doxygen.

for example: on this page, https://github.com/vin-huang/hipBLASLt/blob/ref_link/docs/ext-ops.rst
the original absolute url: 

> https://github.com/ROCm/hipBLASLt/blob/develop/clients/samples/22_layernorm_ext/sample_hipblaslt_ext_op_layernorm.cpp

after we change to the reference link: 

> [:ref:`sample_hipblaslt_ext_op_layernorm`](https://github.com/vin-huang/hipBLASLt/blob/ref_link/docs/ext-ops.rst#id3)


