### PR TITLE
tensilelite: New global parameter 'SkipSlowSolutionRatio' for skipping slow slow during warm-up stage

### DIFF
--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -630,6 +630,7 @@ def writeClientConfigIni(problemSizes, biasTypeArgs, factorDimArgs, activationAr
         param("num-enqueues-per-sync",    globalParameters["EnqueuesPerSync"])
         param("max-enqueues-per-sync",    globalParameters["MaxEnqueuesPerSync"])
         param("num-syncs-per-benchmark",  globalParameters["SyncsPerBenchmark"])
+        param("skip-slow-solution-ratio", globalParameters["SkipSlowSolutionRatio"])
         param("use-gpu-timer",            globalParameters["KernelTime"])
         param("hardware-monitor",         globalParameters["HardwareMonitor"])
         param("num-warmups",              globalParameters["NumWarmups"])

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -72,6 +72,14 @@ globalParameters["SyncsPerBenchmark"] = 1         # how iterations of the stream
 globalParameters["EnqueuesPerSync"] = 1           # how many solution enqueues to perform per synchronization
 globalParameters["MaxEnqueuesPerSync"] = -1       # max solution enqueues to perform per synchronization
 globalParameters["SleepPercent"] = 300            # how long to sleep after every data point: 25 means 25% of solution time. Sleeping lets gpu cool down more.
+globalParameters["SkipSlowSolutionRatio"] = 0.0   # Skip slow solution during warm-up stage.
+# The valid range of this ratio is (0.0 ~ 1.0), and 0.0 means no skipping.
+# Skip condition:  warm-up time * ratio > current best sol's warm-up time
+# Suggestion:
+#     Small size :  0.5
+#     Medium size: 0.75
+#     Large size :  0.9
+
 # cProfile
 globalParameters["Profiler"] = 0                  # Enable profiler. 0=off, 1=cProfile. This will set CpuThreads to 1.
 # validation

--- a/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
+++ b/tensilelite/Tensile/Source/client/include/BenchmarkTimer.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -66,7 +66,9 @@ namespace TensileLite
             virtual size_t numWarmupRuns() override;
             virtual void   setNumWarmupRuns(size_t count) override;
             virtual void   preWarmup() override;
-            virtual void   postWarmup() override;
+            virtual void   postWarmup(TimingEvents const& startEvents,
+                                      TimingEvents const& stopEvents,
+                                      hipStream_t const&  stream) override;
             virtual void   validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                            TimingEvents const&            startEvents,
                                            TimingEvents const&            stopEvents) override;
@@ -128,7 +130,11 @@ namespace TensileLite
 
             double_millis m_timeInSolution;
             double_millis m_totalGPUTime;
+            double_millis m_currentBestWarmUpTime;
             float         m_flushTimeUs;
+            float         m_skip_slow_solution_ratio;
+            bool          m_skip_slow_solution;
+            size_t        m_numSolutionSkip;
         };
     } // namespace Client
 } // namespace TensileLite

--- a/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
+++ b/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
@@ -82,7 +82,7 @@ namespace TensileLite
 
         static bool IsProblemDependent(InitMode const& mode)
         {
-             return mode == InitMode::SerialIdx || mode == InitMode::SerialDim0
+            return mode == InitMode::SerialIdx || mode == InitMode::SerialDim0
                    || mode == InitMode::SerialDim1 || mode == InitMode::Identity
                    || mode == InitMode::TrigSin || mode == InitMode::TrigCos
                    || mode == InitMode::TrigAbsSin || mode == InitMode::TrigAbsCos;
@@ -356,7 +356,10 @@ namespace TensileLite
                                 {
                                     auto& p = it->second;
                                     if(i <= ContractionProblemGemm::TENSOR::METADATA)
-                                        HIP_CHECK_EXC(hipMemcpy(mem[j][i].data.get(), p.gpuInput.current.get(), mem[j][i].size, hipMemcpyDeviceToDevice));
+                                        HIP_CHECK_EXC(hipMemcpy(mem[j][i].data.get(),
+                                                                p.gpuInput.current.get(),
+                                                                mem[j][i].size,
+                                                                hipMemcpyDeviceToDevice));
                                 }
                             }
                     }
