### PR TITLE
feature: DTV with Swizzling (tensorA)

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -271,7 +271,7 @@ def benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSizeG
         if not cacheValid:
             # enumerate benchmark permutations and create resulting solution objects
             forkPermutations = constructForkPermutations(benchmarkStep.forkParams, \
-                    benchmarkStep.paramGroups)
+                    benchmarkStep.paramGroups) if problemSizeGroupConfig["ForkParameters"] else []
             maxPossibleSolutions = len(forkPermutations)
 
             regSolutions = generateForkedSolutions(benchmarkProcess.problemType, \

--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -564,6 +564,8 @@ def writeClientConfigIni(problemSizes, biasTypeArgs, factorDimArgs, activationAr
         param('use-scaleAB',   problemType.useScaleAB)
         param('use-scaleCD',   problemType.useScaleCD)
         param('use-scaleAlphaVec',   problemType.useScaleAlphaVec)
+        param('swizzle-tensor-a', problemType.swizzleTensorA)
+        param('swizzle-tensor-b', problemType.swizzleTensorB)
         if biasTypeArgs:
           for btype in biasTypeArgs.biasTypes:
             param('bias-type-args',  btype.toEnum())

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -1363,7 +1363,9 @@ defaultProblemType = {
     # AmaxD
     "OutputAmaxD":              False,
     # For kernels putting arguments in workspaces instead of kernel arguments, they can choose to support user arguments input instead.
-    "SupportUserArgs":          True
+    "SupportUserArgs":          True,
+    "SwizzleTensorA":           False,
+    "SwizzleTensorB":           False,
     }
 
 defaultProblemSizes = [{"Range": [ [2880], 0, 0 ]}]

--- a/tensilelite/Tensile/Components/GSU.py
+++ b/tensilelite/Tensile/Components/GSU.py
@@ -213,10 +213,10 @@ class GSUOn(GSU):
 
         tc = tP["tensorChar"]
         depthU = kernel["DepthU"]
-        # Swizzled for A, TODO- test for B
-        depthUDivSW = "%s%s"%(kernel["DepthU"], "*MI_M") if (tP["isSwizzled"] and tc == 'A') else "%s"%kernel["DepthU"]
-        #
         depthUDiv = kernel["DepthU"]
+        # Swizzled for A, TODO- check for SwizzleTensorB
+        depthUDiv = "%s%s"%(kernel["DepthU"], "*MI_M") if (tP["isSwizzled"] and tc == 'A') else "%s"%kernel["DepthU"]
+        #
         gsuOffsetStr = "gsuOffset = DepthU*bpeGR*GSUSumIdx"
         divider = 1
         if kernel["ProblemType"]["Sparse"]:
@@ -233,7 +233,7 @@ class GSUOn(GSU):
         module.add(SAndB32(dst=sgpr(stmp), src0=sgpr("GSU"), src1=hex(0x8000), comment="SCC = (GSUC == 1) ?"))
         module.add(SCBranchSCC1(labelName=gsucLabel.getLabelName(), comment="branch if GSUC == 1"))
         gsuOffsetStr = "gsuOffset = DepthU*GSUSumIdx"
-        module.addModuleAsFlatItems(writer.s_mul_u64_u32(sgpr(stmp+0), sgpr(stmp+1), depthUDivSW, sgpr("GSUSumIdx"), gsuOffsetStr))
+        module.addModuleAsFlatItems(writer.s_mul_u64_u32(sgpr(stmp+0), sgpr(stmp+1), depthUDiv, sgpr("GSUSumIdx"), gsuOffsetStr))
         module.add(SBranch(gsucLabelEnd.getLabelName()))
         module.add(gsucLabel)
         gsuOffsetStr = "gsuOffset = DepthU*accumulatedNumOfLoopCounterL"
@@ -427,7 +427,7 @@ class GSUOn(GSU):
                 # last NLL or  pack DTV case, no deep copy for pack
                 # pack code for local prefetch is generated in noLoadLoopBody and used for DTV even
                 deepCopyPack = pack
-              else: 
+              else:
                 # deepCopy packCode for OptNLL noLoadLoop
                 deepCopyPack = fastdeepcopy(pack)
               noLoadLoopModules.add(writer.noLoadLoop(kernel, tensorParametersA, tensorParametersB, isOptNLL=True, isNGLL=False, pack=deepCopyPack, NLLindex=NLLindex, NLLnum=NLLnum))

--- a/tensilelite/Tensile/Contractions.py
+++ b/tensilelite/Tensile/Contractions.py
@@ -467,7 +467,7 @@ class ProblemPredicate(Properties.Predicate):
         if ('GlobalSplitU' in state) and (state['GlobalSplitU'] > 1):
             if ('_GlobalAccumulation' not in state) or (state['_GlobalAccumulation'] != 'MultipleBuffer'):
                 rv += [cls("DeterministicMode", value = False)]
-        
+
         if ('StreamK' in state) and (state['StreamK'] > 0) and ('StreamKAtomic' in state) and (state['StreamKAtomic'] == 1):
             # StreamKAtomic = 1 uses atomic for partial tiles
             rv += [cls("DeterministicMode", value = False)]
@@ -508,9 +508,14 @@ class ProblemPredicate(Properties.Predicate):
             rv += [cls("WorkgroupMappingXCCCheck", value=[state['WorkGroupMappingXCC'], state['WorkGroupMappingXCCGroup']])]
         if state['ProblemType']['SwizzleTensorA']:
             rv += [cls('SwizzleTensorA', value=state['ProblemType']['SwizzleTensorA'])]
+            rv += [cls("Free0SizeMultiple", index=0, value=state['MacroTile0'])]
+            rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
+
 
         if state['ProblemType']['SwizzleTensorB']:
             rv += [cls('SwizzleTensorB', value=state['ProblemType']['SwizzleTensorB'])]
+            rv += [cls("Free1SizeMultiple", index=0, value=state['MacroTile1'])]
+            rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
 
         return rv
 

--- a/tensilelite/Tensile/Contractions.py
+++ b/tensilelite/Tensile/Contractions.py
@@ -506,11 +506,12 @@ class ProblemPredicate(Properties.Predicate):
 
         if ('WorkGroupMappingXCC' in state) and ('WorkGroupMappingXCCGroup' in state):
             rv += [cls("WorkgroupMappingXCCCheck", value=[state['WorkGroupMappingXCC'], state['WorkGroupMappingXCCGroup']])]
+
+        # TODO- To improve the perf of these non-multiples cases
         if state['ProblemType']['SwizzleTensorA']:
             rv += [cls('SwizzleTensorA', value=state['ProblemType']['SwizzleTensorA'])]
             rv += [cls("Free0SizeMultiple", index=0, value=state['MacroTile0'])]
             rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
-
 
         if state['ProblemType']['SwizzleTensorB']:
             rv += [cls('SwizzleTensorB', value=state['ProblemType']['SwizzleTensorB'])]

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -2366,7 +2366,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # Open persistent loop
     loopComponent = Component.PersistentLoop.find(self)
     module.add(loopComponent.openPersistentLoop(self, kernel))
-        
+
     module.add(self.setupNewTile(kernel, tensorParametersA, tensorParametersB, isOptNLL=False))
 
     if self.do["executeToPrefetchEnd"]:
@@ -3264,7 +3264,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.bpeCexternal = self.states.bpeCexternalGSU1
     if kernel["_GlobalAccumulation"] and kernel["_GlobalAccumulation"] != 'PartialsBuffer':
       self.states.bpeCexternal = self.states.bpeCinternal
-      
+
 
     # special case for wmma h and b
     if (kernel["EnableMatrixInstruction"]
@@ -4071,7 +4071,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.defineSgpr("AddressWS", numSgprAddressWS)
       self.defineSgpr("AddressFlags", numSgprAddressFlags)
       self.states.numSgprStreamK += numSgprAddressWS + numSgprAddressFlags
-    
+
     #asm input interface depen
     self.defineSgpr("StridesD", self.states.d.numSgprStrides)
     self.defineSgpr("StridesC", self.states.c.numSgprStrides)
@@ -4144,7 +4144,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.defineSgpr("StreamKLocalEnd", 1)
       if kernel["StreamKAtomic"] == 0:
         self.defineSgpr("SrdWS", 4, 4)
-    
+
     #------------------------
     # Registers defined below this point are not available in the post-loop
     # Post-loop is after tail loop exits, ie the store code.
@@ -4515,6 +4515,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     tP["localWriteSwapByteOffset"] = 0
     tP["gpr"] = {}
     tP["metadataWriteSwapByteOffset"] = 0
+    tP["isSwizzled"] = (kernel["ProblemType"]["SwizzleTensorB"] and tP["isB"]) or (kernel["ProblemType"]["SwizzleTensorA"] and tP["isA"])
 
   ##############################################################################
   # Global Read Addresses: Tile Assignment A/B

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -566,7 +566,7 @@ class KernelWriterAssembly(KernelWriter):
                 ri += self.states.a.numVgprValuPerBlock
 
     ri = 0
-    if self.states.b.numVgprValu > 0: # Do not generate vgprValuA if numVgprValuA is 0
+    if self.states.b.numVgprValu > 0: # Do not generate vgprValuB if numVgprValuB is 0
       numBiFactor = numBi
       if kernel["DirectToVgprB"] and (self.states.packDTVB or self.states.convDTVB):
         # DirectToVgpr case, we need LoopIters * 2 buffers
@@ -613,7 +613,7 @@ class KernelWriterAssembly(KernelWriter):
         module.add(RegSet("v", "vgprValuMetadata", self.states.m.startVgprValu))
       else:
         ri = 0
-        if self.states.m.numVgprValu > 0: # Do not generate vgprValuA if numVgprValuA is 0
+        if self.states.m.numVgprValu > 0: # Do not generate vgprValu if numVgprValu is 0
           if self.states.lrvwTileMetadata > 1:
             for bi in range(0,PLR): # buffer indices
               for iui in range(0, kernel["InnerUnroll"]):

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -795,6 +795,10 @@ class KernelWriterAssembly(KernelWriter):
     module.add(ValueSet("BpeAGRLog2", log2(tPA["bpeGR"])))
     module.add(ValueSet("BpeBGR", tPB["bpeGR"]))
     module.add(ValueSet("BpeBGRLog2", log2(tPB["bpeGR"])))
+    # TODO- get real value from MI-InstM
+    if kernel["ProblemType"]["SwizzleTensorA"]:
+      module.add(ValueSet("MI_M", 16))
+    #
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
       module.add(ValueSet("BpeMetadata", tPM["bpe"]))
       module.add(ValueSet("BpeMetadataLog2", log2(tPM["bpe"])))
@@ -823,19 +827,23 @@ class KernelWriterAssembly(KernelWriter):
     # Flat addressing modes expect the GLOBAL_OFFSET to initialize a full 64-bit address
 
     GOList =  [ \
-        ("C", list(range(0, kernel["ProblemType"]["NumIndicesC"])), kernel["BufferStore"], None), \
-        ("A", kernel["ProblemType"]["IndexAssignmentsA"], kernel["BufferLoad"], tPA), \
-        ("B", kernel["ProblemType"]["IndexAssignmentsB"], kernel["BufferLoad"], tPB) ]
+        ("C", list(range(0, kernel["ProblemType"]["NumIndicesC"])), kernel["BufferStore"], None, False), \
+        ("A", kernel["ProblemType"]["IndexAssignmentsA"], kernel["BufferLoad"], tPA, False), \
+        ("B", kernel["ProblemType"]["IndexAssignmentsB"], kernel["BufferLoad"], tPB, False) ]
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
-      GOList.append(("Metadata", kernel["ProblemType"]["IndexAssignmentsMetadata"], kernel["BufferLoad"], tPM))
+      GOList.append(("Metadata", kernel["ProblemType"]["IndexAssignmentsMetadata"], kernel["BufferLoad"], tPM, False))
+    if kernel["ProblemType"]["SwizzleTensorA"]:
+      GOList.append(("A", kernel["ProblemType"]["IndexAssignmentsA"], kernel["BufferLoad"], tPA, True))
 
-    for (tc, indices, justOffset32, tP) in GOList:
+    for (tc, indices, justOffset32, tP, isSwizzled) in GOList:
 
       # BufferStore does not use this macro so don't generate it:
       if tc == "C" and kernel["BufferStore"]:
         continue
 
-      module.addComment1("Global Offset %s"%tc)
+      # function name and comment
+      suffix_tc = tc + "_SWIZZLED" if isSwizzled else tc
+      module.addComment1("Global Offset %s"%suffix_tc)
       numDim = len(indices)
       idxChars = []
       for i in indices:
@@ -873,7 +881,11 @@ class KernelWriterAssembly(KernelWriter):
           elif not justOffset32: # buffer/justOffset32 scalars are included in SRD not the offset, so skip here
             calcDims.append(i)
             macroArgs.append("sgprOffset%s:req" % idxChars[i])
-      macro = Macro("GLOBAL_OFFSET_%s" % tc, "vgprAddr:req", *macroArgs, "vgprTmp:req")
+
+      # swizzle: passing fake stride (swizzled stride)
+      if isSwizzled:
+        macroArgs.append("sgprStrideSW%s:req" % tc)
+      macro = Macro("GLOBAL_OFFSET_%s" % suffix_tc, "vgprAddr:req", *macroArgs, "vgprTmp:req")
 
       # Each index may be skipped, scaled by stride, or unscaled
       # If destLo is unset, no accumulation is necessary.
@@ -981,7 +993,13 @@ class KernelWriterAssembly(KernelWriter):
               offset = "v[\\vgprTmp+0]"
 
             # offset * stride
-            macro.add(VMulLOU32(dst=destLo,
+            if isSwizzled:
+              macro.add(VMulLOU32(dst=destLo,
+                src0="s[\\sgprStrideSW%s]" % tc, \
+                src1=offset, \
+                comment="SWZ: mul d%u lower"%i))
+            else:
+              macro.add(VMulLOU32(dst=destLo,
                 src0=self.strideRef(tc, indices[i]), \
                 src1=offset, \
                 comment="mul d%u lower"%i))
@@ -2243,13 +2261,29 @@ class KernelWriterAssembly(KernelWriter):
         module.add(VLShiftLeftB32(dst=vgpr(v), shiftHex=hex(log2(margin)), src=vgpr(v), comment="gro%s%s_%u *= %d"%(tP["tensorChar"], tP["tileChar"], 0, margin)))
       else:
         module.add(VMovB32(dst=vgpr(v), src=vgpr(tP["gpr"]["tReg"]), comment="gro%s%s_%u"%(tP["tensorChar"], tP["tileChar"], 0) ))
+        # TODO- current for A only
+        if tP["isSwizzled"]:
+          swizzleStridePerWave = self.sgprPool.checkOut(1)
+          WvG_M = kernel["MIWaveGroup"][0]
+          # Calc stride = numKr * WaveG[0], TODO- 32 should be MI_K * 2
+          module.add(SLShiftRightB32(dst=sgpr(swizzleStridePerWave), shiftHex=hex(log2(32)), src=sgpr("SizesSum"),  comment="SWZ: numKr = DimK / 32"))
+          module.add(SMulI32(dst=sgpr(swizzleStridePerWave), src0=hex(WvG_M), src1=sgpr(swizzleStridePerWave), comment="SWZ: numKr *= MI_WvG[0] (%u), how many wave-M per WG" % WvG_M))
 
       for l in range(1, tP["nrt"]):
         strideValue = stride
         if strideInterleave and (l & strideMask) != 0:
           strideValue = 1
-        module.add(VAddCOU32(dst=vgpr(v+l), dst1=VCC(), src0=strideValue, \
+        if not tP["isSwizzled"]:
+          module.add(VAddCOU32(dst=vgpr(v+l), dst1=VCC(), src0=strideValue, \
             src1=vgpr(v+l-1), comment="gro%s%s_%u += %s"%(tP["tensorChar"], tP["tileChar"], l, strideIdx) ))
+        # swizzle
+        else:
+          module.add(VAddCOU32(dst=vgpr(v+l), dst1=VCC(), src0=sgpr(swizzleStridePerWave), \
+            src1=vgpr(v+l-1), comment="SWZ: gro%s%s_%u += (numKr * WaveG[0])"%(tP["tensorChar"], tP["tileChar"], l) ))
+      if tP["isSwizzled"]:
+        self.sgprPool.checkIn(swizzleStridePerWave)
+
+      # TODO- check for swizzle
       if numExtraPackedOffsetsPerTile:
         tmpV = self.vgprPool.checkOutAligned(2,2,"packTmp", self.states.preventVgprOverflowDuringNewTile)
 
@@ -2287,6 +2321,13 @@ class KernelWriterAssembly(KernelWriter):
     tc = tP["tensorChar"]
     if kernel["_UseSgprForGRO"]:
       tP["gpr"]["unrollOffsets"] = tP["gpr"]["uReg"]
+    # TODO- so far only A, check B
+    elif tP["isSwizzled"]:
+      numUnrollOffsets = 1
+      tP["gpr"]["unrollOffsets"] = self.vgprPool.checkOut(numUnrollOffsets, "unrollOffsets", self.states.preventVgprOverflowDuringNewTile)
+      v = tP["gpr"]["unrollOffsets"]
+      module.addComment0("SWZ: Unroll increament is calculated in I-Offset since tile-memory is flattened")
+      module.add(VMovB32(dst=vgpr(v), src=vgpr(tP["gpr"]["uReg"]), comment="SWZ: only one gro%s%s_%u Base"%(tP["tensorChar"], self.states.unrollChar, 0)))
     else:
       numUnrollOffsets = tP["nru"]
       tP["gpr"]["unrollOffsets"] = self.vgprPool.checkOut(numUnrollOffsets, "unrollOffsets", self.states.preventVgprOverflowDuringNewTile)
@@ -2484,6 +2525,11 @@ class KernelWriterAssembly(KernelWriter):
     graIdx = 0
     swapPerpPara = (((tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]) and (not tP["tlu"]) and tP["nrp"] > 1)
 
+    if tP["isSwizzled"]:
+      tP["swizzledBlockSize"] = self.sgprPool.checkOut(1)
+      module.add(SMovB32(dst=sgpr(tP["swizzledBlockSize"]), src=hex(16*32), comment="SWZ: swizzled block = MI_M(%u) * MI_K(%u) * 2" %(16, 16)))
+
+    # DTVA/B always go this way, including swizzled
     if not swapPerpPara:
       for perp in range(0, tP["nrp"]):
         for sPerp in range(0, tP["nrpv"]):
@@ -2501,6 +2547,9 @@ class KernelWriterAssembly(KernelWriter):
               # single loop
               singleModule, graIdx = self.graFinalOffsetsSingleLoop(kernel, tP, tc, tmp, graIdx, perp, sPerp, para, sPara)
               module.add(singleModule)
+
+    if tP["isSwizzled"]:
+      self.sgprPool.checkIn(tP["swizzledBlockSize"])
 
     self.vgprPool.checkIn(tP["gpr"]["lwoT"])
     tP["gpr"]["lwoT"] = None
@@ -2550,7 +2599,10 @@ class KernelWriterAssembly(KernelWriter):
     # single loop start
 
     # vgpr assignments
-    if tP["tlu"]:
+    if tP["isSwizzled"]:
+      vgprTile   = tP["vgprTileOffsets"]   + perp*tVW + sPara*tVS
+      vgprUnroll = tP["gpr"]["unrollOffsets"] # unroll: always use base unroll
+    elif tP["tlu"]:
       vgprTile   = tP["vgprTileOffsets"]   + para*tVW + sPara*tVS
       vgprUnroll = tP["gpr"]["unrollOffsets"] + perp*uVW + sPerp*uVS
     else:
@@ -2561,7 +2613,10 @@ class KernelWriterAssembly(KernelWriter):
       # emit global offset macro
       # TODO -refactor this and macro def to pass all indices, use the ones we need
       if kernel["BufferLoad"]:
-        bfName = "GLOBAL_OFFSET_%s" % tP["tensorChar"]
+        if tP["isSwizzled"]:
+          bfName = "GLOBAL_OFFSET_%s_SWIZZLED" % tP["tensorChar"]
+        else:
+          bfName = "GLOBAL_OFFSET_%s" % tP["tensorChar"]
         bfArgs = ["vgprGlobalReadOffset%s+%u"%(tP["tensorChar"], graIdx)]
       else:
         bfName = "GLOBAL_OFFSET_%s" % tP["tensorChar"]
@@ -2589,6 +2644,15 @@ class KernelWriterAssembly(KernelWriter):
             iaToGpr[i] = vgprUnroll
             bfArgs.append( "%2u" % iaToGpr[i] )
           # other summation indices are ignored
+
+      # Swizzled version:
+      #   1. passing swizzled block size as stride to macro
+      #   2. If moving unroll = advance I-Offset for one swizzled block
+      if tP["isSwizzled"]:
+        bfArgs.append(tP["swizzledBlockSize"])
+        if para > 0:
+          module.add(VAddCOU32(dst=vgpr(vgprTile), dst1=VCC(), src0=hex(1), src1=vgpr(vgprTile), \
+                               comment="SWZ: groAL = groA0I + 1 Block of flattened mem"))
 
       bfArgs.append( "%u" % tmp )
       bfComment = "gRO%s_%u_%u_%u_%u" % (tP["tensorChar"], para, sPara, perp, sPerp)
@@ -3174,7 +3238,8 @@ class KernelWriterAssembly(KernelWriter):
 
     # DTV case, use tlu path
     isDTVAB = (tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]
-    if tP["tlu"] or isDTVAB:
+    # swizzled goes to else
+    if (tP["tlu"] or isDTVAB) and (not tP["isSwizzled"]):
       rReg = self.vgprPool.checkOut(1, "lwaTA rReg0", self.states.preventVgprOverflowDuringNewTile) # tile = serial%divisor
       qReg = self.vgprPool.checkOut(1, "lwaTA qReg0", self.states.preventVgprOverflowDuringNewTile) # unroll = serial/divisor
       tReg = rReg
@@ -3207,7 +3272,15 @@ class KernelWriterAssembly(KernelWriter):
     # store DirectToVgpr K interval for later use
     dtvKInterval = 1
 
-    if isDTVAB:
+    if tP["isSwizzled"]:
+      module.addComment0("TileAssignment for DirectToVgpr%s and SwizzleTensor%s" % (tc, tc))
+      module.add(vectorStaticDivideAndRemainder(qReg, rReg, dividendReg, kernel["WavefrontSize"], tmpVgprRes))
+      with self.allocTmpSgpr(1) as tmpSgprInfo:
+        tmpSgpr = tmpSgprInfo.idx
+        # Calc numKr, TODO- 32 should be MI_K * 2
+        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr), shiftHex=hex(log2(32)), src=sgpr("SizesSum"),  comment="SWZ: numKr = DimK / 32"))
+        module.add(VMulU32U24(dst=vgpr(qReg), src0=sgpr(tmpSgpr), src1=vgpr(qReg), comment="SWZ: wave-id *= numKr"))
+    elif isDTVAB:
       # offset calculation for DirectToVgpr
       # call function from LraTileAssignmentMFMA for DirectToVgpr
       module.addComment0("TileAssignment for DirectToVgpr%s" % tc)

--- a/tensilelite/Tensile/SolutionLibrary.py
+++ b/tensilelite/Tensile/SolutionLibrary.py
@@ -406,6 +406,13 @@ class MasterSolutionLibrary:
                         placeholderName += "_HA"
                     else:
                         placeholderName += "_%s"%str(problemType.activationType).upper()
+
+                if problemType.swizzleTensorA:
+                    placeholderName += '_STA'
+
+                if problemType.swizzleTensorB:
+                    placeholderName += '_STB'
+
                 if problemType.useBias:
                     placeholderName += '_Bias'
                 if problemType.useE:

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2745,7 +2745,15 @@ class Solution(collections.abc.Mapping):
       if state["ProblemType"][f"SwizzleTensor{tc}"]:
         if not state["EnableMatrixInstruction"]:
           reject(state, f"Tensor {tc} swizzling supports MI only")
-        state[f"GlobalReadVectorWidth{tc}"] = state[f"MIInputPerThread{tc}"] * 2
+        # Print rejection reason instead of force set
+        if state[f"GlobalReadVectorWidth{tc}"] != state[f"MIInputPerThread{tc}"] * 2:
+          GRVW_TC = state[f"GlobalReadVectorWidth{tc}"]
+          MIInPerThread = state[f"MIInputPerThread{tc}"]
+          reject(state, f"SwizzleTensor{tc} doesn't support GRVW{tc} ({GRVW_TC}) != MIInputPerThread{tc} ({MIInPerThread}) * 2")
+        # TODO- increasing VW might have better perf. But it'll change the swizzling pattern.
+        if state[f"VectorWidth{tc}"] != 1:
+          VW_TC = state[f"VectorWidth{tc}"]
+          reject(state, f"SwizzleTensor{tc} requires VectorWidth{tc} ({VW_TC}) == 1")
 
     if state["ProblemType"]["SwizzleTensorA"]:
       if state["ProblemType"]["TransposeA"] is False:

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2750,10 +2750,14 @@ class Solution(collections.abc.Mapping):
     if state["ProblemType"]["SwizzleTensorA"]:
       if state["ProblemType"]["TransposeA"] is False:
         reject(state, f"Tensor A swizzling supports TN or TT only")
+      if state["DirectToVgprA"] is False:
+        reject(state, f"Tensor A swizzling requires DirectToVgprA")
 
     if state["ProblemType"]["SwizzleTensorB"]:
       if state["ProblemType"]["TransposeB"] is True:
         reject(state, f"Tensor B swizzling supports NN or TN only")
+      if state["DirectToVgprB"] is False:
+        reject(state, f"Tensor B swizzling requires DirectToVgprB")
 
     def calcOptGRVW(lrvw: int, unrollMajorLDS: bool, datatype: DataType) -> int:
       # with UnrollMajorLDS, GRVW need to less or equal than LRVW to have conflict free LDS read with padding.

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -497,6 +497,12 @@ class ProblemType(Mapping):
       name += self["F32XdlMathOp"].toChar()
       name += "_"
 
+    if self["SwizzleTensorA"]:
+      name += "STA_"
+
+    if self["SwizzleTensorB"]:
+      name += "STB_"
+
     # Other
     if self["UseBeta"]: name += "B"
     if self["HighPrecisionAccumulate"] and not self["SilentHighPrecisionAccumulate"]: name += "H"
@@ -2733,6 +2739,21 @@ class Solution(collections.abc.Mapping):
         if (state["ProblemType"]["DataTypeA"].isFloat8() == False) and (state["ProblemType"]["DataTypeB"].isFloat8() == False):
             reject(state, "one of DataTypeA or DataTypeB need to be float8")
             return
+
+    #for tensor swizzling, we force pack-k == 2
+    for tc in ("A", "B",):
+      if state["ProblemType"][f"SwizzleTensor{tc}"]:
+        if not state["EnableMatrixInstruction"]:
+          reject(state, f"Tensor {tc} swizzling supports MI only")
+        state[f"GlobalReadVectorWidth{tc}"] = state[f"MIInputPerThread{tc}"] * 2
+
+    if state["ProblemType"]["SwizzleTensorA"]:
+      if state["ProblemType"]["TransposeA"] is False:
+        reject(state, f"Tensor A swizzling supports TN or TT only")
+
+    if state["ProblemType"]["SwizzleTensorB"]:
+      if state["ProblemType"]["TransposeB"] is True:
+        reject(state, f"Tensor B swizzling supports NN or TN only")
 
     def calcOptGRVW(lrvw: int, unrollMajorLDS: bool, datatype: DataType) -> int:
       # with UnrollMajorLDS, GRVW need to less or equal than LRVW to have conflict free LDS read with padding.

--- a/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
+++ b/tensilelite/Tensile/Source/client/include/ClientProblemFactory.hpp
@@ -100,6 +100,8 @@ namespace TensileLite
             DataType                         m_activationComputeType;
             std::vector<std::vector<size_t>> m_problemSizes;
             bool                             m_useUserArgs;
+            bool                             m_swizzleTensorA;
+            bool                             m_swizzleTensorB;
         };
 
     } // namespace Client

--- a/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
+++ b/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
@@ -335,6 +335,8 @@ namespace TensileLite
                         initializeCPUInputs(problem);
                     if(m_problemDependentData)
                         copyValidToGPUBuffer(problem);
+                    if(problem.swizzleTensorA() || problem.swizzleTensorB())
+                        copySwizzledToGPUBuffer(problem);
 
                     // gpu to gpu
                     copyInputs(m_gpuPtrs,
@@ -847,13 +849,15 @@ namespace TensileLite
             virtual bool needMoreBenchmarkRuns() const override
             {
                 return false;
-            };
-            virtual void preBenchmarkRun() override{};
-            virtual void postBenchmarkRun() override{};
-            virtual void preProblem(ContractionProblem* const problem) override{};
-            virtual void postProblem() override{};
-            virtual void preSolution(ContractionSolution const& solution) override{};
-            virtual void postSolution() override{};
+            }
+            virtual void preBenchmarkRun() override{}
+            virtual void postBenchmarkRun() override{}
+            virtual void preProblem(ContractionProblem* const problem) override{}
+            virtual void postProblem() override{}
+            virtual void preSolution(ContractionSolution const& solution) override{
+
+            }
+            virtual void postSolution() override{}
             virtual bool needMoreRunsInSolution() const override
             {
                 return m_numRunsInSolution < m_numRunsPerSolution;
@@ -863,45 +867,45 @@ namespace TensileLite
             {
                 return 0;
             };
-            virtual void setNumWarmupRuns(size_t count) override{};
-            virtual void preWarmup() override{};
+            virtual void setNumWarmupRuns(size_t count) override{}
+            virtual void preWarmup() override{}
             virtual void postWarmup(TimingEvents const& startEvents,
                                     TimingEvents const& stopEvents,
-                                    hipStream_t const&  stream) override{};
+                                    hipStream_t const&  stream) override{}
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override
             {
                 m_numRunsInSolution++;
-            };
+            }
 
             virtual size_t numSyncs() override
             {
                 return 0;
-            };
-            virtual void setNumSyncs(size_t count) override{};
-            virtual void preSyncs() override{};
-            virtual void postSyncs() override{};
+            }
+            virtual void setNumSyncs(size_t count) override{}
+            virtual void preSyncs() override{}
+            virtual void postSyncs() override{}
 
             virtual size_t numEnqueuesPerSync() override
             {
                 return 0;
-            };
-            virtual void setNumEnqueuesPerSync(size_t count) override{};
-            virtual void preEnqueues(hipStream_t const& stream) override{};
+            }
+            virtual void setNumEnqueuesPerSync(size_t count) override{}
+            virtual void preEnqueues(hipStream_t const& stream) override{}
             virtual void postEnqueues(TimingEvents const& startEvents,
                                       TimingEvents const& stopEvents,
-                                      hipStream_t const&  stream) override{};
+                                      hipStream_t const&  stream) override{}
             virtual void validateEnqueues(std::shared_ptr<ProblemInputs> inputs,
                                           TimingEvents const&            startEvents,
-                                          TimingEvents const&            stopEvents) override{};
+                                          TimingEvents const&            stopEvents) override{}
 
