### PR TITLE
Add TENSILE_ENABLE_MARKER and HIPBLASLT_ENABLE_MARKER for C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,8 @@ option(USE_CUDA "Look for CUDA and use that as a backend if found" OFF)
 option(Tensile_MERGE_FILES "Tensile to merge kernels and solutions files?" ON)
 option(Tensile_SEPARATE_ARCHITECTURES "Tensile to use GPU architecture specific files?" ON)
 option(Tensile_LAZY_LIBRARY_LOADING "Tensile to load kernels on demand?" ON)
+# For roctx
+option(HIPBLASLT_ENABLE_MARKER "Enable roctx marker in hipBLASLt" ON)
 
 if(BUILD_CODE_COVERAGE)
   add_compile_options(-fprofile-arcs -ftest-coverage)
@@ -237,6 +239,15 @@ if( LEGACY_HIPBLAS_DIRECT )
   find_package( hipblas REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm)
 else()
   find_package( hipblas-common REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm)
+endif()
+
+if(HIPBLASLT_ENABLE_MARKER)
+  find_library(rocTracer roctx64)
+  if(NOT rocTracer)
+    message(FATAL_ERROR "roctracer not found, but HIPBLASLT_ENABLE_MARKER is enabled")
+  endif()
+  add_definitions(-DHIPBLASLT_ENABLE_MARKER)
+  rocm_package_add_dependencies(DEPENDS "roctracer >= 1.0.0")
 endif()
 
 # Setup version

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Required software:
 * python3.7-venv or later
 * AMD [ROCm](https://github.com/RadeonOpenCompute/ROCm), version 5.5 or later
 * [hipBLAS-common](https://github.com/ROCm/hipBLAS-common)
+* [roctracer](https://github.com/ROCm/roctracer)
 
 ## Build and install
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -146,7 +146,8 @@ Build library manually
 Dependencies for hipBLASLt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The `hipBLAS-common <https://github.com/ROCm/hipBLAS-common>`_ header files are required to be installed on your system.
+1. The `hipBLAS-common <https://github.com/ROCm/hipBLAS-common>`_ header files are required to be installed on your system.
+2. Usually `roctx <https://github.com/ROCm/roctracer>`_ library is pre-installed, if not please install it on your system.
 
 Building hipBLASLt
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/install.sh
+++ b/install.sh
@@ -392,6 +392,8 @@ tensile_msgpack_backend=true
 update_cmake=true
 enable_gprof=false
 keep_build_tmp=false
+disable_hipblaslt_marker=false
+enable_tensile_marker=false
 
 
 rocm_path=/opt/rocm
@@ -406,7 +408,7 @@ fi
 # check if we have a modern version of getopt that can handle whitespace and long parameters
 getopt -T
 if [[ $? -eq 4 ]]; then
-  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
+  GETOPT_PARSE=$(getopt --name "${0}" --longoptions help,install,clients,dependencies,debug,hip-clang,static,relocatable,codecoverage,relwithdebinfo,address-sanitizer,merge-files,no-merge-files,no_tensile,no-tensile,msgpack,no-msgpack,logic:,cov:,fork:,branch:,test_local_path:,cpu_ref_lib:,build_dir:,use-custom-version:,architecture:,gprof,keep-build-tmp,legacy_hipblas_direct,disable-hipblaslt-marker,enable-tensile-marker --options hicdgrka:j:o:l:f:b:nu:t: -- "$@")
 else
   echo "Need a new version of getopt"
   exit 1
@@ -517,6 +519,12 @@ while true; do
         --legacy_hipblas_direct)
             legacy_hipblas_direct=true
             shift ;;
+        --disable-hipblaslt-marker)
+            disable_hipblaslt_marker=true
+            shift;;
+        --enable-tensile-marker)
+            enable_tensile_marker=true
+            shift;;
         --) shift ; break ;;
         *)  echo "Unexpected command line parameter received: '${1}'; aborting";
             exit 1
@@ -762,6 +770,14 @@ pushd .
 
   if [[ "${keep_build_tmp}" == true ]]; then
     tensile_opt="${tensile_opt} -DTensile_KEEP_BUILD_TMP=ON"
