### PR TITLE
[Experimental] Added `hipblaslt_ext::getAllAlgos` for swizzling

### DIFF
--- a/clients/samples/26_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a_get_all.cpp
+++ b/clients/samples/26_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a_get_all.cpp
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <algorithm>
+#include <hip/hip_runtime.h>
+#include <hipblaslt/hipblaslt-ext.hpp>
+#include <hipblaslt/hipblaslt.h>
+#include <iostream>
+
+#include "TensorDataManipulation.hpp"
+#include "helper.h"
+
+template <typename T>
+void swizzleTensor(T* dst, const T* src, size_t m, size_t k, bool colMaj)
+{
+    using Tensor               = Tensor::Manipulation::Tensor;
+    constexpr size_t MiM       = 16;
+    constexpr size_t MiK       = 16;
+    constexpr size_t MiKv      = 4;
+    constexpr size_t PackK     = 2;
+    auto             tmpTensor = Tensor::create<T>({m, k});
+    memcpy(tmpTensor.template as<void>(), src, m * k * sizeof(T));
+
+    if(colMaj)
+    {
+        auto orgTensor = Tensor::create<T>({k, m});
+        memcpy(orgTensor.template as<void>(), src, m * k * sizeof(T));
+        tmpTensor = permute(orgTensor, {1, 0});
+    }
+
+    tmpTensor.reshape({m / MiM, MiM, k / (MiK * PackK), MiK / MiKv, MiKv * PackK});
+    Tensor permuted = permute(tmpTensor, {0, 2, 3, 1, 4});
+    memcpy(dst, permuted.template as<void>(), m * k * sizeof(T));
+}
+
+void simpleGemm(hipblasLtHandle_t  handle,
+                hipblasOperation_t trans_a,
+                hipblasOperation_t trans_b,
+                int64_t            m,
+                int64_t            n,
+                int64_t            k,
+                int64_t            batch_count,
+                float&             alpha,
+                float&             beta,
+                void*              d_a,
+                void*              d_b,
+                void*              d_c,
+                void*              d_d,
+                void*              d_workspace,
+                int64_t            max_workspace_size,
+                bool               swizzleA,
+                hipStream_t        stream);
+
+int main()
+{
+    constexpr int64_t                                                 m{5280};
+    constexpr int64_t                                                 n{2048};
+    constexpr int64_t                                                 k{1024};
+
+    Runner<hipblasLtHalf, hipblasLtHalf, hipblasLtHalf, float, float> swizzleRunner(
+        m, n, k, 1, 1.f, 1.f, 32 * 128 * 128);
+
+    swizzleRunner.run([&swizzleRunner, m, n, k] {
+        simpleGemm(swizzleRunner.handle,
+                   /*For swizzle-A, it forces to use TN*/
+                   HIPBLAS_OP_T,
+                   HIPBLAS_OP_N,
+                   swizzleRunner.m,
+                   swizzleRunner.n,
+                   swizzleRunner.k,
+                   swizzleRunner.batch_count,
+                   swizzleRunner.alpha,
+                   swizzleRunner.beta,
+                   swizzleRunner.d_a,
+                   swizzleRunner.d_b,
+                   swizzleRunner.d_c,
+                   swizzleRunner.d_d,
+                   swizzleRunner.d_workspace,
+                   swizzleRunner.max_workspace_size,
+                   true,
+                   swizzleRunner.stream);
+    });
+
+    return 0;
+}
+
+void simpleGemm(hipblasLtHandle_t  handle,
+                hipblasOperation_t trans_a,
+                hipblasOperation_t trans_b,
+                int64_t            m,
+                int64_t            n,
+                int64_t            k,
+                int64_t            batch_count,
+                float&             alpha,
+                float&             beta,
+                void*              d_a,
+                void*              d_b,
+                void*              d_c,
+                void*              d_d,
+                void*              d_workspace,
+                int64_t            max_workspace_size,
+                bool               swizzleA,
+                hipStream_t        stream)
+{
+    hipblasLtOrder_t        orderA = swizzleA ? HIPBLASLT_ORDER_ROW16_32C_8 : HIPBLASLT_ORDER_COL;
+    hipblasLtOrder_t        orderB = HIPBLASLT_ORDER_COL;
+    hipblasLtMatrixLayout_t matA, matB, matC, matD;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matB, HIP_R_16F, k, n, k));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matC, HIP_R_16F, m, n, m));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matD, HIP_R_16F, m, n, m));
+
+    if(trans_a == HIPBLAS_OP_T)
+    {
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, k, m, k));
+
+        if(swizzleA)
+        {
+            hipblasLtOrder_t orderA = HIPBLASLT_ORDER_ROW16_32C_8;
+            CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+                matA, HIPBLASLT_MATRIX_LAYOUT_ORDER, &orderA, sizeof(orderA)));
+            std::vector<hipblasLtHalf> src(m * k, 0);
+            std::vector<hipblasLtHalf> dst(m * k, 0);
+            hipMemcpy(src.data(), d_a, m * k * sizeof(hipblasLtHalf), hipMemcpyDeviceToHost);
+            swizzleTensor(dst.data(), src.data(), m, k, true);
+            hipMemcpy(d_a, dst.data(), m * k * sizeof(hipblasLtHalf), hipMemcpyHostToDevice);
+        }
+    }
+    else
+    {
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutCreate(&matA, HIP_R_16F, m, k, m));
+    }
+
+    if(batch_count > 1)
+    {
+        int64_t stride_a = m * k;
+        int64_t stride_b = k * n;
+        int64_t stride_c = m * n;
+        int64_t stride_d = m * n;
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matA, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matA, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_a, sizeof(stride_a)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matB, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matB, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_b, sizeof(stride_b)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matC, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matC, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_c, sizeof(stride_c)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matD, HIPBLASLT_MATRIX_LAYOUT_BATCH_COUNT, &batch_count, sizeof(batch_count)));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutSetAttribute(
+            matD, HIPBLASLT_MATRIX_LAYOUT_STRIDED_BATCH_OFFSET, &stride_d, sizeof(stride_d)));
+    }
+
+    hipblasLtMatmulDesc_t matmul;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescCreate(&matmul, HIPBLAS_COMPUTE_32F, HIP_R_32F));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSA, &trans_a, sizeof(int32_t)));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_TRANSB, &trans_b, sizeof(int32_t)));
+
+    hipblasLtEpilogue_t epilogue = HIPBLASLT_EPILOGUE_DEFAULT;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescSetAttribute(
+        matmul, HIPBLASLT_MATMUL_DESC_EPILOGUE, &epilogue, sizeof(epilogue)));
+
+    // Set User Preference attributes
+    hipblasLtMatmulPreference_t pref;
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceCreate(&pref));
+    CHECK_HIPBLASLT_ERROR(
+        hipblasLtMatmulPreferenceSetAttribute(pref,
+                                              HIPBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                                              &max_workspace_size,
+                                              sizeof(max_workspace_size)));
+
+    std::vector<hipblasLtMatmulHeuristicResult_t> results;
+    CHECK_HIPBLASLT_ERROR(hipblaslt_ext::getAllAlgos(handle,
+                                                     hipblaslt_ext::GemmType::HIPBLASLT_GEMM,
+                                                     trans_a,
+                                                     trans_b,
+                                                     orderA,
+                                                     orderB,
+                                                     HIP_R_16F,
+                                                     HIP_R_16F,
+                                                     HIP_R_16F,
+                                                     HIP_R_16F,
+                                                     HIPBLAS_COMPUTE_32F,
+                                                     results));
+
+    uint64_t workspace_size = 0;
+
+    results.erase(
+        std::remove_if(
+            begin(results),
+            end(results),
+            [&](hipblasLtMatmulHeuristicResult_t& r) {
+                size_t workspace_bytes{};
+                auto   supported = hipblaslt_ext::matmulIsAlgoSupported(
+                    handle, matmul, &alpha, matA, matB, &beta, matC, matC, r.algo, workspace_bytes);
+                if(supported == HIPBLAS_STATUS_SUCCESS)
+                {
+                    workspace_size += workspace_bytes;
+                }
+                return supported;
+            }),
+        end(results));
+
+    if(results.size() == 0)
+    {
+        std::cerr << "No valid solution found!" << std::endl;
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matA));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matB));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matC));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matD));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescDestroy(matmul));
+        CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceDestroy(pref));
+        return;
+    }
+
+    std::cout << results.size() << " sols found" << std::endl;
+
+    float         bestTimeMs = std::numeric_limits<float>::max();
+    constexpr int numWarmupRuns{100};
+    constexpr int numRuns{1000};
+
+    for(size_t j = 0; j < results.size(); ++j)
+    {
+        for(int i = 0; i < numWarmupRuns; ++i)
+        {
+            CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
+                                                  matmul,
+                                                  &alpha,
+                                                  d_a,
+                                                  matA,
+                                                  d_b,
+                                                  matB,
+                                                  &beta,
+                                                  d_c,
+                                                  matC,
+                                                  d_d,
+                                                  matD,
+                                                  &results[j].algo,
+                                                  d_workspace,
+                                                  workspace_size,
+                                                  stream));
+        }
+
+        hipEvent_t start, stop;
+        hipEventCreate(&start);
+        hipEventCreate(&stop);
+        hipEventRecord(start, stream);
+
+        for(int i = 0; i < numRuns; ++i)
+        {
+            CHECK_HIPBLASLT_ERROR(hipblasLtMatmul(handle,
+                                                  matmul,
+                                                  &alpha,
+                                                  d_a,
+                                                  matA,
+                                                  d_b,
+                                                  matB,
+                                                  &beta,
+                                                  d_c,
+                                                  matC,
+                                                  d_d,
+                                                  matD,
+                                                  &results[j].algo,
+                                                  d_workspace,
+                                                  workspace_size,
+                                                  stream));
+        }
+
+        CHECK_HIP_ERROR(hipEventRecord(stop, stream));
+        CHECK_HIP_ERROR(hipStreamSynchronize(stream));
+        CHECK_HIP_ERROR(hipDeviceSynchronize());
+        float timeMs{};
+        CHECK_HIP_ERROR(hipEventElapsedTime(&timeMs, start, stop));
+        CHECK_HIP_ERROR(hipEventDestroy(start));
+        CHECK_HIP_ERROR(hipEventDestroy(stop));
+        bestTimeMs = std::min(timeMs, bestTimeMs);
+    }
+
+    std::cout << "Best solution time: " << bestTimeMs / numRuns * 1000
+              << " us (swizzleA == " << int(swizzleA) << ")\n";
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matA));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matB));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matC));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatrixLayoutDestroy(matD));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulDescDestroy(matmul));
+    CHECK_HIPBLASLT_ERROR(hipblasLtMatmulPreferenceDestroy(pref));
+    return;
+}

