### PR TITLE
Fix lds bias offset out of range

### DIFF
--- a/tensilelite/Tensile/AsmAddressCalculation.py
+++ b/tensilelite/Tensile/AsmAddressCalculation.py
@@ -297,7 +297,7 @@ class AddrCalculation:
                                                 comment="Bias address scaled by BPE"))
                         if kernel["LdsOffsetBias"] != 0:
                           module.add(VAddU32(dst=vgpr(self.addrBiasVgpr), \
-                                             src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                             src0=(kernel["LdsOffsetBias"]), \
                                              src1=vgpr(self.addrBiasVgpr), \
                                              comment="add lds offset"))
                         ss.singleColBiasAddrUpdated = True
@@ -315,7 +315,7 @@ class AddrCalculation:
                                                     comment="ScaleAlpha address scaled by BPE"))
                             if kernel["LdsOffsetBias"] != 0:
                                 module.add(VAddU32(dst=vgpr(self.addrScaleAlphaVecVgpr), \
-                                                   src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                                   src0=(kernel["LdsOffsetBias"]), \
                                                    src1=vgpr(self.addrScaleAlphaVecVgpr), \
                                                    comment="add lds offset"))
                         return module
@@ -331,7 +331,7 @@ class AddrCalculation:
                                                     comment="ScaleAVec address scaled by BPE"))
                             if kernel["LdsOffsetBias"] != 0:
                                 module.add(VAddU32(dst=vgpr(self.addrScaleAVecVgpr), \
-                                                   src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                                   src0=(kernel["LdsOffsetBias"]), \
                                                    src1=vgpr(self.addrScaleAVecVgpr), \
                                                    comment="add lds offset"))
                         return module
@@ -347,7 +347,7 @@ class AddrCalculation:
                                                     comment="ScaleBVec address scaled by BPE"))
                             if kernel["LdsOffsetBias"] != 0:
                                 module.add(VAddU32(dst=vgpr(self.addrScaleBVecVgpr), \
-                                                   src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                                   src0=(kernel["LdsOffsetBias"]), \
                                                    src1=vgpr(self.addrScaleBVecVgpr), \
                                                    comment="add lds offset"))
                         return module
@@ -379,7 +379,7 @@ class AddrCalculation:
                                             comment="Bias address scaled by BPE"))
                     if kernel["LdsOffsetBias"] != 0:
                         module.add(VAddU32(dst=vgpr(self.addrBiasVgpr), \
-                                           src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                           src0=(kernel["LdsOffsetBias"]), \
                                            src1=vgpr(self.addrBiasVgpr), \
                                            comment="add lds offset"))
                     return module
@@ -396,7 +396,7 @@ class AddrCalculation:
                                                 comment="ScaleAlpha address scaled by BPE"))
                         if kernel["LdsOffsetBias"] != 0:
                             module.add(VAddU32(dst=vgpr(self.addrScaleAlphaVecVgpr), \
-                                               src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                               src0=(kernel["LdsOffsetBias"]), \
                                                src1=vgpr(self.addrScaleAlphaVecVgpr), \
                                                comment="add lds offset"))
                     return module
@@ -412,7 +412,7 @@ class AddrCalculation:
                                                 comment="ScaleAVec address scaled by BPE"))
                         if kernel["LdsOffsetBias"] != 0:
                             module.add(VAddU32(dst=vgpr(self.addrScaleAVecVgpr), \
-                                               src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                               src0=(kernel["LdsOffsetBias"]), \
                                                src1=vgpr(self.addrScaleAVecVgpr), \
                                                comment="add lds offset"))
                     return module
@@ -428,7 +428,7 @@ class AddrCalculation:
                                                 comment="ScaleBVec address scaled by BPE"))
                         if kernel["LdsOffsetBias"] != 0:
                             module.add(VAddU32(dst=vgpr(self.addrScaleBVecVgpr), \
-                                               src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                               src0=(kernel["LdsOffsetBias"]), \
                                                src1=vgpr(self.addrScaleBVecVgpr), \
                                                comment="add lds offset"))
                     return module
@@ -458,7 +458,7 @@ class AddrCalculation:
                                         comment="Bias address scaled by BPE"))
                 if kernel["LdsOffsetBias"] != 0:
                     module.add(VAddU32(dst=vgpr(self.addrBiasVgpr), \
-                                       src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                       src0=(kernel["LdsOffsetBias"]), \
                                        src1=vgpr(self.addrBiasVgpr), \
                                        comment="add lds offset"))
                 return module
@@ -475,7 +475,7 @@ class AddrCalculation:
                                             comment="ScaleAlpha address scaled by BPE"))
                     if kernel["LdsOffsetBias"] != 0:
                         module.add(VAddU32(dst=vgpr(self.addrScaleAlphaVecVgpr), \
-                                           src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                           src0=(kernel["LdsOffsetBias"]), \
                                            src1=vgpr(self.addrScaleAlphaVecVgpr), \
                                            comment="add lds offset"))
                 return module
@@ -491,7 +491,7 @@ class AddrCalculation:
                                             comment="ScaleAVec address scaled by BPE"))
                     if kernel["LdsOffsetBias"] != 0:
                         module.add(VAddU32(dst=vgpr(self.addrScaleAVecVgpr), \
-                                           src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                           src0=(kernel["LdsOffsetBias"]), \
                                            src1=vgpr(self.addrScaleAVecVgpr), \
                                            comment="add lds offset"))
                 return module
