### PR TITLE
code-gen: Allowed WaveGroups be distributed along n-dim for DTVA/SwizzledA

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3352,7 +3352,9 @@ class KernelWriterAssembly(KernelWriter):
         tmpSgpr = tmpSgprInfo.idx
         # Calc numKr, TODO- 32 should be MI_K * 2
         module.add(SLShiftRightB32(dst=sgpr(tmpSgpr), shiftHex=hex(log2(32)), src=sgpr("SizesSum"),  comment="SWZ: numKr = DimK / 32"))
-        module.add(VMulU32U24(dst=vgpr(qReg), src0=sgpr(tmpSgpr), src1=vgpr(qReg), comment="SWZ: wave-id *= numKr"))
+        WvG_M = kernel["MIWaveGroup"][0]
+        module.add(VAndB32(dst=vgpr(qReg), src0=hex(WvG_M-1), src1=vgpr(qReg), comment="SWZ: wave_id (along_M) %= MIWG[0]"))
+        module.add(VMulU32U24(dst=vgpr(qReg), src0=sgpr(tmpSgpr), src1=vgpr(qReg), comment="SWZ: wave_id (along_M) *= numKr"))
     elif isDTVAB:
       # offset calculation for DirectToVgpr
       # call function from LraTileAssignmentMFMA for DirectToVgpr
