### PR TITLE
Update NonTemporal setting according to AsmCaps

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2009,6 +2009,12 @@ class Solution(collections.abc.Mapping):
       state["1LDSBuffer"] = 1
       print2("\nSet SIA=2, force PrefetchLocalRead=1, ExpandPointerSwap=1, 1LDSBuffer=1")
 
+    if not globalParameters["AsmCaps"][isa]["HasNTModifier"]:
+      # force to disable nt flag if it is not supported by arch
+      for ch in ["", "A", "B", "C", "D", "E", "WS", "Metadata"]:
+        if state["NonTemporal%s"%ch] >= 4:
+          state["NonTemporal%s"%ch] -= 4
+
     if state["WavefrontSize"] == 32 and not globalParameters["ArchCaps"][isa]["HasWave32"]:
       reject(state, "WavefrontSize=32 not supported for ISA {}".format(isa))
 


### PR DESCRIPTION
During SolutionStructs, check NonTemporal settings against AsmCaps for valid values. If the setting is not supported (ie: "nt" bit) on the current architecture, then update the setting. This change ensures correct kernel name is applied, and avoids duplicate kernels due to NonTemporal settings.