### PR TITLE
Add alternative tool for incremental builds when tuning

### DIFF
--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -42,9 +42,19 @@
 #
 # One can invoke make with this Makefile as follows:
 #
-# make co PROBLEM_DIR=bar-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_1
+# make co PROBLEM_DIR=tensile-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_1
 #
 # where PROBLEM_DIR is the relative path to one problem directory.
+#
+# The Makefile will set the target based on the name of the co file and sets
+# a default wavefront flag but each of these can be customized as follows:
+#
+# make co PROBLEM_DIR=tensile-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_DB_UserArgs_00 \
+#         ARCH="gfx942:xnack-"\
+#         WAVEFRONTSIZE="-mno-wavefrontsize64"
+#
+# In addition, we provide `ASM_ARGS` and `LINK_ARGS` as additional customization
+# points for the assemble and link step respectively.
 # ------------------------------------------------------------------------
 
 AS := /opt/rocm/bin/amdclang++
@@ -54,6 +64,7 @@ OBJFILES := $(patsubst %.s,%.o,$(SRCFILES))
 COFILE := $(shell find ${PROBLEM_DIR}/00_Final/source/library -name '*.co')
 ARCH := $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 WAVEFRONTSIZE := -mwavefrontsize64
+
 co: $(COFILE)
 
 $(COFILE): $(OBJFILES)
@@ -63,4 +74,3 @@ $(COFILE): $(OBJFILES)
 %.o: %.s
 	@echo rebuilding $(lastword $(subst /, ,$@))
 	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${ARCH} ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
-

--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -1,0 +1,66 @@
+# ########################################################################
+# Copyright (C) 2024 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+
+# ------------------------------------------------------------------------
+#
+# Usage:
+# 
+# Assuming one runs the following Tensile command:
+#
+#   Tensile/bin/Tensile <yaml> tensile-out
+#
+# where tensile-out has the following directory structure:
+#
+# tensile-out
+# ├── 0_Build
+# ├── 1_BenchmarkProblems
+# │   ├── Cijk_Ailk_Bjlk_1
+# |   ├── Cijk_Ailk_Bjlk_2
+# |   ...
+# |   ├── Cijk_Ailk_Bjlk_N
+#
+# One can invoke make with this Makefile as follows:
+#
+# make co PROBLEM_DIR=bar-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_1
+#
+# where PROBLEM_DIR is the relative path to one problem directory.
+# ------------------------------------------------------------------------
+
+AS := /opt/rocm/bin/amdclang++
+LDD := /opt/rocm/bin/amdclang++
+SRCFILES := $(shell find ${PROBLEM_DIR}/00_Final/source/build_tmp/SOURCE/assembly -name '*.s')
+OBJFILES := $(patsubst %.s,%.o,$(SRCFILES))
+COFILE := $(shell find ${PROBLEM_DIR}/00_Final/source/library -name '*.co')
+ARCH := $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
+WAVEFRONTSIZE := -mwavefrontsize64
+co: $(COFILE)
+
+$(COFILE): $(OBJFILES)
+	@echo relinking $(lastword $(subst /, ,$@))
+	@$(LDD) -target amdgcn-amd-amdhsa -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
+
+%.o: %.s
+	@echo rebuilding $(lastword $(subst /, ,$@))
+	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${ARCH} ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+

--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -41,14 +41,15 @@
 #
 # make co TENSILE_OUT=tensile-out ARCH="gfx942:xnack-" WAVEFRONTSIZE="-mno-wavefrontsize64"
 #
-# In addition, we provide AS and ASM_ARGS, and LD LINK_ARGS as customization
+# In addition, we provide AS and ASM_ARGS, and LD and LINK_ARGS as customization
 # points for the assemble and link step respectively.
 # ------------------------------------------------------------------------
 
 ROCM_PATH ?= /opt/rocm
 AS := $(ROCM_PATH)/bin/amdclang++
 LDD := $(ROCM_PATH)/bin/amdclang++
