### PR TITLE
Fixed random failures in MBSK post-loop

### DIFF
--- a/tensilelite/Tensile/AsmAddressCalculation.py
+++ b/tensilelite/Tensile/AsmAddressCalculation.py
@@ -766,6 +766,47 @@ class AddrCalculation:
                             src2=VCC(), comment="addrVgpr = C(D) + index*bytes (hi)"))
         return module
 
+    @staticmethod
+    def incrementSrdMultipleRows(srcDstBaseSgpr: str, strideSgpr: str, tmpSgpr: str, numRows: int, bpe: int) -> Module:
+        module = Module("incrementToNextRows")
+        if numRows > 1:
+            module.add(SMulI32(dst=sgpr(tmpSgpr), \
+                               src0=sgpr(strideSgpr), \
+                               src1=numRows*bpe, \
+                               comment="scale %s *= numRows(%u) * bpe"%(strideSgpr, numRows)))
+        elif numRows < 0:
+            module.add(SMulI32(dst=sgpr(tmpSgpr), \
+                               src0=sgpr(strideSgpr), \
+                                src1=(-numRows)*bpe, \
+                                comment="scale %s *= numRows(%u) * bpe"%(strideSgpr, numRows)))
+        else:
+            module.add(SLShiftLeftB32(dst=sgpr(tmpSgpr), \
+                                      src=sgpr(strideSgpr), \
+                                      shiftHex=log2(bpe), \
+                                      comment="incToNextRow: Scale by BPE"))
+        dstLow = f"{srcDstBaseSgpr}+0"
+        dstHigh = f"{srcDstBaseSgpr}+1"
+
+        if numRows >= 0:
+            module.add(SAddU32(dst=sgpr(dstLow), \
+                                        src0=sgpr(dstLow), \
+                                        src1=sgpr(tmpSgpr), \
+                                        comment="incToNextRow: gra SRD += inc(lower)" ))
+            module.add(SAddCU32(dst=sgpr(dstHigh), \
+                                        src0=sgpr(dstHigh), \
+                                        src1=0, \
+                                        comment="incToNextRow: gra SRD += inc(upper)" ))
+        else:
+            module.add(SSubU32(dst=sgpr(dstLow), \
+                                        src0=sgpr(dstLow), \
+                                        src1=sgpr(tmpSgpr), \
+                                        comment="incToNextRow: gra SRD -= inc(lower)" ))
+            module.add(SSubBU32(dst=sgpr(dstHigh), \
+                                        src0=sgpr(dstHigh), \
+                                        src1=0, \
+                                        comment="incToNextRow: gra SRD -= inc(upper)" ))
+        return module
+
     def incrementToNextRow(self, kernel, tc, ss, stmp, bpeType=None, dst=-1):
         """
         Generate code to move to the next row(s)
@@ -785,6 +826,8 @@ class AddrCalculation:
                 if tc == 'Bias' and (not kernel["WorkGroupReduction"]):
                     index = packedC1[0] - 1
                     strideCD1 = "Size%s" % "I" if index == 0 else ("J" if index == 1 else (self.kernelWriter.states.indexChars[index]))
+                elif tc == "WSDstart":
+                    strideCD1 = "StrideD%s"%(self.kernelWriter.states.indexChars[packedC1[0]])
                 else:
                     td = "D" if tc == 'TD' else tc
                     strideCD1 = "Stride%s%s"%(td ,self.kernelWriter.states.indexChars[packedC1[0]])
@@ -807,6 +850,9 @@ class AddrCalculation:
                 if dst == -1:
                     dstLow = "Srd%s+0"%(tc)
                     dstHigh = "Srd%s+1"%(tc)
+                elif isinstance(dst, str):
+                    dstLow = "%s+0"%(tc)
+                    dstHigh = "%s+1"%(tc)
                 else:
                     dstLow = dst+0
                     dstHigh = dst+1
@@ -829,6 +875,5 @@ class AddrCalculation:
                                         src0=sgpr(dstHigh), \
                                         src1=0, \
                                         comment="incToNextRow: gra SRD -= inc(upper)" ))
-            None
 
         return module

--- a/tensilelite/Tensile/AsmAddressCalculation.py
+++ b/tensilelite/Tensile/AsmAddressCalculation.py
@@ -826,8 +826,6 @@ class AddrCalculation:
                 if tc == 'Bias' and (not kernel["WorkGroupReduction"]):
                     index = packedC1[0] - 1
                     strideCD1 = "Size%s" % "I" if index == 0 else ("J" if index == 1 else (self.kernelWriter.states.indexChars[index]))
-                elif tc == "WSDstart":
-                    strideCD1 = "StrideD%s"%(self.kernelWriter.states.indexChars[packedC1[0]])
                 else:
                     td = "D" if tc == 'TD' else tc
                     strideCD1 = "Stride%s%s"%(td ,self.kernelWriter.states.indexChars[packedC1[0]])
@@ -850,9 +848,6 @@ class AddrCalculation:
                 if dst == -1:
                     dstLow = "Srd%s+0"%(tc)
                     dstHigh = "Srd%s+1"%(tc)
-                elif isinstance(dst, str):
-                    dstLow = "%s+0"%(tc)
-                    dstHigh = "%s+1"%(tc)
                 else:
                     dstLow = dst+0
                     dstHigh = dst+1

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8083,8 +8083,8 @@ class KernelWriterAssembly(KernelWriter):
 
     if ((kernel["GlobalSplitUAlgorithm"] == 'MultipleBufferSingleKernel')):
       module.addComment("backup workspace start")
-      module.add(SMovB32(dst=sgpr("WSDstart+0"), src=sgpr("SrdD+0"), comment="recode workspace start"))
-      module.add(SMovB32(dst=sgpr("WSDstart+1"), src=sgpr("SrdD+1"), comment="recode workspace start"))
+      module.add(SMovB32(dst=sgpr("WSDstart+0"), src=sgpr("SrdD+0"), comment="record workspace start"))
+      module.add(SMovB32(dst=sgpr("WSDstart+1"), src=sgpr("SrdD+1"), comment="record workspace start"))
 
     if noMultipleBuffer:
       return module

--- a/tensilelite/Tensile/TensileInstructions/Code.py
+++ b/tensilelite/Tensile/TensileInstructions/Code.py
@@ -203,6 +203,12 @@ class Module(Item):
             return self.itemList.index(targetItem)
         return -1
 
+    def findIndexByType(self, targetType):
+        for i, item in enumerate(self.itemList):
+            if isinstance(item, targetType):
+                return i
+        return None
+
     def addComment(self, comment):
         """
         Convenience function to format arg as a comment and add TextBlock item

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -94,12 +94,9 @@ BenchmarkProblems:
           - Exact: [160,   256, 1, 224]
           - Exact: [160,   256, 1, 256]
           - Exact: [160,   256, 1, 288]
