### PR TITLE
code-gen: Fixed DTVA code-gen and validation failures

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1919,11 +1919,8 @@ class Solution(collections.abc.Mapping):
       return False
 
     # Reject TLU = UnrollMajorLDS
-    if tc == 'A' and (state["ProblemType"]["TLUA"] == state["UnrollMajorLDSA"]):
-      reject(state, "DirectToVgprA does not supports TLUA = UnrollMajorLDSA")
-      return False
-    if tc == 'B' and (state["ProblemType"]["TLUB"] == state["UnrollMajorLDSB"]):
-      reject(state, "DirectToVgprB does not supports TLUB = UnrollMajorLDSB")
+    if state["ProblemType"]["TLU%c"%tc] == state["UnrollMajorLDS%c"%tc]:
+      reject(state, "DirectToVgpr%c does not supports TLU%c = UnrollMajorLDS%c"%(tc, tc, tc))
       return False
 
     # does not work with UnrollLoopSwapGlobalReadOrder

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -39,6 +39,7 @@ from .KernelWriterActivationFunction import KernelWriterActivationFunction
 from .KernelWriterActivationOnly import KernelWriterActivationOnly
 from .KernelWriterReduction import KernelWriterReduction
 
+from .AsmStoreState import VectorDataTypes
 from .Activation import ActivationType
 
 from .CustomKernels import isCustomKernelConfig
@@ -1917,9 +1918,12 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToVgpr%c does not supports InnerUnroll>1"%(tc))
       return False
 
-    # Reject TLU = UnrollMajorLDS (B only)
-    if tc == 'B' and (state["ProblemType"]["TLUA"] == state["UnrollMajorLDSA"] or state["ProblemType"]["TLUB"] == state["UnrollMajorLDSB"]):
-      reject(state, "DirectToVgpr%c does not supports TLU = UnrollMajorLDS"%(tc))
+    # Reject TLU = UnrollMajorLDS
+    if tc == 'A' and (state["ProblemType"]["TLUA"] == state["UnrollMajorLDSA"]):
+      reject(state, "DirectToVgprA does not supports TLUA = UnrollMajorLDSA")
+      return False
+    if tc == 'B' and (state["ProblemType"]["TLUB"] == state["UnrollMajorLDSB"]):
+      reject(state, "DirectToVgprB does not supports TLUB = UnrollMajorLDSB")
       return False
 
     # does not work with UnrollLoopSwapGlobalReadOrder
@@ -2138,7 +2142,7 @@ class Solution(collections.abc.Mapping):
     #   state["BatchSizeEqual"] = 1
 
     isa = tuple(state["ISA"])
-    
+
     if state["StreamK"] != 0:
       state["GlobalSplitU"] = 0 # Cannot enable both Stream-K and GSU
       state["GlobalSplitUAlgorithm"] = "MultipleBuffer" # Set default Algorithm
@@ -3673,6 +3677,40 @@ class Solution(collections.abc.Mapping):
       state["LdsOffsetBiasGSU"] = ldsNumBytesRemapCGSU
       state["LdsOffsetBias"] = ldsNumBytesRemapC
 
+    # Calcualte the correct LDS usages
+    def calcEpilogueTurns(factorDims: List) -> int:
+      divisor = state["SubGroup0"] * state["SubGroup1"]
+      # d will be a list containing 0 or 1
+      maxTurn = 0
+      for d in range(len(factorDims)):
+        turn = math.ceil(state["MacroTile%d"%d] / divisor)
+        maxTurn = max(maxTurn, turn)
+      return maxTurn
+
+    # Calc the required LDS
+    vecDT = VectorDataTypes()
+    biasDim = state["ProblemType"]["UseBias"]
+    savDim = state["ProblemType"]["UseScaleAlphaVec"]
+    sAB = state["ProblemType"]["UseScaleAB"] == "Vector"
+    # Calc LDS for Bias
+    if biasDim == 1:
+      vecDT.bias.turn = calcEpilogueTurns([0])
+    elif biasDim == 2:
+      vecDT.bias.turn = calcEpilogueTurns([1])
+    elif biasDim == 3:
+      vecDT.bias.turn = calcEpilogueTurns([0, 1])
+    # Calc LDS for SAV
+    if savDim == 1:
+      vecDT.scaleAlpha.turn = calcEpilogueTurns([0])
+    elif savDim == 2:
+      vecDT.scaleAlpha.turn = calcEpilogueTurns([1])
+    elif savDim == 3:
+      vecDT.scaleAlpha.turn = calcEpilogueTurns([0, 1])
+    # Calc LDS for ScaleA, ScaleB
+    if sAB:
+      vecDT.scaleA.turn = calcEpilogueTurns([0])
+      vecDT.scaleB.turn = calcEpilogueTurns([1])
+
     epilogueSize = 0
     # Bias
     if state["ProblemType"]["UseBias"]:
