### PR TITLE
Set default cmake code object version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ else()
     set( Tensile_ARCHITECTURE "${AMDGPU_TARGETS}" CACHE STRING "Tensile to use which architecture?" FORCE)
 
     set( Tensile_LOGIC "asm_full" CACHE STRING "Tensile to use which logic?")
-    set( Tensile_CODE_OBJECT_VERSION "default" CACHE STRING "Tensile code_object_version")
+    set( Tensile_CODE_OBJECT_VERSION "4" CACHE STRING "Tensile code_object_version")
     set( Tensile_COMPILER "amdclang++" CACHE STRING "Tensile compiler")
     set( Tensile_LIBRARY_FORMAT "msgpack" CACHE STRING "Tensile library format")
     set( Tensile_CPU_THREADS "" CACHE STRING "Number of threads for Tensile parallel build")


### PR DESCRIPTION
This PR updates the default code object version set in CMakeLists.txt to "4" instead of the previous "default" which is no longer accepted by TensileCreateLibrary