### PR TITLE
Revised output logic YAML to use efficiency instead of gflops.

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -288,6 +288,8 @@ globalParameters["BuildIdKind"] = "sha1"
 globalParameters["ValidateLibrary"] = False
 globalParameters["AsmDebug"] = False # Set to True to keep debug information for compiled code objects
 
+globalParameters["UseEffLike"] = True # Set to False to use winnerGFlops as the performance metric
+
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
 defaultGlobalParameters = deepcopy(globalParameters)
 

--- a/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
+++ b/tensilelite/Tensile/Source/client/include/HardwareMonitor.hpp
@@ -84,6 +84,13 @@ namespace Tensile
                 return m_dataPoints;
             }
 
+            double getMaxGfxFreqValues()
+            {
+                if(m_hasInvalidGpuFreqStatus || !has_maxFreqValues)
+                    return std::numeric_limits<double>::quiet_NaN();
+                return static_cast<double>(m_maxFreqValues);
+            }
+
             /// Begins monitoring until stop() is called.
             void start();
 
@@ -138,15 +145,18 @@ namespace Tensile
 
             uint16_t m_XCDCount;
 
-            std::vector<std::tuple<rsmi_temperature_type_t, rsmi_temperature_metric_t>>
-                                 m_tempMetrics;
-            std::vector<int64_t> m_tempValues;
+            std::vector<std::tuple<rsmi_temperature_type_t, rsmi_temperature_metric_t>> m_tempMetrics;
+            std::vector<int64_t>                                                        m_tempValues;
 
             std::vector<rsmi_clk_type_t> m_clockMetrics;
             std::vector<uint64_t>        m_clockValues;
 
             std::vector<uint32_t> m_fanMetrics;
             std::vector<int64_t>  m_fanValues;
+
+            uint64_t m_maxFreqValues; // The frequency is in Mhz
+            bool     has_maxFreqValues         = false;
+            bool     m_hasInvalidGpuFreqStatus = false;
 
             // Reserved for further performance check.
             std::vector<uint64_t>              m_SYSCLK_sum;

--- a/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
@@ -128,6 +128,7 @@ namespace Tensile
             const std::string DeviceIndex         = "device-idx";
             const std::string FanSpeedRPMs        = "fan-rpm";
             const std::string HardwareSampleCount = "hardware-samples";
+            const std::string GfxFrequency        = "gfx-frequency(maximum)"; // GPU freq in Mhz
         }; // namespace ResultKey
 
         class ResultReporter : public RunListener

--- a/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -37,20 +37,19 @@
 
 #include "ResultReporter.hpp"
 
-#define RSMI_CHECK_EXC(expr)                                                                      \
-    do                                                                                            \
-    {                                                                                             \
-        rsmi_status_t e = (expr);                                                                 \
-        if(e)                                                                                     \
-        {                                                                                         \
-            const char* errName = nullptr;                                                        \
-            rsmi_status_string(e, &errName);                                                      \
-            std::ostringstream msg;                                                               \
-            msg << "Error " << e << "(" << errName << ") " << __FILE__ << ":" << __LINE__ << ": " \
-                << std::endl                                                                      \
-                << #expr << std::endl;                                                            \
-            throw std::runtime_error(msg.str());                                                  \
-        }                                                                                         \
+#define RSMI_CHECK_EXC(expr)                                                                                   \
+    do                                                                                                         \
+    {                                                                                                          \
+        rsmi_status_t e = (expr);                                                                              \
+        if(e)                                                                                                  \
+        {                                                                                                      \
+            const char* errName = nullptr;                                                                     \
+            rsmi_status_string(e, &errName);                                                                   \
+            std::ostringstream msg;                                                                            \
+            msg << "Error " << e << "(" << errName << ") " << __FILE__ << ":" << __LINE__ << ": " << std::endl \
+                << #expr << std::endl;                                                                         \
+            throw std::runtime_error(msg.str());                                                               \
+        }                                                                                                      \
     } while(0)
 
 namespace Tensile
@@ -69,9 +68,8 @@ namespace Tensile
             HIP_CHECK_EXC(hipRuntimeGetVersion(&hip_version));
             if(hip_version >= 50220730)
             {
-                HIP_CHECK_EXC(hipDeviceGetAttribute(&props.multiProcessorCount,
-                                                    hipDeviceAttributePhysicalMultiProcessorCount,
-                                                    hipDeviceIndex));
+                HIP_CHECK_EXC(hipDeviceGetAttribute(
+                    &props.multiProcessorCount, hipDeviceAttributePhysicalMultiProcessorCount, hipDeviceIndex));
             }
 #endif
 
@@ -104,8 +102,7 @@ namespace Tensile
             }
 
             msg << "]" << std::endl;