-            virtual void finalizeReport() override{};
+            virtual void finalizeReport() override{}
 
             virtual int error() const override
             {
                 return 0;
-            };
+            }
 
         protected:
             // Memory input for class DataInitialization
@@ -953,6 +957,8 @@ namespace TensileLite
             void allocNewGPUInputs();
 
             void copyValidToGPUBuffer(ContractionProblemGemm const& problem);
+
+            void copySwizzledToGPUBuffer(ContractionProblemGemm const& problem);
 
             void initializeGPUBatchedInputs(ContractionProblemGemm const& problem);
 

--- a/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
+++ b/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
@@ -304,6 +304,8 @@ namespace TensileLite
 
                 hipMemcpyKind kind;
 
+                bool needSwizzle = problem.swizzleTensorA() || problem.swizzleTensorB();
+
                 if(m_keepPristineCopyOnGPU && !m_problemDependentData)
                 {
                     // use gpu pristine
@@ -316,7 +318,7 @@ namespace TensileLite
                 }
 
                 if(m_gpuInit && m_curBoundsCheck == BoundsCheckMode::Disable
-                   && !m_problemDependentData)
+                   && !m_problemDependentData && !needSwizzle)
                 {
                     if(m_elementsToValidate)
                     {
@@ -335,7 +337,7 @@ namespace TensileLite
                         initializeCPUInputs(problem);
                     if(m_problemDependentData)
                         copyValidToGPUBuffer(problem);
-                    if(problem.swizzleTensorA() || problem.swizzleTensorB())
+                    if(needSwizzle)
                         copySwizzledToGPUBuffer(problem);
 
                     // gpu to gpu

--- a/tensilelite/Tensile/Source/client/include/TensorDataManipulation.hpp
+++ b/tensilelite/Tensile/Source/client/include/TensorDataManipulation.hpp
@@ -1,0 +1,348 @@
+#pragma once
+#include <cassert>
+#include <functional>
+#include <iosfwd>
+#include <memory>
+#include <vector>
+
+namespace Tensor
+{
+    namespace Manipulation
+    {
+
+        using Shape       = std::vector<size_t>;
+        using Strides     = std::vector<size_t>;
+        using Indices     = std::vector<size_t>;
+        using Permutation = std::vector<size_t>;
+        //shape:   [M,     N, K]
+        //strides: [N * K, K, 1]
+
+        class TensorDesc
+        {
+        public:
+            explicit TensorDesc(std::initializer_list<size_t> shape)
+                : shape(shape)
+            {
+                strides.assign(shape.size(), 1);
+
+                for(ssize_t i = strides.size() - 2; i >= 0; --i)
+                {
+                    strides[i] = strides[i + 1] * this->shape[i + 1];
+                }
+            }
+
+            explicit TensorDesc(const Shape& shape)
+                : shape(shape)
+            {
+                strides.assign(shape.size(), 1);
+
+                for(int i = strides.size() - 2; i >= 0; --i)
+                {
+                    strides[i] = strides[i + 1] * this->shape[i + 1];
+                }
+            }
+
+            TensorDesc(std::initializer_list<size_t> shape, std::initializer_list<size_t> strides)
+                : shape(shape)
+                , strides(strides)
+            {
+            }
+
+            TensorDesc(const Shape& shape, const Strides& strides)
+                : shape(shape)
+                , strides(strides)
+            {
+            }
+
+            size_t stride(size_t i) const
+            {
+                return strides.at(i);
+            }
+
+            size_t numDims() const
+            {
+                return shape.size();
+            }
+
+            size_t dim(size_t i) const
+            {
+                return shape.at(i);
+            }
+
+            const Shape& getShape() const
+            {
+                return shape;
+            }
+
+            void setShape(const Shape& shape)
+            {
+                this->shape = shape;
+                strides.assign(shape.size(), 1);
+
+                for(int i = strides.size() - 2; i >= 0; --i)
+                {
+                    strides[i] = strides[i + 1] * this->shape[i + 1];
+                }
+            }
+
+            friend std::ostream& operator<<(std::ostream& os, const TensorDesc& desc)
+            {
+                os << "Shape: [";
+                for(auto i : desc.shape)
+                {
+                    os << i << ", ";
+                }
+                os << "]\n";
+                os << "Strides: [";
+                for(auto i : desc.strides)
+                {
+                    os << i << ", ";
+                }
+                os << "]\n";
+                return os;
+            }
+
+            std::size_t flattenSize() const
+            {
+                size_t s{1};
+                for(auto i : shape)
+                {
+                    s *= i;
+                }
+                return s;
+            }
+
+            bool isShapeCompatible(const Shape& shape) const
+            {
+                TensorDesc newDesc(shape);
+                return flattenSize() == newDesc.flattenSize();
+            }
+
+        private:
+            Shape   shape;
+            Strides strides;
+        };
+
+        class Tensor
+        {
+        public:
+            template <typename T>
+            static Tensor create(const Shape shape)
+            {
+                return Tensor(shape, sizeof(T));
+            }
+
+            Tensor(const Shape shape, size_t elementSize)
+                : desc(shape)
+                , elementSize(elementSize)
+                , data(new char[elementSize * desc.flattenSize()])
+            {
+            }
+
+            template <typename T>
+            const T* as() const
+            {
+                return reinterpret_cast<const T*>(data.get());
+            }
+
+            template <typename T>
+            T* as()
+            {
+                return reinterpret_cast<T*>(data.get());
+            }
+
+            template <typename T>
+            const T& getValue(const Indices& indices) const
+            {
+                size_t offset{};
+
+                for(size_t i = 0; i < indices.size(); ++i)
+                {
+                    const auto idx = indices[i];
+                    offset += desc.stride(i) * idx;
+                }
+
+                return as<T>()[offset];
+            }
+
+            template <typename T>
+            const T& setValue(const Indices& indices, const T& value)
+            {
+                size_t offset{};
+
+                for(size_t i = 0; i < indices.size(); ++i)
+                {
+                    const auto idx = indices[i];
+                    offset += desc.stride(i) * idx;
+                }
+
+                as<T>()[offset] = value;
+                return value;
+            }
+
+            friend std::ostream& operator<<(std::ostream& os, const Tensor& t)
+            {
+                os << t.desc;
+                return os;
+            }
+
+            const TensorDesc& getDesc() const
+            {
+                return desc;
+            }
+
+            size_t getElementSize() const
+            {
+                return elementSize;
+            }
+
+            size_t getNumBytes() const {
+                return getDesc().flattenSize() * getElementSize();
+            }
+
+            void reshape(const Shape& shape)
+            {
+                if(desc.isShapeCompatible(shape))
+                {
+                    desc.setShape(shape);
+                    return;
+                }
+                assert(false && "Incompatible shape");
+            }
+
+        private:
+            size_t                  elementSize{};
+            TensorDesc              desc;
+            std::unique_ptr<char[]> data;
+        };
+
+        Indices permute(const Indices& indices, const Permutation& perm)
+        {
+            assert(indices.size() == perm.size());
+            Indices newIndices = indices;
+            for(size_t i = 0; i < perm.size(); ++i)
+            {
+                newIndices[i] = indices.at(perm.at(i));
+            }
+            return newIndices;
+        }
+
+        using IterateCallback    = std::function<void(const Indices& indices)>;
+        using IterateDimCallback = std::function<void(size_t dim)>;
+
+        void iterate(
+            const Shape&       shape,
+            size_t             dim,
+            Indices&           indices,
+            IterateCallback    callback,
+            IterateDimCallback dimEnterCallback = [](size_t) {},
+            IterateDimCallback dimLeaveCallback = [](size_t) {})
+        {
+
+            if(dim == shape.size())
+            {
+                callback(indices);
+                return;
+            }
+
+            dimEnterCallback(dim);
+
+            for(size_t i = 0; i < shape.at(dim); ++i)
+            {
+                indices[dim] = i;
+                iterate(shape, dim + 1, indices, callback, dimEnterCallback, dimLeaveCallback);
+            }
+
+            dimLeaveCallback(dim);
+        }
+
+        template <typename T>
+        void permute(Tensor& dst, const Tensor& src, const Permutation& perm)
+        {
+            Indices indices(src.getDesc().numDims(), 0);
+
+            iterate(
+                src.getDesc().getShape(), 0, indices, [&dst, &src, &perm](const Indices& indices) {
+                    Indices dstIndices = permute(indices, perm);
+                    auto&&  value      = src.getValue<T>(indices);
+                    dst.setValue<T>(dstIndices, value);
+                });
+        }
+
+        template <typename T>
+        Tensor permute(const Tensor& tensor, const Permutation& perm)
+        {
+            assert(tensor.getDesc().numDims() == perm.size());
+            assert(sizeof(T) == tensor.getElementSize());
+            Shape  newShape = permute(tensor.getDesc().getShape(), perm);
+            Tensor permuted(newShape, tensor.getElementSize());
+            permute<T>(permuted, tensor, perm);
+            return permuted;
+        }
+
+        Tensor permute(const Tensor& tensor, const Permutation& perm)
+        {
+            Shape  newShape = permute(tensor.getDesc().getShape(), perm);
+            Tensor permuted(newShape, tensor.getElementSize());
+            switch(tensor.getElementSize())
+            {
+            case 1:
+                permute<uint8_t>(permuted, tensor, perm);
+                break;
+            case 2:
+                permute<uint16_t>(permuted, tensor, perm);
+                break;
+                break;
+            case 4:
+                permute<uint32_t>(permuted, tensor, perm);
+                break;
+            case 8:
+                permute<uint64_t>(permuted, tensor, perm);
+                break;
+            default:
+                assert(false && "Unsupported element size");
+            }
+            return permuted;
+        }
+
+        template <typename T>
+        void printTensorData(std::ostream& os, const Tensor& tensor)
+        {
+            const auto* data        = tensor.as<T>();
+            const auto  numElements = tensor.getDesc().flattenSize();
+            os << "[";
+
+            for(size_t i = 0; i < numElements; ++i)
+            {
+                os << float(data[i]) << ", ";
+            }
+
+            os << "]\n";
+        }
+
+        template <typename T>
+        void printTensorDataMultiDims(std::ostream& os, const Tensor& tensor)
+        {
+            os << "[";
+
+            Indices indices(tensor.getDesc().numDims(), 0);
+
+            iterate(
+                tensor.getDesc().getShape(),
+                0,
+                indices,
+                [&os, &tensor](const Indices& idx) { os << float(tensor.getValue<T>(idx)) << ", "; },
+                [&os](size_t dim) { os << "["; },
+                [&os, &tensor](size_t dim) {
+                    os << "], ";
+
+                    if(dim + 1 == tensor.getDesc().numDims())
+                    {
+                        os << '\n';
+                    }
+                });
+
+            os << "]\n";
+        }
+    }
+}

--- a/tensilelite/Tensile/Source/client/main.cpp
+++ b/tensilelite/Tensile/Source/client/main.cpp
@@ -203,6 +203,8 @@ namespace TensileLite
                 ("beta-type",                po::value<DataType>()->default_value(DataType::None), "beta data type")
                 ("compute-input-type",       po::value<DataType>()->default_value(DataType::None), "compute input data type")
                 ("f32-xdl-math-op",          po::value<DataType>()->default_value(DataType::None), "Use xf32 compute for float input and output matrices.")
+                ("swizzle-tensor-a",         po::value<bool>()->default_value(false), "Swizzle input tensor A.")
+                ("swizzle-tensor-b",         po::value<bool>()->default_value(false), "Swizzle input tensor B.")
                 ("activation-compute-type",  po::value<DataType>()->default_value(DataType::None), "Activation compute type.")
                 ("high-precision-accumulate", po::value<bool>()->default_value(false), "Use high-precision accumulate.")
                 ("sparse",                   po::value<int>()->default_value(0), "A or B matrix is sparse matrix.")

--- a/tensilelite/Tensile/Source/client/source/ClientProblemFactory.cpp
+++ b/tensilelite/Tensile/Source/client/source/ClientProblemFactory.cpp
@@ -52,6 +52,8 @@ namespace TensileLite
             , m_f32XdlMathOp(DataType::Float)
             , m_activationComputeType(DataType::Float)
             , m_useUserArgs(false)
+            , m_swizzleTensorA(false)
+            , m_swizzleTensorB(false)
         {
             using std::static_pointer_cast;
 
@@ -188,6 +190,16 @@ namespace TensileLite
                 m_f32XdlMathOp = args["f32-xdl-math-op"].as<DataType>();
             }
 
+            if(args.count("swizzle-tensor-a"))
+            {
+                m_swizzleTensorA = args["swizzle-tensor-a"].as<bool>();
+            }
+
+            if(args.count("swizzle-tensor-b"))
+            {
+                m_swizzleTensorB = args["swizzle-tensor-b"].as<bool>();
+            }
+
             if(args.count("use-user-args"))
             {
                 m_useUserArgs = args["use-user-args"].as<bool>();
@@ -315,6 +327,8 @@ namespace TensileLite
                             rv.back().setSparse(m_sparse);
                             rv.back().setActivationType(m_activationType);
                             rv.back().setWorkspaceSize(m_maxWorkspaceSize);
+                            rv.back().setSwizzleTensorA(m_swizzleTensorA);
+                            rv.back().setSwizzleTensorB(m_swizzleTensorB);
                             if(k < m_biasTypeArgs.size())
                             {
                                 auto length

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -26,6 +26,7 @@
 
 #include "DataInitialization.hpp"
 #include "Utility.hpp"
+#include "TensorDataManipulation.hpp"
 // #include "DataInitializationTyped.hpp"
 
 #include <Tensile/Utils.hpp>
@@ -1709,6 +1710,55 @@ namespace TensileLite
                                        p.cpuInput.valid.get(),
                                        p.maxElements,
                                        hipMemcpyHostToDevice);
+                if(ptr == nullptr)
+                    std::__throw_runtime_error("error");
+            }
+        }
+
+        void DataInitialization::copySwizzledToGPUBuffer(ContractionProblemGemm const& problem)
+        {
+            for(size_t i = 0; i < m_vdata.size(); i++)
+            {
+                auto& desc = problem.tensors()[i];
+                auto  it   = m_vdata[i].pristine.find(desc.dataType());
+                if(it == m_vdata[i].pristine.end())
+                    continue;
+                auto& p = m_vdata[i].pristine[desc.dataType()];
+                if(p.gpuInput.valid.get() == nullptr || p.cpuInput.valid.get() == nullptr)
+                    continue;
+
+                bool needSwizzle = (problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                    || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B);
+
+                void *ptr{};
+                //FIXME: Not good, need to use format to specify the way for swizzling.
+                //TODO: Support more swizzling type, such as 32x32x8, currently we have 16x16x8 only.
+                if(needSwizzle)
+                {
+                    using Tensor = Tensor::Manipulation::Tensor;
+                    constexpr size_t MiM = 16;
+                    constexpr size_t MiK = 16;
+                    constexpr size_t MiKv = 4;
+                    constexpr size_t PackK = 2;
+                    auto unrolledSize = desc.sizes()[0];
+                    auto tiledSize = desc.sizes()[1];
+                    auto tmpTensor = Tensor::create<Half>({tiledSize, unrolledSize});
+                    memcpy(tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
+                    tmpTensor.reshape({tiledSize / MiM, MiM, unrolledSize / (MiK * PackK), MiK / MiKv , MiKv * PackK});
+                    Tensor permuted = permute(tmpTensor, {0, 2, 3, 1, 4});
+                    ptr = copyInputBuffers(desc,
+                                           p.gpuInput.valid.get(),
+                                           permuted.as<void>(),
+                                           p.maxElements,
+                                           hipMemcpyHostToDevice);
+                } else {
+                    ptr = copyInputBuffers(desc,
+                                            p.gpuInput.valid.get(),
+                                            p.cpuInput.valid.get(),
+                                            p.maxElements,
+                                            hipMemcpyHostToDevice);
+                }
+
                 if(ptr == nullptr)
                     std::__throw_runtime_error("error");
             }

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -1749,7 +1749,7 @@ namespace TensileLite
                     ptr = copyInputBuffers(desc,
                                            p.gpuInput.valid.get(),
                                            permuted.as<void>(),
-                                           p.maxElements,
+                                           permuted.getDesc().flattenSize(),
                                            hipMemcpyHostToDevice);
                 } else {
                     ptr = copyInputBuffers(desc,

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -980,6 +980,22 @@ namespace TensileLite
             return m_maxProblemSize;
         }
 
+        bool swizzleTensorA() const {
+            return m_swizzleTensorA;
+        }
+
+        bool swizzleTensorB() const {
+            return m_swizzleTensorB;
+        }
+
+        void setSwizzleTensorA(bool swizzle) {
+            m_swizzleTensorA = swizzle;
+        }
+
+        void setSwizzleTensorB(bool swizzle) {
+            m_swizzleTensorB = swizzle;
+        }
+
         /// Allocated elements excluding batch dimensions
         /// Used in assembly kernels to determine buffer limits, if batch dimes not
         /// packed
@@ -1185,6 +1201,8 @@ namespace TensileLite
         bool           m_useGradient             = false;
         bool           m_useE                    = false;
         bool           m_outputAmaxD             = false;
+        bool           m_swizzleTensorA          = false;
+        bool           m_swizzleTensorB          = false;
         int            m_useBias                 = 0;
         std::string    m_useScaleAB              = "";
         bool           m_useScaleCD              = false;

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -2521,6 +2521,72 @@ namespace TensileLite
                 }
             };
 
+            struct SwizzleTensorA : public Predicate_CRTP<SwizzleTensorA, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                bool value;
+
+                SwizzleTensorA() = default;
+                SwizzleTensorA(bool value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "SwizzleTensorA";
+                }
+
+                bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return problem.swizzleTensorA() == value;
+                }
+
+                bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    return debugEvalCmp(
+                        problem, stream, "prob", problem.swizzleTensorA(), "==", "sol", value);
+                }
+            };
+
+            struct SwizzleTensorB : public Predicate_CRTP<SwizzleTensorB, ContractionProblemGemm>
+            {
+                enum
+                {
+                    HasIndex = false,
+                    HasValue = true
+                };
+                bool value;
+
+                SwizzleTensorB() = default;
+                SwizzleTensorB(bool value)
+                    : value(value)
+                {
+                }
+
+                static std::string Type()
+                {
+                    return "SwizzleTensorB";
+                }
+
+                bool operator()(ContractionProblemGemm const& problem) const override
+                {
+                    return problem.swizzleTensorB() == value;
+                }
+
+                bool debugEval(ContractionProblemGemm const& problem,
+                                       std::ostream&                 stream) const override
+                {
+                    return debugEvalCmp(
+                        problem, stream, "prob", problem.swizzleTensorB(), "==", "sol", value);
+                }
+            };
+
             struct F32XdlMathOpEqual
                 : public Predicate_CRTP<F32XdlMathOpEqual, ContractionProblemGemm>
             {

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -504,6 +504,8 @@ namespace TensileLite
             int                   sparse                     = 0;
             bool                  stochasticRounding         = false;
             bool                  supportDeviceUserArguments = false;
+            bool                  swizzleTensorA             = false;
+            bool                  swizzleTensorB             = false;
         };
 
         struct LinearModel

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/ContractionPredicates.hpp
@@ -118,6 +118,8 @@ namespace TensileLite
                     Base::template Pair<Predicates::Contraction::F32XdlMathOpEqual>(),
                     Base::template Pair<Predicates::Contraction::SupportDeviceUserArguments>(),
                     Base::template Pair<Predicates::Contraction::WorkgroupMappingXCCCheck>(),
