### PR TITLE
Enable test option for stream-k full tile or remainder tile

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -942,9 +942,9 @@ validParameters = {
     # TENSILE_STREAMK_FIXED_GRID lets you override the default grid size with a specific number
     #   0 = override disabled (default)
     # TENSILE_STREAMK_FULL_TILES sets the number of full tiles to be included in stream-k work
-    #   -1 = use prediction model for best performance (default)
+    #   -1 = use prediction model for best performance (not yet implemented)
     #   0 = only remainder tiles run in stream-k
-    #   1+ = remainder + 1 (or more) full grids of tiles run in stream-k
+    #   1+ = remainder + 1 (or more) full grids of tiles run in stream-k (default=1)
     # TENSILE_STREAMK_DYNAMIC_GRID enables dynamic grid mode, which automatically limits the number of CUs used:
     #   0 = Off, use all CUs (default)
     #   1 = Only reduce CUs for small problems to number of output tiles when num_tiles < CU count.

--- a/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -202,7 +202,7 @@ namespace Tensile
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
-        int         skFullTiles      = 0;
+        int         skFullTiles      = 1;
         std::string deviceName;
 
         virtual bool   runsKernelTargeting(Processor p) const;
@@ -249,7 +249,7 @@ namespace Tensile
         const int getSKFullTiles() const
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_FULL_TILES");
-            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
+            static const int   value  = (envStr == NULL ? 1 : std::atoi(envStr));
             return value;
         }
 


### PR DESCRIPTION
Re-enable environment variable that can be used to test the number of stream-k tiles that get run in a stream-k kernel.

The default (in 2-tile algorithm) is to run all remainder tiles + 1 extra tile per workgroup. This ensures cases like remainder=1 are not split across a large number of workgroups. But for cases when remainder tiles is large (ie: remainder = WGs - 1), it is generally faster to run only the remainder tiles rather than remainder + #WGs. This way it will run more tiles in data-parallel and improve memory alignment.

This change adds an environment variable that allows the user to override the number of stream-k tiles selected. I developed a prediction model to select the best setting automatically, but that still needs to be ported from Tensile in a future change (this PR is just a first step to allow some experiments to run).

TENSILE_STREAMK_FULL_TILES=0 (runs remainder only)
TENSILE_STREAMK_FULL_TILES=1 (default, runs remainder + #WGs)
TENSILE_STREAMK_FULL_TILES=[large number] (can be used to make a 2-tile kernel double as basic algorithm, ie StreamK=1)