### PR TITLE
Remove Duplicate 7900XTX from Issue Report

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_report.yml
+++ b/.github/ISSUE_TEMPLATE/issue_report.yml
@@ -53,7 +53,6 @@ body:
         - AMD Instinct MI25
         - AMD Radeon Pro V620
         - AMD Radeon Pro VII
-        - AMD Radeon RX 7900 XTX
         - AMD Radeon VII
         - AMD Radeon Pro W7900
         - AMD Radeon Pro W7800


### PR DESCRIPTION
Removing the duplicate 7900XTX entry from the issue report.