### PR TITLE
[TensileLite] Support arbitrary M & K for swizzle-A kernels

### DIFF
--- a/tensilelite/Tensile/Contractions.py
+++ b/tensilelite/Tensile/Contractions.py
@@ -517,15 +517,9 @@ class ProblemPredicate(Properties.Predicate):
 
         if state['ProblemType']['SwizzleTensorA']:
             rv += [cls('SwizzleTensorA', value=state['ProblemType']['SwizzleTensorA'])]
-            # TODO- (TT + DTVA) tail-loop is not working yet.
-            if state['ProblemType']['TransposeB']:
-                rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
 
-        # TODO- Will remove the size predicate once we have SWZ-B request
         if state['ProblemType']['SwizzleTensorB']:
             rv += [cls('SwizzleTensorB', value=state['ProblemType']['SwizzleTensorB'])]
-            rv += [cls("Free1SizeMultiple", index=0, value=state['MacroTile1'])]
-            rv += [cls("BoundSizeMultiple", index=-1, value=state['DepthU'])]
 
         return rv
 

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -2638,11 +2638,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       globalReadMode2nd = 2 if (((tensorParameters2nd["glvw"] * tensorParameters2nd["bpeGR"]) < 4) or \
                                kernel["tailLoopOpt"] == False) else 0
 
-      # if we have swizzled A or B, then size-K is already guarded, we don't have to used guarded-k GR again
-      hasSwizzled = tensorParametersA["isSwizzled"] or tensorParametersB["isSwizzled"]
-      globalReadMode1st = 0 if hasSwizzled else globalReadMode1st
-      globalReadMode2nd = 0 if hasSwizzled else globalReadMode2nd
-
       module.addComment1("Update M0 for DTLDS")
       moduleTmp = self.directToLdsM0Update(kernel, 1, tensorParameters1st)
       module.add(replaceHolder(moduleTmp, 0))

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -2637,6 +2637,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
                                kernel["tailLoopOpt"] == False) else 0
       globalReadMode2nd = 2 if (((tensorParameters2nd["glvw"] * tensorParameters2nd["bpeGR"]) < 4) or \
                                kernel["tailLoopOpt"] == False) else 0
+      globalReadMode1st = 0 if tensorParameters1st["isSwizzled"] else globalReadMode1st
+      globalReadMode2nd = 0 if tensorParameters2nd["isSwizzled"] else globalReadMode2nd
 
       module.addComment1("Update M0 for DTLDS")
       moduleTmp = self.directToLdsM0Update(kernel, 1, tensorParameters1st)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -5398,11 +5398,13 @@ class KernelWriterAssembly(KernelWriter):
               if kernel["LocalSplitU"] > 1:
                 shiftK.add(SMinI32(dst=sgpr(loopCntSgpr), src0=sgpr(loopCounterName), src1=sgpr("LSUTailLoopOffset"), comment="check lsu bound"))
               shiftK.add(VCmpGEI32(dst=sgpr(tmpSgprX2, self.states.laneSGPRCount), src0=vgpr(kReg), src1=sgpr(loopCntSgpr), comment="check K index >= Size L"))
-            for bk in range(0, vgprPerSet0Group):
-              for a in range(0, kernel["MIWaveTileA"]):
-                for iui in range(0, innerUnroll):
-                  aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
-                  shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
+
+            if not tPA["isSwizzled"]:
+              for bk in range(0, vgprPerSet0Group):
+                for a in range(0, kernel["MIWaveTileA"]):
+                  for iui in range(0, innerUnroll):
+                    aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
+                    shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
 
           if kernel["ProblemType"]["Sparse"] == 2 and numMIInput//8 >= 1:
             shiftK.add(vectorStaticRemainder(dummy, kReg, "Serial", kernel["WavefrontSize"], tmpVgpr, tmpSgprInfo))

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -5408,12 +5408,12 @@ class KernelWriterAssembly(KernelWriter):
                 shiftK.add(SMinI32(dst=sgpr(loopCntSgpr), src0=sgpr(loopCounterName), src1=sgpr("LSUTailLoopOffset"), comment="check lsu bound"))
               shiftK.add(VCmpGEI32(dst=sgpr(tmpSgprX2, self.states.laneSGPRCount), src0=vgpr(kReg), src1=sgpr(loopCntSgpr), comment="check K index >= Size L"))
 