@@ -3538,7 +3540,8 @@ class KernelWriterAssembly(KernelWriter):
       else:
         validBytesPerLoad *= (kernel["MacroTile%s"%tc] // kernel["NumLoadsPerpendicular%s"%tc] // (kernel["NumThreads"] // kernel["WavefrontSize"]))
 
-    assert (validBytesPerLoad <= maxBytesPerLoad)
+    # TODO- swizzling
+    # assert (validBytesPerLoad <= maxBytesPerLoad)
     assert (kernel[tP["lsc"]] * kernel[tP["lsp"]] % tP["glvw"] == 0)
 
     if validBytesPerLoad != maxBytesPerLoad:

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3540,8 +3540,7 @@ class KernelWriterAssembly(KernelWriter):
       else:
         validBytesPerLoad *= (kernel["MacroTile%s"%tc] // kernel["NumLoadsPerpendicular%s"%tc] // (kernel["NumThreads"] // kernel["WavefrontSize"]))
 
-    # TODO- swizzling
-    # assert (validBytesPerLoad <= maxBytesPerLoad)
+    assert (validBytesPerLoad <= maxBytesPerLoad)
     assert (kernel[tP["lsc"]] * kernel[tP["lsp"]] % tP["glvw"] == 0)
 
     if validBytesPerLoad != maxBytesPerLoad:

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1901,8 +1901,8 @@ class Solution(collections.abc.Mapping):
     if tc == 'A' and not (state['MatrixInstBN'] == 1):
       reject(state, "MatrixInstBN should be 1 for DirectToVgprA. Current value is %d"%(state['MatrixInstBN']))
       return False
-    if tc == 'B' and not (state['MIWaveGroup'][0] == 1 and state['MatrixInstBM'] == 1):
-      reject(state, "MIWaveGroup[0] and MatrixInstBM should be 1 for DirectToVgprB. Current value is [%d, %d]"%(state['MIWaveGroup'][0], state['MatrixInstBM']))
+    if tc == 'B' and not (state['MatrixInstBM'] == 1):
+      reject(state, "MatrixInstBM should be 1 for DirectToVgprB. Current value is %d"%(state['MatrixInstBM']))
       return False
 
     # Does not work with WaveSeparateGlobalRead
@@ -2996,12 +2996,14 @@ class Solution(collections.abc.Mapping):
         if state["DirectToVgprA"]:
           totalElementsPerpA *= state["MIWaveGroup"][1]
 
-      if state["ProblemType"]["TLUB"]:
+      if state["ProblemType"]["TLUB"]: # NT/TT
         totalElementsCoalescedB = state["MacroTileB"]
         totalElementsPerpB = depthUB
-      else:
+      else: # TN/NN
         totalElementsCoalescedB = depthUB
         totalElementsPerpB = state["MacroTileB"]
+        if state["DirectToVgprB"]:
+          totalElementsPerpB *= state["MIWaveGroup"][0]
 
       totalElementsA = totalElementsCoalescedA * totalElementsPerpA
       totalElementsB = totalElementsCoalescedB * totalElementsPerpB

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1412,10 +1412,10 @@ class Solution(collections.abc.Mapping):
     validDepthU = True
     if grvw not in [1,2,4,8,16,32]:
       validDepthU = False
-    # if totalVectors % state["NumThreads"] != 0:
-    #   reject(None, "totalVectors%s %u %% NumThreads %u != 0" \
-    #       % (tc, totalVectors, state["NumThreads"]))
-    #   validDepthU = False
+    if totalVectors % state["NumThreads"] != 0:
+      reject(None, "totalVectors%s %u %% NumThreads %u != 0" \
+          % (tc, totalVectors, state["NumThreads"]))
+      validDepthU = False
 
     state["GlobalReadVectorWidth%s"%tc] = grvw
 
@@ -1961,7 +1961,7 @@ class Solution(collections.abc.Mapping):
     if state["PrefetchGlobalRead"] == 0:
       reject(state, "DirectToVgpr%c does not supports PrefetchGlobalRead == 0."%(tc))
       return False
-    
+
     # for DTVA, does not work with NN and TLDS0
     if tc == 'A' and state["TransposeLDS"] == 0 and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
       reject(state, "DirectToVgpr%c does not supports NN case with TransposeLDS == 0."%(tc))
@@ -1976,7 +1976,7 @@ class Solution(collections.abc.Mapping):
     if  tc == 'B' and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
         # Use AssertSummationElementMultiple (BoundSizeMultiple in predicates) to exclude failed tail-loop cases
         state["AssertSummationElementMultiple"] = max(state["AssertSummationElementMultiple"], state["DepthU"])
-    
+
     # Does not work with DirectToLDS
     # -> this will be checked after DirectToLDS doable check is done
 
@@ -3252,10 +3252,8 @@ class Solution(collections.abc.Mapping):
     if state["DirectToVgprA"]:
       if not Solution.isDirectToVgprDoable(state, 'A'):
         return  # rejected
-
-
     if state["DirectToVgprB"]:
-      if not  Solution.isDirectToVgprDoable(state, 'B'):
+      if not Solution.isDirectToVgprDoable(state, 'B'):
         return  # rejected
 
     ########################################

--- a/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
@@ -5,7 +5,7 @@ GlobalParameters:
   NumElementsToValidate: -1
   MinimumRequiredVersion: 4.14.0
   PrintLevel: 1
-  PrintSolutionRejectionReason: True
+  # PrintSolutionRejectionReason: True
   Device: 0
   CMakeBuildType: Release
   KernelTime: True
@@ -82,7 +82,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 2,  2,2 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
@@ -104,7 +104,7 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 126]
           - Exact: [255,   255, 1, 190]
           - Exact: [255,   255, 1, 256]
-  
+
   ########################################
   # HHS NT DTL
   ########################################
@@ -170,7 +170,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 2,  2,2 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
@@ -192,7 +192,7 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 256]
-  
+
   ########################################
   # HHS TN DTL
   ########################################
@@ -258,7 +258,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 2,  2,2 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
@@ -345,7 +345,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16, 16, 1,  1,   2, 2,  2,2 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16, 16, 1,  1,   1, 4,  1,4 ]
@@ -367,7 +367,7 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 126]
           - Exact: [255,   255, 1, 190]
           - Exact: [255,   255, 1, 256]
-  
+
   ########################################
   # SGEMM NT DTL
   ########################################
@@ -426,7 +426,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  2,2 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  1,4 ]
@@ -507,7 +507,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  2,2 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 4,  1,4 ]
@@ -528,7 +528,7 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 111]
           - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