--- a/clients/samples/CMakeLists.txt
+++ b/clients/samples/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable( sample_hipblaslt_ext_op_amax 23_amax_ext/sample_hipblaslt_ext_op
 add_executable( sample_hipblaslt_ext_op_amax_with_scale 24_amax_with_scale_ext/sample_hipblaslt_ext_op_amax_with_scale.cpp)
 add_executable( sample_hipblaslt_gemm_with_TF32 25_gemm_with_TF32/sample_hipblaslt_gemm_with_TF32.cpp)
 add_executable( sample_hipblaslt_gemm_swizzle_a 26_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a.cpp)
+add_executable( sample_hipblaslt_gemm_swizzle_a_get_all 26_gemm_swizzle_a/sample_hipblaslt_gemm_swizzle_a_get_all.cpp)
 
 
 set(samples sample_hipblaslt_gemm
@@ -99,7 +100,8 @@ set(samples sample_hipblaslt_gemm
             sample_hipblaslt_ext_op_amax
             sample_hipblaslt_ext_op_amax_with_scale
             sample_hipblaslt_gemm_with_TF32
-            sample_hipblaslt_gemm_swizzle_a)
+            sample_hipblaslt_gemm_swizzle_a
+            sample_hipblaslt_gemm_swizzle_a_get_all)
 
 set( sample_list_all ${samples})
 

--- a/library/include/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt-ext.hpp
@@ -1359,6 +1359,52 @@ namespace hipblaslt_ext
                                 std::vector<hipblasLtMatmulHeuristicResult_t>& heuristicResults);
 
     /*! \ingroup library_module
+     *  \brief Retrieve the possible algorithms
+     *
+     *  \details
+     *  This function retrieves the possible algorithms for the matrix multiply
+     * operation hipblasLtMatmul() function with the given data and compute tpye.
+     * The output is placed in heuristicResults in the order of increasing
+     * estimated compute time. It should use matmulIsAlgoSupported() to check if
+     * the algorithm support the problem before execute hipblasLtMatmul().
+     *
+     *  @param[in]
+     *  handle                  Pointer to the allocated hipBLASLt handle for the
+     * hipBLASLt context. See \ref hipblasLtHandle_t .
+     *  @param[in]
+     *  typeGemm Gemm type. ex. GEMM, GROUPED_GEMM.
+     *  @param[in]
+     *  opA, opB Transpose settings of A, B.
+     *  @param[in]
+     *  orderA, orderB Layout settings of A, B.
+     *  @param[in]
+     *  typeA,typeB,typeC,typeD The data type of matrix A, B, C, D.
+     *  @param[in]
+     *  typeCompute             The compute type.
+     *  @param[out]
+     *  heuristicResults The algorithm heuristic vector.
+     *
+     *  \retval HIPBLAS_STATUS_SUCCESS           If query was successful. Inspect
+     * returnedAlgoCount > 0.state for the status of the
+     * results. \retval HIPBLAS_STATUS_NOT_SUPPORTED     If no heuristic function
+     * available for current configuration. \retval HIPBLAS_STATUS_INVALID_VALUE If
+     * no solution is found.
+     */
+    HIPBLASLT_EXPORT
+    hipblasStatus_t getAllAlgos(hipblasLtHandle_t                              handle,
+                                GemmType                                       typeGemm,
+                                hipblasOperation_t                             opA,
+                                hipblasOperation_t                             opB,
+                                hipblasLtOrder_t                               orderA,
+                                hipblasLtOrder_t                               orderB,
+                                hipDataType                                    typeA,
+                                hipDataType                                    typeB,
+                                hipDataType                                    typeC,
+                                hipDataType                                    typeD,
+                                hipblasComputeType_t                           typeCompute,
+                                std::vector<hipblasLtMatmulHeuristicResult_t>& heuristicResults);
+
+    /*! \ingroup library_module
      *  \brief Retrieve the algorithm index
      *
      *  @param[in]

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -1598,6 +1598,46 @@ namespace hipblaslt_ext
         return exception_to_hipblas_status();
     }
 
+    hipblasStatus_t getAllAlgos(hipblasLtHandle_t                              handle,
+                                GemmType                                       typeGemm,
+                                hipblasOperation_t                             opA,
+                                hipblasOperation_t                             opB,
+                                hipblasLtOrder_t                               orderA,
+                                hipblasLtOrder_t                               orderB,
+                                hipDataType                                    typeA,
+                                hipDataType                                    typeB,
+                                hipDataType                                    typeC,
+                                hipDataType                                    typeD,
+                                hipblasComputeType_t                           typeCompute,
+                                std::vector<hipblasLtMatmulHeuristicResult_t>& heuristicResults)
+    try
+    {
+        rocblaslt::Debug::Instance().markerStart("hipblasLtGetAllAlgosLayoutCpp");
+        auto results
+            = reinterpret_cast<std::vector<rocblaslt_matmul_heuristic_result>*>(&heuristicResults);
+        results->clear();
+        auto status = RocBlasLtStatusToHIPStatus(
+            rocblaslt_matmul_get_all_algos_cpp((rocblaslt_handle)handle,
+                                               static_cast<rocblaslt::RocGemmType>(typeGemm),
+                                               opA,
+                                               opB,
+                                               orderA,
+                                               orderB,
+                                               typeA,
+                                               typeB,
+                                               typeC,
+                                               typeD,
+                                               (rocblaslt_compute_type)typeCompute,
+                                               *results));
+        rocblaslt::Debug::Instance().markerStop();
+        return status;
+
+    }
+    catch(...)
+    {
+        return exception_to_hipblas_status();
+    }
+
     int getIndexFromAlgo(hipblasLtMatmulAlgo_t& algo)
     {
         int* algo_ptr = (int*)algo.data;

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
@@ -368,6 +368,20 @@ rocblaslt_status rocblaslt_matmul_get_all_algos_cpp(
     rocblaslt_compute_type                          typeCompute,
     std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults);
 
+rocblaslt_status rocblaslt_matmul_get_all_algos_cpp(
+    rocblaslt_handle                                handle,
+    rocblaslt::RocGemmType                          typeGemm,
+    hipblasOperation_t                              opA,
+    hipblasOperation_t                              opB,
+    hipblasLtOrder_t                                orderA,
+    hipblasLtOrder_t                                orderB,
+    hipDataType                                     typeA,
+    hipDataType                                     typeB,
+    hipDataType                                     typeC,
+    hipDataType                                     typeD,
+    rocblaslt_compute_type                          typeCompute,
+    std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults);
+
 rocblaslt_status rocblaslt_matmul_get_algos_from_index_cpp(
     rocblaslt_handle                                handle,
     std::vector<int>&                               solutionIndex,

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -1667,6 +1667,34 @@ rocblaslt_status rocblaslt_matmul_get_all_algos_cpp(
     rocblaslt_compute_type                          typeCompute,
     std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults)
 {
+    return rocblaslt_matmul_get_all_algos_cpp(handle,
+                                              typeGemm,
+                                              opA,
+                                              opB,
+                                              HIPBLASLT_ORDER_COL,
+                                              HIPBLASLT_ORDER_COL,
+                                              typeA,
+                                              typeB,
+                                              typeC,
+                                              typeD,
+                                              typeCompute,
+                                              heuristicResults);
+}
+
+rocblaslt_status rocblaslt_matmul_get_all_algos_cpp(
+    rocblaslt_handle                                handle,
+    rocblaslt::RocGemmType                          typeGemm,
+    hipblasOperation_t                              opA,
+    hipblasOperation_t                              opB,
+    hipblasLtOrder_t                                orderA,
+    hipblasLtOrder_t                                orderB,
+    hipDataType                                     typeA,
+    hipDataType                                     typeB,
+    hipDataType                                     typeC,
+    hipDataType                                     typeD,
+    rocblaslt_compute_type                          typeCompute,
+    std::vector<rocblaslt_matmul_heuristic_result>& heuristicResults)
+{
     // Check if handle is valid
     if(handle == nullptr)
     {
@@ -1693,6 +1721,8 @@ rocblaslt_status rocblaslt_matmul_get_all_algos_cpp(
     matmul_desc.op_B                  = opB;
     matmul_desc.compute_type          = typeCompute;
     matmul_desc.scale_type            = typeD;
+    matA.order = orderA;
+    matB.order = orderB;
     rocblaslt_status status           = rocblaslt_status_success;
     size_t           maxWorkspaceSize = std::numeric_limits<size_t>::max();
     try


### PR DESCRIPTION
## Brief ##
Added `hipblaslt_ext::getAllAlgos` for swizzling support.

## Implementations
 - [x] New overload of `hipblasLt::getAllAlgos`
 - [x] An example for new overload.