### PR TITLE
Add a check for unsupported transpose and datatype

### DIFF
--- a/clients/benchmarks/README.md
+++ b/clients/benchmarks/README.md
@@ -36,8 +36,8 @@ cd hipBLASLt; cd build/release
 --compute_input_typeB <value>     Options: f32_r, f16_r, bf16_r, f8_r, bf8_r, The default value indicates that the argument has no effect. (Default value is: INVALID)
 --scale_type <value>       Precision of scalar. Options: f16_r,bf16_r
 --initialization <value>   Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero  (Default value is: hpl)
---transA <value>           N = no transpose, T = transpose, C = conjugate transpose                            (Default value is: N)
---transB <value>           N = no transpose, T = transpose, C = conjugate transpose                            (Default value is: N)
+--transA <value>           N = no transpose, T = transpose                                                     (Default value is: N)
+--transB <value>           N = no transpose, T = transpose                                                     (Default value is: N)
 --batch_count <value>      Number of matrices. Only applicable to batched and strided_batched routines         (Default value is: 1)
 --HMM                      Parameter requesting the use of HipManagedMemory
 --verify |-v               Validate GPU results with CPU?

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -419,11 +419,11 @@ try
 
         ("transA",
          value<char>(&arg.transA)->default_value('N'),
-         "N = no transpose, T = transpose, C = conjugate transpose")
+         "N = no transpose, T = transpose")
 
         ("transB",
          value<char>(&arg.transB)->default_value('N'),
-         "N = no transpose, T = transpose, C = conjugate transpose")
+         "N = no transpose, T = transpose")
 
         ("batch_count",
          value<int32_t>(&arg.batch_count)->default_value(1),

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -789,7 +789,7 @@ try
     bool is_f32 = arg.a_type == HIP_R_32F;
     arg.compute_type
         = compute_type == "" ? (HIPBLAS_COMPUTE_32F) : string_to_hipblas_computetype(compute_type);
-    if(arg.compute_type == static_cast<hipblasComputeType_t>(0))
+    if(arg.compute_type == HIPBLASLT_COMPUTE_TYPE_INVALID)
         throw std::invalid_argument("Invalid value for --compute_type " + compute_type);
 
     //The value HIPBLASLT_DATATYPE_INVALID indicates that the compute_input_typeA has no effect.

--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -86,8 +86,8 @@ For more information, see command:
    --compute_type <value>     Precision of computation. Options: s,f32_r,x,xf32_r,f64_r,i32_r                     (Default value is: f32_r)
    --scale_type <value>       Precision of scalar. Options: f16_r,bf16_r
    --initialization <value>   Initialize matrix data.Options: rand_int, trig_float, hpl(floating), special, zero  (Default value is: hpl)
-   --transA <value>           N = no transpose, T = transpose, C = conjugate transpose                            (Default value is: N)
-   --transB <value>           N = no transpose, T = transpose, C = conjugate transpose                            (Default value is: N)
+   --transA <value>           N = no transpose, T = transpose                                                     (Default value is: N)
+   --transB <value>           N = no transpose, T = transpose                                                     (Default value is: N)
    --batch_count <value>      Number of matrices. Only applicable to batched and strided_batched routines         (Default value is: 1)
    --HMM                      Parameter requesting the use of HipManagedMemory
    --verify |-v               Validate GPU results with CPU?

--- a/library/include/hipblaslt.h
+++ b/library/include/hipblaslt.h
@@ -81,6 +81,8 @@
 // clang-format off
 
 #define HIPBLASLT_DATATYPE_INVALID static_cast<hipDataType>(255)
+// TODO: Replace static_cast<hipblasComputeType_t>(0) with the appropriate value since 0 represents f16_r
+#define HIPBLASLT_COMPUTE_TYPE_INVALID static_cast<hipblasComputeType_t>(0)
 
 /*! \ingroup types_module
  *  \brief Specify the enum type to set the postprocessing options for the epilogue.

--- a/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
@@ -27,6 +27,7 @@
 #pragma once
 #ifndef ROCBLASLT_UTILS_HPP
 #define ROCBLASLT_UTILS_HPP
+#include "auxiliary.hpp"
 #include "handle.h"
 #include "utility.hpp"
 
@@ -139,24 +140,79 @@ inline rocblaslt_status validateMatmulDescrArgs(rocblaslt_handle       handle,
 /*******************************************************************************
  * Validate Matmul Arguments
  ******************************************************************************/
-inline rocblaslt_status validateMatmulArgs(int64_t     m,
-                                           int64_t     n,
-                                           int64_t     k,
-                                           const void* alpha,
-                                           const void* a,
-                                           const void* b,
-                                           const void* beta,
-                                           const void* c,
-                                           const void* d,
-                                           int         num_batches_a  = 1,
-                                           int         num_batches_b  = 1,
-                                           int         num_batches_c  = 1,
-                                           int         num_batches_d  = 1,
-                                           int64_t     batch_stride_a = 0,
-                                           int64_t     batch_stride_b = 0,
-                                           int64_t     batch_stride_c = 0,
-                                           int64_t     batch_stride_d = 0)
+inline rocblaslt_status validateMatmulArgs(int64_t                m,
+                                           int64_t                n,
+                                           int64_t                k,
+                                           const void*            alpha,
+                                           const void*            a,
+                                           const void*            b,
+                                           const void*            beta,
+                                           const void*            c,
+                                           const void*            d,
+                                           hipDataType            type_a,
+                                           hipDataType            type_b,
+                                           hipDataType            type_c,
+                                           hipDataType            type_d,
+                                           rocblaslt_compute_type compute_type,
+                                           hipblasOperation_t     opA,
+                                           hipblasOperation_t     opB,
+                                           int                    num_batches_a  = 1,
+                                           int                    num_batches_b  = 1,
+                                           int                    num_batches_c  = 1,
+                                           int                    num_batches_d  = 1,
+                                           int64_t                batch_stride_a = 0,
+                                           int64_t                batch_stride_b = 0,
+                                           int64_t                batch_stride_c = 0,
+                                           int64_t                batch_stride_d = 0)
 {
+    rocblaslt_status status = rocblaslt_status_continue;
+
+    if(!(type_a == HIP_R_32F && type_b == HIP_R_32F && type_c == HIP_R_32F && type_d == HIP_R_32F)
+       && compute_type == rocblaslt_compute_f32_fast_xf32)
+        status = rocblaslt_status_not_implemented;
+    if(!((type_a == HIP_R_8I && type_b == HIP_R_8I && type_c == HIP_R_32I && type_d == HIP_R_32I)
+         || (type_a == HIP_R_8I && type_b == HIP_R_8I && type_c == HIP_R_8I && type_d == HIP_R_8I))
+       && compute_type == rocblaslt_compute_i32)
+        status = rocblaslt_status_not_implemented;
+    if(string_to_hip_datatype(hip_datatype_to_string(type_a)) == HIPBLASLT_DATATYPE_INVALID
+       || string_to_hip_datatype(hip_datatype_to_string(type_b)) == HIPBLASLT_DATATYPE_INVALID
+       || string_to_hip_datatype(hip_datatype_to_string(type_c)) == HIPBLASLT_DATATYPE_INVALID
+       || string_to_hip_datatype(hip_datatype_to_string(type_d)) == HIPBLASLT_DATATYPE_INVALID)
+        status = rocblaslt_status_not_implemented;
+
+    if(status != rocblaslt_status_continue)
+    {
+        log_error(__func__,
+                  "invalid args",
+                  "datatype",
+                  "matA",
+                  hipDataType_to_string(type_a),
+                  "matB",
+                  hipDataType_to_string(type_b),
+                  "matC",
+                  hipDataType_to_string(type_c),
+                  "matD",
+                  hipDataType_to_string(type_d),
+                  "computeType",
+                  rocblaslt_compute_type_string(compute_type));
+        return status;
+    }
+
+    if(opA == HIPBLAS_OP_C || opB == HIPBLAS_OP_C)
+        status = rocblaslt_status_not_implemented;
+
+    if(status != rocblaslt_status_continue)
+    {
+        log_error(__func__,
+                  "invalid args",
+                  "op",
+                  "opA",
+                  hipblasOperation_to_string(opA),
+                  "opB",
+                  hipblasOperation_to_string(opB));
+        return status;
+    }
+
     // sizes must not be negative
     if(batch_stride_a < 0 || batch_stride_b < 0 || batch_stride_c < 0 || batch_stride_d < 0)
     {
@@ -332,6 +388,13 @@ inline rocblaslt_status rocblaslt_matmul_valid_args(const rocblaslt_matmul_desc 
                                      beta,
                                      C,
                                      D,
+                                     matA->type,
+                                     matB->type,
+                                     matC->type,
+                                     matD->type,
+                                     compute_type,
+                                     matmul_descr->op_A,
+                                     matmul_descr->op_B,
                                      num_batches_a,
                                      num_batches_b,
                                      num_batches_c,
@@ -341,41 +404,30 @@ inline rocblaslt_status rocblaslt_matmul_valid_args(const rocblaslt_matmul_desc 
                                      batch_stride_c,
                                      batch_stride_d);
 
-    if(status == rocblaslt_status_continue)
-    {
-        if(!(matA->type == HIP_R_32F && matB->type == HIP_R_32F && matC->type == HIP_R_32F
-             && matD->type == HIP_R_32F)
-           && compute_type == rocblaslt_compute_f32_fast_xf32)
-            status = rocblaslt_status_not_implemented;
-        if(!((matA->type == HIP_R_8I && matB->type == HIP_R_8I && matC->type == HIP_R_32I
-              && matD->type == HIP_R_32I)
-             || (matA->type == HIP_R_8I && matB->type == HIP_R_8I && matC->type == HIP_R_8I
-                 && matD->type == HIP_R_8I))
-           && compute_type == rocblaslt_compute_i32)
-            status = rocblaslt_status_not_implemented;
-    }
+    if(status != rocblaslt_status_continue)
+        return status;
+
     const void* alphaVecPtr = matmul_descr->pointermode ? alpha : nullptr;
-    if(status == rocblaslt_status_continue)
-        status = rocblaslt_epilogue_valid_args(matmul_descr->epilogue,
-                                               num_rows_d,
-                                               num_cols_d,
-                                               matD->type,
-                                               matmul_descr->bias_type,
-                                               matmul_descr->e,
-                                               matmul_descr->lde,
-                                               matmul_descr->stride_e,
-                                               matmul_descr->bias,
-                                               alphaVecPtr,
-                                               alpha,
-                                               matmul_descr->isScaleAVec,
-                                               matmul_descr->isScaleBVec,
-                                               E,
-                                               lde,
-                                               batch_stride_e,
-                                               bias,
-                                               bias_type,
-                                               scaleAlphaVec,
-                                               gradient);
+    status                  = rocblaslt_epilogue_valid_args(matmul_descr->epilogue,
+                                           num_rows_d,
+                                           num_cols_d,
+                                           matD->type,
+                                           matmul_descr->bias_type,
+                                           matmul_descr->e,
+                                           matmul_descr->lde,
+                                           matmul_descr->stride_e,
+                                           matmul_descr->bias,
+                                           alphaVecPtr,
+                                           alpha,
+                                           matmul_descr->isScaleAVec,
+                                           matmul_descr->isScaleBVec,
+                                           E,
+                                           lde,
+                                           batch_stride_e,
+                                           bias,
+                                           bias_type,
+                                           scaleAlphaVec,
+                                           gradient);
     return status;
 }
 

--- a/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
@@ -177,7 +177,9 @@ inline rocblaslt_status validateMatmulArgs(int64_t                m,
     if(string_to_hip_datatype(hip_datatype_to_string(type_a)) == HIPBLASLT_DATATYPE_INVALID
        || string_to_hip_datatype(hip_datatype_to_string(type_b)) == HIPBLASLT_DATATYPE_INVALID
        || string_to_hip_datatype(hip_datatype_to_string(type_c)) == HIPBLASLT_DATATYPE_INVALID
-       || string_to_hip_datatype(hip_datatype_to_string(type_d)) == HIPBLASLT_DATATYPE_INVALID)
+       || string_to_hip_datatype(hip_datatype_to_string(type_d)) == HIPBLASLT_DATATYPE_INVALID
+       || string_to_hipblas_computetype(rocblaslt_compute_type_string(compute_type))
+              == HIPBLASLT_COMPUTE_TYPE_INVALID)
         status = rocblaslt_status_not_implemented;
 
     if(status != rocblaslt_status_continue)

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -77,18 +77,6 @@ constexpr const char* rocblaslt_compute_type_string(rocblaslt_compute_type type)
         return "f32_f16_r";
     case rocblaslt_compute_f32_fast_bf16:
         return "f32_bf16_r";
-    case rocblaslt_compute_f32_fast_f8_fnuz:
-    case rocblaslt_compute_f32_fast_f8_ocp:
-        return "f32_f8_r";
-    case rocblaslt_compute_f32_fast_bf8_fnuz:
-    case rocblaslt_compute_f32_fast_bf8_ocp:
-        return "f32_bf8_r";
-    case rocblaslt_compute_f32_fast_f8bf8_fnuz:
-    case rocblaslt_compute_f32_fast_f8bf8_ocp:
-        return "f32_f8bf8_r";
-    case rocblaslt_compute_f32_fast_bf8f8_fnuz:
-    case rocblaslt_compute_f32_fast_bf8f8_ocp:
-        return "f32_bf8f8_r";
     default:
         return "invalidType";
     }

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -61,17 +61,34 @@ constexpr const char* rocblaslt_datatype_string(hipDataType type)
     }
 }
 
