### PR TITLE
Avoid divide by 0 when calculating predicted performance with streamk

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -57,7 +57,7 @@ namespace TensileLite
             __device__ __host__ inline constexpr N safe_ceil_div(N n, D d)
             {
                 // Static cast to undo integral promotion.
-                return static_cast<N>(n / d + (n % d != 0 ? 1 : 0));
+                return static_cast<N>(d == 0 ? 0 : (n / d + (n % d != 0 ? 1 : 0)));
             }
         } // namespace math
 


### PR DESCRIPTION
When using getAllAlgos() API, `predicted_runtime()` is called when calculating workspace size of streamk kernels. Since sizes are not specified in the getAllAlgos() API, sizes may be == 0 when passed in, specifically this is the case for unsupported configurations such as conjugate-transpose. In this case, a divide-by-zero exception is thrown.
With this change, with sizes == 0, the division-by-zero will be avoided and simply return 0; this should only affect the predicted_runtime() of cases where the sizes == 0.