### PR TITLE
Fix incorrect verification method of compute type f16

### DIFF
--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -461,12 +461,25 @@ Tests:
   category: pre_checkin
   function:
     matmul: *hpa_half_precisions_compute_fp16
-  matrix_size:
-    - { M:  128, N:  128, K:  128 }
+  M: [4096, 129]
+  N: [4096, 129]
+  K: [4096, 129]
+  transA: N
+  transB: N
+  gpu_arch: '[^1]{2}\d{1,2}'
+
+- name: matmul_fallback_compute_fp16_gfx11
+  category: pre_checkin
+  function:
+    matmul: *hpa_half_precisions_compute_fp16
+  M: [4096, 129]
+  N: [4096, 129]
+  K: [4096, 129]
   transA: N
   transB: N
   norm_check: 1
   unit_check: 0
+  gpu_arch: '110?'
 
 - name: matmul_fallback_equality_NN
   category: pre_checkin

--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -465,6 +465,8 @@ Tests:
     - { M:  128, N:  128, K:  128 }
   transA: N
   transB: N
+  norm_check: 1
+  unit_check: 0
 
 - name: matmul_fallback_equality_NN
   category: pre_checkin


### PR DESCRIPTION
## hipblaslt-test

### gfx1100
```
[----------] Global test environment tear-down
[==========] 13695 tests from 13 test suites ran. (724186 ms total)
[  PASSED  ] 13695 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test 
```

```
hipBLASLt version: 1200

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : Radeon RX 7900 XTX gfx1100
with 25.8 GB memory, max. SCLK 2304 MHz, max. MCLK 1249 MHz, compute capability 11.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

/home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_gentest.py --template /home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_template.yaml -o /tmp/hipblaslt-PzpWWl .vscode/bench.yaml
Note: Google Test filter = *pre_check*
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from _/matmul_test
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1642 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (230 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (243 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (18 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (802 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (33 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (35 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (5 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1241 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (231 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (244 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (19 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (597 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (28 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (30 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_gfx11_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (4 ms)
[----------] 16 tests from _/matmul_test (5411 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (5411 ms total)
[  PASSED  ] 16 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test --yaml .vscode/bench.yaml --gtest_filter=*pre_check* 
```

### gfx1200
```
[----------] Global test environment tear-down
[==========] 34847 tests from 13 test suites ran. (684433 ms total)
[  PASSED  ] 34847 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test 
```

```
hipBLASLt version: 1200

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon Graphics gfx1200
with 17.1 GB memory, max. SCLK 3000 MHz, max. MCLK 1258 MHz, compute capability 12.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

/home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_gentest.py --template /home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_template.yaml -o /tmp/hipblaslt-kMOFQV .vscode/bench.yaml
Note: Google Test filter = *pre_check*
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from _/matmul_test
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1162 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (145 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (204 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (19 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (741 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (36 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (37 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (4 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1297 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (174 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (202 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (14 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (972 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (49 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (52 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (4 ms)
[----------] 16 tests from _/matmul_test (5121 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (5121 ms total)
[  PASSED  ] 16 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test --yaml .vscode/bench.yaml --gtest_filter=*pre_check* 
```

### gfx1201
```
[----------] Global test environment tear-down
[==========] 34847 tests from 13 test suites ran. (771424 ms total)
[  PASSED  ] 34847 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test 
```

```
hipBLASLt version: 1200

Query device success: there are 1 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Radeon Graphics gfx1201
with 17.1 GB memory, max. SCLK 2400 MHz, max. MCLK 1258 MHz, compute capability 12.0
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 32
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

/home/haosheng/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_gentest.py --template /home/haosheng/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_template.yaml -o /tmp/hipblaslt-D0CB60 .vscode/bench.yaml
Note: Google Test filter = *pre_check*
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from _/matmul_test
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1168 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (155 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (204 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (14 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (739 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (37 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (37 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (5 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1395 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (185 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_4096_1_129_4096_0_129_129_1 (210 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_4096_1_129_4096_0_129_129_1 (15 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (1070 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_4096_129_129_1_4096_129_0_4096_4096_1 (51 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_4096_129_1_129_129_0_129_129_1 (52 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_NN_129_129_129_1_129_129_0_129_129_1 (5 ms)
[----------] 16 tests from _/matmul_test (5349 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (5349 ms total)
[  PASSED  ] 16 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test --yaml .vscode/bench.yaml --gtest_filter=*pre_check* 
```

### gfx942
```
[----------] Global test environment tear-down
[==========] 50058 tests from 13 test suites ran. (6376560 ms total)
[  PASSED  ] 50058 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test 
```

```
hipBLASLt version: 1200

Query device success: there are 8 devices
-------------------------------------------------------------------------------
Device ID 0 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 1 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 2 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 3 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 4 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 5 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 6 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
Device ID 7 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
-------------------------------------------------------------------------------
info: parsing of test data may take a couple minutes before any test output appears...

/home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_gentest.py --template /home/haoschen/projects/hipBLASLt/build_a301fe/debug/clients/staging/hipblaslt_template.yaml -o /tmp/hipblaslt-4k7DxE .vscode/bench.yaml
Note: Google Test filter = *pre_check*
[==========] Running 16 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 16 tests from _/matmul_test
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1700 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (1078 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_4096_4096_1_129_4096_0_129_129_1 (147 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_129_4096_1_129_4096_0_129_129_1 (11 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (915 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_4096_129_129_1_4096_129_0_4096_4096_1 (42 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_4096_129_1_129_129_0_129_129_1 (44 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf16_rf16_rf16_r_invalid_NN_129_129_129_1_129_129_0_129_129_1 (4 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_4096_4096_1_4096_4096_0_4096_4096_1 (1871 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_129_4096_1_4096_4096_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_129_4096_1_4096_4096_0_4096_4096_1 (159 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_4096_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_4096_4096_1_129_4096_0_129_129_1 (200 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_129_4096_1_129_4096_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_129_4096_1_129_4096_0_129_129_1 (23 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_4096_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_4096_129_1_4096_129_0_4096_4096_1 (747 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_129_129_1_4096_129_0_4096_4096_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_4096_129_129_1_4096_129_0_4096_4096_1 (37 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_4096_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_4096_129_1_129_129_0_129_129_1 (38 ms)
[ RUN      ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_129_129_1_129_129_0_129_129_1
[       OK ] _/matmul_test.matmul/pre_checkin_matmul_fallback_compute_fp16_f16_rf16_rf32_rf32_rf16_r_invalid_NN_129_129_129_1_129_129_0_129_129_1 (3 ms)
[----------] 16 tests from _/matmul_test (7026 ms total)

[----------] Global test environment tear-down
[==========] 16 tests from 1 test suite ran. (7027 ms total)
[  PASSED  ] 16 tests.
hipBLASLt version: 1200

command line: build_a301fe/debug/clients/staging/hipblaslt-test --yaml .vscode/bench.yaml --gtest_filter=*pre_check* 
```