### PR TITLE
Add extended profile logging along with flush and rotating size 

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -634,10 +634,6 @@ try
     store(parse_command_line(argc, argv, desc), vm);
     notify(vm);
 
-    // Set the values of flush and rotating size, only for internal use
-    hipblasltSetFlushValue(arg.flush);
-    hipblasltSetRotatingBufferSizeValue(arg.rotating);
-
     if((argc <= 1 && !datafile) || vm.count("help"))
     {
         hipblaslt_cout << desc << std::endl;

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -634,6 +634,11 @@ try
     store(parse_command_line(argc, argv, desc), vm);
     notify(vm);
 
+    // Access the singleton instance and set values
+    hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+    singletonClientArguments.setFlushValue(arg.flush);
+    singletonClientArguments.setrotatingMemorySizeValue(arg.rotating);
+
     if((argc <= 1 && !datafile) || vm.count("help"))
     {
         hipblaslt_cout << desc << std::endl;

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -634,11 +634,11 @@ try
     store(parse_command_line(argc, argv, desc), vm);
     notify(vm);
 
-    // Access the singleton instance and set values
-    hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
-        = hipblaslt_ext::SingletonUserClientArguments::getInstance();
-    singletonClientArguments.setFlushValue(arg.flush);
-    singletonClientArguments.setrotatingMemorySizeValue(arg.rotating);
+    // Access the singleton instance to set the values of flush and rotating size, only for internal use
+    SingletonUserClientArguments& singletonClientArguments
+        = SingletonUserClientArguments::getInstance();
+    singletonClientArguments.hipblasltInternalSetFlushValue(arg.flush);
+    singletonClientArguments.hipblasltInternalSetRotatingMemorySizeValue(arg.rotating);
 
     if((argc <= 1 && !datafile) || vm.count("help"))
     {

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -634,11 +634,9 @@ try
     store(parse_command_line(argc, argv, desc), vm);
     notify(vm);
 
-    // Access the singleton instance to set the values of flush and rotating size, only for internal use
-    SingletonUserClientArguments& singletonClientArguments
-        = SingletonUserClientArguments::getInstance();
-    singletonClientArguments.hipblasltInternalSetFlushValue(arg.flush);
-    singletonClientArguments.hipblasltInternalSetRotatingMemorySizeValue(arg.rotating);
+    // Set the values of flush and rotating size, only for internal use
+    hipblasltSetFlushValue(arg.flush);
+    hipblasltSetRotatingMemorySizeValue(arg.rotating);
 
     if((argc <= 1 && !datafile) || vm.count("help"))
     {

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -636,7 +636,7 @@ try
 
     // Set the values of flush and rotating size, only for internal use
     hipblasltSetFlushValue(arg.flush);
-    hipblasltSetRotatingMemorySizeValue(arg.rotating);
+    hipblasltSetRotatingBufferSizeValue(arg.rotating);
 
     if((argc <= 1 && !datafile) || vm.count("help"))
     {

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -635,7 +635,8 @@ try
     notify(vm);
 
     // Access the singleton instance and set values
-    hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+    hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
+        = hipblaslt_ext::SingletonUserClientArguments::getInstance();
     singletonClientArguments.setFlushValue(arg.flush);
     singletonClientArguments.setrotatingMemorySizeValue(arg.rotating);
 

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -929,6 +929,12 @@ void testing_matmul(const Arguments& arg)
     Arguments   arg_revised    = arg;
     arg_revised.bias_type      = real_bias_type;
 
+    // Set the values of flush, rotating size, cold_iters and hot_iters only for internal use
+    hipblasltSetFlushValue(arg.flush);
+    hipblasltSetRotatingBufferSizeValue(arg.rotating);
+    hipblasltSetColdIterationsValue(arg.cold_iters);
+    hipblasltSetHotIterationsValue(arg.iters);
+
     // for all f8/bf8 cases including mix mode
     if((realDataTypeSize(tiA) == 1 || realDataTypeSize(tiB) == 1)
        && !std::is_same<Tc, int32_t>::value) //Tc!=HIPBLAS_COMPUTE_32I

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -2926,6 +2926,7 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         int    flush_iter      = 100000;
         double flush_time_used = 0;
+
         if(arg.flush)
         {
             for(int i = 0; i < flush_iter; i++)

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -2926,7 +2926,6 @@ void testing_matmul_with_bias(const Arguments& arg,
 
         int    flush_iter      = 100000;
         double flush_time_used = 0;
-
         if(arg.flush)
         {
             for(int i = 0; i < flush_iter; i++)

--- a/docs/logging-heuristics.rst
+++ b/docs/logging-heuristics.rst
@@ -33,23 +33,25 @@ You can enable the hipBLASLt logging mechanism by setting the following environm
 
 ``HIPBLASLT_LOG_MASK=<mask>`` - where ``mask`` is a combination of the following:
 
-+-----------------+
-|"0" - Off        |
-+-----------------+
-|"1" - Error      |
-+-----------------+
-|"2" - Trace      |
-+-----------------+
-|"4" - Hints      |
-+-----------------+
-|"8" - Info       |
-+-----------------+
-|"16" - API Trace |
-+-----------------+
-|"32" - Bench     |
-+-----------------+
-|"64" - Profile   |
-+-----------------+
++---------------------------+
+|"0" - Off                  |
++---------------------------+
+|"1" - Error                |
++---------------------------+
+|"2" - Trace                |
++---------------------------+
+|"4" - Hints                |
++---------------------------+
+|"8" - Info                 |
++---------------------------+
+|"16" - API Trace           |
++---------------------------+
+|"32" - Bench               |
++---------------------------+
+|"64" - Profile             |
++---------------------------+
+|"128" - Extended Profile   |
++---------------------------+
 
 ``HIPBLASLT_LOG_FILE=<file_name>`` - where ``file_name`` is a path to a logging file. The file name can contain ``%i``, which is replaced with the process ID, for example, ``<file_name>_%i.log``.
 If ``HIPBLASLT_LOG_FILE`` is not defined, the log messages are printed to stdout.

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -223,9 +223,11 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtAMaxWithScale(const hipDataType dat
                                                            uint32_t          n,
                                                            hipStream_t       stream);
 
-// Exporting the setters of flush and rotating buffer size.
+// Exporting the setters of flush, rotating buffer size, cold iterations and hot iterations.
 HIPBLASLT_EXPORT void hipblasltSetFlushValue(bool newFlush);
 HIPBLASLT_EXPORT void hipblasltSetRotatingBufferSizeValue(int newrotatingBufferSize);
+HIPBLASLT_EXPORT void hipblasltSetColdIterationsValue(int newColdIterations);
+HIPBLASLT_EXPORT void hipblasltSetHotIterationsValue(int newHotIterations);
 
 #ifdef __cplusplus
 }

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -223,37 +223,9 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtAMaxWithScale(const hipDataType dat
                                                            uint32_t          n,
                                                            hipStream_t       stream);
 
-/*! \brief User defined client arguments.
- *
- * \details This Singleton class sets the value of flush and rotating size used in the client which could be further used in the logging, only for internal usage purpose.
- */
-
-class SingletonUserClientArguments
-{
-private:
-    bool flush; // First member variable
-    int  rotatingMemorySize; // Second member variable
-
-    // Private constructor to prevent instantiation
-    SingletonUserClientArguments();
-
-public:
-    // Static method to get the single instance of the class
-    HIPBLASLT_EXPORT static SingletonUserClientArguments& getInstance();
-
-    // Delete copy constructor and assignment operator
-    HIPBLASLT_EXPORT SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
-    HIPBLASLT_EXPORT SingletonUserClientArguments& operator=(const SingletonUserClientArguments&)
-        = delete;
-
-    // Getter and setter for the flush member variable, only for internal usage purpose.
-    HIPBLASLT_EXPORT bool hipblasltInternalGetFlushValue() const;
-    HIPBLASLT_EXPORT void hipblasltInternalSetFlushValue(bool newFlush);
-
-    // Getter and setter for the rotatingMemorySize member variable, only for internal usage purpose.
-    HIPBLASLT_EXPORT int  hipblasltInternalGetRotatingMemorySizeValue() const;
-    HIPBLASLT_EXPORT void hipblasltInternalSetRotatingMemorySizeValue(int newrotatingMemorySize);
-};
+// Exporting the setters of flush and rotating size.
+HIPBLASLT_EXPORT void hipblasltSetFlushValue(bool newFlush);
+HIPBLASLT_EXPORT void hipblasltSetRotatingMemorySizeValue(int newrotatingMemorySize);
 
 #ifdef __cplusplus
 }

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -223,9 +223,9 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtAMaxWithScale(const hipDataType dat
                                                            uint32_t          n,
                                                            hipStream_t       stream);
 
-// Exporting the setters of flush and rotating size.
+// Exporting the setters of flush and rotating buffer size.
 HIPBLASLT_EXPORT void hipblasltSetFlushValue(bool newFlush);
-HIPBLASLT_EXPORT void hipblasltSetRotatingMemorySizeValue(int newrotatingMemorySize);
+HIPBLASLT_EXPORT void hipblasltSetRotatingBufferSizeValue(int newrotatingBufferSize);
 
 #ifdef __cplusplus
 }

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -246,11 +246,11 @@ public:
     HIPBLASLT_EXPORT SingletonUserClientArguments& operator=(const SingletonUserClientArguments&)
         = delete;
 
-    // Getter and setter for the first member variable
+    // Getter and setter for the flush member variable, only for internal usage purpose.
     HIPBLASLT_EXPORT bool hipblasltInternalGetFlushValue() const;
     HIPBLASLT_EXPORT void hipblasltInternalSetFlushValue(bool newFlush);
 
-    // Getter and setter for the second member variable
+    // Getter and setter for the rotatingMemorySize member variable, only for internal usage purpose.
     HIPBLASLT_EXPORT int  hipblasltInternalGetRotatingMemorySizeValue() const;
     HIPBLASLT_EXPORT void hipblasltInternalSetRotatingMemorySizeValue(int newrotatingMemorySize);
 };

--- a/library/include/hipblaslt-ext-op.h
+++ b/library/include/hipblaslt-ext-op.h
@@ -222,6 +222,39 @@ HIPBLASLT_EXPORT hipblasStatus_t hipblasltExtAMaxWithScale(const hipDataType dat
                                                            uint32_t          m,
                                                            uint32_t          n,
                                                            hipStream_t       stream);
+
+/*! \brief User defined client arguments.
+ *
+ * \details This Singleton class sets the value of flush and rotating size used in the client which could be further used in the logging, only for internal usage purpose.
+ */
+
+class SingletonUserClientArguments
+{
+private:
+    bool flush; // First member variable
+    int  rotatingMemorySize; // Second member variable
+
+    // Private constructor to prevent instantiation
+    SingletonUserClientArguments();
+
+public:
+    // Static method to get the single instance of the class
+    HIPBLASLT_EXPORT static SingletonUserClientArguments& getInstance();
+
+    // Delete copy constructor and assignment operator
+    HIPBLASLT_EXPORT SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
+    HIPBLASLT_EXPORT SingletonUserClientArguments& operator=(const SingletonUserClientArguments&)
+        = delete;
+
+    // Getter and setter for the first member variable
+    HIPBLASLT_EXPORT bool hipblasltInternalGetFlushValue() const;
+    HIPBLASLT_EXPORT void hipblasltInternalSetFlushValue(bool newFlush);
+
+    // Getter and setter for the second member variable
+    HIPBLASLT_EXPORT int  hipblasltInternalGetRotatingMemorySizeValue() const;
+    HIPBLASLT_EXPORT void hipblasltInternalSetRotatingMemorySizeValue(int newrotatingMemorySize);
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -411,57 +411,6 @@ namespace hipblaslt_ext
         int   activationType; //!< The activation type.  Only works if mode is set to activation related epilogues.
     } __attribute__((packed));
 
-    /*! \brief User defined client arguments.
-     *
-     * \details This Singleton class sets the value of flush and rotating size used in the client which could be further used in the logging
-     */
-
-    class SingletonUserClientArguments
-    {
-    private:
-        bool flush; // First member variable
-        int  rotatingMemorySize; // Second member variable
-
-        // Private constructor to prevent instantiation
-        SingletonUserClientArguments()
-            : flush(false)
-            , rotatingMemorySize(0)
-        {
-        }
-
-    public:
-        // Static method to get the single instance of the class
-        static SingletonUserClientArguments& getInstance()
-        {
-            static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
-            return instance;
-        }
-
-        // Delete copy constructor and assignment operator
-        SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
-        SingletonUserClientArguments& operator=(const SingletonUserClientArguments&) = delete;
-
-        // Getter and setter for the first member variable
-        bool getFlushValue() const
-        {
-            return flush;
-        }
-        void setFlushValue(bool newFlush)
-        {
-            flush = newFlush;
-        }
-
-        // Getter and setter for the second member variable
-        int getrotatingMemorySizeValue() const
-        {
-            return rotatingMemorySize;
-        }
-        void setrotatingMemorySizeValue(int newrotatingMemorySize)
-        {
-            rotatingMemorySize = newrotatingMemorySize;
-        }
-    };
-
     /*! \ingroup types_module
      *  \brief hipblasLt extension instance for gemm problems.
      */

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -411,6 +411,47 @@ namespace hipblaslt_ext
         int   activationType; //!< The activation type.  Only works if mode is set to activation related epilogues.
     } __attribute__((packed));
 
+    /*! \brief User defined client arguments.
+     *
+     * \details This Singleton class sets the value of flush and rotating size used in the client which could be further used in the logging
+     */
+
+class SingletonUserClientArguments {
+private:
+    bool flush;               // First member variable
+    int  rotatingMemorySize;  // Second member variable
+
+    // Private constructor to prevent instantiation
+    SingletonUserClientArguments() : flush(false), rotatingMemorySize(0) {}
+
+public:
+    // Static method to get the single instance of the class
+    static SingletonUserClientArguments& getInstance() {
+        static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
+        return instance;
+    }
+
+    // Delete copy constructor and assignment operator
+    SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
+    SingletonUserClientArguments& operator=(const SingletonUserClientArguments&) = delete;
+
+    // Getter and setter for the first member variable
+    bool getFlushValue() const {
+        return flush;
+    }
+    void setFlushValue(bool newFlush) {
+        flush = newFlush;
+    }
+
+    // Getter and setter for the second member variable
+    int getrotatingMemorySizeValue() const {
+        return rotatingMemorySize;
+    }
+    void setrotatingMemorySizeValue(int newrotatingMemorySize) {
+        rotatingMemorySize = newrotatingMemorySize;
+    }
+};
+
     /*! \ingroup types_module
      *  \brief hipblasLt extension instance for gemm problems.
      */

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -91,10 +91,10 @@ namespace hipblaslt_ext
         HIPBLASLT_EXPORT GemmPreferenceV2();
         HIPBLASLT_EXPORT ~GemmPreferenceV2();
 
-        HIPBLASLT_EXPORT                   GemmPreferenceV2(const GemmPreferenceV2& pref);
+        HIPBLASLT_EXPORT GemmPreferenceV2(const GemmPreferenceV2& pref);
         HIPBLASLT_EXPORT GemmPreferenceV2& operator=(const GemmPreferenceV2& pref);
 
-        HIPBLASLT_EXPORT                   GemmPreferenceV2(GemmPreferenceV2&& pref);
+        HIPBLASLT_EXPORT GemmPreferenceV2(GemmPreferenceV2&& pref);
         HIPBLASLT_EXPORT GemmPreferenceV2& operator=(GemmPreferenceV2&& pref);
 
         /*! \ingroup library_module
@@ -152,10 +152,10 @@ namespace hipblaslt_ext
                                            hipblasComputeType_t typeCompute);
         HIPBLASLT_EXPORT ~GemmProblemTypeV2();
 
-        HIPBLASLT_EXPORT                    GemmProblemTypeV2(const GemmProblemTypeV2& type);
+        HIPBLASLT_EXPORT GemmProblemTypeV2(const GemmProblemTypeV2& type);
         HIPBLASLT_EXPORT GemmProblemTypeV2& operator=(const GemmProblemTypeV2& type);
 
-        HIPBLASLT_EXPORT                    GemmProblemTypeV2(GemmProblemTypeV2&& type);
+        HIPBLASLT_EXPORT GemmProblemTypeV2(GemmProblemTypeV2&& type);
         HIPBLASLT_EXPORT GemmProblemTypeV2& operator=(GemmProblemTypeV2&& type);
 
         HIPBLASLT_EXPORT void setOpA(hipblasOperation_t op); //!< Set the A martix transpose.
@@ -209,10 +209,10 @@ namespace hipblaslt_ext
         HIPBLASLT_EXPORT GemmEpilogueV2();
         HIPBLASLT_EXPORT ~GemmEpilogueV2();
 
-        HIPBLASLT_EXPORT                 GemmEpilogueV2(const GemmEpilogueV2& epilogue);
+        HIPBLASLT_EXPORT GemmEpilogueV2(const GemmEpilogueV2& epilogue);
         HIPBLASLT_EXPORT GemmEpilogueV2& operator=(const GemmEpilogueV2& epilogue);
 
-        HIPBLASLT_EXPORT                 GemmEpilogueV2(GemmEpilogueV2&& epilogue);
+        HIPBLASLT_EXPORT GemmEpilogueV2(GemmEpilogueV2&& epilogue);
         HIPBLASLT_EXPORT GemmEpilogueV2& operator=(GemmEpilogueV2&& epilogue);
 
         HIPBLASLT_EXPORT void
@@ -261,10 +261,10 @@ namespace hipblaslt_ext
         HIPBLASLT_EXPORT GemmTuningV2();
         HIPBLASLT_EXPORT ~GemmTuningV2();
 
-        HIPBLASLT_EXPORT               GemmTuningV2(const GemmTuningV2& tuning);
+        HIPBLASLT_EXPORT GemmTuningV2(const GemmTuningV2& tuning);
         HIPBLASLT_EXPORT GemmTuningV2& operator=(const GemmTuningV2& tuning);
 
-        HIPBLASLT_EXPORT               GemmTuningV2(GemmTuningV2&& tuning);
+        HIPBLASLT_EXPORT GemmTuningV2(GemmTuningV2&& tuning);
         HIPBLASLT_EXPORT GemmTuningV2& operator=(GemmTuningV2&& tuning);
 
         HIPBLASLT_EXPORT void setSplitK(
@@ -317,10 +317,10 @@ namespace hipblaslt_ext
         HIPBLASLT_EXPORT GemmInputsV2();
         HIPBLASLT_EXPORT ~GemmInputsV2();
 
-        HIPBLASLT_EXPORT               GemmInputsV2(const GemmInputsV2& input);
+        HIPBLASLT_EXPORT GemmInputsV2(const GemmInputsV2& input);
         HIPBLASLT_EXPORT GemmInputsV2& operator=(const GemmInputsV2& input);
 
-        HIPBLASLT_EXPORT               GemmInputsV2(GemmInputsV2&& input);
+        HIPBLASLT_EXPORT GemmInputsV2(GemmInputsV2&& input);
         HIPBLASLT_EXPORT GemmInputsV2& operator=(GemmInputsV2&& input);
 
         HIPBLASLT_EXPORT void setA(const void* a); //!< Set the a matrix input pointer.
@@ -416,41 +416,51 @@ namespace hipblaslt_ext
      * \details This Singleton class sets the value of flush and rotating size used in the client which could be further used in the logging
      */
 
-class SingletonUserClientArguments {
-private:
-    bool flush;               // First member variable
-    int  rotatingMemorySize;  // Second member variable
+    class SingletonUserClientArguments
+    {
+    private:
+        bool flush; // First member variable
+        int  rotatingMemorySize; // Second member variable
 
-    // Private constructor to prevent instantiation
-    SingletonUserClientArguments() : flush(false), rotatingMemorySize(0) {}
+        // Private constructor to prevent instantiation
+        SingletonUserClientArguments()
+            : flush(false)
+            , rotatingMemorySize(0)
+        {
+        }
 
-public:
-    // Static method to get the single instance of the class
-    static SingletonUserClientArguments& getInstance() {
-        static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
-        return instance;
-    }
+    public:
+        // Static method to get the single instance of the class
+        static SingletonUserClientArguments& getInstance()
+        {
+            static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
+            return instance;
+        }
 
-    // Delete copy constructor and assignment operator
-    SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
-    SingletonUserClientArguments& operator=(const SingletonUserClientArguments&) = delete;
+        // Delete copy constructor and assignment operator
+        SingletonUserClientArguments(const SingletonUserClientArguments&) = delete;
+        SingletonUserClientArguments& operator=(const SingletonUserClientArguments&) = delete;
 
-    // Getter and setter for the first member variable
-    bool getFlushValue() const {
-        return flush;
-    }
-    void setFlushValue(bool newFlush) {
-        flush = newFlush;
-    }
+        // Getter and setter for the first member variable
+        bool getFlushValue() const
+        {
+            return flush;
+        }
+        void setFlushValue(bool newFlush)
+        {
+            flush = newFlush;
+        }
 
-    // Getter and setter for the second member variable
-    int getrotatingMemorySizeValue() const {
-        return rotatingMemorySize;
-    }
-    void setrotatingMemorySizeValue(int newrotatingMemorySize) {
-        rotatingMemorySize = newrotatingMemorySize;
-    }
-};
+        // Getter and setter for the second member variable
+        int getrotatingMemorySizeValue() const
+        {
+            return rotatingMemorySize;
+        }
+        void setrotatingMemorySizeValue(int newrotatingMemorySize)
+        {
+            rotatingMemorySize = newrotatingMemorySize;
+        }
+    };
 
     /*! \ingroup types_module
      *  \brief hipblasLt extension instance for gemm problems.
@@ -459,8 +469,8 @@ public:
     {
     public:
         HIPBLASLT_EXPORT virtual ~GemmInstance(){};
-        HIPBLASLT_EXPORT               GemmInstance(const GemmInstance& rhs) = delete;
-        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance& rhs)    = delete;
+        HIPBLASLT_EXPORT GemmInstance(const GemmInstance& rhs) = delete;
+        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance& rhs) = delete;
         HIPBLASLT_EXPORT               GemmInstance(GemmInstance&& rhs) noexcept;
         HIPBLASLT_EXPORT GemmInstance& operator=(GemmInstance&& rhs) noexcept;
 
@@ -805,10 +815,10 @@ public:
                                        void*                   D,
                                        hipblasLtMatrixLayout_t matD);
 
-        HIPBLASLT_EXPORT       Gemm(const Gemm&) = delete;
-        HIPBLASLT_EXPORT       Gemm(Gemm&&) noexcept;
+        HIPBLASLT_EXPORT Gemm(const Gemm&) = delete;
+        HIPBLASLT_EXPORT Gemm(Gemm&&) noexcept;
         HIPBLASLT_EXPORT Gemm& operator=(const Gemm&) = delete;
-        HIPBLASLT_EXPORT Gemm& operator=(Gemm&&) noexcept;
+        HIPBLASLT_EXPORT Gemm& operator               =(Gemm&&) noexcept;
 
         /*! \ingroup library_module
         *  \brief Sets the problem for a gemm problem. (Deprecated)
@@ -1061,10 +1071,10 @@ public:
                                               hipDataType          typeC,
                                               hipDataType          typeD,
                                               hipblasComputeType_t typeCompute);
-        HIPBLASLT_EXPORT              GroupedGemm(const GroupedGemm&) = delete;
-        HIPBLASLT_EXPORT              GroupedGemm(GroupedGemm&&) noexcept;
+        HIPBLASLT_EXPORT GroupedGemm(const GroupedGemm&) = delete;
+        HIPBLASLT_EXPORT GroupedGemm(GroupedGemm&&) noexcept;
         HIPBLASLT_EXPORT GroupedGemm& operator=(const GroupedGemm&) = delete;
-        HIPBLASLT_EXPORT GroupedGemm& operator=(GroupedGemm&&) noexcept;
+        HIPBLASLT_EXPORT GroupedGemm& operator                      =(GroupedGemm&&) noexcept;
 
         /*! \ingroup library_module
         *  \brief Constructor that sets the grouped gemm problem from hipblasLt structures

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -563,3 +563,15 @@ void hipblasltSetRotatingBufferSizeValue(int newrotatingBufferSize)
     UserClientArguments clientArguments;
     clientArguments.SetRotatingBufferSizeValue(newrotatingBufferSize);
 }
+
+void hipblasltSetColdIterationsValue(int newColdIterations)
+{
+    UserClientArguments clientArguments;
+    clientArguments.SetColdIterationsValue(newColdIterations);
+}
+
+void hipblasltSetHotIterationsValue(int newHotIterations)
+{
+    UserClientArguments clientArguments;
+    clientArguments.SetHotIterationsValue(newHotIterations);
+}

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -558,8 +558,8 @@ void hipblasltSetFlushValue(bool newFlush)
     UserClientArguments clientArguments;
     clientArguments.SetFlushValue(newFlush);
 }
-void hipblasltSetRotatingMemorySizeValue(int newrotatingMemorySize)
+void hipblasltSetRotatingBufferSizeValue(int newrotatingBufferSize)
 {
     UserClientArguments clientArguments;
-    clientArguments.SetRotatingMemorySizeValue(newrotatingMemorySize);
+    clientArguments.SetRotatingBufferSizeValue(newrotatingBufferSize);
 }

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -551,37 +551,15 @@ hipblasStatus_t hipblasltAMaxWithScaleRun(const hipDataType datatype,
     return HIPBLAS_STATUS_SUCCESS;
 }
 
-// Private constructor of SingletonUserClientArguments
-SingletonUserClientArguments::SingletonUserClientArguments()
-    : flush(false)
-    , rotatingMemorySize(0)
+// Setter for the members of class UserClientArguments, only for internal use.
+// The class UserClientArguments is declared and defined in utility.hpp and utility.cpp respectively
+void hipblasltSetFlushValue(bool newFlush)
 {
+    UserClientArguments clientArguments;
+    clientArguments.SetFlushValue(newFlush);
 }
-
-// Static method to get the single instance of the class
-SingletonUserClientArguments& SingletonUserClientArguments::getInstance()
+void hipblasltSetRotatingMemorySizeValue(int newrotatingMemorySize)
 {
-    static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
-    return instance;
-}
-
-// Getter and setter for the flush member variable, only for internal usage purpose.
-bool SingletonUserClientArguments::hipblasltInternalGetFlushValue() const
-{
-    return flush;
-}
-void SingletonUserClientArguments::hipblasltInternalSetFlushValue(bool newFlush)
-{
-    flush = newFlush;
-}
-
-// Getter and setter for the rotatingMemorySize member variable, only for internal usage purpose.
-int SingletonUserClientArguments::hipblasltInternalGetRotatingMemorySizeValue() const
-{
-    return rotatingMemorySize;
-}
-void SingletonUserClientArguments::hipblasltInternalSetRotatingMemorySizeValue(
-    int newrotatingMemorySize)
-{
-    rotatingMemorySize = newrotatingMemorySize;
+    UserClientArguments clientArguments;
+    clientArguments.SetRotatingMemorySizeValue(newrotatingMemorySize);
 }

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -298,12 +298,13 @@ hipblasStatus_t hipblasltSoftmaxRun(hipDataType datatype,
     auto        gpu       = TensileLite::hip::GetCurrentDevice();
     const auto  archName  = trimArchName(gpu->archName());
     auto&       masterLib = getExtOpMasterLibrary();
-    const auto& lib
-        = masterLib
-              .getLibrary(archName, hipblaslt_ext::SoftmaxSolutionLibrary::opName, hipDataTypeo_char(datatype))
-              ->as<hipblaslt_ext::SoftmaxSolutionLibrary>();
-    auto sol
-        = lib.findBestSolution(hipblaslt_ext::SoftmaxProblem(m, n, hipDataType_to_tensile_type(datatype)), *gpu);
+    const auto& lib       = masterLib
+                          .getLibrary(archName,
+                                      hipblaslt_ext::SoftmaxSolutionLibrary::opName,
+                                      hipDataTypeo_char(datatype))
+                          ->as<hipblaslt_ext::SoftmaxSolutionLibrary>();
+    auto sol = lib.findBestSolution(
+        hipblaslt_ext::SoftmaxProblem(m, n, hipDataType_to_tensile_type(datatype)), *gpu);
     const auto kernelName = sol->name();
     err                   = adapter->initKernel(kernelName);
     TensileLite::KernelArguments kArgs(false);
@@ -311,15 +312,15 @@ hipblasStatus_t hipblasltSoftmaxRun(hipDataType datatype,
     kArgs.append("output", output);
     kArgs.append("m", m);
     kArgs.append("n", n);
-    const auto                numWorkgroups = getSoftmaxNumWorkgroups(m, tileM);
+    const auto                    numWorkgroups = getSoftmaxNumWorkgroups(m, tileM);
     TensileLite::KernelInvocation invocation{kernelName,
-                                         sol->getCodeObjectPath(),
-                                         false,
-                                         {WORKGROUP_SIZE, 1, 1},
-                                         {numWorkgroups, 1, 1},
-                                         {numWorkgroups * WORKGROUP_SIZE, 1, 1},
-                                         getLdsUsageByte(datatype, tileM, tileN),
-                                         kArgs};
+                                             sol->getCodeObjectPath(),
+                                             false,
+                                             {WORKGROUP_SIZE, 1, 1},
+                                             {numWorkgroups, 1, 1},
+                                             {numWorkgroups * WORKGROUP_SIZE, 1, 1},
+                                             getLdsUsageByte(datatype, tileM, tileN),
+                                             kArgs};
 
     err = adapter->launchKernel(invocation, stream, nullptr, nullptr);
 
@@ -358,12 +359,13 @@ hipblasStatus_t hipblasltLayerNormRun(hipDataType datatype,
     auto        gpu       = TensileLite::hip::GetCurrentDevice();
     const auto  archName  = trimArchName(gpu->archName());
     auto&       masterLib = getExtOpMasterLibrary();
-    const auto& lib
-        = masterLib
-              .getLibrary(archName, hipblaslt_ext::LayerNormSolutionLibrary::opName, hipDataTypeo_char(datatype))
-              ->as<hipblaslt_ext::LayerNormSolutionLibrary>();
-    auto sol
-        = lib.findBestSolution(hipblaslt_ext::LayerNormProblem(m, n, hipDataType_to_tensile_type(datatype)), *gpu);
+    const auto& lib       = masterLib
+                          .getLibrary(archName,
+                                      hipblaslt_ext::LayerNormSolutionLibrary::opName,
+                                      hipDataTypeo_char(datatype))
+                          ->as<hipblaslt_ext::LayerNormSolutionLibrary>();
+    auto sol = lib.findBestSolution(
+        hipblaslt_ext::LayerNormProblem(m, n, hipDataType_to_tensile_type(datatype)), *gpu);
     const auto kernelName    = sol->name();
     err                      = adapter->initKernel(kernelName);
     const auto numWorkgroups = m;
@@ -426,13 +428,15 @@ hipblasStatus_t hipblasltAMaxRun(const hipDataType datatype,
     auto        gpu       = TensileLite::hip::GetCurrentDevice();
     const auto  archName  = trimArchName(gpu->archName());
     auto&       masterLib = getExtOpMasterLibrary();
-    const auto& lib
-        = masterLib.getLibrary(archName, hipblaslt_ext::AMaxSolutionLibrary::opName, hipDataTypeo_char(datatype))
-              ->as<hipblaslt_ext::AMaxSolutionLibrary>();
-    auto       sol        = lib.findBestSolution(hipblaslt_ext::AMaxProblem(len,
-                                                hipDataType_to_tensile_type(datatype),
-                                                hipDataType_to_tensile_type(outDatatype)),
-                                    *gpu);
+    const auto& lib       = masterLib
+                          .getLibrary(archName,
+                                      hipblaslt_ext::AMaxSolutionLibrary::opName,
+                                      hipDataTypeo_char(datatype))
+                          ->as<hipblaslt_ext::AMaxSolutionLibrary>();
+    auto sol = lib.findBestSolution(
+        hipblaslt_ext::AMaxProblem(
+            len, hipDataType_to_tensile_type(datatype), hipDataType_to_tensile_type(outDatatype)),
+        *gpu);
     const auto kernelName = sol->name();
     err                   = adapter->initKernel(kernelName);
 
@@ -494,15 +498,18 @@ hipblasStatus_t hipblasltAMaxWithScaleRun(const hipDataType datatype,
     auto        gpu       = TensileLite::hip::GetCurrentDevice();
     const auto  archName  = trimArchName(gpu->archName());
     auto&       masterLib = getExtOpMasterLibrary();
-    const auto& lib
-        = masterLib.getLibrary(archName, hipblaslt_ext::AMaxSolutionLibrary::opName, hipDataTypeo_char(datatype))
-              ->as<hipblaslt_ext::AMaxSolutionLibrary>();
-    auto sol = lib.findBestSolution(hipblaslt_ext::AMaxProblem(len,
-                                                hipDataType_to_tensile_type(datatype),
-                                                hipDataType_to_tensile_type(outDatatype),
-                                                hipDataType_to_tensile_type(scaleDatatype),
-                                                true),
-                                    *gpu);
+    const auto& lib       = masterLib
+                          .getLibrary(archName,
+                                      hipblaslt_ext::AMaxSolutionLibrary::opName,
+                                      hipDataTypeo_char(datatype))
+                          ->as<hipblaslt_ext::AMaxSolutionLibrary>();
+    auto sol = lib.findBestSolution(
+        hipblaslt_ext::AMaxProblem(len,
+                                   hipDataType_to_tensile_type(datatype),
+                                   hipDataType_to_tensile_type(outDatatype),
+                                   hipDataType_to_tensile_type(scaleDatatype),
+                                   true),
+        *gpu);
 
     if(!sol)
     {
@@ -542,4 +549,39 @@ hipblasStatus_t hipblasltAMaxWithScaleRun(const hipDataType datatype,
     }
 
     return HIPBLAS_STATUS_SUCCESS;
+}
+
+// Private constructor of SingletonUserClientArguments
+SingletonUserClientArguments::SingletonUserClientArguments()
+    : flush(false)
+    , rotatingMemorySize(0)
+{
+}
+
+// Static method to get the single instance of the class
+SingletonUserClientArguments& SingletonUserClientArguments::getInstance()
+{
+    static SingletonUserClientArguments instance; // Guaranteed to be thread-safe
+    return instance;
+}
+
+// Getter and setter for the flush member variable, only for internal usage purpose.
+bool SingletonUserClientArguments::hipblasltInternalGetFlushValue() const
+{
+    return flush;
+}
+void SingletonUserClientArguments::hipblasltInternalSetFlushValue(bool newFlush)
+{
+    flush = newFlush;
+}
+
+// Getter and setter for the rotatingMemorySize member variable, only for internal usage purpose.
+int SingletonUserClientArguments::hipblasltInternalGetRotatingMemorySizeValue() const
+{
+    return rotatingMemorySize;
+}
+void SingletonUserClientArguments::hipblasltInternalSetRotatingMemorySizeValue(
+    int newrotatingMemorySize)
+{
+    rotatingMemorySize = newrotatingMemorySize;
 }

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
@@ -196,14 +196,14 @@ typedef enum rocblaslt_pointer_mode_
  */
 typedef enum rocblaslt_layer_mode
 {
-    rocblaslt_layer_mode_none        = 0, /**< layer is not active. */
-    rocblaslt_layer_mode_log_error   = 1, /**< layer is in error mode. */
-    rocblaslt_layer_mode_log_trace   = 2, /**< layer is in trace mode. */
-    rocblaslt_layer_mode_log_hints   = 4, /**< layer is in hints mode. */
-    rocblaslt_layer_mode_log_info    = 8, /**< layer is in info mode. */
-    rocblaslt_layer_mode_log_api     = 16, /**< layer is in api mode. */
-    rocblaslt_layer_mode_log_bench   = 32, /**< layer is in bench mode. */
-    rocblaslt_layer_mode_log_profile = 64, /**< layer is in profile mode. */
+    rocblaslt_layer_mode_none                 = 0, /**< layer is not active. */
+    rocblaslt_layer_mode_log_error            = 1, /**< layer is in error mode. */
+    rocblaslt_layer_mode_log_trace            = 2, /**< layer is in trace mode. */
+    rocblaslt_layer_mode_log_hints            = 4, /**< layer is in hints mode. */
+    rocblaslt_layer_mode_log_info             = 8, /**< layer is in info mode. */
+    rocblaslt_layer_mode_log_api              = 16, /**< layer is in api mode. */
+    rocblaslt_layer_mode_log_bench            = 32, /**< layer is in bench mode. */
+    rocblaslt_layer_mode_log_profile          = 64, /**< layer is in profile mode. */
     rocblaslt_layer_mode_log_extended_profile = 128, /**< layer is in Extended profile mode. */
 } rocblaslt_layer_mode;
 

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-types.h
@@ -204,6 +204,7 @@ typedef enum rocblaslt_layer_mode
     rocblaslt_layer_mode_log_api     = 16, /**< layer is in api mode. */
     rocblaslt_layer_mode_log_bench   = 32, /**< layer is in bench mode. */
     rocblaslt_layer_mode_log_profile = 64, /**< layer is in profile mode. */
+    rocblaslt_layer_mode_log_extended_profile = 128, /**< layer is in Extended profile mode. */
 } rocblaslt_layer_mode;
 
 /*! \ingroup types_module

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -485,28 +485,50 @@ bool rocblaslt_internal_tensile_supports_ldc_ne_ldd(rocblaslt_handle handle);
 class UserClientArguments
 {
 private:
-    static bool    flush;
-    static int32_t rotatingBufferSize;
+    static bool    m_flush;
+    static int32_t m_rotatingBufferSize;
+    static int32_t m_coldIterations;
+    static int32_t m_hotIterations;
 
 public:
     // Getter and setter for the flush member variable.
     bool GetFlushValue() const
     {
-        return flush;
+        return m_flush;
     }
     void SetFlushValue(bool newFlush)
     {
-        flush = newFlush;
+        m_flush = newFlush;
     }
 
     // Getter and setter for the rotatingBufferSize member variable.
-    int GetRotatingBufferSizeValue() const
+    int32_t GetRotatingBufferSizeValue() const
     {
-        return rotatingBufferSize;
+        return m_rotatingBufferSize;
     }
-    void SetRotatingBufferSizeValue(int newrotatingBufferSize)
+    void SetRotatingBufferSizeValue(int32_t newrotatingBufferSize)
     {
-        rotatingBufferSize = newrotatingBufferSize;
+        m_rotatingBufferSize = newrotatingBufferSize;
+    }
+
+    // Getter and setter for the coldIterations member variable.
+    int32_t GetColdIterationsValue() const
+    {
+        return m_coldIterations;
+    }
+    void SetColdIterationsValue(int32_t newColdIterations)
+    {
+        m_coldIterations = newColdIterations;
+    }
+
+    // Getter and setter for the hotIterations member variable.
+    int32_t GetHotIterationsValue() const
+    {
+        return m_hotIterations;
+    }
+    void SetHotIterationsValue(int32_t newHotIterations)
+    {
+        m_hotIterations = newHotIterations;
     }
 };
 

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -486,7 +486,7 @@ class UserClientArguments
 {
 private:
     static bool    flush;
-    static int32_t rotatingMemorySize;
+    static int32_t rotatingBufferSize;
 
 public:
     // Getter and setter for the flush member variable.
@@ -499,14 +499,14 @@ public:
         flush = newFlush;
     }
 
-    // Getter and setter for the rotatingMemorySize member variable.
-    int GetRotatingMemorySizeValue() const
+    // Getter and setter for the rotatingBufferSize member variable.
+    int GetRotatingBufferSizeValue() const
     {
-        return rotatingMemorySize;
+        return rotatingBufferSize;
     }
-    void SetRotatingMemorySizeValue(int newrotatingMemorySize)
+    void SetRotatingBufferSizeValue(int newrotatingBufferSize)
     {
-        rotatingMemorySize = newrotatingMemorySize;
+        rotatingBufferSize = newrotatingBufferSize;
     }
 };
 

--- a/library/src/amd_detail/rocblaslt/src/include/utility.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/utility.hpp
@@ -200,7 +200,7 @@ void log_base(rocblaslt_layer_mode layer_mode, const char* func, H head, Ts&&...
     if(get_logger_layer_mode() & layer_mode)
     {
         std::lock_guard<std::mutex> lock(log_mutex);
-        std::string comma_separator = " ";
+        std::string                 comma_separator = " ";
 
         std::ostream* os = get_logger_os();
 
@@ -269,7 +269,7 @@ template <typename... Ts>
 void log_bench(const char* func, Ts&&... xs)
 {
     std::lock_guard<std::mutex> lock(log_mutex);
-    std::ostream* os = get_logger_os();
+    std::ostream*               os = get_logger_os();
     *os << "hipblaslt-bench ";
     log_arguments_bench(*os, std::forward<Ts>(xs)...);
     *os << std::endl;
@@ -476,5 +476,38 @@ bool rocblaslt_internal_tensile_supports_ldc_ne_ldd(rocblaslt_handle handle);
 
 // for internal use during testing, fetch arch name
 //std::string rocblaslt_internal_get_arch_name();
+
+/*! \brief User defined client arguments.
+ *
+ * \details This class sets the value of flush and rotating size used in the client which could be further used in the logging, only for internal use.
+ */
+
+class UserClientArguments
+{
+private:
+    static bool    flush;
+    static int32_t rotatingMemorySize;
+
+public:
+    // Getter and setter for the flush member variable.
+    bool GetFlushValue() const
+    {
+        return flush;
+    }
+    void SetFlushValue(bool newFlush)
+    {
+        flush = newFlush;
+    }
+
+    // Getter and setter for the rotatingMemorySize member variable.
+    int GetRotatingMemorySizeValue() const
+    {
+        return rotatingMemorySize;
+    }
+    void SetRotatingMemorySizeValue(int newrotatingMemorySize)
+    {
+        rotatingMemorySize = newrotatingMemorySize;
+    }
+};
 
 #endif // UTILITY_H

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -497,6 +497,8 @@ namespace
                                             const int&     solutionIndex,
                                             bool           flush,
                                             const int32_t& rotatingBufferSize,
+                                            const int32_t& coldIterations,
+                                            const int32_t& hotIterations,
                                             bool           isCpp)
     {
         log_bench(
@@ -591,13 +593,19 @@ namespace
             tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
             flush ? "--flush" : "",
             "--rotating",
-            rotatingBufferSize);
+            rotatingBufferSize,
+            "--cold_iters",
+            coldIterations,
+            "--iters",
+            hotIterations);
     }
 
     inline void logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                               const TensileLite::ContractionInputs&      inputs,
                                               bool                                       flush,
                                               const int32_t& rotatingBufferSize,
