### PR TITLE
code-gen: improved tail loop and edge tile of swizzled A

### DIFF
--- a/tensilelite/Tensile/Contractions.py
+++ b/tensilelite/Tensile/Contractions.py
@@ -507,12 +507,13 @@ class ProblemPredicate(Properties.Predicate):
         if ('WorkGroupMappingXCC' in state) and ('WorkGroupMappingXCCGroup' in state):
             rv += [cls("WorkgroupMappingXCCCheck", value=[state['WorkGroupMappingXCC'], state['WorkGroupMappingXCCGroup']])]
 
-        # TODO- To improve the perf of these non-multiples cases
         if state['ProblemType']['SwizzleTensorA']:
             rv += [cls('SwizzleTensorA', value=state['ProblemType']['SwizzleTensorA'])]
-            rv += [cls("Free0SizeMultiple", index=0, value=state['MacroTile0'])]
-            rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
+            # TODO- (TT + DTVA) tail-loop is not working yet.
+            if state['ProblemType']['TransposeB']:
+                rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
 
+        # TODO- Will remove the size predicate once we have SWZ-B request
         if state['ProblemType']['SwizzleTensorB']:
             rv += [cls('SwizzleTensorB', value=state['ProblemType']['SwizzleTensorB'])]
             rv += [cls("Free1SizeMultiple", index=0, value=state['MacroTile1'])]

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2776,16 +2776,17 @@ class Solution(collections.abc.Mapping):
           reject(state, f"SwizzleTensor{tc} requires VectorWidth{tc} ({VW_TC}) == 1")
 
     if state["ProblemType"]["SwizzleTensorA"]:
-      if state["ProblemType"]["TransposeA"] is False:
-        reject(state, f"Tensor A swizzling supports TN or TT only")
-      if state["DirectToVgprA"] is False:
+      if not state["DirectToVgprA"]:
         reject(state, f"Tensor A swizzling requires DirectToVgprA")
+      if not state["ProblemType"]["TransposeA"]:
+        reject(state, f"Tensor A swizzling supports TN or TT only")
 
     if state["ProblemType"]["SwizzleTensorB"]:
-      if state["ProblemType"]["TransposeB"] is True:
-        reject(state, f"Tensor B swizzling supports NN or TN only")
-      if state["DirectToVgprB"] is False:
+      if not state["DirectToVgprB"]:
         reject(state, f"Tensor B swizzling requires DirectToVgprB")
+      # TODO- NN fails validation due to DTVB + Tail-Loop is not working correctly
+      if not (state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
+        reject(state, f"Tensor B swizzling supports TN only")
 
     def calcOptGRVW(lrvw: int, unrollMajorLDS: bool, datatype: DataType) -> int:
       # with UnrollMajorLDS, GRVW need to less or equal than LRVW to have conflict free LDS read with padding.

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -95,9 +95,10 @@ BenchmarkProblems:
           - Exact: [160,   256, 1, 256]
           - Exact: [160,   256, 1, 288]
 
-          - Exact: [1600,  512, 1, 992]
-          - Exact: [1600,  512, 1, 1024]
-          - Exact: [1600,  512, 1, 1056]
+          # Enable the big sizes when GSU3 + MBSK is ready.
+          # - Exact: [1600,  512, 1, 992]
+          # - Exact: [1600,  512, 1, 1024]
+          # - Exact: [1600,  512, 1, 1056]
 
           - Exact: [512,   256, 1, 224]
           - Exact: [512,   256, 1, 256]

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -11,6 +11,8 @@ GlobalParameters:
   MergeFiles: False
   KernelTime: True
   MaxWorkspaceSize: 13421772800
+  DataInitTypeA: 13
+  DataInitTypeB: 13
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
   BoundsCheck: 2
@@ -55,9 +57,11 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,   4, 16, 4,1 ] # MT = 256x256
           - [16, 16, 16, 1,  1,   8, 8,  4,1 ] # MT = 512x128
           - [16, 16, 16, 1,  1,   8, 16, 4,1 ] # MT = 512x256
-          - [16, 16, 16, 1,  1,   5, 8,  2, 1 ] # MT = 160x128
+          - [16, 16, 16, 1,  1,   5, 8,  2,1 ] # MT = 160x128
+        - AssertFree0ElementMultiple: [16]
+        - AssertSummationElementMultiple: [32]
         - GlobalReadVectorWidthA: [8]
-        - GlobalReadVectorWidthB: [2,4,8]
+        - GlobalReadVectorWidthB: [-1]
         - PrefetchGlobalRead: [1,2]
         - PrefetchLocalRead: [1,2,4]
         - ClusterLocalRead: [1]
@@ -68,7 +72,7 @@ BenchmarkProblems:
         - LocalWritePerMfma: [-1]
         - StaggerU: [4]
         - StaggerUStride: [256]
-        - StaggerUMapping: [2]
+        - StaggerUMapping: [0]
         - WorkGroupMappingXCC: [8]
         - ScheduleIterAlg: [3]
         - LdsBlockSizePerPadA: [-1]
@@ -87,9 +91,17 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
+          - Exact: [160,   256, 1, 224]
           - Exact: [160,   256, 1, 256]
+          - Exact: [160,   256, 1, 288]
+
+          - Exact: [1600,  512, 1, 992]
           - Exact: [1600,  512, 1, 1024]
+          - Exact: [1600,  512, 1, 1056]
+
+          - Exact: [512,   256, 1, 224]
           - Exact: [512,   256, 1, 256]
+          - Exact: [512,   256, 1, 288]
         - BiasTypeArgs: ['h']
         - ActivationArgs:
           - [Enum: none]


### PR DESCRIPTION
- [x] Removed FreeSize0 and BoundSize predicates
- [x] Improved tail-loop perf
- [x] Minor bugs fixed: kernels with STA_DTVA0 or STB_DTVB0 should be rejected.
- [x] Spotted existing failure with DTV kernels: "DTVA + TT + Tail" and "DTVB + NN + Tail"
- [x] Updated pytest

=========================== 1 passed, 4 warnings in 260.42s (0:04:20) ===========================
py310: exit 0 (260.65 seconds) 
  py310: OK (417.47=setup[14.29]+cmd[1.43,141.10,260.65] seconds)
  congratulations :) (417.52 seconds)