### PR TITLE
[Install&Packaging] Fix samples packages installation paths to follow ROCm file organization standard

### DIFF
--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -139,9 +139,28 @@ foreach( exe ${sample_list_hip_device} )
   target_link_libraries( ${exe} PRIVATE hip::device )
 endforeach( )
 
-foreach( exe ${sample_list_all} )
-  rocm_install(TARGETS ${exe} COMPONENT samples)
+# Install executables to libexec
+foreach( exe ${samples} )
+  install(
+    TARGETS ${exe}
+    RUNTIME 
+    DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/hipblaslt-samples
+    COMPONENT samples
+  )
 endforeach( )
+
+# Install source files to share
+install(
+  DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/hipblaslt/samples
+  COMPONENT samples
+  FILES_MATCHING 
+  PATTERN "*.cpp"
+  PATTERN "*.h"
+  PATTERN "CMakeLists.txt" EXCLUDE
+  PATTERN "build" EXCLUDE
+)
 
 # Add tests for samples
 foreach( exe ${samples} )

--- a/install.sh
+++ b/install.sh
@@ -816,7 +816,7 @@ pushd .
   # Build library with AMD toolchain because of existense of device kernels
   if [[ "${build_relocatable}" == true ]]; then
     FC=gfortran CXX=${compiler} ${cmake_executable} ${cmake_common_options} ${cmake_client_options} -DCPACK_SET_DESTDIR=OFF \
-      -DCMAKE_INSTALL_PREFIX=${install_prefix} \
+      -DCMAKE_INSTALL_PREFIX=${rocm_path} \
       -DCPACK_PACKAGING_INSTALL_PREFIX=${rocm_path} \
       -DCMAKE_SHARED_LINKER_FLAGS="${rocm_rpath}" \
       -DCMAKE_PREFIX_PATH="${rocm_path} ${rocm_path}/hcc ${rocm_path}/hip" \


### PR DESCRIPTION
Fixes #[SWDEV-433345] ROCm file organization - Samples packages are misplaced

## Problem
Sample packages were not following the ROCm file organization standard, with executables and source files being placed in incorrect directories.

## Changes Made
1. Modified installation configuration in samples CMakeLists.txt:

2. Updated installation prefix in install.sh:

These changes ensure:
- Executables are installed to `/opt/rocm-<version>/libexec/hipblaslt-samples/`
- Source files are installed to `/opt/rocm-<version>/share/hipblaslt/samples/`

## Testing Done
- Built and installed package using modified scripts
- Verified file locations match expected paths:
![image](https://github.com/user-attachments/assets/30de2bf1-8625-4385-adf6-5a8e797175b7)

- Confirmed all executables are functional in new location

## Related Links
- Issue Link: [TCT] ROCm file organization - Samples packages are misplaced https://ontrack-internal.amd.com/browse/SWDEV-433345