+  fi
+
+  if [[ "${disable_hipblaslt_marker}" == true ]]; then
+    tensile_opt="${tensile_opt} -DHIPBLASLT_ENABLE_MARKER=OFF"
+  fi
+
+  if [[ "${enable_tensile_marker}" == true ]]; then
+    tensile_opt="${tensile_opt} -DTensile_ENABLE_MARKER=ON"
   fi
 
   echo $cmake_common_options

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -177,6 +177,10 @@ else()
   target_link_libraries(hipblaslt PRIVATE ${CUDA_cublaslt_LIBRARY})
 endif()
 
+if(HIPBLASLT_ENABLE_MARKER)
+  target_link_libraries(hipblaslt PRIVATE -lroctx64)
+endif()
+
 # Target properties
 rocm_set_soversion(hipblaslt ${hipblaslt_SOVERSION})
 set_target_properties(hipblaslt PROPERTIES CXX_EXTENSIONS NO)

--- a/library/src/amd_detail/hipblaslt.cpp
+++ b/library/src/amd_detail/hipblaslt.cpp
@@ -35,6 +35,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "Debug.hpp"
+
 #define TO_STR2(x) #x
 #define TO_STR(x) TO_STR2(x)
 
@@ -128,6 +130,7 @@ extern "C" {
 hipblasStatus_t hipblasLtCreate(hipblasLtHandle_t* handle)
 try
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtCreate");
     // TODO: Synchronizer size pass into predicate SynchronizerSizeCheck
     // 1K just for small size now, need to cal corner case if support all situations
     void* d_Synchronizer = nullptr;
@@ -137,6 +140,7 @@ try
     // Check if handle is valid
     if(handle == nullptr)
     {
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
@@ -150,6 +154,7 @@ try
         retval = RocBlasLtStatusToHIPStatus(rocblaslt_create((rocblaslt_handle*)handle));
         (*(rocblaslt_handle*)handle)->Synchronizer = d_Synchronizer;
     }
+    rocblaslt::Debug::Instance().markerStop();
     return retval;
 }
 catch(...)
@@ -160,12 +165,15 @@ catch(...)
 hipblasStatus_t hipblasLtDestroy(const hipblasLtHandle_t handle)
 try
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtDestroy");
     if(handle != nullptr and (*(rocblaslt_handle)handle).Synchronizer != nullptr)
     {
         CHECK_HIP_ERROR(hipFree((*(rocblaslt_handle)handle).Synchronizer));
     }
 