-WAVEFRONTSIZE ?= -mwavefrontsize64
+WAVE ?= 64
+WAVEFRONTSIZE ?= $(if $(WAVE:32=),-mwavefrontsize64, -mno-wavefrontsize64)
 
 .SECONDEXPANSION:
 co: COFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/*/00_Final/source/library -name '*.co')
@@ -67,4 +68,4 @@ ${TENSILE_OUT}/1_BenchmarkProblems%.co: $$(OBJFILES)
      ARCH ?= $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 %.o: %.s
 	@echo rebuilding $(lastword $(subst /, ,$@)) for $(ARCH)
-	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=$(ARCH) ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+	$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=$(ARCH) ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^

--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -45,9 +45,10 @@
 # points for the assemble and link step respectively.
 # ------------------------------------------------------------------------
 
-AS := /opt/rocm/bin/amdclang++
-LDD := /opt/rocm/bin/amdclang++
-WAVEFRONTSIZE := -mwavefrontsize64
+ROCM_PATH ?= /opt/rocm
+AS := $(ROCM_PATH)/bin/amdclang++
+LDD := $(ROCM_PATH)/bin/amdclang++
+WAVEFRONTSIZE ?= -mwavefrontsize64
 
 .SECONDEXPANSION:
 co: COFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/*/00_Final/source/library -name '*.co')
@@ -61,10 +62,9 @@ ${TENSILE_OUT}/1_BenchmarkProblems%.co: $$(OBJFILES)
 	@echo relinking $(PROBLEM) $(lastword $(subst /, ,$@))
 	@$(LDD) -target amdgcn-amd-amdhsa -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
 
-.SECONDEXPANSION:
-#.o: PROBLEM = $(word 3 $(subst /, ,$@))
-#     COFILE = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$$(PROBLEM)/00_Final/source/library -name '*.co')
-#     ARCH = $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$$(COFILE)))))
+%.o: PROBLEM = $(word 3, $(subst /, ,$*))
+     COFILE = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$(PROBLEM)/00_Final/source/library -name '*.co')
+     ARCH ?= $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 %.o: %.s
 	@echo rebuilding $(lastword $(subst /, ,$@)) for $(ARCH)
-	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${ARCH} ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=$(ARCH) ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^

--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -21,7 +21,6 @@
 #
 # ########################################################################
 
-
 # ------------------------------------------------------------------------
 #
 # Usage:
@@ -30,47 +29,39 @@
 #
 #   Tensile/bin/Tensile <yaml> tensile-out
 #
-# where tensile-out has the following directory structure:
+# One can invoke make from the directory containing this Makefile as follows:
 #
-# tensile-out
-# ├── 0_Build
-# ├── 1_BenchmarkProblems
-# │   ├── Cijk_Ailk_Bjlk_1
-# |   ├── Cijk_Ailk_Bjlk_2
-# |   ...
-# |   ├── Cijk_Ailk_Bjlk_N
+# make co TENSILE_OUT=tensile-out
 #
-# One can invoke make with this Makefile as follows:
+# where TENSILE_OUT is the relative path to the tensile output directory.
 #
-# make co PROBLEM_DIR=tensile-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_1
+# The Makefile will set the target based on the name of the co files in 
+# the library directory and sets a default wavefront flag but each of 
+# these can be customized as follows:
 #
-# where PROBLEM_DIR is the relative path to one problem directory.
+# make co TENSILE_OUT=tensile-out ARCH="gfx942:xnack-" WAVEFRONTSIZE="-mno-wavefrontsize64"
 #
-# The Makefile will set the target based on the name of the co file and sets
-# a default wavefront flag but each of these can be customized as follows:
-#
-# make co PROBLEM_DIR=tensile-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_DB_UserArgs_00 \
-#         ARCH="gfx942:xnack-"\
-#         WAVEFRONTSIZE="-mno-wavefrontsize64"
-#
-# In addition, we provide `ASM_ARGS` and `LINK_ARGS` as additional customization
+# In addition, we provide AS and ASM_ARGS, and LD LINK_ARGS as customization
 # points for the assemble and link step respectively.
 # ------------------------------------------------------------------------
 
 AS := /opt/rocm/bin/amdclang++
 LDD := /opt/rocm/bin/amdclang++