+                                              const int32_t& coldIterations,
+                                              const int32_t& hotIterations,
                                               bool           isCpp)
     {
         log_profile("matmul",
@@ -670,7 +678,11 @@ namespace
                     "flush",
                     flush ? "true" : "false",
                     "rotating",
-                    rotatingBufferSize);
+                    rotatingBufferSize,
+                    "cold_iters",
+                    coldIterations,
+                    "iters",
+                    hotIterations);
     }
 
     inline void
@@ -681,6 +693,8 @@ namespace
                                               const std::string& solutionName,
                                               bool               flush,
                                               const int32_t&     rotatingBufferSize,
+                                              const int32_t&     coldIterations,
+                                              const int32_t&     hotIterations,
                                               bool               isCpp)
     {
         log_profile("matmul",
@@ -750,16 +764,20 @@ namespace
                                                               problem.b().dataType()),
                     "activation_type",
                     tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
+                    "flush",
+                    flush ? "true" : "false",
+                    "rotating",
+                    rotatingBufferSize,
+                    "cold_iters",
+                    coldIterations,
+                    "iters",
+                    hotIterations,
                     "solution_index",
                     solutionIndex,
                     "solution_Name",
                     solutionName,
                     "kernel_name",
-                    kernelName,
-                    "flush",
-                    flush ? "true" : "false",
-                    "rotating",
-                    rotatingBufferSize);
+                    kernelName);
     }
 
     inline void
