### PR TITLE
Fix incorrect local index values in MatchTable

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -362,7 +362,7 @@ def generateLogicDataAndSolutions(logicFiles, args, cxxCompiler):
     # Match yaml file solutions to solution index
     for _,masterLibrary in masterLibraries.items():
       for localIdx, _, s in libraryIter(masterLibrary):
-        matchTable[s.index] = [s.srcName, localIdx]
+        matchTable[s.index] = [s.srcName, s.libraryLogicIndex]
     LibraryIO.write("MatchTable", matchTable)
 
   if "fallback" in masterLibraries.keys():


### PR DESCRIPTION
Fix incorrect local index values in `MatchTable.yaml` previously values in the same `masterLibrary` were accumulating across different logic files. The local index value should match the `SolutionIndex` value in the library logic.

This PR sets the local index value to be `libraryLogicIndex` (defined [here](https://github.com/ROCm/hipBLASLt/blob/develop/tensilelite/Tensile/Contractions.py#L688)).

Before
```
5804: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5804]
5805: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5805]
5806: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5806]
5807: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5807]
5808: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5808]
5809: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5809]
5810: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5810]
5811: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5811]
5812: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5812]
```
After
```
5804: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5804]
5805: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5805]
5806: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5806]
5807: [/.../aquavanjaram/FreeSize/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  5807]
5808: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  0]
5809: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  1]
5810: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  2]
5811: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  3]
5812: [/.../aquavanjaram/GridBased/aquavanjaram_Cijk_Ailk_Bljk_S_MX_B_Bias_HAS_SAV_UserArgs.yaml,
  4]
```