### PR TITLE
Fix: dgemm result is incorrect if alpha is not 1

### DIFF
--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -1423,7 +1423,7 @@ Tests:
     - { M:  128,  N:  128,  K:  1024 }
     - { M:  4608, N:  1335, K:  640  }
   transA_transB: *transA_transB_range
-  alpha: 1
+  alpha: [1.0, 2.0]
   beta: [ 0.0, 2.0 ]
   unit_check: 1
   gpu_arch: '9(0a|4[0-2])'

--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -1884,6 +1884,8 @@ class GlobalWriteBatchWriter:
         elif kernel["ProblemType"]["ComputeDataType"].isDouble():
           newSumIdx = sumIdxV * 2 - self.parentWriter.states.c.startVgprValu
           module.add(VMulF64(dst=vgpr("ValuC+%u"%(newSumIdx),2), src0=sgpr("Alpha",2), src1=vgpr("ValuC+%u"%(newSumIdx),2), comment="*= alpha"))
+          if usePK:
+            module.add(VMulF64(dst=vgpr("ValuC+%u"%(newSumIdx+2),2), src0=sgpr("Alpha",2), src1=vgpr("ValuC+%u"%(newSumIdx+2),2), comment="*= alpha"))
 
         # single precision complex
         elif kernel["ProblemType"]["ComputeDataType"].isSingleComplex():


### PR DESCRIPTION
issue is caused by #1524 
For ticket SWDEV-511842