### PR TITLE
Fix: abnormal terminal output if the first solution is rejected when printWinnerOnly is enabled

### DIFF
--- a/tensilelite/Tensile/Source/client/include/LogReporter.hpp
+++ b/tensilelite/Tensile/Source/client/include/LogReporter.hpp
@@ -204,7 +204,7 @@ namespace TensileLite
             {
                 if(value == "PASSED" || value == "NO_CHECK")
                     m_rowLevel = LogLevel::Normal;
-                else if(value == "FAILED" || value == "FAILED_CONV")
+                else if(value == "FAILED")
                     m_rowLevel = LogLevel::Error;
                 else if(value == "WRONG_HARDWARE")
                     m_rowLevel = LogLevel::Terse;
@@ -343,14 +343,15 @@ namespace TensileLite
             {
                 std::unordered_map<std::string, std::string> curRow;
                 m_csvOutput.readCurrentRow(curRow);
-                bool validation = curRow[ResultKey::Validation] == "PASSED"
-                                  || curRow[ResultKey::Validation] == "NO_CHECK";
+                bool  validation    = !(curRow[ResultKey::Validation] == "FAILED"
+                                    || curRow[ResultKey::Validation] == "INVALID");
                 float currentTimeUS = std::stof(curRow[ResultKey::TimeUS]);
                 if(m_rowLevel <= m_level
                    && (!m_PrintWinnersOnly || currentTimeUS < m_winner || !validation
                        || m_firstRun))
                 {
-                    if(std::isnan(currentTimeUS) && validation)
+                    if(std::isnan(currentTimeUS) && !std::stof(curRow[ResultKey::SpeedGFlops])
+                       && validation)
                         std::cout << curRow[ResultKey::BenchmarkRunNumber] << ","
                                   << curRow[ResultKey::ProblemProgress] << ","
                                   << curRow[ResultKey::SolutionProgress]
@@ -358,7 +359,7 @@ namespace TensileLite
                                   << std::endl;
                     else
                         m_csvOutput.writeCurrentRow();
-                    if(validation)
+                    if(validation && !std::isnan(currentTimeUS))
                     {
                         m_winner = currentTimeUS;
                     }

--- a/tensilelite/Tensile/Source/client/include/ReferenceValidator.hpp
+++ b/tensilelite/Tensile/Source/client/include/ReferenceValidator.hpp
@@ -154,6 +154,7 @@ namespace TensileLite
             bool   m_validatedSolution = false;
             bool   m_errorInSolution   = false;
             bool   m_error             = false;
+            bool   m_executedSolution  = false;
             size_t m_errorsReported    = 0;
 
             bool validateSolution(std::shared_ptr<ProblemInputs> inputs);

--- a/tensilelite/Tensile/Source/client/source/ReferenceValidator.cpp
+++ b/tensilelite/Tensile/Source/client/source/ReferenceValidator.cpp
@@ -90,6 +90,7 @@ namespace TensileLite
         {
             m_validatedSolution = false;
             m_errorInSolution   = false;
+            m_executedSolution  = false;
         }
 
         bool ReferenceValidator::needMoreRunsInSolution() const
@@ -116,6 +117,7 @@ namespace TensileLite
                                             TimingEvents const& stopEvents,
                                             hipStream_t const&  stream)
         {
+            m_executedSolution = true;
         }
 
         bool ReferenceValidator::validateSolution(std::shared_ptr<ProblemInputs> inputs)
@@ -718,6 +720,9 @@ namespace TensileLite
 
         void ReferenceValidator::postSolution()
         {
+            if(!m_executedSolution)
+                return;
+
             if(m_enabled && !m_validatedSolution)
                 return;
 


### PR DESCRIPTION
If the first solution is rejected when printWinnerOnly is enabled, terminal output would show NO_CHECK but not DID_NOT_SATISFY_ASSERTS.
And the winner time would be recorded as NaN, which makes the following winner cannot be printed out anymore.