### PR TITLE
Remove unused dependencies for Tensilelite.

### DIFF
--- a/tensilelite/requirements.txt
+++ b/tensilelite/requirements.txt
@@ -4,6 +4,3 @@ pyyaml
 msgpack
 joblib>=1.4.0; python_version >= '3.8'
 joblib>=1.1.1; python_version < '3.8'
-simplejson
-ujson
-orjson


### PR DESCRIPTION
Fix: https://ontrack-internal.amd.com/browse/SWDEV-504328

Build successful with removal of these dependencies (simplejson, ujson, orjson) as they are seemingly unused in the project, but kept 'packages' as it is used in 'Tensile/Parallel.py'.