-// return precision string for rocblaslt_compute_type
 constexpr const char* rocblaslt_compute_type_string(rocblaslt_compute_type type)
 {
     switch(type)
     {
     case rocblaslt_compute_f32:
-        return "f32";
+        return "f32_r";
     case rocblaslt_compute_f32_fast_xf32:
-        return "xf32";
+        return "xf32_r";
     case rocblaslt_compute_i32:
-        return "i32";
+        return "i32_r";
+    case rocblaslt_compute_f64:
+        return "f64_r";
+    case rocblaslt_compute_f32_fast_f16:
+        return "f32_f16_r";
+    case rocblaslt_compute_f32_fast_bf16:
+        return "f32_bf16_r";
+    case rocblaslt_compute_f32_fast_f8_fnuz:
+    case rocblaslt_compute_f32_fast_f8_ocp:
+        return "f32_f8_r";
+    case rocblaslt_compute_f32_fast_bf8_fnuz:
+    case rocblaslt_compute_f32_fast_bf8_ocp:
+        return "f32_bf8_r";
+    case rocblaslt_compute_f32_fast_f8bf8_fnuz:
+    case rocblaslt_compute_f32_fast_f8bf8_ocp:
+        return "f32_f8bf8_r";
+    case rocblaslt_compute_f32_fast_bf8f8_fnuz:
+    case rocblaslt_compute_f32_fast_bf8f8_ocp:
+        return "f32_bf8f8_r";
     default:
         return "invalidType";
     }

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_mat.cpp
@@ -441,6 +441,13 @@ rocblaslt_status
                                             beta[i],
                                             C[i],
                                             D[i],
+                                            matA[i]->type,
+                                            matB[i]->type,
+                                            matC[i]->type,
+                                            matD[i]->type,
+                                            matmul_descr[i]->compute_type,
+                                            matmul_descr[i]->op_A,
+                                            matmul_descr[i]->op_B,
                                             num_batches_a,
                                             num_batches_b,
                                             num_batches_c,
@@ -774,6 +781,33 @@ rocblaslt_status rocblaslt_gemm_create_cpp_impl_2(const rocblaslt_handle handle,
                                                   std::shared_ptr<void>& gemmData,
                                                   size_t&                gemmCount)
 {
+    // Internal assign
+    void*                   A             = inputs.a;
+    void*                   B             = inputs.b;
+    void*                   C             = inputs.c;
+    void*                   D             = inputs.d;
+    void*                   alpha         = inputs.alpha;
+    void*                   beta          = inputs.beta;
+    void*                   scaleA        = inputs.scaleA;
+    void*                   scaleB        = inputs.scaleB;
+    void*                   scaleC        = inputs.scaleC;
+    void*                   scaleD        = inputs.scaleD;
+    void*                   scaleE        = inputs.scaleE;
+    void*                   amaxD         = nullptr;
+    hipblasOperation_t&     opA           = problemtype.op_a;
+    hipblasOperation_t&     opB           = problemtype.op_b;
+    hipDataType&            type_a        = problemtype.type_a;
+    hipDataType&            type_b        = problemtype.type_b;
+    hipDataType&            type_c        = problemtype.type_c;
+    hipDataType&            type_d        = problemtype.type_d;
+    int                     num_batches_a = b;
+    rocblaslt_compute_type& compute_type  = problemtype.type_compute;
+    rocblaslt_epilogue&     epilogue      = rocEpilogue.mode;
+
+    // Others
+    bool strided_batch = true;
+    bool grouped_gemm  = false;
+
     auto status = validateMatmulArgs(m,
                                      n,
                                      k,
@@ -783,6 +817,13 @@ rocblaslt_status rocblaslt_gemm_create_cpp_impl_2(const rocblaslt_handle handle,
                                      inputs.beta,
                                      inputs.c,
                                      inputs.d,
+                                     type_a,
+                                     type_b,
+                                     type_c,
+                                     type_d,
+                                     compute_type,
+                                     opA,
+                                     opB,
                                      b,
                                      b,
                                      b,
@@ -848,33 +889,6 @@ rocblaslt_status rocblaslt_gemm_create_cpp_impl_2(const rocblaslt_handle handle,
     }
     if(status != rocblaslt_status_continue)
         return status;
-
-    // Internal assign
-    void*                   A             = inputs.a;
-    void*                   B             = inputs.b;
-    void*                   C             = inputs.c;
-    void*                   D             = inputs.d;
-    void*                   alpha         = inputs.alpha;
-    void*                   beta          = inputs.beta;
-    void*                   scaleA        = inputs.scaleA;
-    void*                   scaleB        = inputs.scaleB;
-    void*                   scaleC        = inputs.scaleC;
-    void*                   scaleD        = inputs.scaleD;
-    void*                   scaleE        = inputs.scaleE;
-    void*                   amaxD         = nullptr;
-    hipblasOperation_t&     opA           = problemtype.op_a;
-    hipblasOperation_t&     opB           = problemtype.op_b;
-    hipDataType&            type_a        = problemtype.type_a;
-    hipDataType&            type_b        = problemtype.type_b;
-    hipDataType&            type_c        = problemtype.type_c;
-    hipDataType&            type_d        = problemtype.type_d;
-    int                     num_batches_a = b;
-    rocblaslt_compute_type& compute_type  = problemtype.type_compute;
-    rocblaslt_epilogue&     epilogue      = rocEpilogue.mode;
-
-    // Others
-    bool strided_batch = true;
-    bool grouped_gemm  = false;
 
     int8_t alpha_1[16] = {0}; // use dScaleAlphaVec instead, original alpha => 1.0
     if(scaleAlphaVec)
@@ -1190,6 +1204,13 @@ rocblaslt_status rocblaslt_groupedgemm_create_cpp_impl_2(const rocblaslt_handle 
                                             inputs[i].beta,
                                             inputs[i].c,
                                             inputs[i].d,
+                                            type_a,
+                                            type_b,
+                                            type_c,
+                                            type_d,
+                                            compute_type,
+                                            opA,
+                                            opB,
                                             b[i],
                                             b[i],
                                             b[i],

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -215,7 +215,6 @@ const char* hipblasOperation_to_string(hipblasOperation_t op)
     case HIPBLAS_OP_T:
         return "OP_T";
     case HIPBLAS_OP_C:
-        return "OP_C";
     default:
         return "Invalid";
     }

--- a/library/src/include/auxiliary.hpp
+++ b/library/src/include/auxiliary.hpp
@@ -231,14 +231,14 @@ constexpr hipblasComputeType_t string_to_hipblas_computetype(const std::string& 
         value == "i32_r" || value == "i" ? HIPBLAS_COMPUTE_32I :
         value == "f32_f16_r" ? HIPBLAS_COMPUTE_32F_FAST_16F :
         value == "f32_bf16_r" ? HIPBLAS_COMPUTE_32F_FAST_16BF :
-        static_cast<hipblasComputeType_t>(0);
+        HIPBLASLT_COMPUTE_TYPE_INVALID;
 }
 
 HIPBLASLT_EXPORT
 constexpr hipblasComputeType_t string_to_hipblas_computetype_assert(const std::string& value)
 {
     auto computetytpe = string_to_hipblas_computetype(value);
-    if(static_cast<int>(computetytpe) == 0)
+    if(computetytpe == HIPBLASLT_COMPUTE_TYPE_INVALID)
     {
         std::cout << "The supported types are f32_r, xf32_r, f64_r, i32_r, f32_f16_r." << std::endl;
         exit(1);

--- a/library/src/include/auxiliary.hpp
+++ b/library/src/include/auxiliary.hpp
@@ -97,9 +97,9 @@ constexpr const char* hipblas_operation_to_string(hipblasOperation_t value)
     case HIPBLAS_OP_T:
         return "T";
     case HIPBLAS_OP_C:
-        return "C";
+    default:
+        return "invalid";
     }
-    return "invalid";
 }
 
 HIPBLASLT_EXPORT
@@ -115,7 +115,6 @@ constexpr hipblasOperation_t char_to_hipblas_operation(char value)
         return HIPBLAS_OP_T;
     case 'C':
     case 'c':
-        return HIPBLAS_OP_C;
     default:
         return static_cast<hipblasOperation_t>(0);
     }
@@ -214,7 +213,7 @@ HIPBLASLT_EXPORT
 constexpr hipDataType string_to_hip_datatype_assert(const std::string& value)
 {
     auto datatype = string_to_hip_datatype(value);
-    if(static_cast<int>(datatype) == 0)
+    if(datatype == HIPBLASLT_DATATYPE_INVALID)
     {
         std::cout << "The supported types are f32_r, f64_r, f16_r, bf16_r, f8_r, bf8_r, i8_r, i32_r." << std::endl;
         exit(1);


### PR DESCRIPTION
To prevent users from being misled into using the conjugate transpose, this modification removes the description and adds a check for the conjugate transpose.

## Conjugate Transpose from hipblaslt-bench

### Original

```diff
hipblaslt-bench -m 5 -n 1 -k 1 --a_type f8_r --b_type f8_r --c_type f8_r --d_type f8_r --compute_type f32_r --beta 1 --transA C --transB N --print_kernel_info
hipBLASLt version: 1000
hipBLASLt git version: 9b875390-dirty
Query device success: there are 1 devices
 -------------------------------------------------------------------------------
Device ID 0 : AMD Radeon Graphics gfx1201
with 17.1 GB memory, max. SCLK 2426 MHz, max. MCLK 1258 MHz, compute capability 12.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
 -------------------------------------------------------------------------------

- Is supported 1 / Total solutions: 1
- [0]:transA,transB,grouped_gemm,batch_count,m,n,k,alpha,lda,stride_a,beta,ldb,stride_b,ldc,stride_c,ldd,stride_d,a_type,b_type,c_type,d_type,compute_type,scaleA,scaleB,scaleC,scaleD,amaxD,activation_type,bias_vector,bias_type,hipblaslt-Gflops,hipblaslt-GB/s,us
-     C,N,0,1,5,1,1,1,1,5,1,1,1,5,5,5,5,f8_r,f8_r,f8_r,f8_r,f32_r,0,0,0,0,0,none,0,non-supported type,0.00111111,0.00320789,9
-     --Solution index: 754
-     --Solution name:  Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs_MT64x16x64_MI16x16x1_SN_LDSB0_AFC1_CLR1_EPS0_GRVWA8_GRVWB8_GSU1_GSUC0_GSUWGMRR0_K1_LBSPPA128_LBSPPB128_LPA8_LPB8_LRVW8_MIAV1_MIWT1_1_ONLL0_PGR1_PLR3_SIA3_SS1_SU32_SUM0_SUS256_SVW1_TLDS1_WS32_WG64_2_1_WGM8_WGMXCC1_WGMXCCG0
-     --kernel name:    Cijk_Alik_Bljk_F8F8S_BH_BiasSHB_HAS_SAB_SCD_SAV_UserArgs_MT64x16x64_MI16x16x1_SN_LDSB0_AFC1_CLR1_EPS0_GRVWA8_GRVWB8_K1_LBSPPA128_LBSPPB128_LPA8_LPB8_LRVW8_MIAV1_MIWT1_1_ONLL0_PGR1_PLR3_SIA3_SS1_SVW1_TLDS1_WS32_WG64_2_1

```

### Modified

```diff
HIPBLASLT_LOG_LEVEL=5 hipblaslt-bench -m 5 -n 1 -k 1 --a_type f8_r --b_type f8_r --c_type f8_r --d_type f8_r --compute_type f32_r --beta 1 --transA C --transB N --print_kernel_info
# ...
+ [2024-10-04 05:41:15][HIPBLASLT][2566765][Error][rocblaslt_matmul_valid_args] invalid args=op op_A=Invalid op_B=OP_N 
[2024-10-04 05:41:15][HIPBLASLT][2566765][Api][rocblaslt_matmul_algo_get_heuristic] returnAlogCount=0 
# ...
+ error: NO solution found! at /home/haosheng/projects/hipBLASLt+remove_unsupported_transpose_and_datatype/clients/benchmarks/../include/testing_matmul.hpp:2476
```

## Conjugate Transpose from rocBLAS use hipBLASLt as backend

test.yaml
```yaml
---
include: rocblas_common.yaml

Tests:
- name: gemm_ex_get_solutions
  category: pre_checkin
  function: gemm_ex_get_solutions
  M: 250
  N: 250
  K: 250
  lda: 250
  ldb: 250
  ldc: 250
  ldd: 250
  alpha_beta: { alpha:  1, beta:  1 }
  transA_transB: 
    - { transA: T, transB: C }
  precision :
    - { a_type: f32_r, b_type: f32_r, c_type: f32_r, d_type: f32_r, compute_type: f32_r }
```

### Original

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml 
# ...
[2024-10-06 07:38:01][HIPBLASLT][2159688][Api][rocblaslt_algo_get_heuristic_cpp] returnAlogCount=1 
[2024-10-06 07:38:01][HIPBLASLT][2159688][Api][rocblaslt_matmul_get_algos_from_index_cpp] returnAlogCount=1 
[2024-10-06 07:38:01][HIPBLASLT][2159688][Info][isSolutionSupported] Software match: Cijk_Alik_Bljk_HHS_BH_Bias_HAS_SAV_UserArgs_MT32x32x32_MI16x16x1_SN_LDSB0_AFC1_CLR1_EPS0_GRVWA1_GRVWB1_K1_LBSPPA128_LBSPPB128_LPA16_LPB16_LRVW8_MIAV1_MIWT1_1_ONLL1_PGR1_PLR1_SIA3_SS0_SVW8_TLDS1_WS32_WG32_4_1And {
0: OperationIdentifierEqual (((prob=Contraction_l_Alik_Bjlk_Cijk_Dijk) != (sol=Contraction_l_Alik_Bljk_Cijk_Dijk)), )
0: TypesEqual (((prob_a=Float) != (sol_a=Half)), ((prob_b=Float) != (sol_b=Half)), ((prob_c=Float) != (sol_c=Half)), ((prob_d=Float) != (sol_d=Half)), ((prob_compute=Float) != (sol_compute=Half)), )
0: HighPrecisionAccumulate (((prob=0) != (sol=1)), )
}: 0


- [2024-10-06 07:38:01][HIPBLASLT][2159688][Error][isSolutionSupported] Solution is not supported
hipBLASLt error: algo not supported.
This message will be only be displayed once, unless the ROCBLAS_VERBOSE_HIPBLASLT_ERROR environment variable is set.
[2024-10-06 07:38:01][HIPBLASLT][2159688][Api][getAllSolutions] Found hardware solutions: =4 
[2024-10-06 07:38:01][HIPBLASLT][2159688][Api][rocblaslt_destroy] handle=0x7a5e340 
[----------] 1 test from _/gemm_ex_get_solutions (399 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (399 ms total)
- [  PASSED  ] 1 test.
```


### Modified

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml 

# ...
+ [2024-10-06 07:27:44][HIPBLASLT][249110225425][Error][validateMatmulArgs] invalid args=op opA=OP_T opB=Invalid 
+ [2024-10-06 07:27:44][HIPBLASLT][2122257][Error][validateMatmulArgs] invalid args=op opA=OP_T opB=Invalid 
[2024-10-06 07:27:44][HIPBLASLT][2122257][Api][rocblaslt_matmul_get_algos_from_index_cpp] returnAlogCount=1 
hipBLASLt error: hipBLASLt Initialization Failed!
[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1219 ms total)
[  PASSED  ] 0 tests.
+ [  FAILED  ] 1 test, listed below:
[  FAILED  ] _/gemm_ex_get_solutions.blas3_tensile/pre_checkin_gemm_ex_get_solutions_f32_rf32_rf32_rf32_rf32_r_TC_250_250_250_1_250_250_1_250_250, where GetParam() = { function: "gemm_ex_get_solutions", name: "gemm_ex_get_solutions", category: "pre_checkin", known_bug_platforms: "", beta: 1.0, stride_a: 62500, stride_b: 62500, stride_c: 62500, stride_d: 62500, M: 250, N: 250, K: 250, lda: 250, ldb: 250, ldc: 250, ldd: 250, composite_compute_type: invalid, initialization: rand_int, gpu_arch: "", flush_batch_count: 1, transA: 'T', transB: 'C' }


 1 FAILED TEST
```



## Complex Type from rocBLAS use hipBLASLt as backend

test.yaml
```yaml
---
include: rocblas_common.yaml

Tests:
- name: gemm_ex_get_solutions
  category: pre_checkin
  function: gemm_ex_get_solutions
  M: 250
  N: 250
  K: 250
  lda: 250
  ldb: 250
  ldc: 250
  ldd: 250
  alpha_beta: { alpha:  1, beta:  1 }
  transA_transB: 
    - { transA: N, transB: N }
  precision :
    - { a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_c, compute_type: f32_c }
```

### Original

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml 
# ...
[2024-10-06 08:00:06][HIPBLASLT][2233198][Api][rocblaslt_create] handle[out]=0xb152cb0 
hipBLASLt error: Heuristic Fetch Failed!
This message will be only be displayed once, unless the ROCBLAS_VERBOSE_HIPBLASLT_ERROR environment variable is set.
- /home/haosheng/projects/rocBLAS/clients/gtest/../include/blas_ex/testing_gemm_ex_get_solutions.hpp:116: Failure
- Value of: status_match(rocblas_status_success, status_)
-  Actual: false (got rocblas_status_internal_error instead of rocblas_status_success)
- Expected: true
[2024-10-06 08:00:06][HIPBLASLT][2233198][Api][rocblaslt_destroy] handle=0xb152cb0 
# ...
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] _/gemm_ex_get_solutions.blas3_tensile/pre_checkin_gemm_ex_get_solutions_f32_cf32_cf32_cf32_cf32_c_NN_250_250_250_1_250_250_1_250_250, where GetParam() = { function: "gemm_ex_get_solutions", name: "gemm_ex_get_solutions", category: "pre_checkin", known_bug_platforms: "", beta: 1.0, stride_a: 62500, stride_b: 62500, stride_c: 62500, stride_d: 62500, M: 250, N: 250, K: 250, lda: 250, ldb: 250, ldc: 250, ldd: 250, a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_c, compute_type: f32_c, composite_compute_type: invalid, initialization: rand_int, gpu_arch: "", flush_batch_count: 1, transA: 'N', transB: 'N' }


 1 FAILED TEST
rocBLAS version: 4.4.0.71a008cb-dirty

command line: build/release/clients/staging/rocblas-test --gtest_filter=*gemm_ex_get_solutions* --yaml .vscode/test.yaml
```


### Modified

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml
# ...
[2024-10-06 07:51:01][HIPBLASLT][2202367][Api][rocblaslt_create] handle[out]=0xabc1940 
+ [2024-10-06 07:51:02][HIPBLASLT][2202367][Error][validateMatmulArgs] invalid args=datatype matA=Invalid matB=Invalid matC=Invalid matD=Invalid computeType=f32_r 
+ rocblas-test: /home/haosheng/projects/hipBLASLt+remove_unsupported_transpose_and_datatype/library/src/amd_detail/rocblaslt/src/include/tensile_host.hpp:478: Tensile::DataType hipDataType_to_tensile_type(hipDataType): Assertion `!"hipDataType_to_tensile_type: non-supported type"' failed.
SIGNAL raised in: blas3_tensile/pre_checkin_gemm_ex_get_solutions_f32_cf32_cf32_cf32_cf32_c_NN_250_250_250_1_250_250_1_250_250
/home/haosheng/projects/rocBLAS/clients/common/gtest_helpers.cpp:154: Failure
Failed
Received Aborted signal
[2024-10-06 07:51:02][HIPBLASLT][2202367][Api][rocblaslt_destroy] handle=0xabc1940 
# ...
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] _/gemm_ex_get_solutions.blas3_tensile/pre_checkin_gemm_ex_get_solutions_f32_cf32_cf32_cf32_cf32_c_NN_250_250_250_1_250_250_1_250_250, where GetParam() = { function: "gemm_ex_get_solutions", name: "gemm_ex_get_solutions", category: "pre_checkin", known_bug_platforms: "", beta: 1.0, stride_a: 62500, stride_b: 62500, stride_c: 62500, stride_d: 62500, M: 250, N: 250, K: 250, lda: 250, ldb: 250, ldc: 250, ldd: 250, a_type: f32_c, b_type: f32_c, c_type: f32_c, d_type: f32_c, compute_type: f32_c, composite_compute_type: invalid, initialization: rand_int, gpu_arch: "", flush_batch_count: 1, transA: 'N', transB: 'N' }


 1 FAILED TEST
```

## Unsupported compute type from rocBLAS use hipBLASLt as backend

test.yaml
```yaml
---
include: rocblas_common.yaml

Tests:
- name: gemm_ex_get_solutions
  category: pre_checkin
  function: gemm_ex_get_solutions
  M: 250
  N: 250
  K: 250
  lda: 250
  ldb: 250
  ldc: 250
  ldd: 250
  alpha_beta: { alpha:  1, beta:  1 }
  transA_transB: 
    - { transA: N, transB: N }
  precision :
    - { a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r }
```

### Original

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml 
# ...
[2024-10-07 08:07:01][HIPBLASLT][4163622][Api][rocblaslt_create] handle[out]=0xb41ee80 
- hipBLASLt error: Heuristic Fetch Failed!
This message will be only be displayed once, unless the ROCBLAS_VERBOSE_HIPBLASLT_ERROR environment variable is set.
/home/haosheng/projects/rocBLAS/clients/gtest/../include/blas_ex/testing_gemm_ex_get_solutions.hpp:116: Failure
Value of: status_match(rocblas_status_success, status_)
  Actual: false (got rocblas_status_internal_error instead of rocblas_status_success)
Expected: true
# ...
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] _/gemm_ex_get_solutions.blas3_tensile/pre_checkin_gemm_ex_get_solutions_f16_rf16_rf16_rf16_rf16_r_NN_250_250_250_1_250_250_1_250_250, where GetParam() = { function: "gemm_ex_get_solutions", name: "gemm_ex_get_solutions", category: "pre_checkin", known_bug_platforms: "", beta: 1.0, stride_a: 62500, stride_b: 62500, stride_c: 62500, stride_d: 62500, M: 250, N: 250, K: 250, lda: 250, ldb: 250, ldc: 250, ldd: 250, a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r, composite_compute_type: invalid, initialization: rand_int, gpu_arch: "", flush_batch_count: 1, transA: 'N', transB: 'N' }


 1 FAILED TEST
```


### Modified

```diff
HIPBLASLT_LOG_LEVEL=5 rocblas-test --gtest_filter='*gemm_ex_get_solutions*' --yaml test.yaml 
# ...
[2024-10-07 08:01:28][HIPBLASLT][4141006][Api][rocblaslt_create] handle[out]=0xaca2c90 
+ [2024-10-07 08:01:28][HIPBLASLT][4141006][Error][validateMatmulArgs] invalid args=datatype matA=R_16F matB=R_16F matC=R_16F matD=R_16F computeType=invalidType 
hipBLASLt error: Heuristic Fetch Failed!
This message will be only be displayed once, unless the ROCBLAS_VERBOSE_HIPBLASLT_ERROR environment variable is set.
/home/haosheng/projects/rocBLAS/clients/gtest/../include/blas_ex/testing_gemm_ex_get_solutions.hpp:116: Failure
Value of: status_match(rocblas_status_success, status_)
  Actual: false (got rocblas_status_internal_error instead of rocblas_status_success)
Expected: true
# ...
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] _/gemm_ex_get_solutions.blas3_tensile/pre_checkin_gemm_ex_get_solutions_f16_rf16_rf16_rf16_rf16_r_NN_250_250_250_1_250_250_1_250_250, where GetParam() = { function: "gemm_ex_get_solutions", name: "gemm_ex_get_solutions", category: "pre_checkin", known_bug_platforms: "", beta: 1.0, stride_a: 62500, stride_b: 62500, stride_c: 62500, stride_d: 62500, M: 250, N: 250, K: 250, lda: 250, ldb: 250, ldc: 250, ldd: 250, a_type: f16_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: f16_r, composite_compute_type: invalid, initialization: rand_int, gpu_arch: "", flush_batch_count: 1, transA: 'N', transB: 'N' }


 1 FAILED TEST
```