-            std::time_t now
-                = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+            std::time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             msg << std::put_time(gmtime(&now), "%F %T %z");
 
             throw std::runtime_error(concatenate("RSMI Can't find a device with PCI ID ",
@@ -182,8 +179,7 @@ namespace Tensile
             m_thread = std::thread([this]() { this->runLoop(); });
         }
 
-        void HardwareMonitor::addTempMonitor(rsmi_temperature_type_t   sensorType,
-                                             rsmi_temperature_metric_t metric)
+        void HardwareMonitor::addTempMonitor(rsmi_temperature_type_t sensorType, rsmi_temperature_metric_t metric)
         {
             assertNotActive();
 
@@ -207,8 +203,7 @@ namespace Tensile
             m_fanValues.resize(m_fanMetrics.size());
         }
 
-        double HardwareMonitor::getAverageTemp(rsmi_temperature_type_t   sensorType,
-                                               rsmi_temperature_metric_t metric)
+        double HardwareMonitor::getAverageTemp(rsmi_temperature_type_t sensorType, rsmi_temperature_metric_t metric)
         {
             assertNotActive();
 
@@ -227,8 +222,8 @@ namespace Tensile
                 }
             }
 
-            throw std::runtime_error(concatenate(
-                "Can't read temp value that wasn't requested: ", sensorType, " - ", metric));
+            throw std::runtime_error(
+                concatenate("Can't read temp value that wasn't requested: ", sensorType, " - ", metric));
         }
 
         double HardwareMonitor::getAverageClock(rsmi_clk_type_t clockType)
@@ -257,8 +252,7 @@ namespace Tensile
                 }
             }
 
-            throw std::runtime_error(
-                concatenate("Can't read clock value that wasn't requested: ", clockType));
+            throw std::runtime_error(concatenate("Can't read clock value that wasn't requested: ", clockType));
         }
 
         double HardwareMonitor::getAverageFanSpeed(uint32_t sensorIndex)
@@ -280,8 +274,7 @@ namespace Tensile
                 }
             }
 
-            throw std::runtime_error(
-                concatenate("Can't read fan value that wasn't requested: ", sensorIndex));
+            throw std::runtime_error(concatenate("Can't read fan value that wasn't requested: ", sensorIndex));
         }
 
         void HardwareMonitor::start()
@@ -352,8 +345,7 @@ namespace Tensile
                 std::tie(sensorType, metric) = m_tempMetrics[i];
 
                 int64_t newValue = 0;
-                auto    status
-                    = rsmi_dev_temp_metric_get(m_smiDeviceIndex, sensorType, metric, &newValue);
+                auto    status   = rsmi_dev_temp_metric_get(m_smiDeviceIndex, sensorType, metric, &newValue);
                 if(status != RSMI_STATUS_SUCCESS)
                     m_tempValues[i] = std::numeric_limits<int64_t>::max();
                 else
@@ -410,7 +402,6 @@ namespace Tensile
                         m_clockValues[i] += freq.frequency[freq.current];
                     }
                 }
-
             }
 
             for(int i = 0; i < m_fanMetrics.size(); i++)
@@ -422,13 +413,33 @@ namespace Tensile
                 rsmi_frequencies_t freq;
 
                 int64_t newValue = 0;
-                auto status = rsmi_dev_fan_rpms_get(m_smiDeviceIndex, m_fanMetrics[i], &newValue);
+                auto    status   = rsmi_dev_fan_rpms_get(m_smiDeviceIndex, m_fanMetrics[i], &newValue);
                 if(status != RSMI_STATUS_SUCCESS)
                     m_fanValues[i] = std::numeric_limits<int64_t>::max();
                 else
                     m_fanValues[i] += newValue;
             }
 