-            #if not tPA["isSwizzled"]:
-            for bk in range(0, vgprPerSet0Group):
-              for a in range(0, kernel["MIWaveTileA"]):
-                for iui in range(0, innerUnroll):
-                  aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
-                  shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
+            if not tPA["isSwizzled"]:
+              for bk in range(0, vgprPerSet0Group):
+                for a in range(0, kernel["MIWaveTileA"]):
+                  for iui in range(0, innerUnroll):
+                    aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
+                    shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
 
           if kernel["ProblemType"]["Sparse"] == 2 and numMIInput//8 >= 1:
             shiftK.add(vectorStaticRemainder(dummy, kReg, "Serial", kernel["WavefrontSize"], tmpVgpr, tmpSgprInfo))

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -2272,6 +2272,15 @@ class KernelWriterAssembly(KernelWriter):
       module.add(ValueSet(name="globalReadOffsetB%s" % self.states.indexChars[index], value=0))
     return module
 
+  def alignTo(self, dstBase: Union[int, str], srcBase: Union[int, str], alignment: int) -> Module:
+    assert (alignment & (alignment - 1)) == 0 and f"Alignment must be power of two"
+    module = Module()
+    module.addComment(f"Align to {alignment}")
+    module.add(SAddU32(sgpr(dstBase), sgpr(srcBase), alignment-1))
+    module.add(SLShiftRightB32(dst=sgpr(dstBase), src=sgpr(dstBase), shiftHex=log2(alignment)))
+    module.add(SLShiftLeftB32(dst=sgpr(dstBase), src=sgpr(dstBase), shiftHex=log2(alignment)))
+    return module
+
   ##############################################################################
   # Global Read Addresses: Tile Offsets A/B
   ##############################################################################
@@ -3029,12 +3038,15 @@ class KernelWriterAssembly(KernelWriter):
             module.add(SLShiftRightB32(dst=sgpr(stmp), src=size, shiftHex=0x1, comment="(size/2)"))
             module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=0x1, comment="(size/2-1)"))
           else:
