### PR TITLE
Fix F8/BF8 failed cases for GWVW=8 and Beta != 0 

### DIFF
--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -1608,7 +1608,7 @@ Tests:
   algo_method: [0,1]
   transA_transB: *transA_transB_range
   alpha: 1
-  beta: 0
+  beta: [0,1]
   requested_solution_num: -1
   unit_check: 1
   gpu_arch: '94[0-2]'

--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -2005,7 +2005,8 @@ class GlobalWriteBatchWriter:
           else:
             isPK = True
             if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
-              sb = 0 if vi ==0 else 1
+              # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
+              sb = 0 if vi%4 == 0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))
             else:
               # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
@@ -2035,7 +2036,8 @@ class GlobalWriteBatchWriter:
           else:
             isPK = True
             if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
-              sb = 0 if vi ==0 else 1
+              # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
+              sb = 0 if vi%4 == 0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))
             else:
               # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8

--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -1993,7 +1993,7 @@ class GlobalWriteBatchWriter:
           # Generate single f32 code if edge is detected.
           isPK = False
           if ((vi + 1) == self.gwvw) and ((self.gwvw % 2) == 1):
-            if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
+            if self.parentWriter.states.archCaps["NoSDWA"]:
               sb = 0 if self.gwvw == 1 else 1
               module.add(VCvtFP8toF32(dst=vgpr(tmpVgpr), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[0,sb])))
             else:
@@ -2004,7 +2004,7 @@ class GlobalWriteBatchWriter:
             continue
           else:
             isPK = True
-            if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
+            if self.parentWriter.states.archCaps["NoSDWA"]:
               # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
               sb = 0 if vi%4 == 0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))
@@ -2024,7 +2024,7 @@ class GlobalWriteBatchWriter:
           # Generate single f32 code if edge is detected.
           isPK = False
           if ((vi + 1) == self.gwvw) and ((self.gwvw % 2) == 1):
-            if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
+            if self.parentWriter.states.archCaps["NoSDWA"]:
               sb = 0 if self.gwvw == 1 else 1
               module.add(VCvtFP8toF32(dst=vgpr(tmpVgpr), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[0,sb])))
             else:
@@ -2035,7 +2035,7 @@ class GlobalWriteBatchWriter:
             continue
           else:
             isPK = True
-            if self.parentWriter.states.archCaps["NoSDWA"]: #cm review
+            if self.parentWriter.states.archCaps["NoSDWA"]:
               # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
               sb = 0 if vi%4 == 0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))

--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -2008,7 +2008,8 @@ class GlobalWriteBatchWriter:
               sb = 0 if vi ==0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))
             else:
-              sb = SelectBit.WORD_0 if vi == 0 else SelectBit.WORD_1
+              # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
+              sb = SelectBit.WORD_0 if vi%4 == 0 else SelectBit.WORD_1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), sdwa=SDWAModifiers(src0_sel=sb)))
           module.add(SNop(waitState=0))
           if kernel["ProblemType"]["ComputeDataType"].isSingle():
@@ -2037,7 +2038,8 @@ class GlobalWriteBatchWriter:
               sb = 0 if vi ==0 else 1
               module.add(VCvtPkFP8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), vop3=VOP3PModifiers(op_sel=[sb])))
             else:
-              sb = SelectBit.WORD_0 if vi == 0 else SelectBit.WORD_1
+              # Enable WORD_0 of 2-nd VGPR with vi=4 for vw=8
+              sb = SelectBit.WORD_0 if vi%4 == 0 else SelectBit.WORD_1
               module.add(VCvtPkBF8toF32(dst=vgpr(tmpVgpr, 2), src=vgpr(dataV), sdwa=SDWAModifiers(src0_sel=sb)))
           module.add(SNop(waitState=0))
           if kernel["ProblemType"]["ComputeDataType"].isSingle():


### PR DESCRIPTION
In this PR, we fixed the **fp8** and **bf8** failed cases in large vector widths.
1. Ticket: https://ontrack-internal.amd.com/browse/SWDEV-494325
2. Fixed in /hipBLASLt/tensilelite/Tensile/Components/GlobalWriteBatch.py