+            // Retrieves the maximum hardware supported frequency.
+            rsmi_frequencies_t freqs;
+            auto               status = rsmi_dev_gpu_clk_freq_get(m_smiDeviceIndex, RSMI_CLK_TYPE_SYS, &freqs);
+            if(status != RSMI_STATUS_SUCCESS)
+            {
+                m_hasInvalidGpuFreqStatus = true;
+            }
+            else
+            {
+                if(!m_hasInvalidGpuFreqStatus && !has_maxFreqValues)
+                {
+                    m_maxFreqValues = 0;
+                    for(auto freq : freqs.frequency)
+                    {
+                        m_maxFreqValues = std::max(m_maxFreqValues, freq);
+                    }
+                    has_maxFreqValues = true;
+                    m_maxFreqValues /= cMhzToHz; // Convert to MHz
+                }
+            }
             m_dataPoints++;
         }
 

--- a/tensilelite/Tensile/Source/client/source/HardwareMonitorListener.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitorListener.cpp
@@ -71,8 +71,7 @@ namespace Tensile
 
             if(m_useGPUTimer)
             {
-                m_monitor->runBetweenEvents(startEvents->front().front(),
-                                            stopEvents->back().back());
+                m_monitor->runBetweenEvents(startEvents->front().front(), stopEvents->back().back());
             }
             else
             {
@@ -92,15 +91,14 @@ namespace Tensile
             m_reporter->report(ResultKey::DeviceIndex, m_monitor->getDeviceIndex());
             m_reporter->report(ResultKey::TempEdge, m_monitor->getAverageTemp(0));
 
-            m_reporter->report(ResultKey::ClockRateSys,
-                               m_monitor->getAverageClock(RSMI_CLK_TYPE_SYS));
-            m_reporter->report(ResultKey::ClockRateSOC,
-                               m_monitor->getAverageClock(RSMI_CLK_TYPE_SOC));
-            m_reporter->report(ResultKey::ClockRateMem,
-                               m_monitor->getAverageClock(RSMI_CLK_TYPE_MEM));
+            m_reporter->report(ResultKey::ClockRateSys, m_monitor->getAverageClock(RSMI_CLK_TYPE_SYS));
+            m_reporter->report(ResultKey::ClockRateSOC, m_monitor->getAverageClock(RSMI_CLK_TYPE_SOC));
+            m_reporter->report(ResultKey::ClockRateMem, m_monitor->getAverageClock(RSMI_CLK_TYPE_MEM));
 
             m_reporter->report(ResultKey::FanSpeedRPMs, m_monitor->getAverageFanSpeed());
             m_reporter->report(ResultKey::HardwareSampleCount, m_monitor->getSamples());
+            m_reporter->report(ResultKey::GfxFrequency,
+                               m_monitor->getMaxGfxFreqValues()); // Report the maximum frequency values
         }
     } // namespace Client
 } // namespace Tensile

--- a/tensilelite/Tensile/Source/client/source/ResultFileReporter.cpp
+++ b/tensilelite/Tensile/Source/client/source/ResultFileReporter.cpp
@@ -159,6 +159,7 @@ namespace Tensile
                 m_output.setHeaderForKey(ResultKey::LDA, "LDA");
                 m_output.setHeaderForKey(ResultKey::LDB, "LDB");
                 m_output.setHeaderForKey(ResultKey::TotalFlops, "TotalFlops");
+                m_output.setHeaderForKey(ResultKey::GfxFrequency, "DeviceMaxFreq");
                 if(m_extraCol)
                 {
                     m_output.setHeaderForKey(ResultKey::TilesPerCu, "TilesPerCu");


### PR DESCRIPTION
### Main modifications:
1. **Metric Update**: Replaced `winnerGflops` with `effLike` as the primary performance metric.
2. **Max Frequency Monitor**: Added a frequency monitoring feature in TensileLite to retrieve the maximum hardware frequency.
3. **User Option**: Introduced the `UseEffLike` parameter in `globalParameters`, allowing users to select the performance metric.

**Note**: If an error occurs while retrieving or processing frequency, `winnerGflops` will be used as the fallback performance metric. A warning message will notify users in the console and prompt the user to choose to abort or continue with `winnerGflops` as the final performance metric.
![image](https://github.com/user-attachments/assets/3921274a-704b-4119-8b38-da0514fbe16f)


---
### Demonstration of the output difference:
* Using WinnerGflops:
![image](https://github.com/user-attachments/assets/c4cd9f28-a481-4cca-afec-b5b77f3fdb58)
* Using EffLike:
![image](https://github.com/user-attachments/assets/6125641e-dd7f-4a3c-ad42-88818c8f0c2d)
--- 
For more details, refer to the comments in [[link](https://ontrack-internal.amd.com/browse/SWDEV-474557)](https://ontrack-internal.amd.com/browse/SWDEV-474557).