### PR TITLE
Fix short circuit logic for alpha=0 with stream-k

### DIFF
--- a/tensilelite/Tensile/Components/StreamK.py
+++ b/tensilelite/Tensile/Components/StreamK.py
@@ -24,7 +24,7 @@ from ..TensileInstructions import Module, Label, SAddU32, RegisterPoolResource, 
     SCmpLtU32, SCSelectB32, sMagicDivAlg2, SMulI32, SSubU32, SMinU32, SMovB32, SCBranchSCC1, SCmpLeU32, VMovB32, vgpr, \
     SAddCU32, SCmpGtU32, SCMovB32, SAddI32, SCmpEQU32, SCBranchSCC0, SLShiftLeftB32, SLoadB32, SWaitCnt, SMEMModifiers, \
     log2, SBarrier, SStoreB32, SLongBranchPositive, SBranch, ceilDivide, replaceHolder, SNop, staticMultiply, SSleep, \
-    VAddF32, VAddF64, SAndB32, SLShiftRightB32, VReadfirstlaneB32
+    VAddF32, VAddF64, SAndB32, SLShiftRightB32, VReadfirstlaneB32, SBranchIfNotZero
 from ..Common import print2
 # from ..TensileInstructions.Containers import SMEMModifiers
 from ..Component import Component
@@ -233,6 +233,12 @@ class StreamK(Component):
 
         # Use StreamK params for loop count
         module.add(SSubU32(dst=sgpr(loopCounterName), src0=sgpr("StreamKLocalEnd"), src1=sgpr("StreamKLocalStart"), comment="StreamK loop counter = localEnd - localStart"))
+        # Short circuit if alpha==0 (set loopCounter to 0 to skip main loop)
+        alphaLabel2 = Label("SKAlphaCheck2", "")
+        module.add(SBranchIfNotZero("Alpha", kernel["ProblemType"]["ComputeDataType"], alphaLabel2))
+        module.add(SMovB32(dst=sgpr(loopCounterName), src=0, comment="Skip iterations"))
+        module.add(alphaLabel2)
+
         # Adjust loop count for tail loop
         if not kernel["NoTailLoop"]:
             tmpSgpr = tmpSgprInfo.idx
@@ -1910,7 +1916,21 @@ class StreamKTwoTileDPFirst(StreamK):
         module.add(skUpdateDone)
         module.add(SMovB32(dst=sgpr("StreamKIter"), src=sgpr(sTmp+1), comment="Store current iteration"))
 
+        # Map SK index to WG
         module.add(self.skIndexToWG(writer, kernel, sTmp))
+
+        # Short circuit if alpha==0 (skip main loop and reading A/B, only do beta * C)
+        # To skip main loop in stream-k, we check if this WG is responsible for writing results (ie: WG starts tile)
+        # If WG starts tile then set LocalEnd=ItersPerTile to skip fixup step, and set loopCounter to 0 to skip main loop
+        # If WG does not start tile, skip to end of persistent loop to check for other SK tile
+        alphaLabel = Label("SKAlphaCheck", "")
+        module.add(SBranchIfNotZero("Alpha", kernel["ProblemType"]["ComputeDataType"], alphaLabel))
+        # Skip to end if not doing the global write
+        module.add(SCmpEQU32(src0=sgpr("StreamKLocalStart"), src1=0, comment="does wg start tile?"))
+        endLabel = Label("GW_End", "")
+        module.add(writer.longBranchScc0(endLabel, posNeg=1))
+        module.add(SMovB32(dst=sgpr("StreamKLocalEnd"), src=sgpr("ItersPerTile"), comment="Skip iterations"))
+        module.add(alphaLabel)
 
         writer.sgprPool.checkIn(sTmp)
 

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -1891,6 +1891,7 @@ class KernelWriterAssembly(KernelWriter):
         # Conditional set summation dimensions to 0 on SCC==1
         for i in range(0, self.states.numSgprSizesSum):
           module.add(SMovB32(dst=sgpr("SizesSum+%u"%(i)), src=hex(0), comment="Set summation dim=0 if Alpha == 0"))
+        # Short circuit for stream-k is handled in the stream-k component by skipping partial tiles and setting loop counter to 0
 
         # Jump here if alpha is non-zero
         module.add(endCheckLabel)

