### PR TITLE
Passing block_count for memcpy dScaleAB.

### DIFF
--- a/clients/include/hipBuffer.hpp
+++ b/clients/include/hipBuffer.hpp
@@ -152,14 +152,14 @@ private:
 };
 
 inline hipError_t
-    synchronize(HipDeviceBuffer& dBuf, const HipHostBuffer& hBuf, std::size_t repeats = 1)
+    synchronize(HipDeviceBuffer& dBuf, const HipHostBuffer& hBuf, std::size_t block_count = 1)
 {
     hipError_t hip_err;
-    for(size_t i = 0; i < repeats; ++i)
+    for(size_t i_block = 0; i_block < block_count; i_block++)
     {
-        hip_err = hipMemcpy(dBuf.as<char>() + i * dBuf.getNumBytes() / repeats,
+        hip_err = hipMemcpy(dBuf.as<char>() + i_block * dBuf.getNumBytes() / block_count,
                             hBuf.as<char>(),
-                            dBuf.getNumBytes() / repeats,
+                            dBuf.getNumBytes() / block_count,
                             dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyHostToDevice);
 
         if(hip_err != hipSuccess)

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -966,7 +966,7 @@ void testing_matmul_with_bias(const Arguments& arg,
 {
     double gpu_time_used, cpu_time_used, gpu_mem_gbytes;
     gpu_time_used = cpu_time_used = gpu_mem_gbytes = 0.0;
-    bool                   HMM    = arg.HMM;
+    bool                   HMM                     = arg.HMM;
     hipblaslt_local_handle handle{arg};
     hipStream_t            stream;
     CHECK_HIP_ERROR(hipStreamCreate(&stream));
@@ -1522,7 +1522,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                 CHECK_HIP_ERROR(synchronize(hScaleA[i], dScaleA[i]));
             }
             else
-                CHECK_HIP_ERROR(synchronize(dScaleA[i], hScaleA[i]));
+                CHECK_HIP_ERROR(synchronize(dScaleA[i], hScaleA[i], block_count));
         }
 
         if(arg.scaleB)
@@ -1539,7 +1539,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                 CHECK_HIP_ERROR(synchronize(hScaleB[i], dScaleB[i]));
             }
             else
-                CHECK_HIP_ERROR(synchronize(dScaleB[i], hScaleB[i]));
+                CHECK_HIP_ERROR(synchronize(dScaleB[i], hScaleB[i], block_count));
         }
 
         if(arg.scaleC)


### PR DESCRIPTION
Fixed the bug where --rotating, --scaleA and --scaleB were enabled in the hipblaslt-bench:
dScale should copy the memory from hScale for 'block_count' times.

local test:
[0;32m[----------] [mGlobal test environment tear-down
[0;32m[==========] [m48206 tests from 13 test suites ran. (1708912 ms total)
[0;32m[  PASSED  ] [m48206 tests.
hipBLASLt version: 1000