@@ -507,7 +507,7 @@ class AddrCalculation:
                                             comment="ScaleBVec address scaled by BPE"))
                 if kernel["LdsOffsetBias"] != 0:
                     module.add(VAddU32(dst=vgpr(self.addrScaleBVecVgpr), \
-                                       src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                       src0=(kernel["LdsOffsetBias"]), \
                                        src1=vgpr(self.addrScaleBVecVgpr), \
                                        comment="add lds offset"))
                 return module
@@ -743,7 +743,7 @@ class AddrCalculation:
                                         comment="Bias address scaled by BPE"))
                 if kernel["LdsOffsetBias"] != 0:
                     module.add(VAddU32(dst=vgpr(self.addrBiasVgpr), \
-                                       src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                       src0=(kernel["LdsOffsetBias"]), \
                                        src1=vgpr(self.addrBiasVgpr), \
                                        comment="add lds offset"))
             elif tc == 'ScaleAlphaVec' and kernel["ProblemType"]["UseScaleAlphaVec"] and ((kernel["GlobalSplitU"] == 1) or (kernel["GlobalSplitUAlgorithm"] == "MultipleBufferSingleKernel")):
@@ -759,7 +759,7 @@ class AddrCalculation:
                                             comment="ScaleAlpha address scaled by BPE"))
                     if kernel["LdsOffsetBias"] != 0:
                         module.add(VAddU32(dst=vgpr(self.addrScaleAlphaVecVgpr), \
-                                           src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                           src0=(kernel["LdsOffsetBias"]), \
                                            src1=vgpr(self.addrScaleAlphaVecVgpr), \
                                            comment="add lds offset"))
             elif tc == 'ScaleA' and (kernel["ProblemType"]["UseScaleAB"] == "Vector") and ((kernel["GlobalSplitU"] == 1) or (kernel["GlobalSplitUAlgorithm"] == "MultipleBufferSingleKernel")):
@@ -774,7 +774,7 @@ class AddrCalculation:
                                             comment="ScaleAVec address scaled by BPE"))
                 if kernel["LdsOffsetBias"] != 0:
                     module.add(VAddU32(dst=vgpr(self.addrScaleAVecVgpr), \
-                                       src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                       src0=(kernel["LdsOffsetBias"]), \
                                        src1=vgpr(self.addrScaleAVecVgpr), \
                                        comment="add lds offset"))
             elif tc == 'ScaleBVec' and (kernel["ProblemType"]["UseScaleAB"] == "Vector") and ((kernel["GlobalSplitU"] == 1) or (kernel["GlobalSplitUAlgorithm"] == "MultipleBufferSingleKernel")):
@@ -789,7 +789,7 @@ class AddrCalculation:
                                             comment="ScaleBVec address scaled by BPE"))
                 if kernel["LdsOffsetBias"] != 0:
                     module.add(VAddU32(dst=vgpr(self.addrScaleBVecVgpr), \
-                                       src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                                       src0=(kernel["LdsOffsetBias"]), \
                                        src1=vgpr(self.addrScaleBVecVgpr), \
                                        comment="add lds offset"))
             else:

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -10698,7 +10698,7 @@ class KernelWriterAssembly(KernelWriter):
                               comment="Local address scaled by BPE"))
     if kernel["LdsOffsetBias"] != 0:
       module.add(VAddU32(dst=vgpr(offsetVgpr), \
-                         src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                         src0=(kernel["LdsOffsetBias"]), \
                          src1=vgpr(offsetVgpr), \
                          comment="add lds offset"))
 
@@ -10758,7 +10758,7 @@ class KernelWriterAssembly(KernelWriter):
 
     if kernel["LdsOffsetBias"] != 0:
       module.add(VAddU32(dst=vgpr(offsetVgpr), \
-                         src0=(kernel["LdsOffsetBias"]*kernel["ProblemType"]["DataType"].numBytes()), \
+                         src0=(kernel["LdsOffsetBias"]), \
                          src1=vgpr(offsetVgpr), \
                          comment="add bias lds offset"))
 


### PR DESCRIPTION
Doesn't need to multiply the number of bytes of the datatype when calculating the bias's offset.
Since The LdsOffsetBias had already included it.

[SolutionStructs.py#L3642](https://github.com/ROCm/hipBLASLt/blob/develop/tensilelite/Tensile/SolutionStructs.py#L3642)
```
      if state["ProblemType"]["DestDataType"].numBytes() > state["ProblemType"]["DataType"].numBytes():
        # Determine ratio of output to input element size.
        # SRVW remaps output so we need to scale up resources.
        multiplier = state["ProblemType"]["DestDataType"].numBytes()
      else:
        multiplier = state["ProblemType"]["DataType"].numBytes()

      ldsNumBytesRemapCNonGSU = ldsNumBytesRemapC * multiplier
      ldsNumBytesRemapCGSU    = ldsNumBytesRemapC * multiplierGSU
      ldsNumBytesRemapC *= max(multiplier, multiplierGSU)
   ...
      state["LdsOffsetBias"] = ldsNumBytesRemapC
```