### PR TITLE
Use archVGPR when accVGPR is not enough.

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -195,6 +195,8 @@ class StateValues:
   bias: MatrixInfo                       = field(default_factory=MatrixInfo)
   m: ABMatrixInfo                        = field(default_factory=ABMatrixInfo)       # For Sparse Metadata
   totalAgprs: int                        = 0
+  maxLimitAgprs: int                     = 0
+  totalMixedAgprs: int                   = 0
   totalVgprs: int                        = 0
   totalSgprs: int                        = 0
   lastValuAB: int                        = 0
@@ -3629,7 +3631,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # VGPR Assignment
     ####################################
     vgprIdx = 0
-    self.states.totalAgprs = 0
+    self.states.totalAgprs      = 0
+    self.states.totalMixedAgprs = 0
+    self.states.maxLimitAgprs   = self.states.regCaps["PhysicalMaxVgpr"] - self.states.regCaps["MaxVgpr"]
     self.states.c.startVgprValu = vgprIdx; vgprIdx += self.states.c.numVgprValu
 
     if kernel["EnableMatrixInstruction"]:
@@ -3647,8 +3651,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       ########################################
       if not kernel["MIArchVgpr"]:
         self.states.totalAgprs = self.states.c.numVgprValu
-        vgprIdx = 0
-        self.states.c.numVgprValu = 0
+        if self.states.totalAgprs > self.states.maxLimitAgprs:
+          self.states.totalMixedAgprs = self.states.totalAgprs - self.states.maxLimitAgprs
+          self.states.totalAgprs      = self.states.maxLimitAgprs
+        vgprIdx = self.states.totalMixedAgprs
+        self.states.c.numVgprValu = self.states.totalMixedAgprs
 
     # TODO: alignment hack, figure out a better solution
     vgprIdx = ((vgprIdx+1)//2)*2

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3781,15 +3781,15 @@ class KernelWriterAssembly(KernelWriter):
     module.addComment1("initC: remove acc vgpr buffer [%u...%u) from pool"%(0, numAccvgprs))
     self.vgprPool.remove(self.states.a.startVgprValu , self.states.lastValuAB - self.states.a.startVgprValu , "ValuAB")
     module.addComment1("initC: remove ValuA/B vgpr buffer [%u...%u) from pool"%(self.states.a.startVgprValu , self.states.lastValuAB))
-    numCVgpr = max(self.states.c.numVgprValu, numAccvgprs)
+    numCVgpr = self.states.c.numVgprValu + numAccvgprs
 
     if kernel["LdsInitCVgprs"]:
       tmpAddr = self.vgprPool.checkOut(1,"tmp vgpr for lds init C registers")
       module.add(VMovB32(dst=vgpr(tmpAddr), src=self.consts.ldsOOB, comment="set out-of-bound addr"))
 
     for i in range(0, numCVgpr):
-      copyInst = VMovB32 if self.states.c.numVgprValu else VAccvgprWrite
-      regStr = vgpr("ValuC+%u"%i) if self.states.c.numVgprValu else accvgpr(i)
+      copyInst = VMovB32 if i >= numAccvgprs else VAccvgprWrite
+      regStr = vgpr("ValuC+%u"%(i-numAccvgprs)) if i >= numAccvgprs else accvgpr(i)
       if not kernel["LdsInitCVgprs"]:
         module.add(copyInst(dst=regStr, src=hex(0), comment="initC"))
       else:
@@ -5100,9 +5100,9 @@ class KernelWriterAssembly(KernelWriter):
       #instCycles = kernel["MatrixInstM"] // 2 # 32x32 is 64 cycles, 16x16 is 32 cycles, 4x4 is 8 cycles
       #module.add(SNop(waitState=instCycles))
       module.addComment1("Mapping of Acc register -> C Vgpr register")
-      self.codes.accVgprRead = mapAcctoArchRegs(kernel, write=False)
+      self.codes.accVgprRead = mapAcctoArchRegs(kernel, self.states.maxLimitAgprs, write=False)
       if kernel["StreamK"] > 0 and kernel["StreamKAtomic"] == 0:
-        self.codes.accVgprWrite = mapAcctoArchRegs(kernel, write=True)
+        self.codes.accVgprWrite = mapAcctoArchRegs(kernel, self.states.maxLimitAgprs, write=True)
       if kernel["MIArchVgpr"]:
         module.addComment1("Multiply MI out register with Alpha -> C Vgpr register")
         self.codes.mulAlphaMultipleBuffer = moveMIoutToArch(kernel, self.states.startVgprAlphaTmp)
@@ -5181,6 +5181,26 @@ class KernelWriterAssembly(KernelWriter):
     return imod
 
   ##############################################################################
+  # ACC Vgpr R/W Function
+  ##############################################################################
+  def accVgprReadWriteFunction(self, kernel, idx, read=True):
+    if not kernel["MIArchVgpr"]:
+      if idx >= self.states.maxLimitAgprs:
+        return VMovB32
+      else:
+        return VAccvgprReadB32 if read else VAccvgprWriteB32
+    else:
+      return VMovB32
+  def accVgprReadWriteIndex(self, kernel, idx, sz=1):
+    if not kernel["MIArchVgpr"]:
+      if idx >= self.states.maxLimitAgprs:
+        return vgpr(idx - self.states.maxLimitAgprs, sz)
+      else:
+        return accvgpr(idx, sz)
+    else:
+      return vgpr(idx, sz)
+
+  ##############################################################################
   # MFMA Iteration
   ##############################################################################
   def mfmaIter(self, kernel, tPA, tPB, u, innerUnroll, vregSetIdx, unrollLoopIdx = 0, unrollIdx = 0, tail = False, firstIter = False):
@@ -5215,7 +5235,6 @@ class KernelWriterAssembly(KernelWriter):
     vgprPerInput     = max(vgprPerInputA,vgprPerInputB)
     shiftPerElement  = int(numRegistersIn * 32)
     s_nop            = 0
-    gprfunc          = accvgpr if not kernel["MIArchVgpr"] else vgpr
     accumRegType     = "acc" if not kernel["MIArchVgpr"] else "v"
     mfma_1k          = True if kernel["MFMA_BF16_1K"] else False
     accStoreCIdx     = 0
@@ -5589,19 +5608,19 @@ class KernelWriterAssembly(KernelWriter):
                 imod.add(inst)
             variant = [kernel["MatrixInstM"], kernel["MatrixInstN"], kernel["MatrixInstK"], kernel["MatrixInstB"]]
             imod.add(MFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=False, \
-                     acc=gprfunc(accStart, (accEnd-accStart+1)), a=src0, b=src1, acc2=gprfunc(accStart, (accEnd-accStart+1)), \
+                     acc=self.accVgprReadWriteIndex(kernel, accStart, (accEnd-accStart+1)), a=src0, b=src1, acc2=self.accVgprReadWriteIndex(kernel, accStart, (accEnd-accStart+1)), \
                      comment="Cr += Ar*Br"))
             (src0, src1) = (bi, (vgpr(ccVgprs[0] + offsetVgpr[0], numRegistersOut) if ccVgprs[0] else ai)) if kernel["SourceSwap"] else ((vgpr(ccVgprs[0] + offsetVgpr[0], numRegistersOut) if ccVgprs[0] else ai), bi)
             imod.add(MFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=False, \
-                     acc=gprfunc((accStart+accStoreCIdx), (accEnd-accStart+1)), a=src0, b=src1, acc2=gprfunc(accStart, (accEnd-accStart+1)), \
+                     acc=self.accVgprReadWriteIndex(kernel, (accStart+accStoreCIdx), (accEnd-accStart+1)), a=src0, b=src1, acc2=self.accVgprReadWriteIndex(kernel, accStart, (accEnd-accStart+1)), \
                      comment="Cr += %sAi*Bi"%("-" if ccVgprs[0] else "")))
             (src0, src1) = (br, (vgpr(ccVgprs[1] + offsetVgpr[1], numRegistersOut) if ccVgprs[1] else ai)) if kernel["SourceSwap"] else ((vgpr(ccVgprs[1] + offsetVgpr[1], numRegistersOut) if ccVgprs[1] else ai), br)
             imod.add(MFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=False, \
-                     acc=gprfunc((accStart+accImOffset), (accEnd-accStart+1)), a=src0, b=src1, acc2=gprfunc(accStartSrcImg, (accEndSrcImg-accStartSrcImg+1)), \
+                     acc=self.accVgprReadWriteIndex(kernel, (accStart+accImOffset), (accEnd-accStart+1)), a=src0, b=src1, acc2=self.accVgprReadWriteIndex(kernel, accStartSrcImg, (accEndSrcImg-accStartSrcImg+1)), \
                      comment="Ci += %sAi*Br"%("-" if ccVgprs[1] else "")))
             (src0, src1) = (bi, (vgpr(ccVgprs[2] + offsetVgpr[2], numRegistersOut) if ccVgprs[2] else ar)) if kernel["SourceSwap"] else ((vgpr(ccVgprs[2] + offsetVgpr[2], numRegistersOut) if ccVgprs[2] else ar), bi)
             imod.add(MFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=False, \
-                     acc=gprfunc((accStart+accImOffset+accStoreCIdx), (accEnd-accStart+1)), a=src0, b=src1, acc2=gprfunc(accStartSrcImg, (accEndSrcImg-accStartSrcImg+1)), \
+                     acc=self.accVgprReadWriteIndex(kernel, (accStart+accImOffset+accStoreCIdx), (accEnd-accStart+1)), a=src0, b=src1, acc2=self.accVgprReadWriteIndex(kernel, accStartSrcImg, (accEndSrcImg-accStartSrcImg+1)), \
                      comment="Ci += %sAr*Bi"%("-" if ccVgprs[2] else "")))
             for v in ccVgprs:
               if v is not None: self.vgprPool.checkIn(v)
