### PR TITLE
Auto convert ocp f8 to nanoo f8 in hipblaslt-bench on gfx94X

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -172,18 +172,16 @@ int run_bench_test(Arguments& arg, const std::string& filter, bool any_stride, h
         std::string deviceFullString(props.gcnArchName);
         std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
 
-        bool isGFX94X = deviceString.find("gfx940") != std::string::npos ||
-            deviceString.find("gfx941") != std::string::npos ||
-            deviceString.find("gfx942") != std::string::npos;
+        bool isGFX942 = deviceString.find("gfx942") != std::string::npos;
 
-        if (isGFX94X) {
+        if (isGFX942) {
             auto convertF8Type = [](hipDataType type) {
                 if (type == HIP_R_8F_E4M3) {
-                    hipblaslt_cerr << "hipblaslt-bench INFO: Converting f8_r to f8_fnuz_r" << std::endl;
+                    hipblaslt_cerr << "hipblaslt-bench INFO: Using f8_fnuz_r instead of f8_r" << std::endl;
                     return HIP_R_8F_E4M3_FNUZ;
                 }
                 if (type == HIP_R_8F_E5M2) {
-                    hipblaslt_cerr << "hipblaslt-bench INFO: Converting b8_r to b8_fnuz_r" << std::endl;
+                    hipblaslt_cerr << "hipblaslt-bench INFO: Using b8_fnuz_r instead of b8_r" << std::endl;
                     return HIP_R_8F_E5M2_FNUZ;
                 }
                 else

--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -62,7 +62,7 @@ struct perf_matmul : hipblaslt_test_valid
     }
 };
 
-int run_bench_test(Arguments& arg, const std::string& filter, bool any_stride, bool yaml = false)
+int run_bench_test(Arguments& arg, const std::string& filter, bool any_stride, hipDeviceProp_t &props, bool yaml = false)
 {
     hipblaslt_cout << std::setiosflags(std::ios::fixed)
                    << std::setprecision(7); // Set precision to 7 digits
@@ -165,15 +165,48 @@ int run_bench_test(Arguments& arg, const std::string& filter, bool any_stride, b
         }
     }
 
+
+#ifdef ROCM_USE_FLOAT8
+    // Check for F8 OCP data types and convert to NANOO
+    {
+        std::string deviceFullString(props.gcnArchName);
+        std::string deviceString = deviceFullString.substr(0, deviceFullString.find(":"));
+
+        bool isGFX94X = deviceString.find("gfx940") != std::string::npos ||
+            deviceString.find("gfx941") != std::string::npos ||
+            deviceString.find("gfx942") != std::string::npos;
+
+        if (isGFX94X) {
+            auto convertF8Type = [](hipDataType type) {
+                if (type == HIP_R_8F_E4M3) {
+                    hipblaslt_cerr << "hipblaslt-bench INFO: Converting f8_r to f8_fnuz_r" << std::endl;
+                    return HIP_R_8F_E4M3_FNUZ;
+                }
+                if (type == HIP_R_8F_E5M2) {
+                    hipblaslt_cerr << "hipblaslt-bench INFO: Converting b8_r to b8_fnuz_r" << std::endl;
+                    return HIP_R_8F_E5M2_FNUZ;
+                }
+                else
+                    return type;
+            };
+
+            arg.a_type = convertF8Type(arg.a_type);
+            arg.b_type = convertF8Type(arg.b_type);
+            arg.c_type = convertF8Type(arg.c_type);
+            arg.d_type = convertF8Type(arg.d_type);
+        }
+    }
+#endif
+
     perf_matmul{}(arg);
     return 0;
 }
 
-int hipblaslt_bench_datafile(const std::string& filter, bool any_stride)
+int hipblaslt_bench_datafile(const std::string& filter, bool any_stride, hipDeviceProp_t &props)
 {
     int ret = 0;
     for(Arguments arg : HipBlasLt_TestData())
-        ret |= run_bench_test(arg, filter, any_stride, true);
+        ret |= run_bench_test(arg, filter, any_stride, props, true);
     test_cleanup::cleanup();
     return ret;
 }
@@ -744,7 +777,8 @@ try
     }
 
     // Device Query
-    int64_t device_count = query_device_property(device_id);
+    hipDeviceProp_t props;
+    int64_t device_count = query_device_property(device_id, props);
 
     hipblaslt_cout << std::endl;
     if(device_count <= device_id)
@@ -755,7 +789,7 @@ try
     freq_monitor.set_device_id(device_id);
 
     if(datafile)
-        return hipblaslt_bench_datafile(filter, any_stride);
+        return hipblaslt_bench_datafile(filter, any_stride, props);
 
     // single bench run
 
@@ -887,7 +921,7 @@ try
     }
 
     arg.norm_check_assert = false;
-    int status            = run_bench_test(arg, filter, any_stride);
+    int status            = run_bench_test(arg, filter, any_stride, props);
     freeFrequencyMonitor();
     return status;
 }

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -145,7 +145,7 @@ double get_time_us_no_sync(void)
 
 /* ============================================================================================ */
 /*  device query and print out their ID and name; return number of compute-capable devices. */
