### PR TITLE
Fix Hardware Monitor and clk-sys=-nan

### DIFF
--- a/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
+++ b/tensilelite/Tensile/Source/client/source/HardwareMonitor.cpp
@@ -139,7 +139,7 @@ namespace TensileLite
 #if rocm_smi_VERSION_MAJOR >= 7
             auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
 
-            if(status2 != RSMI_STATUS_SUCCESS)
+            if(status2 != RSMI_STATUS_SUCCESS || m_XCDCount == 0)
             {
                 m_XCDCount = 1;
             }
@@ -159,7 +159,7 @@ namespace TensileLite
 #if rocm_smi_VERSION_MAJOR >= 7
             auto status2 = rsmi_dev_metrics_xcd_counter_get(m_smiDeviceIndex, &m_XCDCount);
 
-            if(status2 != RSMI_STATUS_SUCCESS)
+            if(status2 != RSMI_STATUS_SUCCESS || m_XCDCount == 0)
             {
                 m_XCDCount = 1;
             }


### PR DESCRIPTION
On gfx11/12, the api rsmi_dev_metrics_xcd_counter_get returns xcd_count=0 sometimes. This results to broken clk-sys monitoring. To fix it, we try to recover xcd_count when it gets 0.