@@ -5625,18 +5644,18 @@ class KernelWriterAssembly(KernelWriter):
                 idx = idx1 if kernel["ProblemType"]["Sparse"] == 2 else idx0
                 accInStart = miWaveTile * kernel["LoopIters"] * unrollLoopIdx + idx * kernel["LoopIters"] + unrollIdx
                 imod.add(SMFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=mfma_1k, \
-                                        acc=gprfunc((accStart+accStoreCIdx), (accEnd-accStart+1)), \
+                                        acc=self.accVgprReadWriteIndex(kernel, (accStart+accStoreCIdx), (accEnd-accStart+1)), \
                                         a=src0, b=src1, metadata=vgpr("ValuMetadata+%u"%(accInStart)), \
                                         comment="left value = %s[%u+%u:%u+%u]" % (accumRegType, accStart, accStoreCIdx, accEnd, accStoreCIdx)))
               else:
                 imod.add(SMFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=mfma_1k, \
-                           acc=gprfunc((accStart+accStoreCIdx), (accEnd-accStart+1)), \
+                           acc=self.accVgprReadWriteIndex(kernel, (accStart+accStoreCIdx), (accEnd-accStart+1)), \
                            a=src0, b=src1, metadata=mStr, \
                            comment="left value = %s[%u+%u:%u+%u]" % (accumRegType, accStart, accStoreCIdx, accEnd, accStoreCIdx)))
             else:
               imod.add(MFMAInstruction(instType=miInInstType, accType=miOutInstType, variant=variant, mfma1k=mfma_1k, \
-                                       acc=gprfunc((accStart+accStoreCIdx), (accEnd-accStart+1)), \
-                                       a=src0, b=src1, acc2=gprfunc(accStart, (accEnd-accStart+1)), neg=neg_flag,\
+                                       acc=self.accVgprReadWriteIndex(kernel, (accStart+accStoreCIdx), (accEnd-accStart+1)), \
+                                       a=src0, b=src1, acc2=self.accVgprReadWriteIndex(kernel, accStart, (accEnd-accStart+1)), neg=neg_flag,\
                                        comment="left value = %s[%u+%u:%u+%u]" % (accumRegType, accStart, accStoreCIdx, accEnd, accStoreCIdx)))
             prevAccIdx = accIdx
 