-    return RocBlasLtStatusToHIPStatus(rocblaslt_destroy((const rocblaslt_handle)handle));
+    auto status = RocBlasLtStatusToHIPStatus(rocblaslt_destroy((const rocblaslt_handle)handle));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -179,8 +187,11 @@ hipblasStatus_t hipblasLtMatrixLayoutCreate(hipblasLtMatrixLayout_t* matDescr,
                                             int64_t                  ld)
 try
 {
-    return RocBlasLtStatusToHIPStatus(rocblaslt_matrix_layout_create(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixLayoutCreate");
+    auto status = RocBlasLtStatusToHIPStatus(rocblaslt_matrix_layout_create(
         (rocblaslt_matrix_layout*)matDescr, valueType, rows, cols, ld));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -190,8 +201,11 @@ catch(...)
 hipblasStatus_t hipblasLtMatrixLayoutDestroy(const hipblasLtMatrixLayout_t descr)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixLayoutDestroy");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matrix_layout_destory((const rocblaslt_matrix_layout)descr));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -203,8 +217,11 @@ hipblasStatus_t hipblasLtMatmulDescCreate(hipblasLtMatmulDesc_t* matmulDesc,
                                           hipDataType            scaleType)
 try
 {
-    return RocBlasLtStatusToHIPStatus(rocblaslt_matmul_desc_create(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulDescCreate");
+    auto status = RocBlasLtStatusToHIPStatus(rocblaslt_matmul_desc_create(
         (rocblaslt_matmul_desc*)matmulDesc, (rocblaslt_compute_type)computeType, scaleType));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -217,11 +234,14 @@ hipblasStatus_t hipblasLtMatrixLayoutSetAttribute(hipblasLtMatrixLayout_t       
                                                   size_t                           sizeInBytes)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixLayoutSetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matrix_layout_set_attribute((rocblaslt_matrix_layout)matLayout,
                                               (rocblaslt_matrix_layout_attribute)attr,
                                               buf,
                                               sizeInBytes));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -235,12 +255,15 @@ hipblasStatus_t hipblasLtMatrixLayoutGetAttribute(hipblasLtMatrixLayout_t       
                                                   size_t*                          sizeWritten)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixLayoutGetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matrix_layout_get_attribute((rocblaslt_matrix_layout)matLayout,
                                               (rocblaslt_matrix_layout_attribute)attr,
                                               buf,
                                               sizeInBytes,
                                               sizeWritten));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -250,8 +273,11 @@ catch(...)
 hipblasStatus_t hipblasLtMatmulDescDestroy(const hipblasLtMatmulDesc_t descr)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulDescDestroy");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_desc_destroy((const rocblaslt_matmul_desc)descr));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -264,11 +290,14 @@ hipblasStatus_t hipblasLtMatmulDescSetAttribute(hipblasLtMatmulDesc_t           
                                                 size_t                          sizeInBytes)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulDescSetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_desc_set_attribute((rocblaslt_matmul_desc)matmulDesc,
                                             (rocblaslt_matmul_desc_attributes)matmulAttr,
                                             buf,
                                             sizeInBytes));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -281,12 +310,15 @@ hipblasStatus_t hipblasLtMatmulDescGetAttribute(hipblasLtMatmulDesc_t           
                                                 size_t*                         sizeWritten)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulDescGetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_desc_get_attribute((rocblaslt_matmul_desc)matmulDesc,
                                             (rocblaslt_matmul_desc_attributes)matmulAttr,
                                             buf,
                                             sizeInBytes,
                                             sizeWritten));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -296,8 +328,11 @@ catch(...)
 hipblasStatus_t hipblasLtMatmulPreferenceCreate(hipblasLtMatmulPreference_t* pref)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulPreferenceCreate");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_preference_create((rocblaslt_matmul_preference*)pref));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -306,8 +341,11 @@ catch(...)
 hipblasStatus_t hipblasLtMatmulPreferenceDestroy(const hipblasLtMatmulPreference_t pref)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulPreferenceDestroy");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_preference_destroy((const rocblaslt_matmul_preference)pref));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -321,11 +359,14 @@ hipblasStatus_t
                                           size_t                                dataSize)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulPreferenceSetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_preference_set_attribute((rocblaslt_matmul_preference)pref,
                                                   (rocblaslt_matmul_preference_attributes)attribute,
                                                   data,
                                                   dataSize));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -340,12 +381,15 @@ hipblasStatus_t
                                           size_t*                               sizeWritten)
 try
 {
-    return RocBlasLtStatusToHIPStatus(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulPreferenceGetAttribute");
+    auto status = RocBlasLtStatusToHIPStatus(
         rocblaslt_matmul_preference_get_attribute((rocblaslt_matmul_preference)pref,
                                                   (rocblaslt_matmul_preference_attributes)attribute,
                                                   data,
                                                   sizeInBytes,
                                                   sizeWritten));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -365,7 +409,8 @@ hipblasStatus_t
                                     int*                             returnAlgoCount)
 try
 {
-    return RocBlasLtStatusToHIPStatus(rocblaslt_matmul_algo_get_heuristic(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmulAlgoGetHeuristic");
+    auto status = RocBlasLtStatusToHIPStatus(rocblaslt_matmul_algo_get_heuristic(
         (rocblaslt_handle)handle,
         (rocblaslt_matmul_desc)matmulDesc,
         (rocblaslt_matrix_layout)Adesc,
@@ -376,6 +421,8 @@ try
         requestedAlgoCount,
         (rocblaslt_matmul_heuristic_result*)heuristicResultsArray,
         returnAlgoCount));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 catch(...)
 {
@@ -400,6 +447,7 @@ hipblasStatus_t hipblasLtMatmul(hipblasLtHandle_t            handle,
                                 hipStream_t                  stream)
 try
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatmul");
     hipblasStatus_t return_status = HIPBLAS_STATUS_SUCCESS;
 
     return_status = RocBlasLtStatusToHIPStatus(rocblaslt_matmul((rocblaslt_handle)handle,
@@ -418,7 +466,7 @@ try
                                                                 workspace,
                                                                 workspaceSizeInBytes,
                                                                 stream));
-
+    rocblaslt::Debug::Instance().markerStop();
     return return_status;
 }
 catch(...)
@@ -429,6 +477,7 @@ catch(...)
 hipblasStatus_t hipblasLtMatrixTransformDescCreate(hipblasLtMatrixTransformDesc_t* transformDesc,
                                                    hipDataType                     scaleType)
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixTransformDescCreate");
     static_assert(sizeof(rocblaslt_matrix_transform_desc)
                       <= sizeof(hipblasLtMatrixTransformDescOpaque_t),
                   "hipblasLtMatrixTransformDescOpaque_t must have enough space");
@@ -436,13 +485,16 @@ hipblasStatus_t hipblasLtMatrixTransformDescCreate(hipblasLtMatrixTransformDesc_
     desc.scaleType = scaleType;
     *transformDesc = new hipblasLtMatrixTransformDescOpaque_t;
     memcpy((*transformDesc)->data, &desc, sizeof(desc));
+    rocblaslt::Debug::Instance().markerStop();
     return HIPBLAS_STATUS_SUCCESS;
 }
 
 hipblasStatus_t hipblasLtMatrixTransformDescDestroy(hipblasLtMatrixTransformDesc_t transformDesc)
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixTransformDescDestroy");
     if(transformDesc)
         delete transformDesc;
+    rocblaslt::Debug::Instance().markerStop();
     return HIPBLAS_STATUS_SUCCESS;
 }
 
@@ -452,8 +504,10 @@ hipblasStatus_t
                                              const void*                              buf,
                                              size_t                                   sizeInBytes)
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixTransformDescSetAttribute");
     if(!buf || sizeInBytes != sizeof(int32_t))
     {
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
@@ -488,9 +542,11 @@ hipblasStatus_t
     }
     default:
         assert(false && "Unknown attribute");
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
         break;
     }
+    rocblaslt::Debug::Instance().markerStop();
     return HIPBLAS_STATUS_SUCCESS;
 }
 