-  
+
   ########################################
   # SGEMM TN DTL
   ########################################
@@ -588,7 +588,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  2,2 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [32, 32,  2, 1,  1,   2, 1,  2,2 ]
@@ -608,7 +608,7 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 111]
           - Exact: [255,   255, 1, 127]
           - Exact: [255,   255, 1, 128]
-  
+
   ########################################
   # SGEMM TT DTL
   ########################################
@@ -668,7 +668,7 @@ BenchmarkProblems:
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
-          - 
+          -
             - MatrixInstruction: [16, 16,  4, 1,  1,   2, 1,  2,2 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   4, 1,  4,1 ]
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 4,  1,4 ]

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -10,9 +10,12 @@ GlobalParameters:
   CMakeBuildType: Release
   KernelTime: True
   MaxWorkspaceSize: 13421772800
+  DataInitTypeA: 13
+  DataInitTypeB: 12
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
-  BoundsCheck: 2
+  DataInitTypeBias: 13
+  DataInitTypeScaleAlphaVec: 12
   #MaxFileName: 256
 
 BenchmarkProblems:
@@ -439,6 +442,11 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,   5, 1,  2,1 ] # MT = 160x16. Case to check kernel writer works
           - [32, 32,  8, 1,  1,   2, 1,  4,1 ]
           - [32, 32,  8, 1,  1,   4, 1,  4,1 ]
+
+          - [16, 16, 16, 1,  1,  8,1,   1,4 ] # 128x64
+          - [16, 16, 16, 1,  1,  8,1,   2,2 ] # 256x32
+          - [16, 16, 16, 1,  1,  16,1,  2,2 ] # 512x32
+          - [16, 16, 16, 1,  1,  10,1,  2,2 ] # 160x32
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
@@ -613,6 +621,11 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,   1, 5,  1,2 ] # MT = 16x160. Case to check kernel writer works
           - [32, 32,  8, 1,  1,   1, 2,  1,4 ]
           - [32, 32,  8, 1,  1,   1, 4,  1,4 ]
+
+          - [16, 16, 16, 1,  1,  1,8,   4,1 ] # 64x128
+          - [16, 16, 16, 1,  1,  1,8,   2,2 ] # 32x256
+          - [16, 16, 16, 1,  1,  1,16,  2,2 ] # 32x512
+          - [16, 16, 16, 1,  1,  1,10,  2,2 ] # 32x160
         - WorkGroup:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
@@ -1985,6 +1998,10 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,  1,8,   4,1 ] # 64x128
           - [16, 16, 16, 1,  1,  2,8,  4,1 ] # 128x128
           - [16, 16, 16, 1,  1,  4,16,  4,1 ] # 256x256
+
+          - [16, 16, 16, 1,  1,  4,2,   1,4 ] # 64x128
+          - [16, 16, 16, 1,  1,  8,2,   1,4 ] # 128x128
+          - [16, 16, 16, 1,  1,  16,4,  1,4 ] # 256x256
         - AssertFree0ElementMultiple: [16]
         - AssertFree1ElementMultiple: [16]
         - AssertSummationElementMultiple: [32]
@@ -2050,6 +2067,10 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,  4,2,   1,4 ] # 64x128
           - [16, 16, 16, 1,  1,  8,2,  1,4 ] # 128x128
           - [16, 16, 16, 1,  1,  16,4,  1,4 ] # 256x256
+
+          - [16, 16, 16, 1,  1,  2,4,   4,1 ] # 128x64
+          - [16, 16, 16, 1,  1,  2,8,  4,1 ] # 128x128
+          - [16, 16, 16, 1,  1,  4,16,  4,1 ] # 256x256
         - AssertFree0ElementMultiple: [16]
         - AssertFree1ElementMultiple: [16]
         - AssertSummationElementMultiple: [32]

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -11,15 +11,17 @@ GlobalParameters:
   KernelTime: True
   MaxWorkspaceSize: 13421772800
   DataInitTypeA: 13