--- a/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_alpha0.yaml
+++ b/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_alpha0.yaml
@@ -1,0 +1,119 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: False
+  KernelTime: False
+  DataInitTypeAlpha: 0
+  DataInitTypeBeta: 1
+  DataInitTypeA: 12
+  DataInitTypeB: 13
+  DataInitTypeC: 12
+  # ValidationPrintValids: True
+  MaxWorkspaceSize: 134217728
+  # PrintSolutionRejectionReason: True
+  # ForceGenerateKernel: True
+  # GenerateSourcesAndExit: True
+  NumWarmups: 1
+  EnqueuesPerSync: 1
+  # NumBenchmarks: 10
+  KeepBuildTmp: True
+
+BenchmarkProblems:
+  - # sgemm NT
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: False
+      TransposeB: True
+      UseBeta: True
+      Batched: True
+
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+        # - EdgeType: ["ShiftPtr"]
+        - PrefetchLocalRead: [True]
+      ForkParameters:
+        - MatrixInstruction:
+          # - [32, 32, 2, 1, 1, 2,2, 2,2]
+          # - [32, 32, 2, 1, 1, 3,3, 2,2]
+          # - [32, 32, 2, 1, 1, 4,4, 2,2]
+          # - [32, 32, 2, 1, 1, 5,5, 2,2] # MT too big
+          # - [32, 32, 2, 1, 1, 2,1, 2,2]
+          # - [32, 32, 2, 1, 1, 1,1, 2,2]
+          # - [16, 16, 4, 1, 1, 3,3, 2,2]
+          # - [16, 16, 4, 1, 1, 4,1, 2,2]
+          # - [16, 16, 4, 1, 1, 4,2, 2,2]
+          - [16, 16, 4, 1, 1, 4,4, 2,2]
+          # - [16, 16, 4, 1, 1, 4,8, 2,2]
+          # - [16, 16, 4, 1, 1, 8,8, 2,2]
+          # - [16, 16, 4, 1, 1, 8,8, 2,2]
+          # - [16, 16, 4, 1, 1, 2,2, 2,2]
+          # - [16, 16, 4, 1, 1, 2,1, 2,2]
+          # - [16, 16, 4, 1, 1, 1,1, 2,2]
+        #- WorkGroupMapping: [0, 1, 2, 4, 8, 16, 32, 64] # works
+        - WorkGroupMapping: [1]
+        #- GlobalSplitU: [1]
+        - DepthU: [ 64 ]
+        # - DepthU: [ 8, 12, 16, 32 ]
+        # - DepthU: [ 2, 4, 8, 16, 32, 64 ]
+        # - DepthU: [ 8, 9, 10, 11, 12, 13, 14, 15, 16 ] # depthu 14 failed a test
+        # - VectorWidth: [1, 4] # 2?
+        - VectorWidthA: [4]
+        - VectorWidthB: [4]
+        - StreamK: [3]
+        # - StreamKXCCMapping: [0, 8]
+        # - StaggerU: [0, 32]
+        # - StaggerU: [0]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [True]
+        # - SourceSwap: [False]
+        # - ExpandPointerSwap: [False, True]
+        - ExpandPointerSwap: [False]
+        - PrefetchLocalRead: [1]
+        # - PrefetchLocalRead: [1, 3, 5, 9, 13, 17]
+        # - PrefetchLocalRead: [1, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        #- PrefetchGlobalRead: [1, 2]
+        - PrefetchGlobalRead: [2]
+        # - 1LDSBuffer: [0, 1]
+        - 1LDSBuffer: [1]
+        # - EdgeType: ["Branch", "ShiftPtr"]
+        # - EdgeType: ["ShiftPtr"]
+        # - MIArchVgpr: [0, 1]
+        - MIArchVgpr: [0]
+        - StoreVectorWidth: [4]
+        # - StoreVectorWidth: [1]
+        # - NumElementsPerBatchStore: [0, 2, 4, 8]
+        # - NumElementsPerBatchStore: [0, 2, 8] # 4?
+        # - NumElementsPerBatchStore: [0]
+        # - AssertAlphaValue: [1]
+        #- GlobalReadVectorWidth: [2, 4, 8]
+        - GlobalReadVectorWidthA: [4]
+        - GlobalReadVectorWidthB: [4]
+        # - LocalReadVectorWidth: [1, 2, 4]
+        #- StoreRemapVectorWidth: [0, 4]
+        - StoreRemapVectorWidth: [0]
+        # - StoreVectorWidth: [2, 4]
+        # - NonTemporalC: [0, 3]
+        # - NonTemporalD: [0, 3]
+        # - TransposeLDS: [0, 1]
+        # - VgprForLocalReadPacking: [False, True] # Diff from Tensile
+        # - ClusterLocalRead: [False, True]
+        # - VectorAtomicWidth: [2]
+        #- OptPreLoopVmcnt: [False, True]
+        #- WaveSeparateGlobalReadA: [0, 1]
+        #- WaveSeparateGlobalReadB: [0, 1]
+
+      BenchmarkForkParameters:
+      JoinParameters:
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [512, 512, 1, 512]
+          - Exact: [1024, 1024, 1, 1024]
+          - Exact: [1031, 1031, 1, 1031]
+          - Exact: [4096, 4096, 1, 4096]
+          - Exact: [4103, 4103, 1, 4103]

--- a/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_alpha0.yaml
+++ b/tensilelite/Tensile/Tests/common/streamk/sk_sgemm_alpha0.yaml
@@ -6,7 +6,7 @@ GlobalParameters:
   BoundsCheck: False
   KernelTime: False
   DataInitTypeAlpha: 0
-  DataInitTypeBeta: 1
+  DataInitTypeBeta: 2
   DataInitTypeA: 12
   DataInitTypeB: 13
   DataInitTypeC: 12


### PR DESCRIPTION
This update fixes the case when alpha=0 by ensuring that A/B matrices are not read and main loop does not run. Also added a new small test case with stream-k and alpha=0 to validate output.