### PR TITLE
Fix AMDClangVersion isn't assigned before running Tensile

### DIFF
--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -221,6 +221,12 @@ def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler):
   else:
     callCreateLibraryCmd += " --no-merge-files"
 
+  if globalParameters["SeparateArchitectures"]:
+    callCreateLibraryCmd += " --separate-architectures"
+
+  if globalParameters["LazyLibraryLoading"]:
+    callCreateLibraryCmd += " --lazy-library-loading"
+
   if globalParameters["ShortNames"]:
     callCreateLibraryCmd += " --short-file-names"
   else:

--- a/tensilelite/Tensile/Common.py
+++ b/tensilelite/Tensile/Common.py
@@ -1753,6 +1753,9 @@ def assignGlobalParameters(config, cxxCompiler=None):
       if 'HIP version' in line:
         globalParameters['HipClangVersion'] = line.split()[2]
         print1("# Found hipcc version " + globalParameters['HipClangVersion'])
+      if 'AMD clang version' in line:
+        globalParameters['AMDClangVersion'] = line.split()[3]
+        print1("# Found clang version " + globalParameters['AMDClangVersion'])
 
   except (subprocess.CalledProcessError, OSError) as e:
       printWarning("Error: {} running {} {} ".format('hipcc', '--version',  e))

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -321,7 +321,7 @@ def writeSolutionsAndKernels(outputPath, cxxCompiler, assembler, offloadBundler,
   Common.popWorkingPath() # build_tmp
   Common.popWorkingPath() # workingDir
 
-  return codeObjectFiles, numKernels 
+  return codeObjectFiles, numKernels
 
 
 ##############################################################################
@@ -514,7 +514,7 @@ def TensileCreateLibrary():
   argParser.add_argument("LogicPath",       help="Path to LibraryLogic.yaml files.")
   argParser.add_argument("OutputPath",      help="Where to write library files?")
   argParser.add_argument("RuntimeLanguage", help="Which runtime language?", choices=["OCL", "HIP", "HSA"])
-  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       action="store", default=ToolchainDefaults.CXX_COMPILER, 
+  argParser.add_argument("--cxx-compiler",           dest="CxxCompiler",       action="store", default=ToolchainDefaults.CXX_COMPILER,
                          help=f"Default: {ToolchainDefaults.CXX_COMPILER}")
   argParser.add_argument("--c-compiler",             dest="CCompiler",         action="store", default=ToolchainDefaults.C_COMPILER)
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
@@ -530,7 +530,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--library-print-debug",    dest="LibraryPrintDebug", action="store_true")
   argParser.add_argument("--no-library-print-debug", dest="LibraryPrintDebug", action="store_false")
   argParser.add_argument("--no-compress",            dest="NoCompress",        action="store_true", help="Don't compress assembly code objects.")
-  argParser.add_argument("--experimental",           dest="Experimental",      action="store_true", 
+  argParser.add_argument("--experimental",           dest="Experimental",      action="store_true",
                          help="Include logic files in directories named 'Experimental'.")
   argParser.add_argument("--no-enumerate",           action="store_true", help="Do not run rocm_agent_enumerator.")
   argParser.add_argument("--version", help="Version string to embed into library file.")
@@ -729,7 +729,7 @@ def TensileCreateLibrary():
     LibraryIO.write(masterFile, Utils.state(fullMasterLibrary), args.LibraryFormat)
 
   theMasterLibrary = fullMasterLibrary
-  if globalParameters["SeparateArchitectures"]:
+  if globalParameters["SeparateArchitectures"] and len(masterLibraries) > 0:
     theMasterLibrary = list(masterLibraries.values())[0]
 
   print1("# Tensile Library Writer DONE")

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -627,7 +627,6 @@ def TensileCreateLibrary():
   print1(f"# Architecture(s):     {arguments['Architecture']}")
   print1(f"# Library Format:      {libraryFormat}")
 
-  arguments["AMDClangVersion"] = getVersion(cxxCompiler)
   assignGlobalParameters(arguments, cxxCompiler)
 
   if not os.path.exists(logicPath):


### PR DESCRIPTION
## [Fix AMDClangVersion isn't assigned before running Tensile](https://github.com/ROCm/hipBLASLt/pull/1485/commits/f5435b978765d884bfc2bf2a7595b1160593ef17)

The compilation error occurs with the newer image 15181 when using Clang version 19 or higher.

```
Cijk_Alik_Bjlk_F8F8S_BH_BiasS_HAS_UserArgs_MT128Mr1ktSHK1EF_DT2RP9OiFyN_GRwGFIfYB4xxF9CIVPE=.s    not a valid operand.  
 v_cvt_f32_fp8 v134, v147 op_sel:[0,0] :15530:26
                           ^:  error:  not a valid operand. 
```

The `AMDClangVersion` isn't assigned before running Tensile, so it generates the wrong instructions.

`Line #1990 has an uninitialized version value: 0.0.0`

https://github.com/ROCm/hipBLASLt/blob/5997a6c7f72b575778b45d600ab07eb17628e6f1/tensilelite/Tensile/Components/GlobalWriteBatch.py#L1990-L2000

This commit reverts the changes from this [PR](https://github.com/ROCm/hipBLASLt/pull/1413/files#diff-534f55413c363b76edb5e49697958ec2670ddaa03a0db25493eb99e58eddc8beL1811) back to the original method of getting the version.


## [Fix the incorrect build path when it's not at the root level](https://github.com/ROCm/hipBLASLt/pull/1485/commits/1393a9840c8adde6d8a7a87b3529592c4fdc5a74)

These changes allow us to organize builds into a folder, rather than placing them all at the root level of the hipBLASLt repo. Add `--no-lazy-library-loading` and `--no-separate-architectures` flags in install.sh for hipblaslt-test to run the `1_BenchmarkProblems` library generated by Tensile directly. These changes improve the debugging process by keeping different versions of the clients.

```
| original         | modified        |
| ---------------- | --------------- |
| ├── build_f5435b | ├── build       |
| ├── build_f5435c | │   ├── f5435d  |
| ├── build_f5435d | │   ├── f5435c  |
| ├── build_f5435e | │   └── f5435b  |
| ├── clients      | ├── clients     |
| ├── cmake        | ├── cmake       |
| ├── deps         | ├── deps        |
| ├── docker       | ├── docker      |
| ├── docs         | ├── docs        |
| ├── install.sh   | ├── install.sh  |
| ├── library      | ├── library     |
| ├── tensilelite  | ├── tensilelite |
| └── utilities    | └── utilities   |
```
### Some useful commands

#### Build for clients only (the `--no-tensile` option seems to be broken; using `--logic-yaml-filter` is an alternative way to save time).
<img width="985" alt="image" src="https://github.com/user-attachments/assets/fc519c3d-0d9d-4603-81d9-dc0a59d2dc2e" />

> ```./install.sh -cg --architecture gfx1201 --build_dir build/$(git rev-parse --short=6 HEAD) --no-lazy-library-loading --no-separate-architectures --logic-yaml-filter a^```

#### Get the commit message for each build folder
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/846e6224-3cdb-40ff-9d00-773b999b1ab7" />


> ```find build -mindepth 1 -maxdepth 1 -name '*' -not -name '_*' -exec bash -c 'git --no-pager log -n 1 --oneline --pretty=format:"%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%C(bold blue) <%an> %Creset" $(basename {}) && echo' \;```

```
f5435b97 - (haos/fix_amdclangversion, fix_amdclangversion) Fix AMDClangVersion isn't assigned before running Tensile (3 days ago) <Hao-Sheng Chen> 
1393a984 - Fix the incorrect relative build path when it's not at the root level (3 days ago) <Hao-Sheng Chen> 
```

#### Run `hipblaslt-test` on the library generated from Tensile.
<img width="1206" alt="image" src="https://github.com/user-attachments/assets/dc4c0da5-482f-41d1-b73b-0c01b0682c60" />


> ```HIPBLASLT_TENSILE_LIBPATH=build/_asm/tnhhs4096/1_BenchmarkProblems/Cijk_Alik_Bljk_HHS_BH_Bias_AS_UserArgs_00/00_Final/source/library build/$(git rev-parse --short=6 HEAD)/debug/clients/staging/hipblaslt-bench --yaml .vscode/bench.yaml 2>&1 | code -```



## hipblaslt-test

### gfx1201
```
[----------] Global test environment tear-down
[==========] 34847 tests from 13 test suites ran. (770848 ms total)
[  PASSED  ] 34847 tests.
hipBLASLt version: 1200

command line: build/f5435b/debug/clients/staging/hipblaslt-test 
```

### gfx942
```
[----------] Global test environment tear-down
[==========] 50058 tests from 13 test suites ran. (3655055 ms total)
[  PASSED  ] 50058 tests.
hipBLASLt version: 1200

command line: build/f5435b/debug/clients/staging/hipblaslt-test 
```