-  DataInitTypeB: 13
+  DataInitTypeB: 12
   DataInitTypeAlpha: 1
   DataInitTypeBeta: 1
+  DataInitTypeBias: 13
+  DataInitTypeScaleAlphaVec: 12
   BoundsCheck: 2
   #MaxFileName: 256
 
 BenchmarkProblems:
   ########################################
-  # HHS TN DTVA + SWIZZLED_A + BIAS + Activation
+  # HHS TN DTVA + SWIZZLED_A + BIAS + Activation + SAV
   ########################################
   -
     - # ProblemType
@@ -36,6 +38,7 @@ BenchmarkProblems:
       UseBias: 1
       Activation: True
       BiasDataTypeList: ['h']
+      UseScaleAlphaVec: 1
     - # BenchmarkProblemSizeGroup - Standard - All problem
       InitialSolutionParameters:
       BenchmarkCommonParameters:
@@ -57,6 +60,24 @@ BenchmarkProblems:
           - [16, 16, 16, 1,  1,   8, 8,  4,1 ] # MT = 512x128
           - [16, 16, 16, 1,  1,   8, 16, 4,1 ] # MT = 512x256
           - [16, 16, 16, 1,  1,   5, 8,  2,1 ] # MT = 160x128
+
+          - [16, 16, 16, 1,  1,   2, 4,  2,2 ] # MT = 64x128
+          - [16, 16, 16, 1,  1,   2, 8,  2,2 ] # MT = 64x256
+          - [16, 16, 16, 1,  1,   4, 4,  2,2 ] # MT = 128x128
+          - [16, 16, 16, 1,  1,   4, 8,  2,2 ] # MT = 128x256
+          - [16, 16, 16, 1,  1,   8, 4,  2,2 ] # MT = 256x128
+          - [16, 16, 16, 1,  1,   8, 8,  2,2 ] # MT = 256x256
+          - [16, 16, 16, 1,  1,   16, 4, 2,2 ] # MT = 512x128
+          - [16, 16, 16, 1,  1,   16, 8, 2,2 ] # MT = 512x256
+          - [16, 16, 16, 1,  1,   5, 4,  2,2 ] # MT = 160x128
+
+          - [16, 16, 16, 1,  1,   4, 2,  1,4 ] # MT = 64x128
+          - [16, 16, 16, 1,  1,   4, 4,  1,4 ] # MT = 64x256
+          - [16, 16, 16, 1,  1,   8, 2,  1,4 ] # MT = 128x128
+          - [16, 16, 16, 1,  1,   8, 4,  1,4 ] # MT = 128x256
+          - [16, 16, 16, 1,  1,   16, 2, 1,4 ] # MT = 256x128
+          - [16, 16, 16, 1,  1,   16, 4, 1,4 ] # MT = 256x256
+          - [16, 16, 16, 1,  1,   10, 2, 1,4 ] # MT = 160x128
         - AssertFree0ElementMultiple: [16]
         - AssertSummationElementMultiple: [32]
         - GlobalReadVectorWidthA: [8]


### PR DESCRIPTION
Resolved for [SWDEV-504181](https://ontrack-internal.amd.com/browse/SWDEV-504181)

- [x] Implemented for DTVA/SwizzledA when WaveGroups[1] > 1 (N-Dim)
- [x] pytests: for DTVA and SwizzledA
- [x] Support and pytests: for DTVB - WaveGroups[0] > 1 (M-Dim)

[gw2] [ 33%] PASSED Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/self_test/dtvA_swizzleA.yaml] 
[gw0] [ 66%] PASSED Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/self_test/dtl.yaml] 
[gw1] [100%] PASSED Tensile/Tests/common/test_config.py::test_config[Tensile/Tests/self_test/dtv.yaml] 
**=== 3 passed, 4 warnings in 2395.52s (0:39:55) ===**
  py310: OK (2540.72=setup[10.65]+cmd[0.57,133.75,2395.76] seconds)
  congratulations :) (2540.77 seconds)