### PR TITLE
Optimize type checking

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
+++ b/library/src/amd_detail/rocblaslt/src/include/rocblaslt_mat_utils.hpp
@@ -176,10 +176,10 @@ inline rocblaslt_status validateMatmulArgs(int64_t                       m,
          || (type_a == HIP_R_8I && type_b == HIP_R_8I && type_c == HIP_R_8I && type_d == HIP_R_8I))
        && compute_type == rocblaslt_compute_i32)
         status = rocblaslt_status_not_implemented;
-    if(string_to_hip_datatype(hip_datatype_to_string(type_a)) == HIPBLASLT_DATATYPE_INVALID
-       || string_to_hip_datatype(hip_datatype_to_string(type_b)) == HIPBLASLT_DATATYPE_INVALID
-       || string_to_hip_datatype(hip_datatype_to_string(type_c)) == HIPBLASLT_DATATYPE_INVALID
-       || string_to_hip_datatype(hip_datatype_to_string(type_d)) == HIPBLASLT_DATATYPE_INVALID
+    if(!strcmp(hip_datatype_to_string(type_a), hip_datatype_to_string(HIPBLASLT_DATATYPE_INVALID))
+       || !strcmp(hip_datatype_to_string(type_b), hip_datatype_to_string(HIPBLASLT_DATATYPE_INVALID))
+       || !strcmp(hip_datatype_to_string(type_c), hip_datatype_to_string(HIPBLASLT_DATATYPE_INVALID))
+       || !strcmp(hip_datatype_to_string(type_d), hip_datatype_to_string(HIPBLASLT_DATATYPE_INVALID))
        || !strcmp(rocblaslt_compute_type_string(compute_type),
                   rocblaslt_compute_type_string(ROCBLASLT_COMPUTE_TYPE_INVALID)))
         status = rocblaslt_status_not_implemented;


### PR DESCRIPTION
The type checking involved in converting `hipDatatype` to `char*`, then to a std::string, and the subsequent `if-else` checks for different types, adds overhead to the hipblaslt API. This PR avoids using the method that relies on if-else statements to check the datatype and eliminates redundant type conversions.

gfx1201:
> hipblaslt-bench --api_method c -m 9216 -n 1 -k 3072 --lda 3072 --ldb 3072 --ldc 9216 --ldd 9216  --stride_a 0 --stride_b 0 --stride_c 0 --stride_d 0  --alpha 1.000000 --beta 0.000000 --transA T --transB N --batch_count 1 --scaleA 1 --scaleB 1 --bias_vector --bias_source d --a_type f8_r --b_type f8_r --c_type bf16_r --d_type bf16_r --scale_type f32_r --bias_type bf16_r   --compute_type f32_r --algo_method heuristic --requested_solution 3 --activation_type none -i 35000 -j 10 --rotating 512 --flush --print_kernel_info

| gflops                                 |   1st   |   2nd   |   3rd   |
| -------------------------------------- | :-----: | :-----: | :-----: |
| commit 7d9fb6 (without type checking) |  757.031 |       882.168  |      569.522   |
| commit ea65bd (original type checking) | 277.787  |    277.288     |      278.131   |
| new type checking                      | 785.289 | 892.977 | 883.843 |


MI300:
> hipblaslt-bench --api_method c -m 9216 -n 1 -k 3072 --lda 3072 --ldb 3072 --ldc 9216 --ldd 9216  --stride_a 0 --stride_b 0 --stride_c 0 --stride_d 0  --alpha 1.000000 --beta 0.000000 --transA T --transB N --batch_count 1 --scaleA 1 --scaleB 1 --bias_vector --bias_source d --a_type f8_r --b_type f8_r --c_type bf16_r --d_type bf16_r --scale_type f32_r --bias_type bf16_r   --compute_type f32_r --algo_method index --solution_index 703 --activation_type none -i 350000 -j 100000 --rotating 512 --flush --print_kernel_info --device 2

| gflops | w/ new type checking | w/o type checking |
| :---: | :--------------: | :---------------: |
|  1st  |     1734.15      |      1876.64      |
|  2nd  |     1825.81      |      1806.55      |
|  3rd  |     1872.95      |       1915        |
|  4th  |     1817.08      |      1798.66      |
|  5th  |     1953.45      |      1957.21      |
|  6th  |       1864       |      2003.39      |
|  7th  |     2062.61      |      1784.16      |

> hipblaslt-bench --api_method c -m 9216 -n 1 -k 3072 --lda 3072 --ldb 3072 --ldc 9216 --ldd 9216  --stride_a 0 --stride_b 0 --stride_c 0 --stride_d 0  --alpha 1.000000 --beta 0.000000 --transA T --transB N --batch_count 1 --scaleA 1 --scaleB 1 --bias_vector --bias_source d --a_type f8_r --b_type f8_r --c_type bf16_r --d_type bf16_r --scale_type f32_r --bias_type bf16_r   --compute_type f32_r --algo_method all --activation_type none

| gflops                                 |   1st   |   2nd   |   3rd   |
| -------------------------------------- | :-----: | :-----: | :-----: |
| commit aade86 (without type checking) |  2585.53 |       2658.36  |      2066.54   |
| commit ea65bd (original type checking) | 317.75  |    324.488     |      296.922   |
| remove all type checking  | 2389.16 | 1613.19 | 1581.65 |
| new type checking                      | 2274.02 | 1850.43 | 1826.55 |
