### PR TITLE
Add emulation smoke/regression/extended tests.

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -124,6 +124,7 @@ add_custom_command( OUTPUT "${HIPBLASLT_TEST_DATA}"
                             matmul_common.yaml
                             matmul_gtest.yaml
                             auxiliary_gtest.yaml
+                            smoke_gtest.yaml
                     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" )
 add_custom_target( hipblaslt-test-data
                    DEPENDS "${HIPBLASLT_TEST_DATA}" )

--- a/clients/gtest/hipblaslt_gtest.yaml
+++ b/clients/gtest/hipblaslt_gtest.yaml
@@ -1,2 +1,3 @@
 include: matmul_gtest.yaml
 include: auxiliary_gtest.yaml
+include: smoke_gtest.yaml

--- a/clients/gtest/hipblaslt_test.cpp
+++ b/clients/gtest/hipblaslt_test.cpp
@@ -350,7 +350,7 @@ std::string RocBlasLt_TestName_to_string(std::unordered_map<std::string, size_t>
 }
 
 static const char* const validCategories[]
-    = {"quick", "pre_checkin", "nightly", "multi_gpu", "HMM", "known_bug", NULL};
+    = {"smoke", "quick", "pre_checkin", "nightly", "multi_gpu", "HMM", "known_bug", NULL};
 
 static bool valid_category(const char* category)
 {

--- a/clients/gtest/matmul_common.yaml
+++ b/clients/gtest/matmul_common.yaml
@@ -48,6 +48,11 @@ Definitions:
     - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }
     - { M: 128, N: 128, K: 64, lda: 128, ldb: 128, ldc: 128, ldd: 128 }
 
+  - &smoke_matrix_size_range
+    - { M: 8, N: 8, K: 8, lda: 8, ldb: 8, ldc: 8, ldd: 8 }
+    - { M: 16, N: 16, K: 16, lda: 16, ldb: 16, ldc: 16, ldd: 16 }
+    - { M: 32, N: 32, K: 32, lda: 32, ldb: 32, ldc: 32, ldd: 32 }
+
   - &chunk_matrix_size_range
     - { M: 24000, N: 256, K: 256, lda: 24010, ldb: 256, ldc: 24000, ldd: 24000 }
     - { M: 24000, N: 256, K: 256, lda: 24000, ldb: 256, ldc: 24020, ldd: 24020 }

--- a/clients/gtest/smoke_gtest.yaml
+++ b/clients/gtest/smoke_gtest.yaml
@@ -1,0 +1,392 @@
+---
+include: hipblaslt_common.yaml
+include: known_bugs.yaml
+include: matmul_common.yaml
+
+Definitions:
+  - &alpha_beta_range
+    - { alpha:  5, beta:  0 }
+    - { alpha:  0, beta:  3 }
+    - { alpha:  1, beta:  3 }
+    - { alpha:  1, beta:  1 }
+
+  - &alpha_beta_range_small
+    - { alpha: 2, alphai: 2, beta: -1.0, betai: 2.0 }
+
+  - &transA_transB_range
+    - { transA: N, transB: N }
+    - { transA: N, transB: T }
+    - { transA: T, transB: N }
+    - { transA: T, transB: T }
+
+Tests:
+- name: matmul_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha_beta: *alpha_beta_range
+
+- name: matmul_bias_relu_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  activation_type: relu
+  bias_vector: [0, 1]
+  unit_check: 1
+
+- name: matmul_bias_gelu_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  activation_type: gelu
+  bias_vector: [0, 1]
+  unit_check: 0
+  norm_check: 1
+
+- name: matmul_bias_only_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  bias_vector: 1
+  unit_check: 1
+
+- name: matmul_bias_type_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_2b
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  bias_vector: 1
+  bias_type: [default, f32_r]
+  unit_check: 1
+
+- name: matmul_f8_bf8_dst_fp16_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_f16
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [ 0, 1]
+  scaleB: [ 0, 1]
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_f8_bf8_dst_bf16_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_bf16
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [ 0, 1]
+  scaleB: [ 0, 1]
+  bias_vector: [0, 1]
+  bias_type: bf16_r
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+### GFX12 FP8
+- name: matmul_f8_bf8_dst_fp32_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_ocp_dst_f32
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [ 0, 1]
+  scaleB: [ 0, 1]
+  bias_vector: [0, 1]
+  bias_type: bf16_r
+  unit_check: 0
+  norm_check: 1
+  gpu_arch: '120[0-1]'
+
+- name: matmul_f8_bf8_dst_fp16_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_ocp_dst_f16
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [ 0, 1]
+  scaleB: [ 0, 1]
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '120[0-1]'
+
+- name: matmul_f8_bf8_dst_bf16_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_ocp_dst_bf16
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [ 0, 1]
+  scaleB: [ 0, 1]
+  bias_vector: [0, 1]
+  bias_type: bf16_r
+  unit_check: 1
+  gpu_arch: '120[0-1]'
+
+- name: matmul_real_1b_dst_f8_SCDInt1_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_ocp_dst_f8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [0] # will use default value '1'
+  scaleD: [0] # will use default value '1'
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '120[0-1]'
+
+- name: matmul_real_1b_dst_f8_SCDNotInt_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_ocp_dst_f8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [1] # will use random value from 0.0 to 1.0
+  scaleD: [1] # will use random value from 0.0 to 1.0
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '120[0-1]'
+
+- name: matmul_one_integer_precisions_i8_gfx12_smoke
+  category: smoke
+  function:
+    matmul: *integer_precisions_i8
+  matrix_size: *one_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: [ 0.0, 1.0 ]
+  beta: [ 0.0, 2.0 ]
+  gpu_arch: '120[0-1]'
+
+- name: matmul_real_1b_dst_f8_SCDInt1_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_f8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [0] # will use default value '1'
+  scaleD: [0] # will use default value '1'
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_real_1b_dst_1b_smallsize_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_1b
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [0]
+  scaleD: [0]
+  bias_vector: [0, 1]
+  bias_type: f32_r
+  unit_check: 1
+  gpu_arch: '942'
+
+#TODO: extend to all f8 transpose and datatype if necessary
+- name: matmul_real_f8_dst_fp32_smoke
+  category: smoke
+  function:
+    matmul: *f8_precision_dst_fp32
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [0]
+  scaleD: [0]
+  bias_vector: [0, 1]
+  bias_type: f32_r
+  unit_check: 1
+  gpu_arch: '942'
+
+- name: matmul_real_1b_dst_f8_SCDNotInt_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_f8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [1] # will use random value from 0.0 to 1.0
+  scaleD: [1] # will use random value from 0.0 to 1.0
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 0
+  norm_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_real_1b_dst_bf8_SCDInt1_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_bf8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [0] # will use default value '1'
+  scaleD: [0] # will use default value '1'
+  bias_vector: [0,1]
+  bias_type: f16_r
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_real_1b_dst_bf8_SCDNotInt_smoke
+  category: smoke
+  function:
+    matmul: *real_precisions_1b_dst_bf8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  scaleA: [0, 1]
+  scaleB: [0, 1]
+  scaleC: [1] # will use random value from 0.0 to 1.0
+  scaleD: [1] # will use random value from 0.0 to 1.0
+  bias_vector: [0, 1]
+  bias_type: f16_r
+  unit_check: 0
+  norm_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_gemm_xf32_smoke
+  category: smoke
+  function:
+    matmul: *xf32_precision
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_gemm_double_smoke
+  category: smoke
+  function:
+    matmul: *double_precision
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  unit_check: 1
+  gpu_arch: '9(0a|4[0-2])'
+
+- name: matmul_gemm_i8_dst_i32_smoke
+  category: smoke
+  function:
+    matmul: *i8_precision_dst_i32
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0, 2 ]
+  unit_check: 1
+  gpu_arch: '90a'
+
+- name: matmul_gemm_i8_dst_i32_94x_smoke
+  category: smoke
+  function:
+    matmul: *i8_precision_dst_i32
+  matrix_size: *smoke_matrix_size_range
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0, 2 ]
+  scaleAlpha_vector: [0, 1]
+  activation_type: relu
+  unit_check: 1
+  gpu_arch: '94[0-2]'
+
+- name: matmul_gemm_i8_dst_i8_1xxx_smoke
+  category: smoke
+  function:
+    matmul: *i8_precision_dst_i8
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0, 2 ]
+  scaleAlpha_vector: [0, 1]
+  activation_type: relu
+  unit_check: 1
+  gpu_arch: '1[1-2]\d{2}'
+
+- name: matmul_gemm_i8_dst_i32_1xxx_smoke
+  category: smoke
+  function:
+    matmul: *i8_precision_dst_i32
+  matrix_size:
+    - { M:  128,  N:  128,  K:  128  }
+  transA_transB: *transA_transB_range
+  alpha: 1
+  beta: [ 0, 2 ]
+  scaleAlpha_vector: [0, 1]
+  activation_type: relu
+  unit_check: 1
+  gpu_arch: '1[1-2]\d{2}'
+...

