### PR TITLE
Fixed tensilehost adapter may not initialized if hipSetDevice called

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -1395,7 +1395,6 @@ namespace
                 auto lib
                     = Tensile::LoadLibraryFile<Tensile::ContractionProblemGemm>(tensileLibPath);
 #endif
-                static_cast<void>(adapter.initializeLazyLoading(processor, path));
                 if(!lib)
                     std::cerr << "\nrocblaslt error: Could not load " << tensileLibPath
                               << std::endl;
@@ -1407,6 +1406,8 @@ namespace
                 }
                 return 0;
             }();
+
+            static_cast<void>(adapter.initializeLazyLoading(processor, path));
 
             if(!m_library && once != 0)
             {


### PR DESCRIPTION
For [SWDEV-482567](https://ontrack-internal.amd.com/browse/SWDEV-482567), it only happens if lazy loading enabled and switching between different devices.

gfx90a & gfx942 local test passed:
```bash
[----------] Global test environment tear-down
[==========] 13061 tests from 13 test suites ran. (3797348 ms total)
[  PASSED  ] 13061 tests.
hipBLASLt version: 1000
```

```bash
[----------] Global test environment tear-down
[==========] 48206 tests from 13 test suites ran. (2430006 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1000
```