### PR TITLE
hipblaslt-bench: new option "skip_slow_solution_ratio" to skip slow solution

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -558,6 +558,12 @@ try
          value<bool>(&arg.use_gpu_timer)->default_value(false),
          "Use hipEventElapsedTime to profile elapsed time.")
 
+        ("skip_slow_solution_ratio",
+          value<float>(&arg.skip_slow_solution_ratio)->default_value(0.0),
+          "Specifies a ratio to skip slow solution when warm up stage. "
+          "Skip condition: (current solution's warm up time * ratio) > best solution's warm up time. "
+          "Ratio range: 0 ~ 1. 0 means no skip.")
+
         ("splitk",
          valueVec<uint32_t>(&gsu_vector),
          "[Tuning parameter] Set split K for a solution, 0 is use solution's default value. (Only support GEMM + api_method mix or cpp)")
@@ -843,6 +849,10 @@ try
     int copied = snprintf(arg.function, sizeof(arg.function), "%s", function.c_str());
     if(copied <= 0 || copied >= sizeof(arg.function))
         throw std::invalid_argument("Invalid value for --function");
+
+    if(arg.skip_slow_solution_ratio < 0 || arg.skip_slow_solution_ratio > 1)
+        throw std::invalid_argument(
+            "Valid value for --skip_slow_solution_ratio is in range (0.0 ~ 1.0).");
 
     if(verify)
     {

--- a/clients/benchmarks/program_options.hpp
+++ b/clients/benchmarks/program_options.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -549,7 +549,7 @@ namespace roc
                 const value_base* val = opt.get_val().get();
                 if(printvalue && !dynamic_cast<const value<bool>*>(val))
                     left << " <value>";
-                os << std::setw(26) << std::left << left.str() << " " << std::setw(82) << std::left
+                os << std::setw(34) << std::left << left.str() << " " << std::setw(82) << std::left
                    << opt.get_desc() << " ";
                 left.str(std::string());
 

--- a/clients/common/hipblaslt_arguments.cpp
+++ b/clients/common/hipblaslt_arguments.cpp
@@ -120,13 +120,13 @@ void Arguments::init()
     gradient          = false;
     norm_check_assert = true;
 
-    use_ext            = false;
-    use_ext_setproblem = false;
-    algo_method        = 0;
-    use_user_args      = false;
-    rotating           = 0;
-    use_gpu_timer      = false;
-
+    use_ext                  = false;
+    use_ext_setproblem       = false;
+    algo_method              = 0;
+    use_user_args            = false;
+    rotating                 = 0;
+    use_gpu_timer            = false;
+    skip_slow_solution_ratio = 0.0;
     // tuning
     gsu_vector[0] = 0;
     for(int32_t i = 1; i < MAX_SUPPORTED_NUM_PROBLEMS; i++)

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -160,7 +160,7 @@ struct Arguments
     bool    use_user_args;
     int32_t rotating;
     bool    use_gpu_timer;
-
+    float   skip_slow_solution_ratio;
     // tuning
     int32_t gsu_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
     int32_t wgm_vector[MAX_SUPPORTED_NUM_PROBLEMS]; // This is for client
@@ -257,6 +257,7 @@ struct Arguments
     OPER(use_user_args) SEP          \
     OPER(rotating) SEP               \
     OPER(use_gpu_timer) SEP          \
+    OPER(skip_slow_solution_ratio) SEP\
     OPER(gsu_vector) SEP             \
     OPER(wgm_vector) SEP             \
     OPER(print_solution_found) SEP   \
@@ -853,7 +854,7 @@ namespace ArgumentsHelper
                 func("rotating_buffer", arg.rotating);
         };
 };
-    // clang-format on
+// clang-format on
 
 #else
 #error "Unsupported C++ version"

--- a/clients/include/hipblaslt_common.yaml
+++ b/clients/include/hipblaslt_common.yaml
@@ -374,6 +374,7 @@ Arguments:
   - use_user_args: c_bool
   - rotating: c_int32
   - use_gpu_timer: c_bool
+  - skip_slow_solution_ratio: c_float
   - gsu_vector: c_int32*32
   - wgm_vector: c_int32*32
   - print_solution_found: c_bool
@@ -473,6 +474,7 @@ Defaults:
   use_user_args: false
   rotating: 0
   use_gpu_timer: false
+  skip_slow_solution_ratio: 0.0
   gsu_vector: 0
   wgm_vector: 0
   print_solution_found: false


### PR DESCRIPTION
Example:
hipblaslt-bench --use_gpu_timer --transA N --transB N -r f16_r -m 4096 -n 4096 -k 4096 --algo_method all --rotating 512 --flush -i 1000 -j 100 **--skip_slow_solution_ratio 0.5**
![image](https://github.com/user-attachments/assets/a0cf24fa-7a67-49ff-b95a-ae4f417b3e68)