--- a/tensilelite/Tensile/Tests/common/gemm/largeMT.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/largeMT.yaml
@@ -1,0 +1,378 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  MinimumRequiredVersion: 4.14.0
+  PrintLevel: 1
+  PrintSolutionRejectionReason: True
+  Device: 0
+  CMakeBuildType: Release
+  MergeFiles: False
+  KernelTime: True
+  MaxWorkspaceSize: 13421772800
+  DataInitTypeAlpha: 1
+  DataInitTypeBeta: 0
+  NumElementsToValidate: -1
+  BoundsCheck: 2
+
+BenchmarkProblems:
+  ########################################
+  # BBS TN + DTVA
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: b
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Activation: True
+      ActivationType: hipblaslt_all
+      UseScaleAlphaVec: 1
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1, 5, 16, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 16, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 17, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 18, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 19, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 20, 4, 1]
+          - [16, 16, 16, 1,  1, 4, 21, 4, 1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - GlobalReadVectorWidthA: [4, 8]
+        - GlobalReadVectorWidthB: [-1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - DirectToVgprA: [1]
+        - VectorWidthA: [1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [32]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+        - WorkGroupMapping: [6]
+        - WorkGroupMappingXCC: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+        - GlobalSplitU: [1] #[1,2]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer",] #["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1,     127, 1, 127]
+          - Exact: [2,     127, 1, 127]
+          - Exact: [3,     127, 1, 127]
+          - Exact: [1,     1,   1, 127]
+          - Exact: [127,   1,   1, 127]
+          - Exact: [127,   2,   1, 127]
+          - Exact: [127,   3,   1, 127]
+          - Exact: [127,   127, 1, 127]
+          - Exact: [128,   128, 1, 128]
+          - Exact: [129,   129, 1, 129]
+          - Exact: [127,   127, 1, 128]
+          - Exact: [127,   127, 1, 129]
+          - Exact: [127,   128, 1, 640]
+          - Exact: [129,   128, 1, 640]
+          - Exact: [512,   512, 1, 640]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+
+  ########################################
+  # HHS TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Activation: True
+      ActivationType: hipblaslt_all
+      UseScaleAlphaVec: 1
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1, 8, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 9, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 10, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 11, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 12, 2, 2]
+          - [16, 16, 16, 1,  1, 9, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 10, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 11, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 12, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 9, 9, 2, 2]
+          - [16, 16, 16, 1,  1, 9, 10, 2, 2]
+          - [16, 16, 16, 1,  1, 10, 9, 2, 2]
+          - [16, 16, 16, 1,  1, 21, 4, 1, 4]
+          - [16, 16, 16, 1,  1, 4, 21, 4, 1]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - GlobalReadVectorWidthA: [-1]
+        - GlobalReadVectorWidthB: [-1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [32]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+        - WorkGroupMapping: [6]
+        - WorkGroupMappingXCC: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1,     127, 1, 127]
+          - Exact: [2,     127, 1, 127]
+          - Exact: [3,     127, 1, 127]
+          - Exact: [1,     1,   1, 127]
+          - Exact: [127,   1,   1, 127]
+          - Exact: [127,   2,   1, 127]
+          - Exact: [127,   3,   1, 127]
+          - Exact: [127,   127, 1, 127]
+          - Exact: [128,   128, 1, 128]
+          - Exact: [129,   129, 1, 129]
+          - Exact: [127,   127, 1, 128]
+          - Exact: [127,   127, 1, 129]
+          - Exact: [127,   128, 1, 640]
+          - Exact: [129,   128, 1, 640]
+          - Exact: [512,   512, 1, 640]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+
+  ########################################
+  # BBS NT + VW
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: b
+      DestDataType: b
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Activation: True
+      ActivationType: hipblaslt_all
+      UseScaleAlphaVec: 1
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1, 9, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 9, 2, 2]
+          - [16, 16, 16, 1,  1, 10, 8, 2, 2]
+          - [16, 16, 16, 1,  1, 8, 10, 2, 2]
+          - [16, 16, 16, 1,  1, 4, 17, 4, 1]
+          - [16, 16, 16, 1,  1, 17, 4, 1, 4]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - GlobalReadVectorWidthA: [1,2,-1]
+        - GlobalReadVectorWidthB: [1,2,-1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - VectorWidthA: [1,-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [32]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+        - WorkGroupMapping: [6]
+        - WorkGroupMappingXCC: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [0]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+        - GlobalSplitU: [1,2,9]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1,     127, 1, 127]
+          - Exact: [2,     127, 1, 127]
+          - Exact: [3,     127, 1, 127]
+          - Exact: [1,     1,   1, 127]
+          - Exact: [127,   1,   1, 127]
+          - Exact: [127,   2,   1, 127]
+          - Exact: [127,   3,   1, 127]
+          - Exact: [127,   127, 1, 127]
+          - Exact: [128,   128, 1, 128]
+          - Exact: [129,   129, 1, 129]
+          - Exact: [127,   127, 1, 128]
+          - Exact: [127,   127, 1, 129]
+          - Exact: [127,   128, 1, 640]
+          - Exact: [129,   128, 1, 640]
+          - Exact: [512,   512, 1, 640]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]
+
+  ########################################
+  # F8BS TN
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: f8
+      DestDataType: b
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Activation: True
+      ActivationType: hipblaslt_all
+      UseScaleAlphaVec: 1
+      BiasDataTypeList: [s, b]
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 32, 1,  1, 8, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 8, 9, 2, 2]
+          - [16, 16, 32, 1,  1, 8, 10, 2, 2]
+          - [16, 16, 32, 1,  1, 8, 11, 2, 2]
+          - [16, 16, 32, 1,  1, 8, 12, 2, 2]
+          - [16, 16, 32, 1,  1, 8, 13, 2, 2]
+          - [16, 16, 32, 1,  1, 11, 9, 2, 2]
+          - [16, 16, 32, 1,  1, 11, 10, 2, 2]
+          - [16, 16, 32, 1,  1, 9, 11, 2, 2]
+          - [16, 16, 32, 1,  1, 10, 11, 2, 2]
+          - [16, 16, 32, 1,  1, 10, 10, 2, 2]
+          - [16, 16, 32, 1,  1, 9, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 10, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 11, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 12, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 13, 8, 2, 2]
+          - [16, 16, 32, 1,  1, 9, 9, 2, 2]
+          - [16, 16, 32, 1,  1, 9, 10, 2, 2]
+          - [16, 16, 32, 1,  1, 10, 9, 2, 2]
+        - AssertFree0ElementMultiple: [1]
+        - AssertFree1ElementMultiple: [1]
+        - AssertSummationElementMultiple: [1]
+        - GlobalReadVectorWidthA: [-1]
+        - GlobalReadVectorWidthB: [-1]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ClusterLocalRead: [1]
+        - DepthU: [32]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [32]
+        - StaggerUStride: [256]
+        - StaggerUMapping: [0]
+        - WorkGroupMapping: [6]
+        - WorkGroupMappingXCC: [8]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [1]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [1,     127, 1, 127]
+          - Exact: [2,     127, 1, 127]
+          - Exact: [3,     127, 1, 127]
+          - Exact: [1,     1,   1, 127]
+          - Exact: [127,   1,   1, 127]
+          - Exact: [127,   2,   1, 127]
+          - Exact: [127,   3,   1, 127]
+          - Exact: [127,   127, 1, 127]
+          - Exact: [128,   128, 1, 128]
+          - Exact: [129,   129, 1, 129]
+          - Exact: [127,   127, 1, 128]
+          - Exact: [127,   127, 1, 129]
+          - Exact: [127,   128, 1, 640]
+          - Exact: [129,   128, 1, 640]
+          - Exact: [512,   512, 1, 640]
+        - BiasTypeArgs: ['s', 'b']
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
This PR is to support larger MT such as 256x320.
Generally, we only have 256 accVGPRs.
If MT is larger than 256x256, we need some extra archVGPR to store the acc results.