### PR TITLE
Cherry-pick to release/rocm-rel-6.3: Clarify release and version number for 6.3.0 (#1255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Full documentation for hipBLASLt is available at [rocm.docs.amd.com/projects/hipBLASLt](https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/index.html).
 
-## (Unreleased) hipBLASLt 0.10.0
+## hipBLASLt 0.10.0 for ROCm 6.3.0
 
 ### Added
 


### PR DESCRIPTION
(cherry picked from commit abf820fba9ef2f638968ef3b05f74ed79b9dd02b)