-
-          # Enable the big sizes when GSU3 + MBSK is ready.
-          # - Exact: [1600,  512, 1, 992]
-          # - Exact: [1600,  512, 1, 1024]
-          # - Exact: [1600,  512, 1, 1056]
-
+          - Exact: [1600,  512, 1, 992]
+          - Exact: [1600,  512, 1, 1024]
+          - Exact: [1600,  512, 1, 1056]
           - Exact: [512,   256, 1, 224]
           - Exact: [512,   256, 1, 256]
           - Exact: [512,   256, 1, 288]


### PR DESCRIPTION
## Brief ##
This PR fixes random failures of MBSK kernels.

## Detail ##
### Root Cause ###
These random failures happen only when `optSrdIncForRow == 1`, MBSK enabled and more than 1 store batches. For MBSK post-loop, there's a synchronizer that track the value of an int32 tensor with shape `[b, B, W, M, N]`, where
 - b: number of store batches
 - B: batch size of GEMM problem
 - W: number of waves in a workgroup
 - M: number of workgroups for dim0 of GEMM
 - N: number of workgroups for dim1 of GEMM.

Hence each store batch may perform reduction on different workgroups, it depends on the execution order of the workgroup.

Here's a simplified flow for two store batches:
<img width="140" alt="image" src="https://github.com/user-attachments/assets/b7cb950e-90c3-489d-9ff3-9516dc55830e" />

If `optSrdIncForRow` enabled, the D and WSD pointer increments are included in reduction{0, 1} and storeD{0, 1} phases respectively. So if the first batch was skipped due to its non-zero synchronizer, then increments of D and WSD pointer are also skipped and hence incorrect store addresses would be used.

### Solution ###
Amended the flow as following:

<img width="186" alt="image" src="https://github.com/user-attachments/assets/8ea17319-3fea-44ff-99d1-8f0dc1d3d3bb" />

## Implementation ##
 - [x] Properly insert SRD increments in MBSK post-loop
 - [x] Re-enabled large size test cases of swizzle-A.

## Tests ##
### hipblaslt-test ###
```bash
[----------] Global test environment tear-down
[==========] 50058 tests from 13 test suites ran. (1158529 ms total)
[  PASSED  ] 50058 tests.
hipBLASLt version: 1200

command line: ./hipblaslt-test 
```
### tox ###
```bash
============ 84 passed, 37 skipped, 1 warning in 3692.23s (1:01:32) ============
py3: exit 0 (3692.51 seconds) /data0/sergelu/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tensilelite-tox/tox/tox/py3/tmp --junit-xml=/data0/sergelu/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tensilelite-tox/tox/tox/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=2163253
  py3: OK (3835.17=setup[13.76]+cmd[0.41,128.49,3692.51] seconds)
  congratulations :) (3835.26 seconds)
```