@@ -501,18 +557,22 @@ hipblasStatus_t
                                              size_t                                   sizeInBytes,
                                              size_t*                                  sizeWritten)
 {
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixTransformDescGetAttribute");
     if(!sizeInBytes && !sizeWritten)
     {
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     if(sizeInBytes && !sizeWritten)
     {
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
     if(sizeInBytes != sizeof(int32_t))
     {
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
     }
 
@@ -543,6 +603,7 @@ hipblasStatus_t
         break;
     }
     default:
+        rocblaslt::Debug::Instance().markerStop();
         return HIPBLAS_STATUS_INVALID_VALUE;
         assert(false && "Unknown attribute");
         break;
@@ -550,6 +611,7 @@ hipblasStatus_t
 
     memcpy(buf, &value, sizeInBytes);
     *sizeWritten = sizeof(int32_t);
+    rocblaslt::Debug::Instance().markerStop();
     return HIPBLAS_STATUS_SUCCESS;
 }
 
@@ -565,7 +627,8 @@ hipblasStatus_t hipblasLtMatrixTransform(hipblasLtHandle_t              lightHan
                                          hipblasLtMatrixLayout_t Cdesc,
                                          hipStream_t             stream)
 {
-    return RocBlasLtStatusToHIPStatus(rocblaslt_matrix_transform(
+    rocblaslt::Debug::Instance().markerStart("hipblasLtMatrixTransform");
+    auto status = RocBlasLtStatusToHIPStatus(rocblaslt_matrix_transform(
         (rocblaslt_handle)lightHandle,
         reinterpret_cast<rocblaslt_matrix_transform_desc*>(&transformDesc->data[0]),
         alpha,
@@ -577,6 +640,8 @@ hipblasStatus_t hipblasLtMatrixTransform(hipblasLtHandle_t              lightHan
         C,
         (rocblaslt_matrix_layout)Cdesc,
         stream));
+    rocblaslt::Debug::Instance().markerStop();
+    return status;
 }
 
 // Other Utilities

--- a/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
+++ b/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
@@ -123,6 +123,7 @@ set(DL_LIB dl)
 
 # rocBLASLt source
 set(rocblaslt_source
+  src/amd_detail/rocblaslt/src/Debug.cpp
   src/amd_detail/rocblaslt/src/handle.cpp
   src/amd_detail/rocblaslt/src/status.cpp
   src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp

--- a/library/src/amd_detail/rocblaslt/src/Debug.cpp
+++ b/library/src/amd_detail/rocblaslt/src/Debug.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,15 +24,33 @@
  *
  *******************************************************************************/
 
-#pragma once
-#include "handle.h"
-#ifndef LEGACY_HIPBLAS_DIRECT
-#include <hipblas-common/hipblas-common.h>
-#else
-#include <hipblas/hipblas.h>
-#endif
-#include <rocblaslt.h>
 #include <Debug.hpp>
-hipblasStatus_t hipErrorToHIPBLASStatus(hipError_t status);
 
-hipblasStatus_t RocBlasLtStatusToHIPStatus(rocblaslt_status_ status);
+#include <mutex>
+
+#ifndef DEBUG_SM
+#define DEBUG_SM 0
+#endif
+
+#ifndef DEBUG_SM2
+#define DEBUG_SM2 0
+#endif
+
+namespace rocblaslt
+{
+    Debug::Debug()
+        : m_value(DEBUG_SM)
+        , m_value2(DEBUG_SM2)
+    {
+        const char* hipblaslt_marker = std::getenv("HIPBLASLT_ENABLE_MARKER");
+        if(hipblaslt_marker)
+        {
+            m_printMarker = strtol(hipblaslt_marker, nullptr, 0) != 0;
+#ifndef HIPBLASLT_ENABLE_MARKER
+            if(m_printMarker)
+                printf("HIPBLASLT_ENABLE_MARKER is not defined. Please rebuild with -DHIPBLASLT_ENABLE_MARKER=ON\n");
+#endif
+        }
+    }
+
+} // namespace rocblaslt

--- a/tensilelite/Tensile/ClientExecutable.py
+++ b/tensilelite/Tensile/ClientExecutable.py
@@ -67,6 +67,7 @@ def clientExecutableEnvironment(builddir=None):
                'TENSILE_USE_MSGPACK': 'ON',
                'TENSILE_USE_LLVM': 'OFF' if (os.name == "nt") else 'ON',
                'Tensile_LIBRARY_FORMAT': globalParameters["LibraryFormat"],
+               'Tensile_ENABLE_MARKER' : globalParameters["EnableMarker"],
                'CMAKE_CXX_COMPILER': os.path.join(globalParameters["ROCmBinPath"], CxxCompiler),
                'CMAKE_C_COMPILER': os.path.join(globalParameters["ROCmBinPath"], CCompiler)}
 

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -274,6 +274,8 @@ globalParameters["SeparateArchitectures"] = False # write Tensile library metada
 
 globalParameters["LazyLibraryLoading"] = False # Load library and code object files when needed instead of at startup
 
+globalParameters["EnableMarker"] = False # Enable Tensile markers
+
 globalParameters["UseUserArgs"] = False
 
 globalParameters["RotatingBufferSize"] = 0 # Size in MB
@@ -738,7 +740,7 @@ validParameters = {
     # These predicates can be used to adjust solution selection compute-bound or memory-bound problems.
     "AssertAIGreaterThanEqual": -1,
     "AssertAILessThanEqual":    -1,
-    
+
     # Stagger the start summation position of the tiles.
     # Elements from the summation dimension are loaded at offsets rather than all starting at 0.
     # StaggerU is the max 'clicks' of StaggerUStride bytes where each wg starts ; see StaggerUMapping
@@ -793,7 +795,7 @@ validParameters = {
     # True:  wg issused oder = {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
     #   -> workgroups split up the summation -> faster GR but slower GW
     "GlobalSplitUWorkGroupMappingRoundRobin":        [False, True],
-    
+
     # 0=don't use magic div (source only)
     # 1=magic div alg #1.  Slightly faster but limited range (if magic number is 2^32)
     # 2=magic div alg#2.  Slightly slower but handles all unsigned ints up to 2^32
@@ -1184,7 +1186,7 @@ defaultBenchmarkCommonParameters = [
     {"AssertSummationElementMultiple": [ 1 ] },
     {"AssertFree0ElementMultiple": [ 1 ] },
     {"AssertFree1ElementMultiple": [ 1 ] },
-  
+
     {"AssertAIGreaterThanEqual":   [-1]},
     {"AssertAILessThanEqual":      [-1]},
 

--- a/tensilelite/Tensile/Source/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/CMakeLists.txt
@@ -30,6 +30,16 @@ list(APPEND CMAKE_PREFIX_PATH ${ROCM_PATH_ENV_VALUE} /opt/rocm)
 
 project(Tensile)
 
+option(Tensile_ENABLE_MARKER "ENable roctx marker in Tensile" OFF)
+
+if(Tensile_ENABLE_MARKER)
+    find_library(rocTracer roctx64)
+    if(NOT rocTracer)
+        message(FATAL_ERROR "roctracer not found, but Tensile_ENABLE_MARKER is enabled")
+    endif()
+    add_definitions(-DTensile_ENABLE_MARKER)
+endif()
+
 set(TENSILE_USE_HIP      ON CACHE BOOL "Use the Hip runtime.")
 if(Tensile_LIBRARY_FORMAT MATCHES "msgpack")
     set(TENSILE_USE_MSGPACK  ON CACHE BOOL "Use message pack for parsing config files.")

--- a/tensilelite/Tensile/Source/TensileCreateLibrary.cmake
+++ b/tensilelite/Tensile/Source/TensileCreateLibrary.cmake
@@ -40,6 +40,7 @@ function(TensileCreateLibraryCmake
     Tensile_CPU_THREADS
     Tensile_SEPARATE_ARCHITECTURES
     Tensile_LAZY_LIBRARY_LOADING,
+    Tensile_ENABLE_MARKER,
     Tensile_BUILD_ID)
 
 # make Tensile_PACKAGE_LIBRARY and optional parameter
@@ -87,6 +88,10 @@ function(TensileCreateLibraryCmake
 
   if(${Tensile_LAZY_LIBRARY_LOADING})
     set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--lazy-library-loading")
+  endif()
+
+  if(Tensile_ENABLE_MARKER)
+    set(Tensile_CREATE_COMMAND ${Tensile_CREATE_COMMAND} "--enable-marker")
   endif()
 
   if(${Tensile_SHORT_FILE_NAMES})

--- a/tensilelite/Tensile/Source/client/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/client/CMakeLists.txt
@@ -62,6 +62,11 @@ endif()
 target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")# "${rocm_smi_root}/include")
 
 target_link_libraries(TensileClient PRIVATE TensileHost ${Boost_LIBRARIES} rocm_smi)
+
+if(Tensile_ENABLE_MARKER)
+    target_link_libraries(TensileClient PRIVATE -lroctx64)
+endif()
+
 if(TENSILE_USE_OPENMP)
     target_link_libraries(TensileClient PRIVATE custom_openmp_cxx)
 endif()

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Debug.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Debug.hpp
@@ -28,6 +28,9 @@
 
 #include <cstdlib>
 #include <string>
+#ifdef Tensile_ENABLE_MARKER
+#include <roctracer/roctx.h>
+#endif
 
 #include <Tensile/Singleton.hpp>
 
@@ -81,12 +84,45 @@ namespace Tensile
         bool getSolutionSelectionTrace() const;
 
         int getGridbasedTopSols() const;
-        
+
         bool printStreamKGridInfo() const;
 
         bool gridBasedKDTree() const;
 
         bool gridBasedBatchExp() const;
+
+        __attribute__((always_inline)) inline void markerStart(const char* name) const
+        {
+#ifdef Tensile_ENABLE_MARKER
+            if(m_printMarker)
+            {
+                roctxRangePush(name);
+            }
+#endif
+        }
+
+
+        __attribute__((always_inline))
+        inline void markerStart(const char* name, const std::string& objPath) const
+        {
+#ifdef Tensile_ENABLE_MARKER
+            if(m_printMarker)
+            {
+                std::string s = name + std::string(": ") + objPath;
+                roctxRangePush(s.c_str());
+            }
+#endif
+        }
+
+        __attribute__((always_inline)) inline void markerStop() const
+        {
+#ifdef Tensile_ENABLE_MARKER
+            if(m_printMarker)
+            {
+                roctxRangePop();
+            }
+#endif
+        }
 
     private:
         friend LazySingleton<Debug>;
@@ -103,6 +139,7 @@ namespace Tensile
         bool        m_benchmark           = false;
         bool        m_gridbasedKdTree     = false;
         bool        m_gridbasedBatchExp   = false;
+        bool        m_printMarker         = false;
 
         Debug();
     };

--- a/tensilelite/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/PropertyMatching.hpp
@@ -41,10 +41,6 @@
 #include <Tensile/Properties.hpp>
 #include <Tensile/Utils.hpp>
 
-// #ifdef ENABLE_ROCTX
-// #include <roctracer/roctx.h>
-// #endif
-
 namespace Tensile
 {
     /**

--- a/tensilelite/Tensile/Source/lib/source/Debug.cpp
+++ b/tensilelite/Tensile/Source/lib/source/Debug.cpp
@@ -216,6 +216,16 @@ namespace Tensile
         const char* tensile_gridbased_batch_exp = std::getenv("TENSILE_GRIDBASED_BATCH_EXP");
         if(tensile_gridbased_batch_exp)
             m_gridbasedBatchExp = strtol(tensile_gridbased_batch_exp, nullptr, 0) != 0;
+
+        const char* tensile_marker = std::getenv("TENSILE_ENABLE_MARKER");
+        if(tensile_marker)
+        {
+            m_printMarker = strtol(tensile_marker, nullptr, 0) != 0;
+#ifndef Tensile_ENABLE_MARKER
+            if(m_printMarker)
+                printf("TENSILE_ENABLE_MARKER is not supported in this build. Please rebuild with -DTensile_ENABLE_MARKER=ON\n");
+#endif
+        }
     }
 
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -65,8 +65,10 @@ namespace Tensile
 
         SolutionAdapter::~SolutionAdapter()
         {
+            Debug::Instance().markerStart("UnloadCodeObjectFiles");
             for(auto module : m_modules)
                 HIP_CHECK_PRINT(hipModuleUnload(module));
+            Debug::Instance().markerStop();
         }
 
         std::string removeXnack(std::string coFilename)
@@ -81,6 +83,7 @@ namespace Tensile
 
         hipError_t SolutionAdapter::loadCodeObjectFile(std::string const& path)
         {
+            Debug::Instance().markerStart("loadCodeObjectFile", path);
             hipModule_t module;
 
             HIP_CHECK_RETURN(hipModuleLoad(&module, path.c_str()));
@@ -98,6 +101,7 @@ namespace Tensile
                 start        = (start == std::string::npos) ? 0 : start + 1;
                 m_loadedCOFiles.insert(removeXnack(std::string(path.begin() + start, path.end())));
             }
+            Debug::Instance().markerStop();
             return hipSuccess;
         }
 

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -1294,6 +1294,8 @@ def TensileCreateLibrary():
                          default=False, help="Separates TensileLibrary file by architecture")
   argParser.add_argument("--lazy-library-loading", dest="LazyLibraryLoading", action="store_true",
                          default=False, help="Loads Tensile libraries when needed instead of upfront.")
+  argParser.add_argument("--enable-marker", dest="EnableMarker", action="store_true",
+                         default=False, help="Enable marker in Tensile.")
   argParser.add_argument("--build-client", dest="BuildClient", action="store_true",
                          help="Build Tensile client")
   argParser.add_argument("--client-config", dest="ClientConfig", action="store_true",
@@ -1323,6 +1325,7 @@ def TensileCreateLibrary():
   arguments["Architecture"] = args.Architecture
   arguments["SeparateArchitectures"] = args.SeparateArchitectures
   arguments["LazyLibraryLoading"] = args.LazyLibraryLoading
+  arguments["EnableMarker"] = args.EnableMarker
   arguments["CxxCompiler"] = args.CxxCompiler
   if args.CmakeCxxCompiler:
     os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler

--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -145,6 +145,10 @@ function(TensileCreateLibraryFiles
     set(Options ${Options} "--lazy-library-loading")
   endif()
 
+  if(Tensile_ENABLE_MARKER)
+    set(Options ${Options} "--enable-marker")
+  endif()
+
   if(Tensile_KEEP_BUILD_TMP)
     set(Options ${Options} "--keep-build-tmp")
   endif()


### PR DESCRIPTION
TENSILE_ENABLE_MARKER default is off.

HIPBLASLT_ENABLE_MARKER default is on.


TENSILE_ENABLE_MARKER enables markers inside Tensile lib.

HIPBLASLT_ENABLE_MARKER enables markers for hipBLASLt API calls.