-SRCFILES := $(shell find ${PROBLEM_DIR}/00_Final/source/build_tmp/SOURCE/assembly -name '*.s')
-OBJFILES := $(patsubst %.s,%.o,$(SRCFILES))
-COFILE := $(shell find ${PROBLEM_DIR}/00_Final/source/library -name '*.co')
+
 ARCH := $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 WAVEFRONTSIZE := -mwavefrontsize64
 
-co: $(COFILE)
+.SECONDEXPANSION:
+co: COFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/*/00_Final/source/library -name '*.co')
+co: $$(COFILES)
 
-$(COFILE): $(OBJFILES)
-	@echo relinking $(lastword $(subst /, ,$@))
+.SECONDEXPANSION:
+${TENSILE_OUT}/1_BenchmarkProblems%.co: PROBLEM  = $(firstword $(subst /, ,$*))
+                                        OBJFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$(PROBLEM)/00_Final/source/build_tmp/SOURCE/assembly -name '*.o')
+${TENSILE_OUT}/1_BenchmarkProblems%.co: $$(OBJFILES)
+	@echo relinking $(PROBLEM) $(lastword $(subst /, ,$@))
 	@$(LDD) -target amdgcn-amd-amdhsa -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
 
 %.o: %.s
 	@echo rebuilding $(lastword $(subst /, ,$@))
-	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${ARCH} ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=gfx90a ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^

--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -47,8 +47,6 @@
 
 AS := /opt/rocm/bin/amdclang++
 LDD := /opt/rocm/bin/amdclang++
-
-ARCH := $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 WAVEFRONTSIZE := -mwavefrontsize64
 
 .SECONDEXPANSION:
@@ -57,11 +55,16 @@ co: $$(COFILES)
 
 .SECONDEXPANSION:
 ${TENSILE_OUT}/1_BenchmarkProblems%.co: PROBLEM  = $(firstword $(subst /, ,$*))
-                                        OBJFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$(PROBLEM)/00_Final/source/build_tmp/SOURCE/assembly -name '*.o')
+                                        SRCFILES = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$(PROBLEM)/00_Final/source/build_tmp/SOURCE/assembly -name '*.s')
+                                        OBJFILES = $(patsubst %.s,%.o,$(SRCFILES))
 ${TENSILE_OUT}/1_BenchmarkProblems%.co: $$(OBJFILES)
 	@echo relinking $(PROBLEM) $(lastword $(subst /, ,$@))
 	@$(LDD) -target amdgcn-amd-amdhsa -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
 
+.SECONDEXPANSION:
+#.o: PROBLEM = $(word 3 $(subst /, ,$@))
+#     COFILE = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$$(PROBLEM)/00_Final/source/library -name '*.co')
+#     ARCH = $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$$(COFILE)))))
 %.o: %.s
-	@echo rebuilding $(lastword $(subst /, ,$@))
-	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=gfx90a ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+	@echo rebuilding $(lastword $(subst /, ,$@)) for $(ARCH)
+	@$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=${ARCH} ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -471,8 +471,6 @@ def writeSolutionsAndKernels(outputPath, CxxCompiler, problemTypes, solutions, k
   ##############################################################################
   kernelsWithBuildErrs = {}
 
-  prepAsm(kernelWriterAssembly)
-
   # Kernels may be intended for different co files, but generate the same .o file
   # Mark duplicate kernels to avoid race condition
   # @TODO improve organization so this problem doesn't appear

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -361,65 +361,6 @@ def buildSourceCodeObjectFiles(CxxCompiler, kernelFiles, outputPath):
 
     return itertools.chain.from_iterable(coFiles)
 
-################################################################################
-def prepAsm(kernelWriterAssembly):
-  """
-  Create and prepare the assembly directory  - called ONCE per output dir:
-  """
-  asmPath = ensurePath(os.path.join(globalParameters["WorkingPath"], "assembly") )
-  assemblerFileName = os.path.join(asmPath, \
-      "asm-new.%s"%("bat" if os.name=="nt" else "sh"))
-  assemblerFile = open(assemblerFileName, "w")
-  if os.name == "nt":
-    assemblerFile.write("echo Windows: Copying instead of Assembling\n")
-    assemblerFile.write("copy %1.s %1.o\n")
-    assemblerFile.write("copy %1.o %1.co\n")
-  else:
-    assemblerFile.write("#!/bin/sh {log}\n".format(log = "-x" if globalParameters["PrintLevel"] >=2  else ""))
-    assemblerFile.write("# usage: asm-new.sh kernelName(no extension) [--wave32]\n")
-
-    assemblerFile.write("f=$1\n")
-    assemblerFile.write("filename=${1##*/}\n")
-    assemblerFile.write("dirname=${1%/*}\n")
-    assemblerFile.write("shift\n")
-    assemblerFile.write('if [ ! -z "$1" ] && [ "$1" = "--wave32" ]; then\n')
-    assemblerFile.write("    wave=32\n")
-    assemblerFile.write("    shift\n")
-    assemblerFile.write("else\n")
-    assemblerFile.write("    wave=64\n")
-    assemblerFile.write("fi\n")
-
-
-    isa = globalParameters["CurrentISA"]
-    assemblerFile.write("h={gfxName}\n".format(gfxName = getGfxName(isa)))
-
-    debug = globalParameters.get("AsmDebug", False)
-    cArgs32 = kernelWriterAssembly.getCompileArgs("$f.s", "$f.o", isa=isa, wavefrontSize=32, debug=debug)
-    cArgs64 = kernelWriterAssembly.getCompileArgs("$f.s", "$f.o", isa=isa, wavefrontSize=64, debug=debug)
-    lArgs = kernelWriterAssembly.getLinkCodeObjectArgs(["$f.o"], "$f.co")
-
-    assemblerFile.write("if [ $wave -eq 32 ]; then\n")
-    assemblerFile.write(" ".join(cArgs32) + "\n")
-    assemblerFile.write("else\n")
-    assemblerFile.write(" ".join(cArgs64) + "\n")
-    assemblerFile.write("fi\n")
-
-
-    assemblerFile.write(" ".join(lArgs) + "\n")
-
-    assemblerFile.write("ERR=$?\n")
-    assemblerFile.write("if [ $ERR -ne 0 ]\n")
-    assemblerFile.write("then\n")
-    assemblerFile.write("    echo one\n")
-    assemblerFile.write("    exit $ERR\n")
-    assemblerFile.write("fi\n")
-
-    assemblerFile.write("cp $f.co ${dirname}/../../../library/${filename}_$h.co\n")
-    assemblerFile.write("mkdir -p ${dirname}/../../../asm_backup && ")
-    assemblerFile.write("cp $f.s ${dirname}/../../../asm_backup/${filename}.s\n")
-
-  assemblerFile.close()
-  os.chmod(assemblerFileName, 0o777)
 
 ################################################################################
 def buildKernelSourceAndHeaderFiles(results, outputPath, kernelsWithBuildErrs):