-int64_t query_device_property(int device_id)
+int64_t query_device_property(int device_id, hipDeviceProp_t &props)
 {
     int             device_count;
     hipblasStatus_t status = (hipblasStatus_t)hipGetDeviceCount(&device_count);
@@ -167,7 +167,6 @@ int64_t query_device_property(int device_id)
         return device_count;
     }
 
-    hipDeviceProp_t props;
     status = (hipblasStatus_t)hipGetDeviceProperties(&props, device_id);
     if(status != HIPBLAS_STATUS_SUCCESS)
     {

--- a/clients/gtest/hipblaslt_gtest_main.cpp
+++ b/clients/gtest/hipblaslt_gtest_main.cpp
@@ -218,8 +218,9 @@ static void hipblaslt_print_args(const std::string& args)
 // Device Query
 static void hipblaslt_set_test_device()
 {
+    hipDeviceProp_t props;
     int device_id    = 0;
-    int device_count = query_device_property(device_id);
+    int device_count = query_device_property(device_id, props);
     if(device_count <= device_id)
     {
         hipblaslt_cerr << "Error: invalid device ID. There may not be such device ID." << std::endl;

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -317,7 +317,7 @@ public:
 
 /* ============================================================================================ */
 /*  device query and print out their ID and name */
-int64_t query_device_property(int device_id);
+int64_t query_device_property(int device_id, hipDeviceProp_t &props);
 
 /*  set current device to device_id */
 void set_device(int64_t device_id);

--- a/library/include/hipblaslt-types.h
+++ b/library/include/hipblaslt-types.h
@@ -32,8 +32,8 @@
 #ifndef _HIPBLASLT_TYPES_H_
 #define _HIPBLASLT_TYPES_H_
 
-#if HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR > 2 \
-    && HIP_VERSION_PATCH > 42130 //tmp before gfx94 use hip f8 header
+#if (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
+	|| (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3)//tmp before gfx94 use hip f8 header
 
 #define HIPBLASLT_USE_F8_FNUZ_BC 1 // Always use custom impl for now
 #define HIPBLASLT_USE_F8_OCP_BC 0 // Always use ocp impl for hip header

--- a/library/src/include/auxiliary.hpp
+++ b/library/src/include/auxiliary.hpp
@@ -192,6 +192,15 @@ constexpr hipDataType string_to_hip_datatype(const std::string& value)
     {
         return HIP_R_8F_E5M2;
     }
+#else
+    if (value == "f8_r")
+    {
+        return HIP_R_8F_E4M3_FNUZ;
+    }
+    else if (value == "bf8_r")
+    {
+        return HIP_R_8F_E5M2_FNUZ;
+    }
 #endif
 
     return

--- a/tensilelite/Tensile/Source/TensileTypes.h
+++ b/tensilelite/Tensile/Source/TensileTypes.h
@@ -28,8 +28,8 @@
 #define TENSILETYPES_H
 #include "tensile_bfloat16.h"
 
-#if HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR > 2 \
-    && HIP_VERSION_PATCH > 42130 //tmp before gfx94 use hip f8 header
+#if (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
+	|| (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3)//tmp before gfx94 use hip f8 header
 
 // Using hip header for both NANOO and OCP data types
 #if defined(__HIPCC__)

--- a/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
@@ -36,8 +36,8 @@
 
 #include <Tensile/Comparison.hpp>
 #include <Tensile/DataTypes_BFloat16.hpp>
-#if HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR > 2                     \
-    && HIP_VERSION_PATCH > 42130 //tmp before gfx94 use hip f8 header
+#if (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
+	|| (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3)//tmp before gfx94 use hip f8 header
 
 // Using hip header for both NANOO and OCP data types
 #if defined(__HIPCC__)


### PR DESCRIPTION
This PR adds automatic conversion of `f8_r` data type inputs to `f8_fnuz_r` on gfx94X devices. A warning is emitted when conversion is done. Sample output

```
$ ./hipblaslt-bench --sizem 128 --sizen 128 --sizek 128 --a_type f8_r --b_type f8_fnuz_r --c_type f32_r --d_type f32_r
hipBLASLt version: 1300
hipBLASLt git version: d0de0f04-dirty
[...]
Device ID 0 : AMD Instinct MI300X gfx942:sramecc+:xnack-
with 206.1 GB memory, max. SCLK 2100 MHz, max. MCLK 1300 MHz, compute capability 9.4
maxGridDimX 2147483647, sharedMemPerBlock 65.5 KB, maxThreadsPerBlock 1024, warpSize 64

hipblaslt-bench INFO: Converting f8_r to f8_fnuz_r
Is supported 1 / Total solutions: 1
[0]:transA,transB,grouped_gemm,batch_count,m,n,k,alpha,lda,stride_a,beta,ldb,stride_b,ldc,stride_c,ldd,stride_d,a_type,b_type,c_type,d_type,compute_type,scaleA,scaleB,scaleC,scaleD,amaxD,activation_type,bias_vector,bias_type,hipblaslt-Gflops,hipblaslt-GB/s,us
    N,N,0,1,128,128,128,1,128,16384,0,128,16384,128,16384,128,16384,f8_fnuz_r,f8_fnuz_r,f32_r,f32_r,f32_r,0,0,0,0,0,none,0,bf16_r,[...],[...],[...]
```




Also fixed incorrect hip header version checking for nanoo/ocp support.
