### PR TITLE
Add ENABLE_MAKER to the option set defined at Tensilelite's cmake configuration.

### DIFF
--- a/tensilelite/Tensile/cmake/TensileConfig.cmake
+++ b/tensilelite/Tensile/cmake/TensileConfig.cmake
@@ -91,6 +91,7 @@ function(TensileCreateLibraryFiles
        KEEP_BUILD_TMP
        NO_COMPRESS
        EXPERIMENTAL 
+       ENABLE_MAKRER
        )
 
   # Single value settings


### PR DESCRIPTION
If the ENABLE_MARKER option is not enabled, Maker functionality cannot be activated through TensileCreateLibraryFiles().