### PR TITLE
Disable non-supported features for DTVA.

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1956,8 +1956,8 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToVgpr%c does not supports Sparse"%(tc))
       return False
 
-    # for DTVA, does not work with PGR0
-    if tc == 'A' and state["PrefetchGlobalRead"] == 0:
+    # for DTVA/DTVB, does not work with PGR0
+    if state["PrefetchGlobalRead"] == 0:
       reject(state, "DirectToVgpr%c does not supports PrefetchGlobalRead == 0."%(tc))
       return False
     
@@ -1968,13 +1968,13 @@ class Solution(collections.abc.Mapping):
 
     # for DTVA, does not work with TT and Tail-loop
     if tc == 'A' and (state["ProblemType"]["TransposeA"] and state["ProblemType"]["TransposeB"]):
-        reject(state, "DirectToVgpr%c does not supports TT case with Tail Loop."%(tc))
-        return False
+        # Use AssertSummationElementMultiple (BoundSizeMultiple in predicates) to exclude failed tail-loop cases
+        state["AssertSummationElementMultiple"] = max(state["AssertSummationElementMultiple"], state["DepthU"])
 
     # for DTVB, does not work with NN and Tail-loop
     if  tc == 'B' and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
-        reject(state, "DirectToVgpr%c does not supports NN cases with Tail Loop."%(tc))
-        return False
+        # Use AssertSummationElementMultiple (BoundSizeMultiple in predicates) to exclude failed tail-loop cases
+        state["AssertSummationElementMultiple"] = max(state["AssertSummationElementMultiple"], state["DepthU"])
     
     # Does not work with DirectToLDS
     # -> this will be checked after DirectToLDS doable check is done

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1956,6 +1956,26 @@ class Solution(collections.abc.Mapping):
       reject(state, "DirectToVgpr%c does not supports Sparse"%(tc))
       return False
 
+    # for DTVA, does not work with PGR0
+    if tc == 'A' and state["PrefetchGlobalRead"] == 0:
+      reject(state, "DirectToVgpr%c does not supports PrefetchGlobalRead == 0."%(tc))
+      return False
+    
+    # for DTVA, does not work with NN and TLDS0
+    if tc == 'A' and state["TransposeLDS"] == 0 and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
+      reject(state, "DirectToVgpr%c does not supports NN case with TransposeLDS == 0."%(tc))
+      return False
+
+    # for DTVA, does not work with TT and Tail-loop
+    if tc == 'A' and (state["ProblemType"]["TransposeA"] and state["ProblemType"]["TransposeB"]):
+        reject(state, "DirectToVgpr%c does not supports TT case with Tail Loop."%(tc))
+        return False
+
+    # for DTVB, does not work with NN and Tail-loop
+    if  tc == 'B' and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
+        reject(state, "DirectToVgpr%c does not supports NN cases with Tail Loop."%(tc))
+        return False
+    
     # Does not work with DirectToLDS
     # -> this will be checked after DirectToLDS doable check is done
 

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -1957,3 +1957,135 @@ BenchmarkProblems:
           - Exact: [255,   255, 1, 191]
           - Exact: [255,   255, 1, 255]
           - Exact: [255,   255, 1, 256]
