### PR TITLE
hipblaslt-bench performance improvements

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -100,7 +100,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       find_package(ROCmSMI REQUIRED)
       list( APPEND COMMON_LINK_LIBS rocm_smi )
   endif()
-  
+
   # common source files used in subdirectories benchmarks and gtest thus ../common
   set( hipblaslt_test_bench_common
       ../common/singletons.cpp
@@ -111,6 +111,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       ../common/hipblaslt_parse_data.cpp
       ../common/hipblaslt_arguments.cpp
       ../common/hipblaslt_random.cpp
+      ../common/hipblaslt_init_device.cpp
       ${BLIS_CPP}
     )
 

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -63,6 +63,34 @@ __device__ uint32_t pseudo_random_device(size_t idx)
     return s;
 }
 
+/*! \brief  generate a random number in range [1,2,3,4,5,6,7,8,9,10] */
+template <typename T>
+__device__ T random_int(size_t idx)
+{
+    return T(pseudo_random_device(idx) % 10 + 1.f);
+}
+
+/*! \brief  generate a random number in range [-2,-1,0,1,2] */
+template <>
+__device__ hipblasLtHalf random_int<hipblasLtHalf>(size_t idx)
+{
+    return hipblasLtHalf(pseudo_random_device(idx) % 5 - 2.f);
+}
+
+/*! \brief  generate a random number in range [-2,-1,0,1,2] */
+template <>
+__device__ hip_bfloat16 random_int<hip_bfloat16>(size_t idx)
+{
+    return hip_bfloat16(pseudo_random_device(idx) % 5 - 2.f);
+}
+
+/*! \brief  generate a random number in range [1,2,3] */
+template <>
+__device__ int8_t random_int<int8_t>(size_t idx)
+{
+    return pseudo_random_device(idx) % 3 + 1;
+}
+
 template <typename T>
 void hipblaslt_init_device(ABC                      abc,
                            hipblaslt_initialization init,
@@ -90,7 +118,7 @@ void hipblaslt_init_device(ABC                      abc,
         case hipblaslt_initialization::rand_int:
             if(abc == ABC::A || abc == ABC::C)
                 fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
-                    return T(pseudo_random_device(idx) % 10 + 1.f);
+                    return random_int<T>(idx);
                 });
             else if(abc == ABC::B)
             {
@@ -99,7 +127,7 @@ void hipblaslt_init_device(ABC                      abc,
                     auto b     = idx / stride;
                     auto j     = (idx - b * stride) / lda;
                     auto i     = (idx - b * stride) - j * lda;
-                    auto value = T(pseudo_random_device(idx) % 10 + 1.f);
+                    auto value = random_int<T>(idx);
                     return (i ^ j) & 1 ? value : negate(value);
                 });
             }

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -1,0 +1,206 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include "hipblaslt_datatype2string.hpp"
+#include "hipblaslt_init.hpp"
+#include "hipblaslt_ostream.hpp"
+#include "hipblaslt_random.hpp"
+#include <hipblaslt/hipblaslt.h>
+
+template <typename T, typename F>
+__global__ void fill_kernel(T* A, size_t size, F f)
+{
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if(idx < size)
+        A[idx] = f(idx);
+}
+
+template <typename T, typename F>
+void fill_batch(T* A, size_t M, size_t N, size_t lda, size_t stride, size_t batch_count, const F& f)
+{
+    size_t size       = std::max(lda * N, stride) * batch_count;
+    size_t block_size = 256;
+    size_t grid_size  = (size + block_size - 1) / block_size;
+    fill_kernel<<<dim3(grid_size), dim3(block_size), 0, hipStreamDefault>>>(A, size, f);
+}
+
+__device__ uint32_t pseudo_random_device(size_t idx)
+{
+    // Numerical Recipes ranqd1, Chapter 7.1, ?An Even Quicker Generator, Eq. 7.1.6. parameters from Knuth and H. W. Lewis
+    auto s = idx * 1664525 + 1013904223;
+    // Run a few extra iterations to make the generators diverge
+    // in case the seeds are still poor (consecutive ints)
+    for(int i = 0; i < 3; i++)
+    {
+        // Marsaglia, G. (2003). "Xorshift RNGs". Journal of Statistical Software. 8 (14). doi:10.18637/jss.v008.i14
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+    }
+    return s;
+}
+
+template <typename T>
+void hipblaslt_init_device(ABC                      abc,
+                           hipblaslt_initialization init,
+                           bool                     is_nan,
+                           T*                       A,
+                           size_t                   M,
+                           size_t                   N,
+                           size_t                   lda,
+                           size_t                   stride,
+                           size_t                   batch_count)
+{
+    if(is_nan)
+    {
+        std::array<T, 100> rand_nans;
+        for(auto& r : rand_nans)
+            r = T(hipblaslt_nan_rng());
+        fill_batch(A, M, N, lda, stride, batch_count, [rand_nans](size_t idx) -> T {
+            return rand_nans[pseudo_random_device(idx) % rand_nans.size()];
+        });
+    }
+    else
+    {
+        switch(init)
+        {
+        case hipblaslt_initialization::rand_int:
+            if(abc == ABC::A || abc == ABC::C)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(pseudo_random_device(idx) % 10 + 1.f);
+                });
+            else if(abc == ABC::B)
+            {
+                stride = std::max(lda * N, stride);
+                fill_batch(A, M, N, lda, stride, batch_count, [stride, lda](size_t idx) -> T {
+                    auto b     = idx / stride;
+                    auto j     = (idx - b * stride) / lda;
+                    auto i     = (idx - b * stride) - j * lda;
+                    auto value = T(pseudo_random_device(idx) % 10 + 1.f);
+                    return (i ^ j) & 1 ? value : negate(value);
+                });
+            }
+            break;
+        case hipblaslt_initialization::trig_float:
+            if(abc == ABC::A || abc == ABC::C)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(sin(double(idx)));
+                });
+            else if(abc == ABC::B)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(cos(double(idx)));
+                });
+            break;
+        case hipblaslt_initialization::hpl:
+            fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                auto r = pseudo_random_device(idx);
+                return T(double(r) / double(std::numeric_limits<decltype(r)>::max()) - 0.5);
+            });
+            break;
+        case hipblaslt_initialization::special:
+            if(abc == ABC::A)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(hipblasLtHalf(65280.0));
+                });
+            else if(abc == ABC::B)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(hipblasLtHalf(0.0000607967376708984375));
+                });
+            else if(abc == ABC::C)
+                fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
+                    return T(pseudo_random_device(idx) % 10 + 1.f);
+                });
+            break;
+        case hipblaslt_initialization::zero:
+            fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T { return T(0); });
+            break;
+        default:
+            hipblaslt_cerr << "Error type in hipblaslt_init_device" << std::endl;
+            break;
+        }
+    }
+}
+
+void hipblaslt_init_device(ABC                      abc,
+                           hipblaslt_initialization init,
+                           bool                     is_nan,
+                           void*                    A,
+                           size_t                   M,
+                           size_t                   N,
+                           size_t                   lda,
+                           hipDataType              type,
+                           size_t                   stride,
+                           size_t                   batch_count)
+{
+    switch(type)
+    {
+    case HIP_R_32F:
+        hipblaslt_init_device<float>(
+            abc, init, is_nan, static_cast<float*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_64F:
+        hipblaslt_init_device<double>(
+            abc, init, is_nan, static_cast<double*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_16F:
+        hipblaslt_init_device<hipblasLtHalf>(
+            abc, init, is_nan, static_cast<hipblasLtHalf*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_16BF:
+        hipblaslt_init_device<hip_bfloat16>(
+            abc, init, is_nan, static_cast<hip_bfloat16*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_8F_E4M3_FNUZ:
+        hipblaslt_init_device<hipblaslt_f8_fnuz>(
+            abc, init, is_nan, static_cast<hipblaslt_f8_fnuz*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_8F_E5M2_FNUZ:
+        hipblaslt_init_device<hipblaslt_bf8_fnuz>(
+            abc, init, is_nan, static_cast<hipblaslt_bf8_fnuz*>(A), M, N, lda, stride, batch_count);
+        break;
+#ifdef ROCM_USE_FLOAT8
+    case HIP_R_8F_E4M3:
+        hipblaslt_init_device<hipblaslt_f8>(
+            abc, init, is_nan, static_cast<hipblaslt_f8*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_8F_E5M2:
+        hipblaslt_init_device<hipblaslt_bf8>(
+            abc, init, is_nan, static_cast<hipblaslt_bf8*>(A), M, N, lda, stride, batch_count);
+        break;
+#endif
+    case HIP_R_32I:
+        hipblaslt_init_device<int32_t>(
+            abc, init, is_nan, static_cast<int32_t*>(A), M, N, lda, stride, batch_count);
+        break;
+    case HIP_R_8I:
+        hipblaslt_init_device<hipblasLtInt8>(
+            abc, init, is_nan, static_cast<hipblasLtInt8*>(A), M, N, lda, stride, batch_count);
+        break;
+    default:
+        hipblaslt_cerr << "Error type in hipblaslt_init_device" << std::endl;
+        break;
+    }
+}

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -140,7 +140,6 @@ public:
             m_size = m_capacity = 0;
         }
         m_d.reset(d);
-        // m_d = std::make_unique<char[]>(capacity);
     }
 
     char* get()
@@ -154,7 +153,6 @@ public:
 
 private:
     std::unique_ptr<char, decltype(&hipHostFree)> m_d{nullptr, &hipHostFree};
-    // std::unique_ptr<char[]> m_d;
 };
 
 /* ============================================================================================ */
@@ -213,6 +211,7 @@ private:
     void restore(M& dm)
     {
         auto& pool = dm.is_managed() ? m_pool_managed : m_pool;
+        // insert in (sorted) pool
         pool.insert(std::lower_bound(pool.begin(), pool.end(), dm.capacity()), std::move(dm));
     }
 };

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -210,6 +210,8 @@ private:
 
     void restore(M& dm)
     {
+        if(!dm.get() || !dm.capacity())
+            return;
         auto& pool = dm.is_managed() ? m_pool_managed : m_pool;
         // insert in (sorted) pool
         pool.insert(std::lower_bound(pool.begin(), pool.end(), dm.capacity()), std::move(dm));

--- a/clients/include/d_vector.hpp
+++ b/clients/include/d_vector.hpp
@@ -38,14 +38,195 @@
 #define MAX_DTYPE_SIZE sizeof(double)
 
 /* ============================================================================================ */
+/*! \brief  (abstract class) wrapper around a pointer to hip device or pinned host memory, including allocation size in bytes */
+class hip_memory
+{
+public:
+    size_t bytes() const
+    {
+        return m_size;
+    }
+    size_t capacity() const
+    {
+        return m_capacity;
+    }
+
+    void resize(size_t s)
+    {
+        assert(s <= m_capacity);
+        m_size = s;
+    }
+
+    bool is_managed() const
+    {
+        return m_managed;
+    }
+
+    bool operator<(size_t s) const
+    {
+        return capacity() < s;
+    }
+
+protected:
+    hip_memory(size_t size, size_t capacity, bool use_HMM = false)
+        : m_size(size)
+        , m_capacity(capacity)
+        , m_managed(use_HMM)
+    {
+    }
+    virtual ~hip_memory() = default;
+
+    size_t m_size     = 0;
+    size_t m_capacity = 0;
+    bool   m_managed  = false;
+};
+
+/* ============================================================================================ */
+/*! \brief  wrapper around a pointer to device memory, including allocation size in bytes */
+class d_memory : public hip_memory
+{
+public:
+    d_memory()
+        : hip_memory(0, 0, false)
+    {
+    }
+
+    d_memory(size_t size, size_t capacity, bool use_HMM = false)
+        : hip_memory(size, capacity, use_HMM)
+    {
+        char* d = nullptr;
+        if((use_HMM ? hipMallocManaged(&d, capacity) : hipMalloc(&d, capacity)) != hipSuccess)
+        {
+            hipblaslt_cerr << "Error allocating (" << (m_size >> 30) << " GB) device memory"
+                           << std::endl;
+            d      = nullptr;
+            m_size = m_capacity = 0;
+        }
+        m_d.reset(d);
+    }
+
+    char* get()
+    {
+        return m_d.get();
+    }
+    const char* get() const
+    {
+        return m_d.get();
+    }
+
+private:
+    std::unique_ptr<char, decltype(&hipFree)> m_d{nullptr, &hipFree};
+};
+
+/* ============================================================================================ */
+/*! \brief  wrapper around a pointer to pinned host memory (hipHostMalloc), including allocation size in bytes */
+class h_memory : public hip_memory
+{
+public:
+    h_memory()
+        : hip_memory(0, 0, false)
+    {
+    }
+
+    h_memory(size_t size, size_t capacity, bool use_HMM = false)
+        : hip_memory(size, capacity, false)
+    {
+        char* d = nullptr;
+        if(hipHostMalloc(&d, capacity) != hipSuccess)
+        {
+            hipblaslt_cerr << "Error allocating (" << (m_size >> 30) << " GB) host memory"
+                           << std::endl;
+            d      = nullptr;
+            m_size = m_capacity = 0;
+        }
+        m_d.reset(d);
+        // m_d = std::make_unique<char[]>(capacity);
+    }
+
+    char* get()
+    {
+        return m_d.get();
+    }
+    const char* get() const
+    {
+        return m_d.get();
+    }
+
+private:
+    std::unique_ptr<char, decltype(&hipHostFree)> m_d{nullptr, &hipHostFree};
+    // std::unique_ptr<char[]> m_d;
+};
+
+/* ============================================================================================ */
+/*! \brief  memory pool class to keep track of memory in either M = d_memory, or M = h_memory objects */
+template <typename M>
+class memory_pool
+{
+public:
+    static M Get(size_t m_bytes, bool use_HMM = false)
+    {
+        return Instance().get(m_bytes, use_HMM);
+    }
+
+    static void Restore(M& dm)
+    {
+        Instance().restore(dm);
+    }
+
+private:
+    std::vector<M> m_pool, m_pool_managed;
+
+    static memory_pool& Instance()
+    {
+        static memory_pool buffer;
+        return buffer;
+    }
+
+    M get(size_t bytes, bool use_HMM = false)
+    {
+        auto& pool = use_HMM ? m_pool_managed : m_pool;
+        auto  it   = std::lower_bound(pool.begin(), pool.end(), bytes);
+        if(it != pool.end() && // found a buffer that is large enough ..
+           it->capacity() < 4 * bytes) // but not way too large
+        {
+            auto p = std::move(*it);
+            p.resize(bytes);
+            pool.erase(it);
+            return p;
+        }
+        else
+        {
+            // remove the (largest) buffer that was too small
+            if(it != pool.begin())
+                pool.erase(it - 1);
+            // Allocate 20% extra for later reuse
+            auto e = M(bytes, bytes * 1.2, use_HMM);
+            if(e.get())
+                return e;
+            hipblaslt_cerr << "Clearing memory pool" << std::endl;
+            // allocation failed, so clear the pool and try again (without the 20%)
+            pool.clear();
+            return M(bytes, bytes, use_HMM);
+        }
+    }
+
+    void restore(M& dm)
+    {
+        auto& pool = dm.is_managed() ? m_pool_managed : m_pool;
+        pool.insert(std::lower_bound(pool.begin(), pool.end(), dm.capacity()), std::move(dm));
+    }
+};
+
+/* ============================================================================================ */
 /*! \brief  base-class to allocate/deallocate device memory */
 template <typename T>
 class d_vector
 {
 private:
-    size_t m_size;
-    size_t m_pad, m_guard_len;
-    size_t m_bytes;
+    size_t   m_size;
+    size_t   m_pad, m_guard_len;
+    size_t   m_bytes;
+    d_memory m_mem;
 
     static bool m_init_guard;
 
@@ -89,16 +270,10 @@ public:
 
     T* device_vector_setup()
     {
-        T* d = nullptr;
-        if(use_HMM ? hipMallocManaged(&d, m_bytes) : (hipMalloc)(&d, m_bytes) != hipSuccess)
-        {
-            hipblaslt_cerr << "Error allocating " << m_bytes << " m_bytes (" << (m_bytes >> 30)
-                           << " GB)" << std::endl;
-
-            d = nullptr;
-        }
+        m_mem = memory_pool<d_memory>::Get(m_bytes, use_HMM);
+        T* d  = reinterpret_cast<T*>(m_mem.get());
 #ifdef GOOGLE_TEST
-        else
+        if(d)
         {
             if(m_guard_len > 0)
             {
@@ -173,12 +348,8 @@ public:
                 delete[] host;
             }
 #endif
-            // Free device memory
-            if((hipFree)(d) != hipSuccess)
-            {
-                hipblaslt_cerr << "free device memory failed" << std::endl;
-            }
         }
+        memory_pool<d_memory>::Restore(m_mem);
     }
 };
 
@@ -191,6 +362,7 @@ private:
     hipDataType m_dtype;
     size_t      m_pad, m_guard_len;
     size_t      m_bytes;
+    d_memory    m_mem;
 
     inline static bool m_init_guard_type;
 
@@ -236,16 +408,10 @@ public:
 
     char* device_vector_setup()
     {
-        char* d = nullptr;
-        if(use_HMM ? hipMallocManaged(&d, m_bytes) : (hipMalloc)(&d, m_bytes) != hipSuccess)
-        {
-            hipblaslt_cerr << "Error allocating " << m_bytes << " m_bytes (" << (m_bytes >> 30)
-                           << " GB)" << std::endl;
-
-            d = nullptr;
-        }
+        m_mem   = memory_pool<d_memory>::Get(m_bytes, use_HMM);
+        char* d = m_mem.get();
 #ifdef GOOGLE_TEST
-        else
+        if(d)
         {
             if(m_guard_len > 0)
             {
@@ -330,12 +496,8 @@ public:
                 delete[] host;
             }
 #endif
-            // Free device memory
-            if((hipFree)(d) != hipSuccess)
-            {
-                hipblaslt_cerr << "free device memory failed" << std::endl;
-            }
         }
+        memory_pool<d_memory>::Restore(m_mem);
     }
 };
 

--- a/clients/include/hipBuffer.hpp
+++ b/clients/include/hipBuffer.hpp
@@ -162,6 +162,24 @@ inline hipError_t
     return hip_err;
 }
 
+inline hipError_t broadcast(HipDeviceBuffer& dBuf, std::size_t repeats)
+{
+    hipError_t hip_err;
+    for(size_t i = 1; i < repeats; ++i)
+    {
+        hip_err = hipMemcpy(dBuf.as<char>() + i * dBuf.getNumBytes() / repeats,
+                            dBuf.as<char>(),
+                            dBuf.getNumBytes() / repeats,
+                            dBuf.use_HMM ? hipMemcpyHostToHost : hipMemcpyDeviceToDevice);
+
+        if(hip_err != hipSuccess)
+        {
+            return hip_err;
+        }
+    }
+    return hip_err;
+}
+
 inline hipError_t synchronize(HipHostBuffer& hBuf, const HipDeviceBuffer& dBuf)
 {
     hipError_t hip_err;

--- a/clients/include/hipBuffer.hpp
+++ b/clients/include/hipBuffer.hpp
@@ -36,29 +36,29 @@ public:
     HipDeviceBuffer(hipDataType dtype, std::size_t numElements, bool HMM = false)
         : d_vector_type(dtype, numElements, HMM)
         , numBytes(realDataTypeSize(dtype) * numElements)
-        , buffer{this->device_vector_setup(), &hipFree}
+        , buffer(this->device_vector_setup())
     {
     }
 
     ~HipDeviceBuffer()
     {
-        this->device_vector_teardown(static_cast<char*>(buffer.get()));
+        this->device_vector_teardown(static_cast<char*>(buffer));
         buffer = nullptr;
     }
 
-    HipDeviceBuffer(const HipDeviceBuffer&)            = delete;
-    HipDeviceBuffer(HipDeviceBuffer&&)                 = default;
+    HipDeviceBuffer(const HipDeviceBuffer&) = delete;
+    HipDeviceBuffer(HipDeviceBuffer&&)      = default;
     HipDeviceBuffer& operator=(const HipDeviceBuffer&) = delete;
-    HipDeviceBuffer& operator=(HipDeviceBuffer&&)      = default;
+    HipDeviceBuffer& operator=(HipDeviceBuffer&&) = default;
 
     void* buf()
     {
-        return buffer.get();
+        return buffer;
     }
 
     const void* buf() const
     {
-        return buffer.get();
+        return buffer;
     }
 
     std::size_t getNumBytes() const
@@ -79,25 +79,28 @@ public:
     }
 
 private:
-    std::size_t                               numBytes;
-    std::unique_ptr<void, decltype(&hipFree)> buffer;
+    std::size_t numBytes;
+    void*       buffer;
 };
 
 class HipHostBuffer
 {
 public:
     HipHostBuffer(hipDataType dtype, std::size_t numElements)
-        : numBytes(realDataTypeSize(dtype) * numElements ? realDataTypeSize(dtype) * numElements
-                                                         : realDataTypeSize(dtype))
-        , buffer(createBuffer(numBytes))
+        : buffer(memory_pool<h_memory>::Get(realDataTypeSize(dtype) * numElements
+                                                ? realDataTypeSize(dtype) * numElements
+                                                : realDataTypeSize(dtype)))
     {
     }
 
-    ~HipHostBuffer()                               = default;
-    HipHostBuffer(const HipHostBuffer&)            = delete;
-    HipHostBuffer(HipHostBuffer&&)                 = default;
+    ~HipHostBuffer()
+    {
+        memory_pool<h_memory>::Restore(buffer);
+    }
+    HipHostBuffer(const HipHostBuffer&) = delete;
+    HipHostBuffer(HipHostBuffer&&)      = default;
     HipHostBuffer& operator=(const HipHostBuffer&) = delete;
-    HipHostBuffer& operator=(HipHostBuffer&&)      = default;
+    HipHostBuffer& operator=(HipHostBuffer&&) = default;
 
     void* end()
     {
@@ -121,7 +124,7 @@ public:
 
     std::size_t getNumBytes() const
     {
-        return numBytes;
+        return buffer.bytes();
     }
 
     template <typename T>
@@ -137,18 +140,7 @@ public:
     }
 
 private:
-    std::size_t                                      numBytes;
-    std::unique_ptr<void, decltype(&hipFree)>        buffer;
-    static std::unique_ptr<void, decltype(&hipFree)> createBuffer(std::size_t numBytes)
-    {
-        void* rawBuf{};
-        (void)hipHostMalloc(&rawBuf, numBytes);
-        if(!rawBuf)
-        {
-            hipblaslt_cerr << "Error to allocate memory in HipHostBuffer" << std::endl;
-        }
-        return std::unique_ptr<void, decltype(&hipFree)>(rawBuf, &hipFree);
-    }
+    h_memory buffer;
 };
 
 inline hipError_t

