### PR TITLE
Fix F8 related CI errors

### DIFF
--- a/library/include/hipblaslt_float8.h
+++ b/library/include/hipblaslt_float8.h
@@ -30,6 +30,7 @@
 #if __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
 /*! \brief Struct to represent a 8 bit floating-point number. */
 
+#if !HIPBLASLT_USE_F8_FNUZ_BC
 typedef struct
 {
     uint8_t __x;
@@ -38,17 +39,21 @@ typedef struct
 typedef struct
 {
     uint8_t __x;
+} hipblaslt_bf8_fnuz;
+
+#endif
+
+#if !HIPBLASLT_USE_F8_OCP_BC
+typedef struct
+{
+    uint8_t __x;
 } hipblaslt_f8;
 
 typedef struct
 {
     uint8_t __x;
-} hipblaslt_bf8_fnuz;
-
-typedef struct
-{
-    uint8_t __x;
 } hipblaslt_bf8;
+#endif
 
 #else // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
 

--- a/library/include/hipblaslt_float8_bc.h
+++ b/library/include/hipblaslt_float8_bc.h
@@ -27,6 +27,36 @@
 #ifndef _HIPBLASLT_FLOAT8_BC_H_
 #define _HIPBLASLT_FLOAT8_BC_H_
 
+#if __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+/*! \brief Struct to represent a 8 bit floating-point number. */
+
+#if HIPBLASLT_USE_F8_FNUZ_BC
+typedef struct
+{
+    uint8_t __x;
+} hipblaslt_f8_fnuz;
+
+typedef struct
+{
+    uint8_t __x;
+} hipblaslt_bf8_fnuz;
+
+#endif
+
+#if HIPBLASLT_USE_F8_OCP_BC
+typedef struct
+{
+    uint8_t __x;
+} hipblaslt_f8;
+
+typedef struct
+{
+    uint8_t __x;
+} hipblaslt_bf8;
+#endif
+
+#else // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
+
 #define HIP_HOST_DEVICE __host__ __device__
 #define HIP_HOST __host__
 #define HIP_DEVICE __device__
@@ -902,5 +932,5 @@ struct HIPBLASLT_EXPORT hipblaslt_bf8
 };
 
 #endif // #if HIPBLASLT_USE_F8_OCP_BC
-
+#endif // __cplusplus < 201103L || (!defined(__HCC__) && !defined(__HIPCC__))
 #endif // _HIPBLASLT_FLOAT8_BC_H_

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
@@ -4,13 +4,13 @@
 /******************************************/
 .amdgcn_target "amdgcn-amd-amdhsa--gfx942"
 .text
-.protected Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
-.globl Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
+.protected Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
+.globl Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
 .p2align 8
-.type Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942,@function
+.type Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942,@function
 .section .rodata,#alloc
 .p2align 6
-.amdhsa_kernel Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
+.amdhsa_kernel Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
   .amdhsa_user_sgpr_kernarg_segment_ptr 1
   .amdhsa_accum_offset 128 // accvgpr offset
   .amdhsa_next_free_vgpr 256 // vgprs
@@ -87,8 +87,8 @@ amdhsa.version:
   - 1
   - 1
 amdhsa.kernels:
-  - .name: Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
-    .symbol: 'Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.kd'
+  - .name: Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942
+    .symbol: 'Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.kd'
     .language:                   OpenCL C
     .language_version:
       - 2
@@ -249,7 +249,7 @@ amdhsa.kernels:
     .wavefront_size:             64
 ...
 .end_amdgpu_metadata
-Custom_Cijk_Ailk_Bljk_F8H_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942:
+Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942:
 .long 0xC00206C0, 0x00000000
 .long 0xC0020B80, 0x00000018
 .long 0xC0060180, 0x00000004


### PR DESCRIPTION
Address some F8-related failures.
- Add missing macro guards in backward compatibility header for non-rocm compilers
- Fix naming in custom f8 kernel . 