+                    Base::template Pair<Predicates::Contraction::SwizzleTensorA>(),
+                    Base::template Pair<Predicates::Contraction::SwizzleTensorB>()
                 });
 
                 auto gmap = Generic::GetSubclasses();
@@ -506,6 +508,18 @@ namespace TensileLite
         template <typename IO>
         struct MappingTraits<Predicates::Contraction::F32XdlMathOpEqual, IO>
             : public AutoMappingTraits<Predicates::Contraction::F32XdlMathOpEqual, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::SwizzleTensorA, IO>
+            : public AutoMappingTraits<Predicates::Contraction::SwizzleTensorA, IO>
+        {
+        };
+
+        template <typename IO>
+        struct MappingTraits<Predicates::Contraction::SwizzleTensorB, IO>
+            : public AutoMappingTraits<Predicates::Contraction::SwizzleTensorB, IO>
         {
         };
 

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/ContractionSolution.hpp
@@ -181,6 +181,8 @@ namespace TensileLite
                 iot::mapOptional(io, "sparse", s.sparse);
                 iot::mapOptional(io, "f32XdlMathOp", s.f32XdlMathOp);
                 iot::mapOptional(io, "supportDeviceUserArguments", s.supportDeviceUserArguments);
+                iot::mapOptional(io, "swizzleTensorA", s.swizzleTensorA);
+                iot::mapOptional(io, "swizzleTensorB", s.swizzleTensorB);
             }
 
             const static bool flow = false;

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -1,0 +1,96 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  MinimumRequiredVersion: 4.14.0
+  PrintLevel: 1
+  #PrintSolutionRejectionReason: True
+  Device: 0
+  CMakeBuildType: Release
+  MergeFiles: False
+  KernelTime: True
+  MaxWorkspaceSize: 13421772800
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 1
+  BoundsCheck: 2
+  #MaxFileName: 256
+
+BenchmarkProblems:
+  ########################################
+  # HHS TN DTVA + SWIZZLED_A + BIAS + Activation
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      SwizzleTensorA: True
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Activation: True
+      BiasDataTypeList: ['h']
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,   1, 1,  4,1 ] # MT = 64x16
+          - [16, 16, 16, 1,  1,   2, 1,  4,1 ] # MT = 128x16
+          - [16, 16, 16, 1,  1,   4, 1,  4,1 ] # MT = 256x16
+          - [16, 16, 16, 1,  1,   8, 1,  4,1 ] # MT = 512x16
+          - [16, 16, 16, 1,  1,   5, 1,  2,1 ] # MT = 160x16
+
+          - [16, 16, 16, 1,  1,   1, 8,  4,1 ] # MT = 64x128
+          - [16, 16, 16, 1,  1,   1, 16, 4,1 ] # MT = 64x256
+          - [16, 16, 16, 1,  1,   2, 8,  4,1 ] # MT = 128x128
+          - [16, 16, 16, 1,  1,   2, 16, 4,1 ] # MT = 128x256
+          - [16, 16, 16, 1,  1,   4, 8,  4,1 ] # MT = 256x128
+          - [16, 16, 16, 1,  1,   4, 16, 4,1 ] # MT = 256x256
+          - [16, 16, 16, 1,  1,   8, 8,  4,1 ] # MT = 512x128
+          - [16, 16, 16, 1,  1,   8, 16, 4,1 ] # MT = 512x256
+          - [16, 16, 16, 1,  1,   5, 8,  2, 1 ] # MT = 160x128
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [2,4,8]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,4]
+        - ClusterLocalRead: [1]
+        - NumElementsPerBatchStore: [0]
+        - DepthU: [32,64,128]
+        - VectorWidthA: [1]
+        - VectorWidthB: [-1]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [4]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [2]
+        - WorkGroupMappingXCC: [8]
+        - ScheduleIterAlg: [3]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+        - GlobalSplitU: [1,3]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - LocalReadVectorWidth: [2,4,8]
+        - DirectToVgprA: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [160,   256, 1, 256]
+          - Exact: [1600,  512, 1, 1024]
+          - Exact: [512,   256, 1, 256]
+          - Exact: [5120,  512, 1, 1024]
+        - BiasTypeArgs: ['h']
+        - ActivationArgs:
+          - [Enum: none]
+          - [Enum: relu]


### PR DESCRIPTION
SWDEV-481183
Co-author: @Serge45 

- [x] Host-side swizzling implementation by @Serge45 
- [x] Code-gen of swizzlingA (SwizzleTensorA): Requires TN type and DTVA
- [x] FP16, BF16 MFMA_16x16x16_x1 only, Supported useBias and SAV
- [x] pytest yaml

Current restriction:
- [x] Predicate: **M-dim = multiple of MT0** (performance concerns)
- [x] Predicate: **K-dim = multiple of DU** (performance concerns)


---

For peers to have a better understanding to review:
https://confluence.amd.com/pages/viewpage.action?pageId=1676570207   (Limited access, AMD internal)

---

hipBlaslt client-side has not been implemented yet, so no logic yamls updated in this PR

---

**Local pytest passed:**

Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/selftest/dtvA_swizzleA.yaml] 
[gw0] [100%] PASSED Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/common/selftest/dtvA_swizzleA.yaml] 