+
+  ########################################
+  # HHS TT DTVA with/wo tail loop
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+      # UseBias: 1
+      # BiasDataTypeList: [s,h]
+      # Activation: True
+      # ActivationType: hipblaslt_all
+      # UseScaleAlphaVec: 1
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,  1,8,   4,1 ] # 64x128
+          - [16, 16, 16, 1,  1,  2,8,  4,1 ] # 128x128
+          - [16, 16, 16, 1,  1,  4,16,  4,1 ] # 256x256
+        - AssertFree0ElementMultiple: [16]
+        - AssertFree1ElementMultiple: [16]
+        - AssertSummationElementMultiple: [32]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,4]
+        - DepthU: [128] # Has tail
+        - GlobalReadVectorWidthA: [-1,8] # force testing 8 (prepared for swizzleA)
+        - GlobalReadVectorWidthB: [-1]
+        - VectorWidthA: [-1,1] # force testing 1 (prepared for swizzleA)
+        - VectorWidthB: [-1]
+        - LocalReadVectorWidth: [-1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        # - StaggerU: [0] #
+        # - StaggerUStride: [-1] #
+        # - WorkGroupMapping: [1] #
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [0,1]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreRemapVectorWidth: [0]
+        - StoreVectorWidth: [-1]
+        - NumElementsPerBatchStore: [0]
+        - ClusterLocalRead: [1]
+        - WorkGroupMappingXCC: [8]
+        - UseSgprForGRO: [1]
+        # - UseSgprForGRO: [0] # Also failed
+        - DirectToVgprA: [1]
+
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [960, 1280, 1, 192]
+          - Exact: [960, 1280, 1, 256] # no tail
+          - Exact: [1280, 1280, 1, 192]
+          - Exact: [1600, 1280, 1, 192]
+
+  ########################################
+  # HHS NN DTVB with/wo tail loop
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+      # UseBias: 1
+      # BiasDataTypeList: [s,h]
+      # Activation: True
+      # ActivationType: hipblaslt_all
+      # UseScaleAlphaVec: 1
+    - # BenchmarkProblemSizeGroup - Standard
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 16, 1,  1,  4,2,   1,4 ] # 64x128
+          - [16, 16, 16, 1,  1,  8,2,  1,4 ] # 128x128
+          - [16, 16, 16, 1,  1,  16,4,  1,4 ] # 256x256
+        - AssertFree0ElementMultiple: [16]
+        - AssertFree1ElementMultiple: [16]
+        - AssertSummationElementMultiple: [32]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2,4]
+        - DepthU: [128] # Has tail
+        - GlobalReadVectorWidthA: [-1]
+        - GlobalReadVectorWidthB: [-1,8] # force testing 8 (prepared for swizzleB)
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1,1] # force testing 1 (prepared for swizzleB)
+        - LocalReadVectorWidth: [-1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        # - StaggerU: [0] #
+        # - StaggerUStride: [-1] #
+        # - WorkGroupMapping: [1] #
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - 1LDSBuffer: [0,1]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreRemapVectorWidth: [0]
+        - StoreVectorWidth: [-1]
+        - NumElementsPerBatchStore: [0]
+        - ClusterLocalRead: [1]
+        - WorkGroupMappingXCC: [8]
+        - UseSgprForGRO: [1]
+        # - UseSgprForGRO: [0] # Also failed
+        - DirectToVgprB: [1]
+
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [960, 1280, 1, 192]
+          - Exact: [960, 1280, 1, 256]
+          - Exact: [1280, 1280, 1, 192]
+          - Exact: [1600, 1280, 1, 192]

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -51,7 +51,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1,2]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -79,6 +79,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - StreamK: [0,3]
         - Groups:
           -
@@ -149,11 +150,11 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
-        - DepthU: [16,64]
+        - DepthU: [16,32,64]
         - VectorWidthA: [-1]
         - VectorWidthB: [-1]
         - MIArchVgpr: [0]
@@ -177,6 +178,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - StreamK: [0,2]
         - Groups:
           -
@@ -196,6 +198,9 @@ BenchmarkProblems:
               WorkGroup: [16,4,4]
             - MatrixInstruction: [32, 32,  8, 1,  1,   2, 2,  1,1 ]
               WorkGroup: [16,4,4]
+            - MatrixInstruction: [16, 16, 16, 1,  1,   2, 8,  4,1 ]
+            - MatrixInstruction: [16, 16, 16, 1,  1,   4, 16,  4,1 ]
+
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -338,7 +343,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -367,6 +372,7 @@ BenchmarkProblems:
         - LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - StreamK: [0,3]
         - Groups:
           -
@@ -438,7 +444,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
         - GlobalReadVectorWidthB: [2,4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1,2]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -453,7 +459,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0]
-        - TransposeLDS: [1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -462,13 +467,13 @@ BenchmarkProblems:
         - LdsPadA: [-1]
         - LdsPadB: [-1]
         - 1LDSBuffer: [1]
-        - TransposeLDS: [0,1]
         #- GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [0, 1]
         - LocalReadVectorWidth: [2,4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - ActivationFuncCall: [0, 1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -778,7 +783,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
         - GlobalReadVectorWidthB: [1,2]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - NumElementsPerBatchStore: [0]
         - DepthU: [16]
@@ -792,7 +797,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0,1]
-        - TransposeLDS: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -806,6 +810,7 @@ BenchmarkProblems:
         #- SourceSwap: [0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - StreamK: [0,1]
         - Groups:
           -
@@ -949,7 +954,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
         - GlobalReadVectorWidthB: [1,2]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1,2]
         - NumElementsPerBatchStore: [0]
         - DepthU: [16]
@@ -963,7 +968,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         #- ExpandPointerSwap: [0,1]
-        - TransposeLDS: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -977,6 +981,7 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - StreamK: [0,2]
         - Groups:
           -
@@ -1036,7 +1041,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2,4]
         - GlobalReadVectorWidthB: [1,2]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - NumElementsPerBatchStore: [0]
         - DepthU: [16]
