### PR TITLE
Fix incorrect global read of i8 and f8 on gfx1201

### DIFF
--- a/tensilelite/Tensile/AsmStoreState.py
+++ b/tensilelite/Tensile/AsmStoreState.py
@@ -102,7 +102,7 @@ class StoreState:
             # Really only used if gwvw=1 - edge cases
             # exception: data vgpr cannot be shared if UseInitialStridesCD is enabled and card enable EccHalf,
             #            since each buffer_load_short would overwrite undefined 16bit as zero.
-            self.halfDataRegPerVI = gwvw*self.numVgprsPerDataPerVI == 0.5 and not (kernel["ProblemType"]["UseInitialStridesCD"] and kernelWriter.states.archCaps["HasEccHalf"]) and not (kernel["ProblemType"]["DestDataType"].numRegisters() == 0.25)
+            self.halfDataRegPerVI = gwvw*self.numVgprsPerDataPerVI == 0.5 and not (kernel["ProblemType"]["UseInitialStridesCD"] and (kernelWriter.states.archCaps["HasEccHalf"] or not kernelWriter.states.asmCaps["HasWMMA_V1"])) and not (kernel["ProblemType"]["DestDataType"].numRegisters() == 0.25)
             # indicates the VGPRs index offset from LSU Reduction.
             # Used for multi-batch/Edge cases.
             self.lsuStartVgprOffset = 0

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3434,7 +3434,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if not kernel["DirectToVgprSparseMetadata"]:
         self.states.m.numVgprG2L = roundUp((kernel["NumLoadsCoalescedMetadata"] * kernel["NumLoadsPerpendicularMetadata"] * \
           kernel["GlobalReadVectorWidthMetadata"] * tensorParametersM["bpeDS"]) / (float)(self.states.bpr))
-        if self.states.archCaps["HasEccHalf"]:
+        if self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]:
           tpM = self.states.bpr if tensorParametersM["bpeDS"] * vwm < self.states.bpr else tensorParametersM["bpeDS"] * vwm
           self.states.m.numVgprG2LAllocated = roundUp((kernel["NumLoadsCoalescedMetadata"] * kernel["NumLoadsPerpendicularMetadata"] * \
             tpM) / (float)(self.states.bpr))

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -6452,7 +6452,7 @@ class KernelWriterAssembly(KernelWriter):
               loadModule = Module("load%u"%loopCnt)
               imod.middle.add(loadModule)
 
-              if self.states.archCaps["HasEccHalf"] and not tP["isM"]:
+              if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and not tP["isM"]:
                 numVgprG2L = self.states.a.numVgprG2L if tc == 'A' else self.states.b.numVgprG2L if tc =='B' else self.states.m.numVgprG2L
                 eccBpe = tP["bpeDS"] if kernel["ConvertAfterDS"] else max(tP["bpeGR"], tP["bpe"])
                 eccOffset = _getEccOffset(loadWidth, bpr=self.states.bpr, bpe=eccBpe, \
@@ -7039,7 +7039,7 @@ class KernelWriterAssembly(KernelWriter):
               g2lIdxDict[g2lIdx] = 0
             instHi = g2lIdxDict[g2lIdx]
 
-            if self.states.archCaps["HasEccHalf"]:
+            if self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]:
               numVgprG2L = self.states.a.numVgprG2L if tc == 'A' else self.states.b.numVgprG2L if tc == 'B' else self.states.m.numVgprG2L
               eccinstHi = instHi
               # FIXME: Workaround, unique pattern in 8bit + glvw == 2...


### PR DESCRIPTION
Since the [modification](https://github.com/ROCm/hipBLASLt/pull/913/files#diff-cb522516ea5f6801fed56bc37d5eabeec102b818a03b76c5ef0f7be25134261bL386) in [PR #913](https://github.com/ROCm/hipBLASLt/pull/913), the expected amount of data that a VGPR can store has changed to 1 * 8-bit. Although gfx1201 is capable of storing 2 * 8-bit values in a VGPR, it is difficult to maintain two different methods in the current generator. The better way to implement a vgpr storing 2 * 8-bit probably is to refactor the current code. This PR's modification is to patch the missing parts of [PR #913](https://github.com/ROCm/hipBLASLt/pull/913). Without it, the VGPR index will be calculated incorrectly. The description needs confirmation from @cmingch and @TonyYHsieh.

![](https://github.com/user-attachments/assets/012589b5-1700-48b7-94ef-cb38f395ca7a)
The left-hand side shows the code generated by `grvw = 1` before modification, where the data will override 3 times in a VGPR. The right-hand side is enable ECCHALF.