### PR TITLE
fix frequency monitor

### DIFF
--- a/clients/common/frequency_monitor.cpp
+++ b/clients/common/frequency_monitor.cpp
@@ -139,7 +139,7 @@ public:
 #if rocm_smi_VERSION_MAJOR >= 7
         auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
 
-        if(status2 != RSMI_STATUS_SUCCESS)
+        if(status2 != RSMI_STATUS_SUCCESS || m_XCDCount == 0)
         {
             m_XCDCount = 1;
         }


### PR DESCRIPTION
rsmi_dev_metrics_xcd_counter_get gets xcd_counter=0 by chance which leads to segmentation fault in the following instruction.
![image](https://github.com/user-attachments/assets/8f04a688-413c-41b6-b45a-26525fac8bf1)