@@ -3690,14 +3728,14 @@ class Solution(collections.abc.Mapping):
         if tile01 > -1:
           maxKId = state["WavefrontSize"] // ((state["MatrixInstM"] if (tile01 == 0) else state["MatrixInstN"]) * state["MatrixInstB"])
           for dataType in state["ProblemType"]["BiasDataTypeList"]:
-            epilogueSize = max(epilogueSize, state["MacroTile%d"%tile01] * maxKId * dataType.numBytes())
+            epilogueSize = max(epilogueSize, state["MacroTile%d"%tile01] * maxKId * dataType.numBytes()) # TODO- GetTurn ?
       else:
-        epilogueSize = state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes()
+        epilogueSize = state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes() * vecDT.bias.turn
     # Calculate max ldsNumBytes for other epilogues
     if state["ProblemType"]["UseScaleAlphaVec"]:
-      epilogueSize += state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes()
+      epilogueSize += state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes() * vecDT.scaleAlpha.turn
     if state["ProblemType"]["UseScaleAB"] == "Vector":
-      epilogueSize += state["NumThreads"] * 2 * state["ProblemType"]["ComputeDataType"].numBytes()
+      epilogueSize += state["NumThreads"] * state["ProblemType"]["ComputeDataType"].numBytes() * (vecDT.scaleA.turn + vecDT.scaleB.turn)
     ldsNumBytes = max(ldsNumBytes, state["LdsOffsetBias"] + epilogueSize)
 
     state["LdsBytesNoAmax"] = ldsNumBytes

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -80,7 +80,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         - StreamK: [0,3]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 2,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   8, 1,  4,1 ]
@@ -177,7 +177,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         - StreamK: [0,2]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   8, 1,  4,1 ]
@@ -269,7 +269,7 @@ BenchmarkProblems:
         - DirectToVgprB: [1]
         - StreamK: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 8,  1,4 ]
@@ -365,7 +365,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         - StreamK: [0,3]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   8, 1,  4,1 ]
@@ -423,19 +423,22 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1,  1,   2, 1,  4,1 ]
+          - [16, 16, 16, 1,  1,   1, 1,  4,1 ] # MT = 64x16. Case to check kernel writer works
+          - [16, 16, 16, 1,  1,   2, 1,  4,1 ] # MT = 128x16. Check kernel works without vgprValuA
           - [16, 16, 16, 1,  1,   4, 1,  4,1 ]
+          - [16, 16, 16, 1,  1,   8, 1,  4,1 ] # MT = 512x16. Case to check LDS usage of Epilogues
+          - [16, 16, 16, 1,  1,   5, 1,  2,1 ] # MT = 160x16. Case to check kernel writer works
           - [32, 32,  8, 1,  1,   2, 1,  4,1 ]
           - [32, 32,  8, 1,  1,   4, 1,  4,1 ]
         - WorkGroup:
           - [16,16,1]
-        - GlobalReadVectorWidthA: [4]#[4,8]
-        - GlobalReadVectorWidthB: [4]#[4,8]
+        - GlobalReadVectorWidthA: [2,4,8]
+        - GlobalReadVectorWidthB: [2,4,8]
         - PrefetchGlobalRead: [1,2]
-        - PrefetchLocalRead: [1]
+        - PrefetchLocalRead: [1,2]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
-        - DepthU: [128]
+        - DepthU: [32,64,128]
         - VectorWidthA: [-1]
         - VectorWidthB: [-1]
         - MIArchVgpr: [0, 1]
@@ -455,10 +458,11 @@ BenchmarkProblems:
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
+        - TransposeLDS: [0,1]
         #- GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
-        - LocalReadVectorWidth: [4]#[4,8]
+        - LocalReadVectorWidth: [2,4,8]
         - DirectToVgprA: [1]
         - ActivationFuncCall: [0, 1]
       BenchmarkJoinParameters:
@@ -468,6 +472,7 @@ BenchmarkProblems:
           - Exact: [129,   128, 1, 640]
           - Exact: [256,   255, 1, 1101]
           - Exact: [256,   257, 1, 1101]
+          - Exact: [512,   128, 1, 256]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: relu]
@@ -533,7 +538,7 @@ BenchmarkProblems:
         - LocalReadVectorWidth: [4,8]
         - DirectToVgprB: [1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 8,  1,4 ]
@@ -591,19 +596,22 @@ BenchmarkProblems:
         - KernelLanguage: ["Assembly"]
       ForkParameters:
         - MatrixInstruction:
-          - [16, 16, 16, 1,  1,   1, 2,  1,4 ]
+          - [16, 16, 16, 1,  1,   1, 1,  1,4 ] # MT = 16x64. Case to check kernel writer works
+          - [16, 16, 16, 1,  1,   1, 2,  1,4 ] # MT = 16x128. Check kernel works without vgprValuA
           - [16, 16, 16, 1,  1,   1, 4,  1,4 ]
