### PR TITLE
Remove duplicate fields in some logic files

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -38442,7 +38442,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3
@@ -38688,7 +38687,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -38442,7 +38442,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3
@@ -38688,7 +38687,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HHS_BH_Bias_GG_HAH_SAV.yaml
@@ -51462,7 +51462,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3
@@ -51708,7 +51707,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3

--- a/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
+++ b/library/src/amd_detail/rocblaslt/src/Tensile/Logic/asm_full/aldebaran/110CU/GridBased/aldebaran_Cijk_Alik_Bljk_HSS_BH_Bias_GG_HAH_SAV.yaml
@@ -51462,7 +51462,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3
@@ -51708,7 +51707,6 @@
       UseE: false
       UseInitialStridesAB: false
       UseInitialStridesCD: false
-      UseScaleAlphaVec: 0
       UseScaleAlphaVec: 1
     ScheduleGlobalRead: 1
     ScheduleIterAlg: 3


### PR DESCRIPTION
Removed duplicate fields in some logic files, the value kept corresponds to the value used in the global `problemType` field. 