### PR DESCRIPTION
During the tuning process, it is of interest to modify an assembly file/s and rebuild the corresponding object file/s and then relink the corresponding co file. Currently, we generate additional source files and a script to provide this workflow (which requires using `MergeFiles: False`). 

This PR adds a new `Makefile` that manages rebuilding a co file during iterative development when tuning. One modifies an assembly file of interest, then runs `make` and make will detect what file/s changed and rebuild accordingly.

Assumptions:

- Each problem directory contains a library directory with one co file corresponding to one architecture

Example:

```
cd hipBLASLt/tensilelite
Tensile/bin/Tensile Tensile/Tests/gemm/fp16_use_e.yaml tensile-out
# modify an assembly file in tensile-out/1_BenchmarkProblems/Cijk_Ailk_Bjlk_DB_UserArgs_00/00_Final/source/build_tmp/SOURCE/assembly
make co TENSILE_OUT=tensile-out
# re-run the client
```

The Makefile will set the target based on the name of the co file and sets a default wavefront flag but each of these can be customized as follows:

```
make co TENSILE_OUT=tensile-out ARCH="gfx942:xnack-" WAVEFRONTSIZE="-mwavefrontsize64"
```

In addition, we provide `ASM_ARGS` and `LINK_ARGS` as additional customization points for the assemble and link step respectively.