@@ -862,7 +865,9 @@ namespace TensileLite
             };
             virtual void setNumWarmupRuns(size_t count) override{};
             virtual void preWarmup() override{};
-            virtual void postWarmup() override{};
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override{};
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override
@@ -1044,7 +1049,7 @@ namespace TensileLite
             /// cannot be used with problem dependent data.
             bool m_problemDependentData = false;
 
-            int64_t               m_rotatingBuffer          = 0;
+            int64_t                         m_rotatingBuffer = 0;
             std::shared_ptr<RotatingMemory> m_rm;
             int32_t                         m_rotatingMode = 0;
         };

--- a/tensilelite/Tensile/Source/client/include/HardwareMonitorListener.hpp
+++ b/tensilelite/Tensile/Source/client/include/HardwareMonitorListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -68,7 +68,9 @@ namespace TensileLite
             };
             virtual void setNumWarmupRuns(size_t count) override{};
             virtual void preWarmup() override{};
-            virtual void postWarmup() override{};
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override{};
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override{};

--- a/tensilelite/Tensile/Source/client/include/LogReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/LogReporter.hpp
@@ -350,7 +350,14 @@ namespace TensileLite
                    && (!m_PrintWinnersOnly || currentTimeUS < m_winner || !validation
                        || m_firstRun))
                 {
-                    m_csvOutput.writeCurrentRow();
+                    if(std::isnan(currentTimeUS) && validation)
+                        std::cout << curRow[ResultKey::BenchmarkRunNumber] << ","
+                                  << curRow[ResultKey::ProblemProgress] << ","
+                                  << curRow[ResultKey::SolutionProgress]
+                                  << ", Skip Slow Solution: " << curRow[ResultKey::SolutionName]
+                                  << std::endl;
+                    else
+                        m_csvOutput.writeCurrentRow();
                     if(validation)
                     {
                         m_winner = currentTimeUS;

--- a/tensilelite/Tensile/Source/client/include/MetaResultReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/MetaResultReporter.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -179,10 +179,12 @@ namespace TensileLite
                     (*iter)->preWarmup();
             }
 
-            virtual void postWarmup() override
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override
             {
                 for(auto iter = m_reporters.begin(); iter != m_reporters.end(); iter++)
-                    (*iter)->postWarmup();
+                    (*iter)->postWarmup(startEvents, stopEvents, stream);
             }
 
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,

--- a/tensilelite/Tensile/Source/client/include/MetaRunListener.hpp
+++ b/tensilelite/Tensile/Source/client/include/MetaRunListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,9 @@ namespace TensileLite
             virtual size_t numWarmupRuns() override;
             virtual void   setNumWarmupRuns(size_t count) override;
             virtual void   preWarmup() override;
-            virtual void   postWarmup() override;
+            virtual void   postWarmup(TimingEvents const& startEvents,
+                                      TimingEvents const& stopEvents,
+                                      hipStream_t const&  stream) override;
             virtual void   validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                            TimingEvents const&            startEvents,
                                            TimingEvents const&            stopEvents) override;

--- a/tensilelite/Tensile/Source/client/include/ProgressListener.hpp
+++ b/tensilelite/Tensile/Source/client/include/ProgressListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -65,7 +65,9 @@ namespace TensileLite
             virtual void   setNumWarmupRuns(size_t count) override;
             virtual void   preWarmup() override;
 
-            virtual void postWarmup() override;
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override;
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override;

--- a/tensilelite/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/tensilelite/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -64,7 +64,9 @@ namespace TensileLite
             virtual size_t numWarmupRuns() override;
             virtual void   setNumWarmupRuns(size_t count) override;
             virtual void   preWarmup() override;
-            virtual void   postWarmup() override;
+            virtual void   postWarmup(TimingEvents const& startEvents,
+                                      TimingEvents const& stopEvents,
+                                      hipStream_t const&  stream) override;
             virtual void   validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                            TimingEvents const&            startEvents,
                                            TimingEvents const&            stopEvents) override;