-            if tP["isA"] and tP["isSwizzled"] and idx == kernel["ProblemType"]["Index0"]:
-              module.addComment("Align M to 16")
-              module.add(SAddU32(sgpr(stmp), sgpr("SizeI"), 15))
-              module.add(SLShiftRightB32(dst=sgpr(stmp), src=sgpr(stmp), shiftHex=4))
-              module.add(SLShiftLeftB32(dst=sgpr(stmp), src=sgpr(stmp), shiftHex=4))
-              module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=1, comment="(size-1)"))
+            if tP["isA"] and tP["isSwizzled"]:
+              if idx in kernel["ProblemType"]["IndicesSummation"]:
+                module.addModuleAsFlatItems(self.alignTo(stmp, "SizeL", 32))
+                module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=1, comment="(size-1)"))
+              elif idx == kernel["ProblemType"]["Index0"]:
+                module.addModuleAsFlatItems(self.alignTo(stmp, "SizeI", 16))
+                module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=1, comment="(size-1)"))
+              else:
+                module.add(SSubU32(dst=sgpr(stmp), src0=size, src1=0x1, comment="(size-1)"))
             else:
               module.add(SSubU32(dst=sgpr(stmp), src0=size, src1=0x1, comment="(size-1)"))
           module.addModuleAsFlatItems(self.s_mul_u64_u32(sgpr(stmp), sgpr(stmp+1), stride, \
@@ -3136,10 +3148,7 @@ class KernelWriterAssembly(KernelWriter):
     graIdx = 0
 
     if tP["isA"] and tP["isSwizzled"]:
-      module.addComment("Align StrideA0I to 32")
-      module.add(SAddU32(sgpr("StrideA0I"), sgpr("StrideA0I"), 31))
-      module.add(SLShiftRightB32(sgpr("StrideA0I"), src=sgpr("StrideA0I"), shiftHex=hex(5)))
-      module.add(SLShiftLeftB32(sgpr("StrideA0I"), src=sgpr("StrideA0I"), shiftHex=hex(5)))
+      module.addModuleAsFlatItems(self.alignTo("StrideA0I", "StrideA0I", 32))
 
     if kernel["BufferLoad"]:
       # maxAddrSgpr = size[n] * stride[n-1]
@@ -5399,12 +5408,12 @@ class KernelWriterAssembly(KernelWriter):
                 shiftK.add(SMinI32(dst=sgpr(loopCntSgpr), src0=sgpr(loopCounterName), src1=sgpr("LSUTailLoopOffset"), comment="check lsu bound"))
               shiftK.add(VCmpGEI32(dst=sgpr(tmpSgprX2, self.states.laneSGPRCount), src0=vgpr(kReg), src1=sgpr(loopCntSgpr), comment="check K index >= Size L"))
 
-            if not tPA["isSwizzled"]:
-              for bk in range(0, vgprPerSet0Group):
-                for a in range(0, kernel["MIWaveTileA"]):
-                  for iui in range(0, innerUnroll):
-                    aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
-                    shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
+            #if not tPA["isSwizzled"]:
+            for bk in range(0, vgprPerSet0Group):
+              for a in range(0, kernel["MIWaveTileA"]):
+                for iui in range(0, innerUnroll):
+                  aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
+                  shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
 
           if kernel["ProblemType"]["Sparse"] == 2 and numMIInput//8 >= 1:
             shiftK.add(vectorStaticRemainder(dummy, kReg, "Serial", kernel["WavefrontSize"], tmpVgpr, tmpSgprInfo))

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -5398,13 +5398,11 @@ class KernelWriterAssembly(KernelWriter):
               if kernel["LocalSplitU"] > 1:
                 shiftK.add(SMinI32(dst=sgpr(loopCntSgpr), src0=sgpr(loopCounterName), src1=sgpr("LSUTailLoopOffset"), comment="check lsu bound"))
               shiftK.add(VCmpGEI32(dst=sgpr(tmpSgprX2, self.states.laneSGPRCount), src0=vgpr(kReg), src1=sgpr(loopCntSgpr), comment="check K index >= Size L"))
-            # if A is swizzled, then no need to do this since MatB will be set to 0
-            if not tPA["isSwizzled"]:
-              for bk in range(0, vgprPerSet0Group):
-                for a in range(0, kernel["MIWaveTileA"]):
-                  for iui in range(0, innerUnroll):
-                    aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
-                    shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
+            for bk in range(0, vgprPerSet0Group):
+              for a in range(0, kernel["MIWaveTileA"]):
+                for iui in range(0, innerUnroll):
+                  aStr = vgpr(self.generateSrcStrForMFMA(kernel, tPA, innerUnroll, vregSetIdx, vgprPerInputA, m, u, iui, a, bk=bk + group * vgprPerSet0Group), 1)
+                  shiftK.add(VCndMaskB32(dst=aStr, src0=aStr, src1=hex(0), src2=sgpr(tmpSgprX2, self.states.laneSGPRCount), comment="set 0 if K_idx >= sizeL"))
 
           if kernel["ProblemType"]["Sparse"] == 2 and numMIInput//8 >= 1:
             shiftK.add(vectorStaticRemainder(dummy, kReg, "Serial", kernel["WavefrontSize"], tmpVgpr, tmpSgprInfo))

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -2313,7 +2313,10 @@ class KernelWriterAssembly(KernelWriter):
           swizzleStridePerWave = self.sgprPool.checkOut(1)
           WvG_M = kernel["MIWaveGroup"][0]
           # Calc stride = numKr * WaveG[0], TODO- 32 should be MI_K * 2
-          module.add(SLShiftRightB32(dst=sgpr(swizzleStridePerWave), shiftHex=hex(log2(32)), src=sgpr("SizesSum"),  comment="SWZ: numKr = DimK / 32"))
+          swizzleStrideVal = 32
+          module.addComment(f"Align to {swizzleStrideVal}")
+          module.add(SAddU32(sgpr(swizzleStridePerWave), sgpr("SizesSum"), swizzleStrideVal-1))
+          module.add(SLShiftRightB32(dst=sgpr(swizzleStridePerWave), src=sgpr(swizzleStridePerWave), shiftHex=hex(log2(swizzleStrideVal))))
           module.add(SMulI32(dst=sgpr(swizzleStridePerWave), src0=hex(WvG_M), src1=sgpr(swizzleStridePerWave), comment="SWZ: numKr *= MI_WvG[0] (%u), how many wave-M per WG" % WvG_M))
 
       for l in range(1, tP["nrt"]):
@@ -3026,7 +3029,14 @@ class KernelWriterAssembly(KernelWriter):
             module.add(SLShiftRightB32(dst=sgpr(stmp), src=size, shiftHex=0x1, comment="(size/2)"))
             module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=0x1, comment="(size/2-1)"))
           else:
