### PR TITLE
Fixed syntax error for genSolTable if Python < 3.8

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1142,7 +1142,7 @@ def generateLogicDataAndSolutions(logicFiles, args):
     def libraryIter(lib: MasterSolutionLibrary):
       if len(lib.solutions):
         for i, s in enumerate(lib.solutions.items()):
-          yield i, *s
+          yield (i, *s)
       else:
         for _, lazyLib in lib.lazyLibraries.items():
           yield from libraryIter(lazyLib)


### PR DESCRIPTION
## Brief 
For [SWDEV-483726](https://ontrack-internal.amd.com/browse/SWDEV-483726), yield/return with unpacking is only allowed on Python 3.8+.

## Rerfence
[https://bugs.python.org/issue32117](https://bugs.python.org/issue32117)