### PR TITLE
Add include guard for fp8 header

### DIFF
--- a/library/include/hipblaslt.h
+++ b/library/include/hipblaslt.h
@@ -69,7 +69,9 @@
 #undef ROCM_USE_FLOAT8
 #endif
 
+#if defined(__HIPCC__)
 #include <hip/hip_fp8.h>
+#endif
 
 #if defined(__HIP_PLATFORM_AMD__)
 #include "hipblaslt-types.h"


### PR DESCRIPTION
The fp8 header contains builtins and is meant for hipcc compiler. The include hence should be guarded.