### PR TITLE
Fix invalid stream-k test case, make dynamic grid the default

### DIFF
--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -956,11 +956,12 @@ validParameters = {
     #   -1 = use prediction model for best performance (not yet implemented)
     #   0 = only remainder tiles run in stream-k
     #   1+ = remainder + 1 (or more) full grids of tiles run in stream-k (default=1)
-    # TENSILE_STREAMK_DYNAMIC_GRID enables dynamic grid mode, which automatically limits the number of CUs used:
-    #   0 = Off, use all CUs (default)
+    # TENSILE_STREAMK_DYNAMIC_GRID selects dynamic grid mode, which automatically limits the number of CUs used:
+    #   0 = Off, always use all CUs.
     #   1 = Only reduce CUs for small problems to number of output tiles when num_tiles < CU count.
     #   2 = Also reduce CUs used for large sizes to improve data-parallel portion and reduce power.
-    #   3 = Analytically predict the best grid-size by weighing the cost of the fix-up step and the cost of processing MACs.
+    #   3 = Analytically predict the best grid-size by weighing the cost of the fix-up step and the cost of processing MACs (default).
+    #       Note: dynamic grid coefficients currently apply to gfx942 variants
     # TENSILE_STREAMK_MAX_CUS allows the user to manually set maximum number of CUs used, which could free up some CUs for
     #   other operations to run in parallel with gemm.
     # TENSILE_STREAMK_GRID_MULTIPLIER lets you set how many workgroups are created per CU being used.

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2144,13 +2144,13 @@ class Solution(collections.abc.Mapping):
       state["GlobalSplitU"] = 0 # Cannot enable both Stream-K and GSU
       state["GlobalSplitUAlgorithm"] = "MultipleBuffer" # Set default Algorithm
       if not (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()):
-        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+        reject(state, "Type {} for DataType not yet supported with StreamK".format(state["ProblemType"]["DataType"].toChar()))
       if not (state["ProblemType"]["DataTypeA"].isSingle() or state["ProblemType"]["DataTypeA"].isHalf() or state["ProblemType"]["DataTypeA"].isBFloat16()):
-        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+        reject(state, "Type {} for DataTypeA not yet supported with StreamK".format(state["ProblemType"]["DataTypeA"].toChar()))
       if not (state["ProblemType"]["DataTypeB"].isSingle() or state["ProblemType"]["DataTypeB"].isHalf() or state["ProblemType"]["DataTypeB"].isBFloat16()):
-        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+        reject(state, "Type {} for DataTypeB not yet supported with StreamK".format(state["ProblemType"]["DataTypeB"].toChar()))
       if not (state["ProblemType"]["DestDataType"].isSingle() or state["ProblemType"]["DestDataType"].isHalf() or state["ProblemType"]["DestDataType"].isBFloat16()):
-        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+        reject(state, "Type {} for DestDataType not yet supported with StreamK".format(state["ProblemType"]["DestDataType"].toChar()))
       if state["MIWaveGroup"][0] * state["MIWaveGroup"][1] != 4:
         reject(state, "Stream-K requries MIWaveGroup0*MIWaveGroup1=4")
       if not state["EnableMatrixInstruction"]:

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2143,13 +2143,13 @@ class Solution(collections.abc.Mapping):
     if state["StreamK"] != 0:
       state["GlobalSplitU"] = 0 # Cannot enable both Stream-K and GSU
       state["GlobalSplitUAlgorithm"] = "MultipleBuffer" # Set default Algorithm
-      if not (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isHalf()):
+      if not (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()):
         reject(state, "Stream-K currently only tested for F32, F16, BF16")
-      if not (state["ProblemType"]["DataTypeA"].isSingle() or state["ProblemType"]["DataTypeA"].isHalf()):
+      if not (state["ProblemType"]["DataTypeA"].isSingle() or state["ProblemType"]["DataTypeA"].isHalf() or state["ProblemType"]["DataTypeA"].isBFloat16()):
         reject(state, "Stream-K currently only tested for F32, F16, BF16")
-      if not (state["ProblemType"]["DataTypeB"].isSingle() or state["ProblemType"]["DataTypeB"].isHalf()):
+      if not (state["ProblemType"]["DataTypeB"].isSingle() or state["ProblemType"]["DataTypeB"].isHalf() or state["ProblemType"]["DataTypeB"].isBFloat16()):
         reject(state, "Stream-K currently only tested for F32, F16, BF16")
-      if not (state["ProblemType"]["DestDataType"].isSingle() or state["ProblemType"]["DestDataType"].isHalf()):
+      if not (state["ProblemType"]["DestDataType"].isSingle() or state["ProblemType"]["DestDataType"].isHalf() or state["ProblemType"]["DestDataType"].isBFloat16()):
         reject(state, "Stream-K currently only tested for F32, F16, BF16")
       if state["MIWaveGroup"][0] * state["MIWaveGroup"][1] != 4:
         reject(state, "Stream-K requries MIWaveGroup0*MIWaveGroup1=4")

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2143,6 +2143,14 @@ class Solution(collections.abc.Mapping):
     if state["StreamK"] != 0:
       state["GlobalSplitU"] = 0 # Cannot enable both Stream-K and GSU
       state["GlobalSplitUAlgorithm"] = "MultipleBuffer" # Set default Algorithm
+      if not (state["ProblemType"]["DataType"].isSingle() or state["ProblemType"]["DataType"].isHalf()):
+        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+      if not (state["ProblemType"]["DataTypeA"].isSingle() or state["ProblemType"]["DataTypeA"].isHalf()):
+        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+      if not (state["ProblemType"]["DataTypeB"].isSingle() or state["ProblemType"]["DataTypeB"].isHalf()):
+        reject(state, "Stream-K currently only tested for F32, F16, BF16")
+      if not (state["ProblemType"]["DestDataType"].isSingle() or state["ProblemType"]["DestDataType"].isHalf()):
+        reject(state, "Stream-K currently only tested for F32, F16, BF16")
       if state["MIWaveGroup"][0] * state["MIWaveGroup"][1] != 4:
         reject(state, "Stream-K requries MIWaveGroup0*MIWaveGroup1=4")
       if not state["EnableMatrixInstruction"]:

--- a/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -198,7 +198,7 @@ namespace TensileLite
         int         wavefrontSize    = 64;
         int         simdPerCu        = 4;
         int         computeUnitCount = 0;
-        int         skDynamicGrid    = 0;
+        int         skDynamicGrid    = 3;
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
@@ -221,7 +221,7 @@ namespace TensileLite
         const int getSKDynamicGrid() const
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_GRID");
-            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
+            static const int   value  = (envStr == NULL ? 3 : std::atoi(envStr));
             return value;
         }
 

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -107,8 +107,8 @@ namespace TensileLite
                                      size_t m,
                                      size_t n,
                                      size_t k,
-                                     int    grid_start = 1,
-                                     int    grid_end   = 304)
+                                     int    grid_start,
+                                     int    grid_end)
         {
             static const bool debug = Debug::Instance().printStreamKGridInfo();
 

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -1808,7 +1808,7 @@ BenchmarkProblems:
         - LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - ConvertAfterDS: [1]
-        - StreamK: [0,3]
+        # - StreamK: [0,3]
         - Groups:
           -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 1,  4,1 ]


### PR DESCRIPTION
This PR re-introduces the change to make dynamic grid selection the default mode for stream-k.
A previous commit added a test case for DTV+F8+streamk, but stream-k does not currently support F8 data type (additional implementation and extensive testing are required). This change removes the invalid test case for now, and adds reject conditions to avoid generating F8 stream-k kernels.