-            module.add(SSubU32(dst=sgpr(stmp), src0=size, src1=0x1, comment="(size-1)"))
+            if tP["isA"] and tP["isSwizzled"] and idx == kernel["ProblemType"]["Index0"]:
+              module.addComment("Align M to 16")
+              module.add(SAddU32(sgpr(stmp), sgpr("SizeI"), 15))
+              module.add(SLShiftRightB32(dst=sgpr(stmp), src=sgpr(stmp), shiftHex=4))
+              module.add(SLShiftLeftB32(dst=sgpr(stmp), src=sgpr(stmp), shiftHex=4))
+              module.add(SSubU32(dst=sgpr(stmp), src0=sgpr(stmp), src1=1, comment="(size-1)"))
+            else:
+              module.add(SSubU32(dst=sgpr(stmp), src0=size, src1=0x1, comment="(size-1)"))
           module.addModuleAsFlatItems(self.s_mul_u64_u32(sgpr(stmp), sgpr(stmp+1), stride, \
                       sgpr(stmp), "stride x (size-1)"))
           module.add(SAddU32(dst=sgpr(tensor2dSize0), src0=sgpr(tensor2dSize0), src1=sgpr(stmp+0), comment="sum tensor size"))
@@ -3124,6 +3134,12 @@ class KernelWriterAssembly(KernelWriter):
     module = Module("graAddresses")
     tc = tP["tensorChar"]
     graIdx = 0
+
+    if tP["isA"] and tP["isSwizzled"]:
+      module.addComment("Align StrideA0I to 32")
+      module.add(SAddU32(sgpr("StrideA0I"), sgpr("StrideA0I"), 31))
+      module.add(SLShiftRightB32(sgpr("StrideA0I"), src=sgpr("StrideA0I"), shiftHex=hex(5)))
+      module.add(SLShiftLeftB32(sgpr("StrideA0I"), src=sgpr("StrideA0I"), shiftHex=hex(5)))
 
     if kernel["BufferLoad"]:
       # maxAddrSgpr = size[n] * stride[n-1]
@@ -3362,7 +3378,10 @@ class KernelWriterAssembly(KernelWriter):
       with self.allocTmpSgpr(1) as tmpSgprInfo:
         tmpSgpr = tmpSgprInfo.idx
         # Calc numKr, TODO- 32 should be MI_K * 2
-        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr), shiftHex=hex(log2(32)), src=sgpr("SizesSum"),  comment="SWZ: numKr = DimK / 32"))
+        swizzleStrideVal = 32
+        module.addComment(f"Align to {swizzleStrideVal}")
+        module.add(SAddU32(sgpr(tmpSgpr), sgpr("SizesSum"), swizzleStrideVal-1))
+        module.add(SLShiftRightB32(dst=sgpr(tmpSgpr), shiftHex=hex(log2(swizzleStrideVal)), src=sgpr(tmpSgpr),  comment="SWZ: numKr = DimK / 32"))
         WvG_M = kernel["MIWaveGroup"][0]
         module.add(VAndB32(dst=vgpr(qReg), src0=hex(WvG_M-1), src1=vgpr(qReg), comment="SWZ: wave_id (along_M) %= MIWG[0]"))
         module.add(VMulU32U24(dst=vgpr(qReg), src0=sgpr(tmpSgpr), src1=vgpr(qReg), comment="SWZ: wave_id (along_M) *= numKr"))

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -518,13 +518,15 @@ namespace TensileLite
                                   void*                   dst,
                                   void*                   src,
                                   size_t                  totalElements,
-                                  hipMemcpyKind           kind)
+                                  hipMemcpyKind           kind,
+                                  ptrdiff_t               customPadding = -1)
         {
-            ptrdiff_t dPadding  = totalElements - descriptor.totalAllocatedElements();
+            const ptrdiff_t dPadding  = (customPadding == -1) ? totalElements - descriptor.totalAllocatedElements() : customPadding;
+            const size_t numElementsToCopy = (customPadding == -1) ? descriptor.totalAllocatedElements() : (descriptor.totalAllocatedElements() + customPadding);
             uint8_t*  dstOffset = (uint8_t*)dst + (dPadding * descriptor.elementBytes());
             HIP_CHECK_EXC(hipMemcpy(dstOffset,
                                     src,
-                                    descriptor.elementBytes() * descriptor.totalAllocatedElements(),
+                                    descriptor.elementBytes() * numElementsToCopy,
                                     kind));
             return dstOffset;
         }
@@ -599,6 +601,17 @@ namespace TensileLite
             }
 
             return stream;
