### PR TITLE
Patch unsupported assignment expression for py36

### DIFF
--- a/tensilelite/Tensile/BuildCommands/SourceCommands.py
+++ b/tensilelite/Tensile/BuildCommands/SourceCommands.py
@@ -163,7 +163,8 @@ def _buildSourceCodeObjectFile(cxxCompiler: str, outputPath: Union[Path, str], k
       raise RuntimeError("No bundler found; set TENSILE_ROCM_OFFLOAD_BUNDLER_PATH to point to clang-offload-bundler")
 
     for target in _listTargetTriples(bundler, objPath):
-      if match := re.search("gfx.*$", target):
+      match = re.search("gfx.*$", target)
+      if match:
         arch = re.sub(":", "-", match.group())
         coPathRaw = _computeSourceCodeObjectFilename(target, kernelPath.stem, buildPath, arch)
         if not coPathRaw: continue


### PR DESCRIPTION
Python 3.6 doesn't support the assignment expression operator. This simple PR to removes the unsupported operator.

**Testing**
Environment: Docker, Python 3.6.8, Almalinux 8.10, ROCm 6.2.0 stack
Test command: `./install.sh -a gfx1101 --debug`