@@ -768,6 +786,8 @@ namespace
                                     const int&                                        solutionIndex,
                                     bool                                              flush,
                                     const int32_t& rotatingBufferSize,
+                                    const int32_t& coldIterations,
+                                    const int32_t& hotIterations,
                                     bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -871,7 +891,11 @@ namespace
             tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()),
             flush ? "--flush" : "",
             "--rotating",
-            rotatingBufferSize);
+            rotatingBufferSize,
+            "--cold_iters",
+            coldIterations,
+            "--iters",
+            hotIterations);
     }
 
     inline void
@@ -879,6 +903,8 @@ namespace
                                       const TensileLite::ContractionGroupedInputs&      inputs,
                                       bool                                              flush,
                                       const int32_t& rotatingBufferSize,
+                                      const int32_t& coldIterations,
+                                      const int32_t& hotIterations,
                                       bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -996,7 +1022,11 @@ namespace
             "flush",
             flush ? "true" : "false",
             "rotating",
-            rotatingBufferSize);
+            rotatingBufferSize,
+            "cold_iters",
+            coldIterations,
+            "iters",
+            hotIterations);
     }
 #undef GEN_BENCH_ARG
 
@@ -2083,6 +2113,8 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         UserClientArguments ClientArguments;
         bool                flush              = ClientArguments.GetFlushValue();
         int32_t             rotatingBufferSize = ClientArguments.GetRotatingBufferSizeValue();
