### PR TITLE
hipblaslt-bench: throw error if c_type is not equal to d_type

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -780,6 +780,11 @@ try
     if(arg.d_type == HIPBLASLT_DATATYPE_INVALID)
         throw std::invalid_argument("Invalid value for --d_type " + d_type);
 
+    if(arg.c_type != arg.d_type)
+        throw std::invalid_argument(
+            "Invalid: --c_type " + std::string(hip_datatype_to_string(arg.c_type))
+            + " is not equal to --d_type " + std::string(hip_datatype_to_string(arg.d_type)));
+
     bool is_f16 = arg.a_type == HIP_R_16F || arg.a_type == HIP_R_16BF;
     bool is_f32 = arg.a_type == HIP_R_32F;
     arg.compute_type


### PR DESCRIPTION
### Example: user miss d_type configuration
####  Command:
hipblaslt-bench   --a_type bf16_r --b_type bf16_r --c_type bf16_r --transA T --transB N -j 1 -i 1

#### Original output: (no solution found without any reason)
error: NO solution found! at /workspace/hipBLASLt/clients/benchmarks/../include/testing_matmul.hpp:2534
#### New output: (notify user that configuration is incorrect)
Invalid: --c_type bf16_r is not equal to **--d_type f16_r**