@@ -1050,7 +1055,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         #- ExpandPointerSwap: [0,1]
-        - TransposeLDS: [1]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -1064,6 +1068,7 @@ BenchmarkProblems:
         - SourceSwap: [0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - Groups:
           -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
@@ -1119,7 +1124,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
         - GlobalReadVectorWidthB: [1,2]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - NumElementsPerBatchStore: [0]
         - DepthU: [16]
@@ -1133,7 +1138,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0,1]
-        - TransposeLDS: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -1147,6 +1151,7 @@ BenchmarkProblems:
         #- SourceSwap: [0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         #- StreamK: [0,1]
         - Groups:
           -
@@ -1281,7 +1286,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [1,2]
         - GlobalReadVectorWidthB: [1,2]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1,2]
         - NumElementsPerBatchStore: [0]
         - DepthU: [16]
@@ -1295,7 +1300,6 @@ BenchmarkProblems:
         - WorkGroupMapping: [1]
         - ScheduleIterAlg: [3]
         #- ExpandPointerSwap: [0,1]
-        - TransposeLDS: [0]
         - LdsBlockSizePerPadA: [-1]
         - LdsBlockSizePerPadB: [-1]
         - StorePriorityOpt: [0]
@@ -1309,6 +1313,7 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - Groups:
           -
             - MatrixInstruction: [16, 16,  4, 1,  1,   1, 1,  4,1 ]
@@ -1362,7 +1367,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -1390,6 +1395,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - Groups:
           -
             - MatrixInstruction: [16, 16, 32, 1,  1,   1, 1,  4,1 ]
@@ -1491,7 +1497,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [2]#[1,2]
+        - PrefetchGlobalRead: [0,2] #[1,2]
         - PrefetchLocalRead: [1,2]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -1520,6 +1526,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
@@ -1621,7 +1628,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [2,4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -1649,6 +1656,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - ConvertAfterDS: [1]
         #- StreamK: [0,2]
         - Groups:
@@ -1800,7 +1808,7 @@ BenchmarkProblems:
           - [16,16,1]
         - GlobalReadVectorWidthA: [4,8]
         - GlobalReadVectorWidthB: [4,8]
-        - PrefetchGlobalRead: [1,2]
+        - PrefetchGlobalRead: [0,1,2]
         - PrefetchLocalRead: [1]
         - ClusterLocalRead: [1]
         - NumElementsPerBatchStore: [0]
@@ -1829,6 +1837,7 @@ BenchmarkProblems:
         - LocalReadVectorWidth: [4,8]
         - DirectToVgprA: [1]
         - UseSgprForGRO: [0,1]
+        - TransposeLDS: [0,1]
         - ConvertAfterDS: [1]
         # - StreamK: [0,3]
         - Groups:

--- a/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtv.yaml
@@ -2012,8 +2012,7 @@ BenchmarkProblems:
         - NumElementsPerBatchStore: [0]
         - ClusterLocalRead: [1]
         - WorkGroupMappingXCC: [8]
-        - UseSgprForGRO: [1]
-        # - UseSgprForGRO: [0] # Also failed
+        - UseSgprForGRO: [0]
         - DirectToVgprA: [1]
 
       BenchmarkJoinParameters:
@@ -2078,8 +2077,7 @@ BenchmarkProblems:
         - NumElementsPerBatchStore: [0]
         - ClusterLocalRead: [1]
         - WorkGroupMappingXCC: [8]
-        - UseSgprForGRO: [1]
-        # - UseSgprForGRO: [0] # Also failed
+        - UseSgprForGRO: [0]
         - DirectToVgprB: [1]
 
       BenchmarkJoinParameters:


### PR DESCRIPTION
## For ticket: https://ontrack-internal.amd.com/browse/SWDEV-506439
- Disable following features:
1. DTVA=1 + PGR=0 (No assignee)
https://ontrack-internal.amd.com/browse/SWDEV-503281

2. DTVA=1 + NN + TLDS=0 (No assignee)
https://ontrack-internal.amd.com/browse/SWDEV-504863

3. DTVA/B + TT/NN + Tail-loop (No assignee)
https://ontrack-internal.amd.com/browse/SWDEV-505516