+        }
+
+        size_t getSwizzledTensorNumAllocatedElements(const TensorDescriptor &desc, size_t miM, size_t miK, size_t packK)
+        {
+            const auto k = desc.sizes()[0];
+            const auto m = desc.sizes()[1];
+            const auto b = desc.sizes()[2];
+            const auto swizzleK = miK * packK;
+            const auto paddedM = (m + miM - 1) / miM * miM;
+            const auto paddedK = (k + swizzleK - 1) / swizzleK * swizzleK;
+            return paddedM * paddedK * b;
         }
 
         double DataInitialization::GetRepresentativeBetaValue(po::variables_map const& args)
@@ -692,23 +705,17 @@ namespace TensileLite
                         auto& pristine = m_vdata[i].pristine[dataType];
                         pristine.initDescriptor.resize(1);
                         
-                        //TODO: support more swizzle types
-                        constexpr size_t MiM = 16;
-                        constexpr size_t MiK = 16;
-                        constexpr size_t PackK = 2;
-                        constexpr size_t SwizzleK = MiK * PackK;
                         auto numAllocatedElements = problem.tensors()[i].totalAllocatedElements(); 
                         auto numAllocatedBytes = problem.tensors()[i].totalAllocatedBytes(); 
 
                         if ((problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
                             || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
                         {
-                            auto& desc = problem.tensors()[i];
-                            auto unrolledSize = desc.sizes()[0];
-                            auto tiledSize = desc.sizes()[1];
-                            unrolledSize = (unrolledSize / SwizzleK + !!(unrolledSize % SwizzleK)) * SwizzleK;
-                            tiledSize = (tiledSize / MiM + !!(tiledSize % MiM)) * MiM;
-                            numAllocatedElements = unrolledSize * tiledSize;
+                            //TODO: support more swizzle types
+                            constexpr size_t MiM = 16;
+                            constexpr size_t MiK = 16;
+                            constexpr size_t PackK = 2;
+                            numAllocatedElements = getSwizzledTensorNumAllocatedElements(problem.tensors()[i], MiM, MiK, PackK);
                             numAllocatedBytes = numAllocatedElements * GetElementSize(dataType);
                         }
 
@@ -1251,6 +1258,15 @@ namespace TensileLite
                 else if(m_curBoundsCheck == BoundsCheckMode::GuardPageBack)
                 {
                     padding = pUnit.maxElements - problem.tensors()[i].totalAllocatedElements();
+
+                    if((problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                        || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
+                    {
+                        constexpr size_t MiM = 16;
+                        constexpr size_t MiK = 16;
+                        constexpr size_t PackK = 2;
+                        padding = pUnit.maxElements - getSwizzledTensorNumAllocatedElements(problem.tensors()[i], MiM, MiK, PackK);
+                    }
                 }
                 padding *= DataTypeInfo::Get(problem.tensors()[i].dataType()).elementSize;
                 uint8_t* offset = (uint8_t*)pUnit.gpuInput.current.get();
@@ -1581,24 +1597,35 @@ namespace TensileLite
                     if(it != m_vdata[i].pristine.end())
                     {
                         auto& p = it->second;
+                        ptrdiff_t swizzlePadding{-1};
+
+                        if(problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A
+                            || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
+                        {
+                            swizzlePadding = getSwizzledTensorNumAllocatedElements(desc, 16, 16, 2) - desc.totalAllocatedElements();
+                        }
+
                         if(kind == hipMemcpyHostToHost)
                             ptr = copyNaNInputBuffers(desc,
                                                       p.cpuInput.current.get(),
                                                       p.cpuInput.valid.get(),
                                                       p.maxElements,
-                                                      kind);
+                                                      kind,
+                                                      swizzlePadding);
                         else if(kind == hipMemcpyHostToDevice)
                             ptr = copyNaNInputBuffers(desc,
                                                       p.gpuInput.current.get(),
                                                       p.cpuInput.valid.get(),
                                                       p.maxElements,
-                                                      kind);
+                                                      kind,
+                                                      swizzlePadding);
                         else if(kind == hipMemcpyDeviceToDevice)
                             ptr = copyNaNInputBuffers(desc,
                                                       p.gpuInput.current.get(),
                                                       p.gpuInput.valid.get(),
                                                       p.maxElements,
-                                                      kind);
+                                                      kind,
+                                                      swizzlePadding);
                         ptrs.push_back(ptr);
                         batchPtrs.push_back(p.getInputByKind(kind).batch.get());
                         maxElements.push_back(p.maxElements);

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -691,8 +691,30 @@ namespace TensileLite
                         }
                         auto& pristine = m_vdata[i].pristine[dataType];
                         pristine.initDescriptor.resize(1);
+                        
+                        //TODO: support more swizzle types
+                        constexpr size_t MiM = 16;
+                        constexpr size_t MiK = 16;
+                        constexpr size_t PackK = 2;
+                        constexpr size_t SwizzleK = MiK * PackK;
+                        auto numAllocatedElements = problem.tensors()[i].totalAllocatedElements(); 
+                        auto numAllocatedBytes = problem.tensors()[i].totalAllocatedBytes(); 
+
+                        if ((problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                            || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B))
+                        {
+                            auto& desc = problem.tensors()[i];
+                            auto unrolledSize = desc.sizes()[0];
+                            auto tiledSize = desc.sizes()[1];
+                            unrolledSize = (unrolledSize / SwizzleK + !!(unrolledSize % SwizzleK)) * SwizzleK;
+                            tiledSize = (tiledSize / MiM + !!(tiledSize % MiM)) * MiM;
+                            numAllocatedElements = unrolledSize * tiledSize;
+                            numAllocatedBytes = numAllocatedElements * GetElementSize(dataType);
+                        }
+
                         pristine.maxElements = std::max(
-                            pristine.maxElements, problem.tensors()[i].totalAllocatedElements());
+                            pristine.maxElements, numAllocatedElements);
+
                         if(m_rotatingBuffer)
                         {
                             if(i <= ContractionProblemGemm::TENSOR::METADATA)
@@ -703,7 +725,7 @@ namespace TensileLite
                                 }
                                 else
                                 {
-                                    vec_rm.push_back(problem.tensors()[i].totalAllocatedBytes());
+                                    vec_rm.push_back(numAllocatedBytes);
                                 }
                             }
                         }
