### PR TITLE
[Release] Fixed syntax error for genSolTable if Python <= 3.8

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1142,7 +1142,7 @@ def generateLogicDataAndSolutions(logicFiles, args):
     def libraryIter(lib: MasterSolutionLibrary):
       if len(lib.solutions):
         for i, s in enumerate(lib.solutions.items()):
-          yield i, *s
+          yield (i, *s)
       else:
         for _, lazyLib in lib.lazyLibraries.items():
           yield from libraryIter(lazyLib)


### PR DESCRIPTION
Same as #1076, for release 6.3.