### PR TITLE
hipblaslt-bench: only print device caps of target device

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,7 @@
 using namespace roc; // For emulated program_options
 using namespace std::literals; // For std::string literals of form "str"s
 
-struct perf_matmul: hipblaslt_test_valid
+struct perf_matmul : hipblaslt_test_valid
 {
     void operator()(const Arguments& arg)
     {
@@ -734,7 +734,7 @@ try
     }
 
     // Device Query
-    int64_t device_count = query_device_property();
+    int64_t device_count = query_device_property(device_id);
 
     hipblaslt_cout << std::endl;
     if(device_count <= device_id)

--- a/clients/gtest/hipblaslt_gtest_main.cpp
+++ b/clients/gtest/hipblaslt_gtest_main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -219,7 +219,7 @@ static void hipblaslt_print_args(const std::string& args)
 static void hipblaslt_set_test_device()
 {
     int device_id    = 0;
-    int device_count = query_device_property();
+    int device_count = query_device_property(device_id);
     if(device_count <= device_id)
     {
         hipblaslt_cerr << "Error: invalid device ID. There may not be such device ID." << std::endl;

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -317,7 +317,7 @@ public:
 
 /* ============================================================================================ */
 /*  device query and print out their ID and name */
-int64_t query_device_property();
+int64_t query_device_property(int device_id);
 
 /*  set current device to device_id */
 void set_device(int64_t device_id);


### PR DESCRIPTION
hipblaslt-bench output with this PR:

> hipBLASLt version: 1300
hipBLASLt git version: 7d25c31f-dirty
Query device success: there are 8 devices. (Target device ID is 0)
Device ID 0 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64
