### PR TITLE
Fix default value for tensile logic build parameter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -380,6 +380,7 @@ matrices_dir=
 matrices_dir_install=
 gpu_architecture=all
 cpu_ref_lib=blis
+tensile_logic=
 tensile_cov=
 tensile_threads=$(nproc)
 tensile_fork=
@@ -735,8 +736,11 @@ pushd .
   tensile_opt=""
   if [[ "${build_tensile}" == false ]]; then
     tensile_opt="${tensile_opt} -DBUILD_WITH_TENSILE=OFF"
-   else
-    tensile_opt="${tensile_opt} -DTensile_LOGIC=${tensile_logic} -DTensile_CODE_OBJECT_VERSION=${tensile_cov}"
+  else
+    if [[ -n "${tensile_logic}" ]]; then
+      tensile_opt="${tensile_opt} -DTensile_LOGIC=${tensile_logic}"
+    fi
+    tensile_opt="${tensile_opt} -DTensile_CODE_OBJECT_VERSION=${tensile_cov}"
     if [[ ${tensile_threads} != $(nproc) ]]; then
       tensile_opt="${tensile_opt} -DTensile_CPU_THREADS=${tensile_threads}"
     fi


### PR DESCRIPTION
The install script allows you to specify which logic directory to build by setting the "-l" or "--logic" option. The default in the CMake file tries to set the value to "asm_full", but if the user doesn't specify a logic directory then the install script overrides the default with the base Logic directory causing all libraries to be built.

This change fixes the default logic directory by checking if the user set a value for the "-l" flag before overriding CMake's default value.