+          - [16, 16, 16, 1,  1,   1, 8,  1,4 ] # MT = 16x512. Case to check LDS usage of Epilogues
+          - [16, 16, 16, 1,  1,   1, 5,  1,2 ] # MT = 16x160. Case to check kernel writer works
           - [32, 32,  8, 1,  1,   1, 2,  1,4 ]
           - [32, 32,  8, 1,  1,   1, 4,  1,4 ]
         - WorkGroup:
           - [16,16,1]
-        - GlobalReadVectorWidthA: [4]#[4,8]
-        - GlobalReadVectorWidthB: [4]#[4,8]
+        - GlobalReadVectorWidthA: [2,4,8]
+        - GlobalReadVectorWidthB: [2,4,8]
         - PrefetchGlobalRead: [1,2]
-        - PrefetchLocalRead: [1]
+        - PrefetchLocalRead: [1,2]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
-        - DepthU: [128]
+        - DepthU: [32,64,128]
         - VectorWidthA: [-1]
         - VectorWidthB: [-1]
         - MIArchVgpr: [0, 1]
@@ -623,10 +631,11 @@ BenchmarkProblems:
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
+        - TransposeLDS: [0,1]
         - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
-        - LocalReadVectorWidth: [4]#[4,8]
+        - LocalReadVectorWidth: [2,4,8]
         - DirectToVgprB: [1]
         - ActivationFuncCall: [0, 1]
       BenchmarkJoinParameters:
@@ -636,6 +645,7 @@ BenchmarkProblems:
           - Exact: [129,   128, 1, 640]
           - Exact: [256,   255, 1, 1101]
           - Exact: [256,   257, 1, 1101]
+          - Exact: [128,   512, 1, 256]
         - BiasTypeArgs: ['s']
         - ActivationArgs:
           - [Enum: relu]
@@ -698,7 +708,7 @@ BenchmarkProblems:
         - DirectToVgprB: [1]
         - StreamK: [0,2]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 8,  1,4 ]
@@ -789,7 +799,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         - StreamK: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
@@ -873,7 +883,7 @@ BenchmarkProblems:
         - DirectToVgprB: [1]
         - StreamK: [0,3]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  1,4 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 4,  1,4 ]
@@ -958,7 +968,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         - StreamK: [0,2]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
@@ -1043,7 +1053,7 @@ BenchmarkProblems:
         - SourceSwap: [0, 1]
         - DirectToVgprA: [1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
@@ -1126,7 +1136,7 @@ BenchmarkProblems:
         - DirectToVgprA: [1]
         #- StreamK: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
@@ -1206,7 +1216,7 @@ BenchmarkProblems:
         - DirectToVgprB: [1]
         #- StreamK: [0,3]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  1,4 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 4,  1,4 ]
@@ -1285,7 +1295,7 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - DirectToVgprA: [1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
@@ -1365,7 +1375,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 32, 1,  1,   1, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 32, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 32, 1,  1,   4, 1,  4,1 ]
@@ -1622,7 +1632,7 @@ BenchmarkProblems:
         - ConvertAfterDS: [1]
         #- StreamK: [0,2]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   8, 1,  4,1 ]
@@ -1709,7 +1719,7 @@ BenchmarkProblems:
         - ConvertAfterDS: [1]
         #- StreamK: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 8,  1,4 ]
@@ -1800,7 +1810,7 @@ BenchmarkProblems:
         - ConvertAfterDS: [1]
         - StreamK: [0,3]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   8, 1,  4,1 ]
@@ -1890,7 +1900,7 @@ BenchmarkProblems:
         - DirectToVgprB: [1]
         - ConvertAfterDS: [1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 2,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 8,  1,4 ]
@@ -1915,5 +1925,3 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
-
-


### PR DESCRIPTION
Resolve [SWDEV#495947](https://ontrack-internal.amd.com/browse/SWDEV-495947) 

Several test cases failed in DTV-A cases. Categorized into 3 situations:

1. Kernel Writer error:
  1.1 Writer failed when generating kernel: **`KeyError: 'vgprValuA_X0_I0'`**
2. Validation failiures:
  2.1 Using unset **`vpgrValuA____`** which shouldn't be generated.
  2.2 Validation failed when **SAV=1** (and MatB is small)

---

============================================== 79 passed, 32 skipped, 11 warnings in 14514.15s (4:01:54) ===============================================
py310: exit 0 (14514.35 seconds) /root/repos/hipBLASLt-1/tensilelite> py.test -v --basetemp=/root/repos/hipBLASLt-1/tensilelite/tmp/.tensile-tox/py310/tmp --junit-xml=/root/repos/hipBLASLt-1/tensilelite/python_tests.xml --junit-prefix=py310 --color=yes -n 4 --prebuilt-client=/root/repos/hipBLASLt-1/tensilelite/tmp/.tensile-tox/py310/client/0_Build/client/tensile_client Tensile/Tests -m common pid=850416
  py310: OK (14655.80=setup[11.03]+cmd[0.66,129.76,14514.35] seconds)
  congratulations :) (14655.87 seconds)