+        int32_t             hotIterations      = ClientArguments.GetHotIterationsValue();
+        int32_t             coldIterations     = ClientArguments.GetColdIterationsValue();
 
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
@@ -2090,14 +2122,25 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
         {
-            logBenchFromTensileDataGemm(
-                data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, false);
+            logBenchFromTensileDataGemm(data->problem,
+                                        data->inputs,
+                                        data->algoIndex,
+                                        flush,
+                                        rotatingBufferSize,
+                                        coldIterations,
+                                        hotIterations,
+                                        false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
         {
-            logProfileFromTensileDataGemm(
-                data->problem, data->inputs, flush, rotatingBufferSize, false);
+            logProfileFromTensileDataGemm(data->problem,
+                                          data->inputs,
+                                          flush,
+                                          rotatingBufferSize,
+                                          coldIterations,
+                                          hotIterations,
+                                          false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_extended_profile)
@@ -2112,6 +2155,8 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
                                                   Solution_name,
                                                   flush,
                                                   rotatingBufferSize,
+                                                  coldIterations,
+                                                  hotIterations,
                                                   false);
         }
 
@@ -2508,6 +2553,8 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
         UserClientArguments ClientArguments;
         bool                flush              = ClientArguments.GetFlushValue();
         int32_t             rotatingBufferSize = ClientArguments.GetRotatingBufferSizeValue();
+        int32_t             hotIterations      = ClientArguments.GetHotIterationsValue();
+        int32_t             coldIterations     = ClientArguments.GetColdIterationsValue();
 
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {
@@ -2515,13 +2562,24 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
                 = std::static_pointer_cast<TensileDataGemm>(gemmData);
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(
-                    data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, true);
+                logBenchFromTensileDataGemm(data->problem,
+                                            data->inputs,
+                                            data->algoIndex,
+                                            flush,
+                                            rotatingBufferSize,
+                                            coldIterations,
+                                            hotIterations,
+                                            true);
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
             {
-                logProfileFromTensileDataGemm(
-                    data->problem, data->inputs, flush, rotatingBufferSize, true);
+                logProfileFromTensileDataGemm(data->problem,
+                                              data->inputs,
+                                              flush,
+                                              rotatingBufferSize,
+                                              coldIterations,
+                                              hotIterations,
+                                              true);
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
         }
@@ -2537,8 +2595,14 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(
-                    data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, true);
+                logBenchFromTensileDataGemm(data->problem,
+                                            data->inputs,
+                                            data->algoIndex,
+                                            flush,
+                                            rotatingBufferSize,
+                                            coldIterations,
+                                            hotIterations,
+                                            true);
             }
             //TODO: add profile logging for grouped gemm
             /*if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -51,6 +51,7 @@
 #include <atomic>
 #include <complex>
 #include <exception>
+#include <hipblaslt/hipblaslt-ext-op.h>
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <iomanip>
 #include <memory>
@@ -589,7 +590,10 @@ namespace
             "--solution_index",
             solutionIndex,
             "--activation_type",
-            tensileActivationtType_to_bench_string(problem.getParams().activationEnum()));
+            tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
+            flush ? "--flush" : "",
+            "--rotating",
+            rotating_memory_size);
     }
 
     inline void logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
@@ -664,7 +668,11 @@ namespace
                                                               problem.a().dataType(),
                                                               problem.b().dataType()),
                     "activation_type",
-                    tensileActivationtType_to_bench_string(problem.getParams().activationEnum()));
+                    tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
+                    "flush",
+                    flush ? "true" : "false",
+                    "rotating",
+                    rotating_memory_size);
     }
 
     inline void
@@ -749,7 +757,11 @@ namespace
                     "solution_Name",
                     solutionName,
                     "kernel_name",
-                    kernelName);
+                    kernelName,
+                    "flush",
+                    flush ? "true" : "false",
+                    "rotating",
+                    rotating_memory_size);
     }
 
     inline void
@@ -858,7 +870,10 @@ namespace
             "--solution_index",
             solutionIndex,
             "--activation_type",
-            tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()));
+            tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()),
+            flush ? "--flush" : "",
+            "--rotating",
+            rotating_memory_size);
     }
 
     inline void
@@ -979,7 +994,11 @@ namespace
                                                       problem.gemms[0].a().dataType(),
                                                       problem.gemms[0].b().dataType()),
             "activation_type",
-            tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()));
+            tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()),
+            "flush",
+            flush ? "true" : "false",
+            "rotating",
+            rotating_memory_size);
     }
 #undef GEN_BENCH_ARG
 
@@ -2063,10 +2082,11 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         updateTensileProblem(prob, data->problem);
 
-        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
-            = hipblaslt_ext::SingletonUserClientArguments::getInstance();
-        bool    flush                = singletonClientArguments.getFlushValue();
-        int32_t rotating_memory_size = singletonClientArguments.getrotatingMemorySizeValue();
+        SingletonUserClientArguments& singletonClientArguments
+            = SingletonUserClientArguments::getInstance();
+        bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();
+        int32_t rotating_memory_size
+            = singletonClientArguments.hipblasltInternalGetRotatingMemorySizeValue();
 
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
@@ -2488,10 +2508,11 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_pointer;
         }
 
-        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
-            = hipblaslt_ext::SingletonUserClientArguments::getInstance();
-        bool    flush                = singletonClientArguments.getFlushValue();
-        int32_t rotating_memory_size = singletonClientArguments.getrotatingMemorySizeValue();
+        SingletonUserClientArguments& singletonClientArguments
+            = SingletonUserClientArguments::getInstance();
+        bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();
+        int32_t rotating_memory_size
+            = singletonClientArguments.hipblasltInternalGetRotatingMemorySizeValue();
 
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -38,7 +38,7 @@
 #include "rocblaslt_mat_utils.hpp"
 #include "tensile_host.hpp"
 
-//#include <Tensile/AMDGPU.hpp>
+#include <hipblaslt/hipblaslt-ext.hpp>
 #include <Tensile/Contractions.hpp>
 #include <Tensile/EmbeddedLibrary.hpp>
 #include <Tensile/MasterSolutionLibrary.hpp>
@@ -496,6 +496,8 @@ namespace
     inline void logBenchFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                             const TensileLite::ContractionInputs&      inputs,
                                             const int& solutionIndex,
+                                              bool                                       flush,
+                                              const int32_t&                           rotating_memory_size,                                             
                                             bool       isCpp)
     {
         log_bench(
@@ -592,6 +594,8 @@ namespace
 
     inline void logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                               const TensileLite::ContractionInputs&      inputs,
+                                              bool                                       flush,
+                                              const int32_t&                                 rotating_memory_size,                                              
                                               bool                                       isCpp)
     {
         log_profile("matmul",
@@ -663,10 +667,96 @@ namespace
                     tensileActivationtType_to_bench_string(problem.getParams().activationEnum()));
     }
 
+    inline void logExtendedProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
+                                                      const TensileLite::ContractionInputs&      inputs,
+                                                      const int&                             solutionIndex,
+                                                      const std::string&                     kernelName,
+                                                      const std::string&                     solutionName,
+                                                      bool                                   flush,
+                                                      const int32_t&                         rotating_memory_size,
+                                                      bool                                   isCpp)
+    {
+        log_profile("matmul",
+                    "M",
+                    problem.c().sizes()[0],
+                    "N",
+                    problem.c().sizes()[1],
+                    "K",
+                    problem.a().sizes()[problem.boundIndices()[0].a],
+                    "lda",
+                    problem.a().strides()[1],
+                    "ldb",
+                    problem.b().strides()[1],
+                    "ldc",
+                    problem.c().strides()[1],
+                    "ldd",
+                    problem.d().strides()[1],
+                    "stride_a",
+                    problem.a().strides()[2],
+                    "stride_b",
+                    problem.b().strides()[2],
+                    "stride_c",
+                    problem.c().strides()[2],
+                    "stride_d",
+                    problem.d().strides()[2],
+                    "alpha",
+                    ToString(inputs.alpha),
+                    "beta",
+                    ToString(inputs.beta),
+                    "transA",
+                    problem.transA() ? "T" : "N",
+                    "transB",
+                    problem.transB() ? "T" : "N",
+                    "batch_count",
+                    problem.batchSize(0),
+                    "scaleA",
+                    problem.useScaleAB().empty() ? 0 : (problem.useScaleAB() == "Vector" ? 2 : 1),
+                    "scaleB",
+                    problem.useScaleAB().empty() ? 0 : (problem.useScaleAB() == "Vector" ? 2 : 1),
+                    "scaleAlpha_vector",
+                    problem.useScaleAlphaVec() ? "true" : "false",
+                    "gradient",
+                    problem.useGradient() ? "true" : "false",
+                    "use_e",
+                    problem.useE() ? "true" : "false",
+                    "bias_vector",
+                    problem.useBias() ? "true" : "false",
+                    "bias_source",
+                    problem.useBias() ? problem.tensor(problem.biasSrc()).getName() : "d",
+                    "a_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.a().dataType())),
+                    "b_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.b().dataType())),
+                    "c_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.c().dataType())),
+                    "d_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.d().dataType())),
+                    "scale_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.alphaType())),
+                    "bias_type",
+                    hipDataType_to_bench_string(tensile2HipType(problem.bias().dataType())),
+                    "compute_type",
+                    tensileComputeInputType_to_profile_string(problem.computeType(),
+                                                              problem.f32XdlMathOp(),
+                                                              problem.computeInputType(),
+                                                              problem.a().dataType(),
+                                                              problem.b().dataType()),
+                    "activation_type",
+                    tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
+                    "solution_index",
+                    solutionIndex,
+                    "solution_Name",
+                    solutionName,
+                    "kernel_name",
+                    kernelName);
+    }
+
     inline void
         logBenchFromTensileDataGemm(const TensileLite::ContractionProblemGroupedGemm& problem,
                                     const TensileLite::ContractionGroupedInputs&      inputs,
                                     const int&                                        solutionIndex,
+                                    bool                                              flush,
+                                    const int32_t&                                    rotating_memory_size,                                    
                                     bool                                              isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -773,6 +863,8 @@ namespace
     inline void
         logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGroupedGemm& problem,
                                       const TensileLite::ContractionGroupedInputs&      inputs,
+                                      bool                                              flush,
+                                      const int32_t&                                    rotating_memory_size, 
                                       bool                                              isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -1068,6 +1160,7 @@ namespace
         tensileProblem.setUseScaleAB((prob.scaleA == nullptr && prob.scaleB == nullptr)
                                          ? ""
                                          : (prob.isScaleAVec ? "Vector" : "Scalar"));
+
         tensileProblem.setUseScaleCD(prob.scaleC != nullptr || prob.scaleD != nullptr);
         tensileProblem.setUseScaleAlphaVec(prob.scaleAlphaVec != nullptr);
         tensileProblem.setScaleAlphaVec(compute_type, d.sizes()[0]);
@@ -1969,18 +2062,32 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         updateTensileProblem(prob, data->problem);
 
+        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+        bool flush = singletonClientArguments.getFlushValue();
+        int32_t rotating_memory_size =  singletonClientArguments.getrotatingMemorySizeValue();
+
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
         data->inputs       = GetTensileInputs(prob);
+
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
         {
-            logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, false);
+            logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
         {
-            logProfileFromTensileDataGemm(data->problem, data->inputs, false);
+            logProfileFromTensileDataGemm(data->problem, data->inputs, flush, rotating_memory_size, false);
         }
+
+        if(get_logger_layer_mode() & rocblaslt_layer_mode_log_extended_profile)
+        {
+            std::string kernel_name = getKernelNameFromAlgoIndex(handle, *algo);
+            std::string Solution_name = getSolutionNameFromAlgoIndex(handle, *algo);
+
+            logExtendedProfileFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, kernel_name, Solution_name, flush, rotating_memory_size, false);
+        }
+
         auto solution = library->getSolutionByIndex(data->problem, *hardware, *solutionIndex);
         if(!solution)
         {
@@ -2370,17 +2477,21 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_pointer;
         }
 
+        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+        bool flush = singletonClientArguments.getFlushValue();
+        int32_t rotating_memory_size =  singletonClientArguments.getrotatingMemorySizeValue();
+
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {
             std::shared_ptr<TensileDataGemm> data
                 = std::static_pointer_cast<TensileDataGemm>(gemmData);
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, true);
+                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, true);
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
             {
-                logProfileFromTensileDataGemm(data->problem, data->inputs, true);
+                logProfileFromTensileDataGemm(data->problem, data->inputs, flush, rotating_memory_size, true);
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
         }
@@ -2396,7 +2507,7 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, true);
+                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, true);
             }
             //TODO: add profile logging for grouped gemm
             /*if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -52,7 +52,6 @@
 #include <complex>
 #include <exception>
 #include <hipblaslt/hipblaslt-ext-op.h>
-#include <hipblaslt/hipblaslt-ext.hpp>
 #include <iomanip>
 #include <memory>
 #include <mutex>
@@ -1180,7 +1179,6 @@ namespace
         tensileProblem.setUseScaleAB((prob.scaleA == nullptr && prob.scaleB == nullptr)
                                          ? ""
                                          : (prob.isScaleAVec ? "Vector" : "Scalar"));
-
         tensileProblem.setUseScaleCD(prob.scaleC != nullptr || prob.scaleD != nullptr);
         tensileProblem.setUseScaleAlphaVec(prob.scaleAlphaVec != nullptr);
         tensileProblem.setScaleAlphaVec(compute_type, d.sizes()[0]);
@@ -2082,6 +2080,7 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         updateTensileProblem(prob, data->problem);
 
+        // Static method to get the single instance of the SingletonUserClientArguments class and get the values of flush and rotating size
         SingletonUserClientArguments& singletonClientArguments
             = SingletonUserClientArguments::getInstance();
         bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();
@@ -2508,6 +2507,7 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_pointer;
         }
 
+        // Static method to get the single instance of the SingletonUserClientArguments class and get the values of flush and rotating size
         SingletonUserClientArguments& singletonClientArguments
             = SingletonUserClientArguments::getInstance();
         bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2080,12 +2080,10 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         updateTensileProblem(prob, data->problem);
 
-        // Static method to get the single instance of the SingletonUserClientArguments class and get the values of flush and rotating size
-        SingletonUserClientArguments& singletonClientArguments
-            = SingletonUserClientArguments::getInstance();
-        bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();
-        int32_t rotating_memory_size
-            = singletonClientArguments.hipblasltInternalGetRotatingMemorySizeValue();
+        // Get the values of static member variables flush and rotating size from UserClientArguments
+        UserClientArguments ClientArguments;
+        bool                flush                = ClientArguments.GetFlushValue();
+        int32_t             rotating_memory_size = ClientArguments.GetRotatingMemorySizeValue();
 
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
@@ -2507,12 +2505,10 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_pointer;
         }
 
-        // Static method to get the single instance of the SingletonUserClientArguments class and get the values of flush and rotating size
-        SingletonUserClientArguments& singletonClientArguments
-            = SingletonUserClientArguments::getInstance();
-        bool    flush = singletonClientArguments.hipblasltInternalGetFlushValue();
-        int32_t rotating_memory_size
-            = singletonClientArguments.hipblasltInternalGetRotatingMemorySizeValue();
+        // Get the values of static member variables flush and rotating size from UserClientArguments
+        UserClientArguments ClientArguments;
+        bool                flush                = ClientArguments.GetFlushValue();
+        int32_t             rotating_memory_size = ClientArguments.GetRotatingMemorySizeValue();
 
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -38,7 +38,6 @@
 #include "rocblaslt_mat_utils.hpp"
 #include "tensile_host.hpp"
 
-#include <hipblaslt/hipblaslt-ext.hpp>
 #include <Tensile/Contractions.hpp>
 #include <Tensile/EmbeddedLibrary.hpp>
 #include <Tensile/MasterSolutionLibrary.hpp>
@@ -52,6 +51,7 @@
 #include <atomic>
 #include <complex>
 #include <exception>
+#include <hipblaslt/hipblaslt-ext.hpp>
 #include <iomanip>
 #include <memory>
 #include <mutex>
@@ -495,10 +495,10 @@ namespace
 
     inline void logBenchFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                             const TensileLite::ContractionInputs&      inputs,
-                                            const int& solutionIndex,
-                                              bool                                       flush,
-                                              const int32_t&                           rotating_memory_size,                                             
-                                            bool       isCpp)
+                                            const int&     solutionIndex,
+                                            bool           flush,
+                                            const int32_t& rotating_memory_size,
+                                            bool           isCpp)
     {
         log_bench(
             __func__,
@@ -595,8 +595,8 @@ namespace
     inline void logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                               const TensileLite::ContractionInputs&      inputs,
                                               bool                                       flush,
-                                              const int32_t&                                 rotating_memory_size,                                              
-                                              bool                                       isCpp)
+                                              const int32_t& rotating_memory_size,
+                                              bool           isCpp)
     {
         log_profile("matmul",
                     "M",
@@ -667,14 +667,15 @@ namespace
                     tensileActivationtType_to_bench_string(problem.getParams().activationEnum()));
     }
 
-    inline void logExtendedProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
-                                                      const TensileLite::ContractionInputs&      inputs,
-                                                      const int&                             solutionIndex,
-                                                      const std::string&                     kernelName,
-                                                      const std::string&                     solutionName,
-                                                      bool                                   flush,
-                                                      const int32_t&                         rotating_memory_size,
-                                                      bool                                   isCpp)
+    inline void
+        logExtendedProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
+                                              const TensileLite::ContractionInputs&      inputs,
+                                              const int&         solutionIndex,
+                                              const std::string& kernelName,
+                                              const std::string& solutionName,
+                                              bool               flush,
+                                              const int32_t&     rotating_memory_size,
+                                              bool               isCpp)
     {
         log_profile("matmul",
                     "M",
@@ -756,8 +757,8 @@ namespace
                                     const TensileLite::ContractionGroupedInputs&      inputs,
                                     const int&                                        solutionIndex,
                                     bool                                              flush,
-                                    const int32_t&                                    rotating_memory_size,                                    
-                                    bool                                              isCpp)
+                                    const int32_t& rotating_memory_size,
+                                    bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
         std::stringstream grouped_gemm_bench_string;
@@ -864,8 +865,8 @@ namespace
         logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGroupedGemm& problem,
                                       const TensileLite::ContractionGroupedInputs&      inputs,
                                       bool                                              flush,
-                                      const int32_t&                                    rotating_memory_size, 
-                                      bool                                              isCpp)
+                                      const int32_t& rotating_memory_size,
+                                      bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
         std::stringstream grouped_gemm_profile_string;
@@ -2062,9 +2063,10 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         updateTensileProblem(prob, data->problem);
 
-        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
-        bool flush = singletonClientArguments.getFlushValue();
-        int32_t rotating_memory_size =  singletonClientArguments.getrotatingMemorySizeValue();
+        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
+            = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+        bool    flush                = singletonClientArguments.getFlushValue();
+        int32_t rotating_memory_size = singletonClientArguments.getrotatingMemorySizeValue();
 
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
@@ -2072,20 +2074,29 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
         {
-            logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, false);
+            logBenchFromTensileDataGemm(
+                data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
         {
-            logProfileFromTensileDataGemm(data->problem, data->inputs, flush, rotating_memory_size, false);
+            logProfileFromTensileDataGemm(
+                data->problem, data->inputs, flush, rotating_memory_size, false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_extended_profile)
         {
-            std::string kernel_name = getKernelNameFromAlgoIndex(handle, *algo);
+            std::string kernel_name   = getKernelNameFromAlgoIndex(handle, *algo);
             std::string Solution_name = getSolutionNameFromAlgoIndex(handle, *algo);
 
-            logExtendedProfileFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, kernel_name, Solution_name, flush, rotating_memory_size, false);
+            logExtendedProfileFromTensileDataGemm(data->problem,
+                                                  data->inputs,
+                                                  data->algoIndex,
+                                                  kernel_name,
+                                                  Solution_name,
+                                                  flush,
+                                                  rotating_memory_size,
+                                                  false);
         }
 
         auto solution = library->getSolutionByIndex(data->problem, *hardware, *solutionIndex);
@@ -2477,9 +2488,10 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_pointer;
         }
 
-        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments = hipblaslt_ext::SingletonUserClientArguments::getInstance();
-        bool flush = singletonClientArguments.getFlushValue();
-        int32_t rotating_memory_size =  singletonClientArguments.getrotatingMemorySizeValue();
+        hipblaslt_ext::SingletonUserClientArguments& singletonClientArguments
+            = hipblaslt_ext::SingletonUserClientArguments::getInstance();
+        bool    flush                = singletonClientArguments.getFlushValue();
+        int32_t rotating_memory_size = singletonClientArguments.getrotatingMemorySizeValue();
 
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {
@@ -2487,11 +2499,17 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
                 = std::static_pointer_cast<TensileDataGemm>(gemmData);
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, true);
+                logBenchFromTensileDataGemm(data->problem,
+                                            data->inputs,
+                                            data->algoIndex,
+                                            flush,
+                                            rotating_memory_size,
+                                            true);
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
             {
-                logProfileFromTensileDataGemm(data->problem, data->inputs, flush, rotating_memory_size, true);
+                logProfileFromTensileDataGemm(
+                    data->problem, data->inputs, flush, rotating_memory_size, true);
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
         }
@@ -2507,7 +2525,12 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, true);
+                logBenchFromTensileDataGemm(data->problem,
+                                            data->inputs,
+                                            data->algoIndex,
+                                            flush,
+                                            rotating_memory_size,
+                                            true);
             }
             //TODO: add profile logging for grouped gemm
             /*if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -51,7 +51,6 @@
 #include <atomic>
 #include <complex>
 #include <exception>
-#include <hipblaslt/hipblaslt-ext-op.h>
 #include <iomanip>
 #include <memory>
 #include <mutex>
@@ -497,7 +496,7 @@ namespace
                                             const TensileLite::ContractionInputs&      inputs,
                                             const int&     solutionIndex,
                                             bool           flush,
-                                            const int32_t& rotating_memory_size,
+                                            const int32_t& rotatingBufferSize,
                                             bool           isCpp)
     {
         log_bench(
@@ -592,13 +591,13 @@ namespace
             tensileActivationtType_to_bench_string(problem.getParams().activationEnum()),
             flush ? "--flush" : "",
             "--rotating",
-            rotating_memory_size);
+            rotatingBufferSize);
     }
 
     inline void logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGemm& problem,
                                               const TensileLite::ContractionInputs&      inputs,
                                               bool                                       flush,
-                                              const int32_t& rotating_memory_size,
+                                              const int32_t& rotatingBufferSize,
                                               bool           isCpp)
     {
         log_profile("matmul",
@@ -671,7 +670,7 @@ namespace
                     "flush",
                     flush ? "true" : "false",
                     "rotating",
-                    rotating_memory_size);
+                    rotatingBufferSize);
     }
 
     inline void
@@ -681,7 +680,7 @@ namespace
                                               const std::string& kernelName,
                                               const std::string& solutionName,
                                               bool               flush,
-                                              const int32_t&     rotating_memory_size,
+                                              const int32_t&     rotatingBufferSize,
                                               bool               isCpp)
     {
         log_profile("matmul",
@@ -760,7 +759,7 @@ namespace
                     "flush",
                     flush ? "true" : "false",
                     "rotating",
-                    rotating_memory_size);
+                    rotatingBufferSize);
     }
 
     inline void
@@ -768,7 +767,7 @@ namespace
                                     const TensileLite::ContractionGroupedInputs&      inputs,
                                     const int&                                        solutionIndex,
                                     bool                                              flush,
-                                    const int32_t& rotating_memory_size,
+                                    const int32_t& rotatingBufferSize,
                                     bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -872,14 +871,14 @@ namespace
             tensileActivationtType_to_bench_string(problem.gemms[0].getParams().activationEnum()),
             flush ? "--flush" : "",
             "--rotating",
-            rotating_memory_size);
+            rotatingBufferSize);
     }
 
     inline void
         logProfileFromTensileDataGemm(const TensileLite::ContractionProblemGroupedGemm& problem,
                                       const TensileLite::ContractionGroupedInputs&      inputs,
                                       bool                                              flush,
-                                      const int32_t& rotating_memory_size,
+                                      const int32_t& rotatingBufferSize,
                                       bool           isCpp)
     {
         size_t            gemmCount = problem.gemms.size();
@@ -997,7 +996,7 @@ namespace
             "flush",
             flush ? "true" : "false",
             "rotating",
-            rotating_memory_size);
+            rotatingBufferSize);
     }
 #undef GEN_BENCH_ARG
 
@@ -2082,8 +2081,8 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
 
         // Get the values of static member variables flush and rotating size from UserClientArguments
         UserClientArguments ClientArguments;
-        bool                flush                = ClientArguments.GetFlushValue();
-        int32_t             rotating_memory_size = ClientArguments.GetRotatingMemorySizeValue();
+        bool                flush              = ClientArguments.GetFlushValue();
+        int32_t             rotatingBufferSize = ClientArguments.GetRotatingBufferSizeValue();
 
         int* solutionIndex = (int*)algo->data;
         data->algoIndex    = *solutionIndex;
@@ -2092,13 +2091,13 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
         {
             logBenchFromTensileDataGemm(
-                data->problem, data->inputs, data->algoIndex, flush, rotating_memory_size, false);
+                data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
         {
             logProfileFromTensileDataGemm(
-                data->problem, data->inputs, flush, rotating_memory_size, false);
+                data->problem, data->inputs, flush, rotatingBufferSize, false);
         }
 
         if(get_logger_layer_mode() & rocblaslt_layer_mode_log_extended_profile)
@@ -2112,7 +2111,7 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
                                                   kernel_name,
                                                   Solution_name,
                                                   flush,
-                                                  rotating_memory_size,
+                                                  rotatingBufferSize,
                                                   false);
         }
 
@@ -2507,8 +2506,8 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
 
         // Get the values of static member variables flush and rotating size from UserClientArguments
         UserClientArguments ClientArguments;
-        bool                flush                = ClientArguments.GetFlushValue();
-        int32_t             rotating_memory_size = ClientArguments.GetRotatingMemorySizeValue();
+        bool                flush              = ClientArguments.GetFlushValue();
+        int32_t             rotatingBufferSize = ClientArguments.GetRotatingBufferSizeValue();
 
         if(gemmType == rocblaslt::RocGemmType::ROCBLASLT_GEMM)
         {
@@ -2516,17 +2515,13 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
                 = std::static_pointer_cast<TensileDataGemm>(gemmData);
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem,
-                                            data->inputs,
-                                            data->algoIndex,
-                                            flush,
-                                            rotating_memory_size,
-                                            true);
+                logBenchFromTensileDataGemm(
+                    data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, true);
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)
             {
                 logProfileFromTensileDataGemm(
-                    data->problem, data->inputs, flush, rotating_memory_size, true);
+                    data->problem, data->inputs, flush, rotatingBufferSize, true);
             }
             status = hip2RocStatus(adapter->launchKernels(data->kernels, stream, start, stop));
         }
@@ -2542,12 +2537,8 @@ rocblaslt_status runKernelFromInvocation(rocblaslt_handle       handle,
             }
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_bench)
             {
-                logBenchFromTensileDataGemm(data->problem,
-                                            data->inputs,
-                                            data->algoIndex,
-                                            flush,
-                                            rotating_memory_size,
-                                            true);
+                logBenchFromTensileDataGemm(
+                    data->problem, data->inputs, data->algoIndex, flush, rotatingBufferSize, true);
             }
             //TODO: add profile logging for grouped gemm
             /*if(get_logger_layer_mode() & rocblaslt_layer_mode_log_profile)

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -333,5 +333,7 @@ std::string rocblaslt_matmul_desc_to_string(rocblaslt_matmul_desc matmul_desc)
 }
 
 // Define and initialize static member flush and rotatingBufferSize outside the class UserClientArguments
-bool    UserClientArguments::flush              = false;
-int32_t UserClientArguments::rotatingBufferSize = 0;
+bool    UserClientArguments::m_flush              = false;
+int32_t UserClientArguments::m_rotatingBufferSize = 0;
+int32_t UserClientArguments::m_coldIterations     = 0;
+int32_t UserClientArguments::m_hotIterations      = 0;

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -332,6 +332,6 @@ std::string rocblaslt_matmul_desc_to_string(rocblaslt_matmul_desc matmul_desc)
     return std::string(buf.get());
 }
 
-// Define and initialize static member flush and rotatingMemorySize outside the class UserClientArguments
+// Define and initialize static member flush and rotatingBufferSize outside the class UserClientArguments
 bool    UserClientArguments::flush              = false;
-int32_t UserClientArguments::rotatingMemorySize = 0;
+int32_t UserClientArguments::rotatingBufferSize = 0;

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -240,6 +240,8 @@ const char* rocblaslt_layer_mode2string(rocblaslt_layer_mode layer_mode)
         return "Bench";
     case rocblaslt_layer_mode_log_profile:
         return "Profile";
+    case rocblaslt_layer_mode_log_extended_profile:
+        return "ExtendedProfile";
     default:
         return "Invalid";
     }

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -331,3 +331,7 @@ std::string rocblaslt_matmul_desc_to_string(rocblaslt_matmul_desc matmul_desc)
                      hipDataType_to_string(matmul_desc->bias_type));
     return std::string(buf.get());
 }
+
+// Define and initialize static member flush and rotatingMemorySize outside the class UserClientArguments
+bool    UserClientArguments::flush              = false;
+int32_t UserClientArguments::rotatingMemorySize = 0;


### PR DESCRIPTION
1. Added Extended profile logging which prints out extra information: Solution Index, Solution name and Kernel name.
2. Add flush and rotating size to bench, profile and Extended profile logging.