### PR TITLE
[Release] Fixed STL compactibility issue of matrix transform for rhel-8

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
@@ -159,13 +159,15 @@ namespace
                 betaPtr = dummyScalarPtr<ScaleType>();
             }
 
+            const ScaleType *nullScalePtr = nullptr;
+
             kArgs.appendAligned("c", c);
             kArgs.appendAligned("a", a);
             kArgs.appendAligned("b", b);
             kArgs.appendAligned("alpha", *alphaPtr);
-            kArgs.appendAligned("alphaPtr", nullptr);
+            kArgs.appendAligned("alphaPtr", nullScalePtr);
             kArgs.appendAligned("beta", *betaPtr);
-            kArgs.appendAligned("betaPtr", nullptr);
+            kArgs.appendAligned("betaPtr", nullScalePtr);
             kArgs.appendAligned("m", m);
             kArgs.appendAligned("n", n);
             kArgs.appendAligned("ldA", ldA);


### PR DESCRIPTION
## Brief
Fixed compile error on RHEL-8.

## Tests
Since this change is only for matrix transform, here's the test result:
```bash
[----------] 1440 tests from AllCombinations/MatrixTransformTest (20167 ms total)

[----------] Global test environment tear-down
[==========] 1444 tests from 2 test suites ran. (20506 ms total)
[  PASSED  ] 1444 tests.
hipBLASLt version: 1000

command line: ./hipblaslt-test --gtest_filter=*MatrixTransform*
```

## Reference
https://cplusplus.github.io/LWG/lwg-defects.html#2221