### PR TITLE
Resolve RPM failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,9 @@ endif()
 
 set( CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib" )
 
+# work around code object stripping failure if using /usr/bin/strip
+set( CPACK_RPM_SPEC_MORE_DEFINE "%define __strip ${rocm_bin}/../llvm/bin/llvm-strip")
+
 # Give hipblaslt compiled for CUDA backend a different name
 if( NOT USE_CUDA )
     set( package_name hipblaslt )


### PR DESCRIPTION
When using RPM to package the tensilelite artifacts, /usr/lib/rpm/strip fails. This change set modifies the RPM spec file such that llvm-strip is used rather then the system strip.