--- a/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/ResultReporter.hpp
@@ -238,7 +238,11 @@ namespace TensileLite
             }
             virtual void setNumWarmupRuns(size_t count) override {}
             virtual void preWarmup() override {}
-            virtual void postWarmup() override {}
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override
+            {
+            }
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override

--- a/tensilelite/Tensile/Source/client/include/RunListener.hpp
+++ b/tensilelite/Tensile/Source/client/include/RunListener.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -97,10 +97,13 @@ namespace TensileLite
             virtual size_t numWarmupRuns()                = 0;
             virtual void   setNumWarmupRuns(size_t count) = 0;
             virtual void   preWarmup()                    = 0;
-            virtual void   postWarmup()                   = 0;
-            virtual void   validateWarmups(std::shared_ptr<ProblemInputs> inputs,
-                                           TimingEvents const&            startEvents,
-                                           TimingEvents const&            stopEvents)
+            virtual void   postWarmup(TimingEvents const& startEvents,
+                                      TimingEvents const& stopEvents,
+                                      hipStream_t const&  stream)
+                = 0;
+            virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
+                                         TimingEvents const&            startEvents,
+                                         TimingEvents const&            stopEvents)
                 = 0;
 
             virtual size_t numSyncs()                = 0;

--- a/tensilelite/Tensile/Source/client/include/SolutionIterator.hpp
+++ b/tensilelite/Tensile/Source/client/include/SolutionIterator.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -71,7 +71,11 @@ namespace TensileLite
             }
             virtual void setNumWarmupRuns(size_t count) override {}
             virtual void preWarmup() override {}
-            virtual void postWarmup() override {}
+            virtual void postWarmup(TimingEvents const& startEvents,
+                                    TimingEvents const& stopEvents,
+                                    hipStream_t const&  stream) override
+            {
+            }
             virtual void validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                          TimingEvents const&            startEvents,
                                          TimingEvents const&            stopEvents) override

--- a/tensilelite/Tensile/Source/client/source/MetaRunListener.cpp
+++ b/tensilelite/Tensile/Source/client/source/MetaRunListener.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -139,10 +139,12 @@ namespace TensileLite
                 (*iter)->preWarmup();
         }
 
-        void MetaRunListener::postWarmup()
+        void MetaRunListener::postWarmup(TimingEvents const& startEvents,
+                                         TimingEvents const& stopEvents,
+                                         hipStream_t const&  stream)
         {
             for(auto iter = m_listeners.rbegin(); iter != m_listeners.rend(); iter++)
-                (*iter)->postWarmup();
+                (*iter)->postWarmup(startEvents, stopEvents, stream);
         }
 
         void MetaRunListener::validateWarmups(std::shared_ptr<ProblemInputs> inputs,

--- a/tensilelite/Tensile/Source/client/source/ProgressListener.cpp
+++ b/tensilelite/Tensile/Source/client/source/ProgressListener.cpp
@@ -138,7 +138,11 @@ namespace TensileLite
 
         void ProgressListener::preWarmup() {}
 
-        void ProgressListener::postWarmup() {}
+        void ProgressListener::postWarmup(TimingEvents const& startEvents,
+                                          TimingEvents const& stopEvents,
+                                          hipStream_t const&  stream)
+        {
+        }
 
         void ProgressListener::validateWarmups(std::shared_ptr<ProblemInputs> inputs,
                                                TimingEvents const&            startEvents,

--- a/tensilelite/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/tensilelite/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -112,7 +112,11 @@ namespace TensileLite
 
         void ReferenceValidator::preWarmup() {}
 
-        void ReferenceValidator::postWarmup() {}
+        void ReferenceValidator::postWarmup(TimingEvents const& startEvents,
+                                            TimingEvents const& stopEvents,
+                                            hipStream_t const&  stream)
+        {
+        }
 
         bool ReferenceValidator::validateSolution(std::shared_ptr<ProblemInputs> inputs)
         {


### PR DESCRIPTION
Same mechanism with https://github.com/ROCm/hipBLASLt/pull/1278
This PR is for tensilelite tuning.
![image](https://github.com/user-attachments/assets/d198ea4a-9681-4b42-a077-230fdf698427)
