### PR TITLE
Set debug flag as default

### DIFF
--- a/tensilelite/Makefile
+++ b/tensilelite/Makefile
@@ -61,11 +61,11 @@ ${TENSILE_OUT}/1_BenchmarkProblems%.co: PROBLEM  = $(firstword $(subst /, ,$*))
                                         OBJFILES = $(patsubst %.s,%.o,$(SRCFILES))
 ${TENSILE_OUT}/1_BenchmarkProblems%.co: $$(OBJFILES)
 	@echo relinking $(PROBLEM) $(lastword $(subst /, ,$@))
-	@$(LDD) -target amdgcn-amd-amdhsa -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
+	@$(LDD) -target amdgcn-amd-amdhsa -g -Xlinker --build-id=sha1 ${LINK_ARGS} -o $@ $^
 
 %.o: PROBLEM = $(word 3, $(subst /, ,$*))
      COFILE = $(shell find ${TENSILE_OUT}/1_BenchmarkProblems/$(PROBLEM)/00_Final/source/library -name '*.co')
      ARCH ?= $(subst .co,,$(subst TensileLibrary_,,$(lastword $(subst /, ,$(COFILE)))))
 %.o: %.s
 	@echo rebuilding $(lastword $(subst /, ,$@)) for $(ARCH)
-	$(AS) -x assembler -target amdgcn-amd-amdhsa -mcode-object-version=4 -mcpu=$(ARCH) ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^
+	$(AS) -x assembler -target amdgcn-amd-amdhsa -g -mcode-object-version=4 -mcpu=$(ARCH) ${WAVEFRONTSIZE} ${ASM_ARGS} -c -o $@ $^


### PR DESCRIPTION
When profiling a kernel that was recompiled without the debug flag, it shows the old source file because the debug symbols haven't been updated.

<img width="985" alt="image" src="https://github.com/user-attachments/assets/d7c1a4eb-e549-47c2-ad36-32284d41c662" />

Expected:
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/26c1226b-0cd7-4b87-8dc2-2937d0e7096e" />