@@ -1744,8 +1766,13 @@ namespace TensileLite
                     auto tiledSize = desc.sizes()[1];
                     auto tmpTensor = Tensor::create<Half>({tiledSize, unrolledSize});
                     memcpy(tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
-                    tmpTensor.reshape({tiledSize / MiM, MiM, unrolledSize / (MiK * PackK), MiK / MiKv , MiKv * PackK});
-                    Tensor permuted = permute(tmpTensor, {0, 2, 3, 1, 4});
+                    ::Tensor::Manipulation::Shape paddedShape{((tiledSize / MiM) + !!(tiledSize % MiM)) * MiM,
+                        (unrolledSize / (MiK * PackK) + !!(unrolledSize % (MiK * PackK))) * MiK * PackK};
+                    //Temporary hack
+                    uint64_t padVal{};
+                    auto paddedTensor = ::Tensor::Manipulation::pad(tmpTensor, paddedShape, &padVal, tmpTensor.getElementSize());
+                    paddedTensor.reshape({paddedShape[0] / MiM, MiM, paddedShape[1] / (MiK * PackK), MiK / MiKv , MiKv * PackK});
+                    Tensor permuted = permute(paddedTensor, {0, 2, 3, 1, 4});
                     ptr = copyInputBuffers(desc,
                                            p.gpuInput.valid.get(),
                                            permuted.as<void>(),

--- a/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtvA_swizzleA.yaml
@@ -120,6 +120,10 @@ BenchmarkProblems:
           - Exact: [512,   256, 1, 224]
           - Exact: [512,   256, 1, 256]
           - Exact: [512,   256, 1, 288]
+          - Exact: [127, 127, 1, 127]
+          - Exact: [128, 127, 1, 127]
+          - Exact: [1, 127, 1, 127]
+          - Exact: [127, 1, 1, 127]
         - BiasTypeArgs: ['h']
         - ActivationArgs:
           - [Enum: none]


### PR DESCRIPTION
Extracted changes of tensilelite from #1521, including
 - generator for arbitrary M & K for swizzle-A
 - auto-padding mechanism for tensilelite-client

Local tox test result:
```bash
------------------------------------- generated xml file: /data0/sergelu/hipBLASLt/tensilelite/python_tests.xml --------------------------------------
=============================================== 84 passed, 37 skipped, 1 warning in 3605.93s (1:00:05) ===============================================
py3: exit 0 (3606.27 seconds) /data0/sergelu/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tensile-tox/py3/tmp --junit-xml=/data0/sergelu/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tensile-tox/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=2700001
  py3: OK (3760.56=setup[16.16]+cmd[0.61,137.52,3606.27] seconds)
  congratulations :) (3760.62 seconds)
```