### PR TITLE
Fix stream-k dynamic grid model

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -3092,7 +3092,9 @@ namespace Tensile
                                                      sizeMapping.depthU,
                                                      x,
                                                      y,
-                                                     z);
+                                                     z,
+                                                     1,
+                                                     cuCount);
         }
 
         // Limit the CUs Stream-K is launched on either max or the specified,

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -3092,8 +3092,7 @@ namespace Tensile
                                                      sizeMapping.depthU,
                                                      x,
                                                      y,
-                                                     z,
-                                                     cuCount);
+                                                     z);
         }
 
         // Limit the CUs Stream-K is launched on either max or the specified,


### PR DESCRIPTION
Fix a typo in the call to dynamic grid prediction model. This will enable faster stream-k performance by enabling the predictor for optimal grid size.