--- a/rtest.py
+++ b/rtest.py
@@ -1,0 +1,103 @@
+#!/usr/bin/python3
+
+# ########################################################################
+# Copyright (c) 2025 Advanced Micro Devices, Inc. All rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+"""Copyright 2025 Advanced Micro Devices, Inc. All rights Reserved.
+Run tests on build"""
+
+import os
+import sys
+import argparse
+import pathlib
+import subprocess
+
+
+def parse_args():
+    """Parse command-line arguments"""
+    parser = argparse.ArgumentParser(description="""
+    Checks build arguments
+    """)
+
+    # Mutually exclusive group for --test and --emulation
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-e',  '--emulation', type=str, choices=['smoke', 'regression', 'extended'],
+                        help='Enable specific emulation test mode, e.g. smoke test')
+    parser.add_argument('-i', '--install_dir', type=str, required=False, default="",
+                        help='Installation directory where build or release folders are (optional, default: $PWD)')
+    parser.add_argument('-o', '--output', type=str, required=False, default="xml", 
+                        help='Test output file (optional, default: test_detail.xml)')
+    args = parser.parse_args()
+
+    return args
+
+
+def run_cmd(args, filter):
+
+    test_binary = ""
+    if args.install_dir :
+        test_binary = os.path.join(args.install_dir, "hipblaslt-test")
+    else:
+        test_binary = os.path.join(pathlib.os.curdir, "hipblaslt-test")
+
+    if not os.path.isfile(test_binary):
+        return
+
+    sub_env = os.environ.copy()
+    sub_env["PATH"] = os.getcwd() + os.pathsep + sub_env["PATH"]
+    
+    output_file = "--gtest_output=" + args.output if args.output else ""
+    
+    cmd = [test_binary, filter, output_file]
+    test_proc = subprocess.run(cmd, stdout=sys.stdout, stderr=sys.stderr, env=sub_env)
+
+    return test_proc.returncode
+
+
+def run_test(args):
+
+    cwd = os.curdir
+
+    if args.emulation == "smoke":
+        run_cmd(args, "--gtest_filter=*smoke*")
+    elif args.emulation == "regression":
+        run_cmd(args, "--gtest_filter=*quick*")
+    elif args.emulation == "extended":
+        run_cmd(args, "--gtest_filter=*pre_checkin*:*nightly*")
+
+    if (os.curdir != cwd):
+        os.chdir( cwd )
+
+    return 0
+
+def main():
+
+    args = parse_args()
+
+    status = run_test(args)
+
+    sys.exit
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
# Emulation Smoke/Regression/Extended Tests
---
## Usage -- rtest.py
Add emulation tests.
```
-   smoke test: rtest.py --emulation smoke --install_dir ${PATH_TO_hipblaslt-test}
-   regression test: rtest.py --emulation regression --install_dir ${PATH_TO_hipblaslt-test}
-   extended test: : rtest.py --emulation extended--install_dir ${PATH_TO_hipblaslt-test}
  ```
## Smoke-test yaml

Cover functionality and APIs for each Library to see that things ‘work’

- Should cover as many data types and APIs/features as possible, instead of covering every size permutation and edge cases that is normally run in CI
- Should cover any new data types that might be present on the new ASIC
- Should not cover every size permutation as the emulator runs extremely slowly, between 100x to 10,000x the speed of silicon.


## Runtime
- Use the following command to run the smoke/regression/extended tests.
``` python3 rtest.py --emulation smoke --install_dir build/release/clients/staging```
- The total filter must be finished in less than 1 minute using MI300 silicon (GPU time).
```
[----------] Global test environment tear-down
[==========] 2760 tests from 1 test suite ran. (32580 ms total)
[  PASSED  ] 2760 tests.
hipBLASLt version: 1300

command line: build/release/clients/staging/hipblaslt-test --gtest_filter=*smoke* --gtest_output=xml 
```
## Tickets:
1. hipBLASLt Emulation Smoke Tests: https://ontrack-internal.amd.com/browse/SWDEV-481982
2. hipBLASLt Emulation Regression Tests: https://ontrack-internal.amd.com/browse/SWDEV-484899
3. hipBLASLt Emulation Extended Tests: https://ontrack-internal.amd.com/browse/SWDEV-485109