--- a/clients/include/hipblaslt_init.hpp
+++ b/clients/include/hipblaslt_init.hpp
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include "hipblaslt_datatype2string.hpp"
 #include "hipblaslt_math.hpp"
 #include "hipblaslt_ostream.hpp"
 #include "hipblaslt_random.hpp"
@@ -34,6 +35,24 @@
 #include <iostream>
 #include <omp.h>
 #include <vector>
+
+enum class ABC
+{
+    A,
+    B,
+    C
+};
+
+void hipblaslt_init_device(ABC                      abc,
+                           hipblaslt_initialization init,
+                           bool                     is_nan,
+                           void*                    A,
+                           size_t                   M,
+                           size_t                   N,
+                           size_t                   lda,
+                           hipDataType              type,
+                           size_t                   stride,
+                           size_t                   batch_count);
 
 /* ============================================================================================ */
 /*! \brief  matrix/vector initialization: */
@@ -118,8 +137,7 @@ inline void hipblaslt_init(void*       A,
         break;
 #ifdef ROCM_USE_FLOAT8
     case HIP_R_8F_E4M3:
-        hipblaslt_init<hipblaslt_f8>(
-            static_cast<hipblaslt_f8*>(A), M, N, lda, stride, batch_count);
+        hipblaslt_init<hipblaslt_f8>(static_cast<hipblaslt_f8*>(A), M, N, lda, stride, batch_count);
         break;
     case HIP_R_8F_E5M2:
         hipblaslt_init<hipblaslt_bf8>(
@@ -238,7 +256,7 @@ inline void hipblaslt_init_sin(void*       A,
 }
 
 // Initialize matrix so adjacent entries have alternating sign.
-// In gemm if either A or B are initialized with alernating
+// In gemm if either A or B are initialized with alternating
 // sign the reduction sum will be summing positive
 // and negative numbers, so it should not get too large.
 // This helps reduce floating point inaccuracies for 16bit
@@ -625,12 +643,10 @@ inline void hipblaslt_init_nan(void* A, size_t start_offset, size_t end_offset, 
         break;
 #ifdef ROCM_USE_FLOAT8
     case HIP_R_8F_E4M3:
-        hipblaslt_init_nan<hipblaslt_f8>(
-            static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
+        hipblaslt_init_nan<hipblaslt_f8>(static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
         break;
     case HIP_R_8F_E5M2:
-        hipblaslt_init_nan<hipblaslt_bf8>(
-            static_cast<hipblaslt_bf8*>(A), start_offset, end_offset);
+        hipblaslt_init_nan<hipblaslt_bf8>(static_cast<hipblaslt_bf8*>(A), start_offset, end_offset);
         break;
 #endif
     case HIP_R_32I:
@@ -875,12 +891,10 @@ inline void hipblaslt_init_inf(void* A, size_t start_offset, size_t end_offset, 
         break;
 #ifdef ROCM_USE_FLOAT8
     case HIP_R_8F_E4M3:
-        hipblaslt_init_inf<hipblaslt_f8>(
-            static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
+        hipblaslt_init_inf<hipblaslt_f8>(static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
         break;
     case HIP_R_8F_E5M2:
-        hipblaslt_init_inf<hipblaslt_bf8>(
-            static_cast<hipblaslt_bf8*>(A), start_offset, end_offset);
+        hipblaslt_init_inf<hipblaslt_bf8>(static_cast<hipblaslt_bf8*>(A), start_offset, end_offset);
         break;
 #endif
     case HIP_R_32I:
@@ -1062,8 +1076,7 @@ inline void hipblaslt_init_zero(void* A, size_t start_offset, size_t end_offset,
         break;
 #ifdef ROCM_USE_FLOAT8
     case HIP_R_8F_E4M3:
-        hipblaslt_init_zero<hipblaslt_f8>(
-            static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
+        hipblaslt_init_zero<hipblaslt_f8>(static_cast<hipblaslt_f8*>(A), start_offset, end_offset);
         break;
     case HIP_R_8F_E5M2:
         hipblaslt_init_zero<hipblaslt_bf8>(

--- a/clients/include/hipblaslt_math.hpp
+++ b/clients/include/hipblaslt_math.hpp
@@ -49,13 +49,13 @@ inline __host__ hip_bfloat16 float_to_bfloat16_truncate(float val)
 /*! \brief negate a value */
 
 template <class T>
-inline T negate(T x)
+inline __device__ __host__ T negate(T x)
 {
     return -x;
 }
 
 template <>
-inline hip_bfloat16 negate(hip_bfloat16 x)
+inline __device__ __host__ hip_bfloat16 negate(hip_bfloat16 x)
 {
 
 #if defined(__HIP_PLATFORM_AMD__)
@@ -69,14 +69,14 @@ inline hip_bfloat16 negate(hip_bfloat16 x)
 }
 
 template <>
-inline hipblaslt_f8_fnuz negate(hipblaslt_f8_fnuz x)
+inline __device__ __host__ hipblaslt_f8_fnuz negate(hipblaslt_f8_fnuz x)
 {
     x.data ^= 0x80;
     return x;
 }
 
 template <>
-inline hipblaslt_bf8_fnuz negate(hipblaslt_bf8_fnuz x)
+inline __device__ __host__ hipblaslt_bf8_fnuz negate(hipblaslt_bf8_fnuz x)
 {
     x.data ^= 0x80;
     return x;
@@ -84,14 +84,14 @@ inline hipblaslt_bf8_fnuz negate(hipblaslt_bf8_fnuz x)
 
 #ifdef ROCM_USE_FLOAT8
 template <>
-inline hipblaslt_f8 negate(hipblaslt_f8 x)
+inline __device__ __host__ hipblaslt_f8 negate(hipblaslt_f8 x)
 {
     x.data ^= 0x80;
     return x;
 }
 
 template <>
-inline hipblaslt_bf8 negate(hipblaslt_bf8 x)
+inline __device__ __host__ hipblaslt_bf8 negate(hipblaslt_bf8 x)
 {
     x.data ^= 0x80;
     return x;

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -1376,7 +1376,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                               lda[i],
                               TiA,
                               stride_a[i],
-                              block_count);
+                              num_batches[i]);
         hipblaslt_init_device(ABC::B,
                               arg.initialization,
                               alpha_isnan_type(arg, Talpha),
@@ -1386,7 +1386,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                               ldb[i],
                               TiB,
                               stride_b[i],
-                              block_count);
+                              num_batches[i]);
         hipblaslt_init_device(ABC::C,
                               arg.initialization,
                               beta_isnan_type(arg, Talpha),
@@ -1396,7 +1396,13 @@ void testing_matmul_with_bias(const Arguments& arg,
                               ldc[i],
                               To,
                               stride_c[i],
-                              block_count);
+                              num_batches[i]);
+
+        // broadcast first block
+        CHECK_HIP_ERROR(broadcast(dA[i], block_count));
+        CHECK_HIP_ERROR(broadcast(dB[i], block_count));
+        CHECK_HIP_ERROR(broadcast(dC[i], block_count));
+
         if(arg.unit_check || arg.norm_check || arg.allclose_check)
         {
             CHECK_HIP_ERROR(synchronize(hA[i], dA[i]));

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -966,7 +966,7 @@ void testing_matmul_with_bias(const Arguments& arg,
 {
     double gpu_time_used, cpu_time_used, gpu_mem_gbytes;
     gpu_time_used = cpu_time_used = gpu_mem_gbytes = 0.0;
-    bool                   HMM    = arg.HMM;
+    bool                   HMM                     = arg.HMM;
     hipblaslt_local_handle handle{arg};
     hipStream_t            stream;
     CHECK_HIP_ERROR(hipStreamCreate(&stream));
@@ -1367,72 +1367,41 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         hipblaslt_seedrand();
 
-        // Initial Data on CPU
-        if(alpha_isnan_type(arg, Talpha))
+        hipblaslt_init_device(ABC::A,
+                              arg.initialization,
+                              alpha_isnan_type(arg, Talpha),
+                              dA[i].buf(),
+                              A_row[i],
+                              A_col[i],
+                              lda[i],
+                              TiA,
+                              stride_a[i],
+                              num_batches[i]);
+        hipblaslt_init_device(ABC::B,
+                              arg.initialization,
+                              alpha_isnan_type(arg, Talpha),
+                              dB[i].buf(),
+                              B_row[i],
+                              B_col[i],
+                              ldb[i],
+                              TiB,
+                              stride_b[i],
+                              num_batches[i]);
+        hipblaslt_init_device(ABC::C,
+                              arg.initialization,
+                              beta_isnan_type(arg, Talpha),
+                              dC[i].buf(),
+                              M[i],
+                              N[i],
+                              ldc[i],
+                              To,
+                              stride_c[i],
+                              num_batches[i]);
+        if(arg.unit_check || arg.norm_check || arg.allclose_check)
         {
-            hipblaslt_init_nan(
-                hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
-            hipblaslt_init_nan(
-                hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
-        }
-        else
-        {
-            if(arg.initialization == hipblaslt_initialization::rand_int)
-            {
-                hipblaslt_init(
-                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
-                hipblaslt_init_alternating_sign(
-                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
-            }
-            else if(arg.initialization == hipblaslt_initialization::trig_float)
-            {
-                hipblaslt_init_sin(
-                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
-                hipblaslt_init_cos(
-                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
-            }
-            else if(arg.initialization == hipblaslt_initialization::hpl)
-            {
-                hipblaslt_init_hpl(
-                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
-                hipblaslt_init_hpl(
-                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
-            }
-            else if(arg.initialization == hipblaslt_initialization::special)
-            {
-                hipblaslt_init_alt_impl_big(
-                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, num_batches[i]);
-                hipblaslt_init_alt_impl_small(
-                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, num_batches[i]);
-            }
-            else if(arg.initialization == hipblaslt_initialization::zero)
-            {
-                hipblaslt_init_zero(
-                    hA[i].buf(), A_row[i], A_col[i], lda[i], TiA, stride_a[i], num_batches[i]);
-                hipblaslt_init_zero(
-                    hB[i].buf(), B_row[i], B_col[i], ldb[i], TiB, stride_b[i], num_batches[i]);
-            }
-        }
-
-        if(beta_isnan_type(arg, Talpha))
-        {
-            hipblaslt_init_nan(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
-        }
-        else
-        {
-            if(arg.initialization == hipblaslt_initialization::rand_int)
-                hipblaslt_init(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
-            else if(arg.initialization == hipblaslt_initialization::trig_float)
-                hipblaslt_init_sin(
-                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
-            else if(arg.initialization == hipblaslt_initialization::hpl)
-                hipblaslt_init_hpl(
-                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
-            else if(arg.initialization == hipblaslt_initialization::special)
-                hipblaslt_init(hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
-            else if(arg.initialization == hipblaslt_initialization::zero)
-                hipblaslt_init_zero(
-                    hC[i].buf(), M[i], N[i], ldc[i], To, stride_c[i], num_batches[i]);
+            CHECK_HIP_ERROR(synchronize(hA[i], dA[i]));
+            CHECK_HIP_ERROR(synchronize(hB[i], dB[i]));
+            CHECK_HIP_ERROR(synchronize(hC[i], dC[i]));
         }
 
         if(arg.gradient && arg.use_e)
@@ -1484,10 +1453,6 @@ void testing_matmul_with_bias(const Arguments& arg,
         if(arg.scaleAlpha_vector)
             hipblaslt_init(hScaleAlphaVec[i].buf(), M[i], 1, M[i], Talpha);
 
-        // copy data from CPU to device
-        CHECK_HIP_ERROR(synchronize(dA[i], hA[i], block_count));
-        CHECK_HIP_ERROR(synchronize(dB[i], hB[i], block_count));
-        CHECK_HIP_ERROR(synchronize(dC[i], hC[i], block_count));
         if(arg.gradient && arg.use_e)
         {
             CHECK_HIP_ERROR(synchronize(dE[i], hE[i], block_count));
@@ -1753,7 +1718,7 @@ void testing_matmul_with_bias(const Arguments& arg,
     // Get Heuristic results
     int32_t requestAlgoCount = arg.requested_solution_num < 0 ? HIPBLASLT_MAX_REQUESTED_SOLUTION_NUM
                                                               : arg.requested_solution_num;
-    int     returnedAlgoCount = 0;
+    int                                           returnedAlgoCount = 0;
     std::vector<hipblasLtMatmulHeuristicResult_t> heuristicResult;
     std::vector<size_t>                           heuristicTuningIndex;
 
@@ -1772,22 +1737,24 @@ void testing_matmul_with_bias(const Arguments& arg,
 
     for(int32_t b = 0; b < block_count; b++)
     {
-        gemmVec.push_back(hipblaslt_ext::Gemm(handle,
-                                              transA,
-                                              transB,
-                                              arg.a_type,
-                                              arg.b_type,
-                                              arg.c_type,
-                                              arg.d_type,
-                                              arg.compute_type));
-        groupedGemmVec.push_back(hipblaslt_ext::GroupedGemm(handle,
-                                                            transA,
-                                                            transB,
-                                                            arg.a_type,
-                                                            arg.b_type,
-                                                            arg.c_type,
-                                                            arg.d_type,
-                                                            arg.compute_type));
+        if(!do_grouped_gemm)
+            gemmVec.push_back(hipblaslt_ext::Gemm(handle,
+                                                  transA,
+                                                  transB,
+                                                  arg.a_type,
+                                                  arg.b_type,
+                                                  arg.c_type,
+                                                  arg.d_type,
+                                                  arg.compute_type));
+        else
+            groupedGemmVec.push_back(hipblaslt_ext::GroupedGemm(handle,
+                                                                transA,
+                                                                transB,
+                                                                arg.a_type,
+                                                                arg.b_type,
+                                                                arg.c_type,
+                                                                arg.d_type,
+                                                                arg.compute_type));
     }
 
     std::vector<hipblaslt_ext::GemmEpilogueV2> extepilogue;
@@ -2580,12 +2547,12 @@ void testing_matmul_with_bias(const Arguments& arg,
                                TciA,
                                TciB,
                                false);
-                    auto                        pos       = stride_d[gemmIdx] * batchIdx;
-                    std::vector<HipHostBuffer>* hEInst    = arg.gradient ? &hE : &hE_gold;
-                    void*                       ePos      = ((*hEInst).size() <= gemmIdx)
-                                                                ? nullptr
-                                                                : ((*hEInst)[gemmIdx].as<char>() + pos * realDataTypeSize(To));
-                    auto                        applyBias = arg.gradient ? false : arg.bias_vector;
+                    auto                        pos    = stride_d[gemmIdx] * batchIdx;
+                    std::vector<HipHostBuffer>* hEInst = arg.gradient ? &hE : &hE_gold;
+                    void*                       ePos   = ((*hEInst).size() <= gemmIdx)
+                                     ? nullptr
+                                     : ((*hEInst)[gemmIdx].as<char>() + pos * realDataTypeSize(To));
+                    auto  applyBias = arg.gradient ? false : arg.bias_vector;
                     void* hBias_buf = ((hBias).size() <= gemmIdx) ? nullptr : hBias[gemmIdx].buf();
 
                     switch(arg.activation_type)
@@ -2954,9 +2921,9 @@ void testing_matmul_with_bias(const Arguments& arg,
                     {
                         auto ptr_matmul = matmul[i % block_count][0];
                         auto ptr_alpha  = arg.scaleAlpha_vector
-                                              ? (dScaleAlphaVec[0].as<char>())
+                                             ? (dScaleAlphaVec[0].as<char>())
                                                    + (i % block_count) * size_scaleAlphaVec[0]
-                                              : alpha_in[0];
+                                             : alpha_in[0];
                         EXPECT_HIPBLAS_STATUS(
                             hipblasLtMatmul(
                                 handle,
@@ -2994,9 +2961,9 @@ void testing_matmul_with_bias(const Arguments& arg,
                     {
                         auto ptr_matmul = matmul[i % block_count][0];
                         auto ptr_alpha  = arg.scaleAlpha_vector
-                                              ? (dScaleAlphaVec[0].as<char>())
+                                             ? (dScaleAlphaVec[0].as<char>())
                                                    + (i % block_count) * size_scaleAlphaVec[0]
-                                              : alpha_in[0];
+                                             : alpha_in[0];
                         EXPECT_HIPBLAS_STATUS(
                             hipblasLtMatmul(
                                 handle,

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -1376,7 +1376,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                               lda[i],
                               TiA,
                               stride_a[i],
-                              num_batches[i]);
+                              block_count);
         hipblaslt_init_device(ABC::B,
                               arg.initialization,
                               alpha_isnan_type(arg, Talpha),
@@ -1386,7 +1386,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                               ldb[i],
                               TiB,
                               stride_b[i],
-                              num_batches[i]);
+                              block_count);
         hipblaslt_init_device(ABC::C,
                               arg.initialization,
                               beta_isnan_type(arg, Talpha),
@@ -1396,7 +1396,7 @@ void testing_matmul_with_bias(const Arguments& arg,
                               ldc[i],
                               To,
                               stride_c[i],
-                              num_batches[i]);
+                              block_count);
         if(arg.unit_check || arg.norm_check || arg.allclose_check)
         {
             CHECK_HIP_ERROR(synchronize(hA[i], dA[i]));


### PR DESCRIPTION
This improves performance of hipblaslt-bench when timing a large number of matmuls.

There are 2 main changes

- Initialization of A, B and C matrices is done on the device instead of the host. This also avoids the hipMemcpy from host to device. But when a host copy is needed for the correctness check, the device matrix is still copied back to the host.
- A memory pool to reuse memory allocated with hipMalloc/hipMallocManaged or hipHostMalloc. This might slightly increase memory use.

Both changes together significantly improve performance. 
I have a test yaml input file with ~500K tests. 
With these changes, the code runs in ~42 minutes, compared to 8 hours before (on MI300).

I initially used rocRAND, but then removed this dependency. I can add that back if it is preferred over my own naive random number generator.

This is based on a commit by @bethune-bryant 