### PR TITLE
gfx12 - separate waitcnt for better perf.

### DIFF
--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -199,7 +199,7 @@ class GlobalWriteBatchWriter:
         lgkmcnt = -1
       # Get vscnt
       if vmcnt != -1:
-        if self.parentWriter.states.archCaps["SeparateVscnt"]:
+        if self.parentWriter.states.archCaps["SeparateVscnt"] or self.parentWriter.states.archCaps["SeparateVMcnt"]:
           vscnt = 0
         else:
           vscnt = self.storesIssued if not self.kernel["GroupLoadStore"] else 0


### PR DESCRIPTION
gfx942
[----------] Global test environment tear-down
[==========] 48206 tests from 13 test suites ran. (1115527 ms total)
[  PASSED  ] 48206 tests.
hipBLASLt version: 1100

gfx1201
[----------] Global test environment tear-down
[==========] 22565 tests from 13 test suites ran. (242378 ms total)
[  PASSED  ] 22565 tests.
hipBLASLt version: 1100

