### PR TITLE
Add a condition to split local write.

### DIFF
--- a/tensilelite/Tensile/Components/SIA.py
+++ b/tensilelite/Tensile/Components/SIA.py
@@ -939,6 +939,15 @@ def splitDSInstructionIntoSmaller(writer, kernel, item, numLocalWritesPerSched, 
     # LW b32 4-way bank conflict latency ~ 108 cycles
     # round up with quad-cycle
     finalLWCycles  = roundUp(108 / 4)
+
+    # How many mfmas between 2 LWs
+    # the MFMA buffer must be larger then the latency
+    numMfmaBetweenLW = PRECISION // numLocalWritesPerSched
+    mfmaBuffer = numMfmaBetweenLW * miLatency
+    if mfmaBuffer <= finalLWCycles:
+        # no enough cycles between LWs
+        return None, 0, 0
+
     extraSched = roundUp(finalLWCycles / miLatency)
     if (currentModIdx + numLocalWritesPerSched * (div - 1 + extraSched)) >= lenOfItems:
         # no enough cycles before barrier


### PR DESCRIPTION
If there is no enough space between 2 LW instructions, don't split LW.

For example, 
mfma0 -> lw_b128 -> mfma1 -> GR -> mfma2 -> mfma3  -> mfma4  -> mfma5 -> mfma6 -> mfma7 -> lw_b128  -> mfma8
can be split into
mfma0 -> **lw_b32** -> mfma1  -> lw_b32 -> mfma2 -> lw_b32 ->mfma3  -> lw_b32 -> mfma4  ->  GR -> mfma5 -> mfma6 -> mfma7 -> **lw_b32** -> mfma8 -> lw_b32 ....
The LW FIFO is 4 for 4-wave cases. 
If the previous **lw_b32** is not finished, the following **lw_b32** cannot be issued.
The instruction stall happens.