### PR TITLE
Use 4-tuple-triple for clang-offload-bundler

### DIFF
--- a/tensilelite/Tensile/BuildCommands/SharedCommands.py
+++ b/tensilelite/Tensile/BuildCommands/SharedCommands.py
@@ -24,7 +24,7 @@ def compressCodeObject(
         "--compress",
         "--type=o",
         "--bundle-align=4096",
-        f"--targets=host-x86_64-unknown-linux,hipv4-amdgcn-amd-amdhsa--{gfx}",
+        f"--targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa-unknown-{gfx}",
         "--input=/dev/null",
         f"--input={str(coPathSrc)}",
         f"--output={str(coPathDest)}",


### PR DESCRIPTION
Summary

Change usage of clang-offload-bundler from 3-tuple to 4-tuple with the new parameter. PR is destined for the existing release-staging branch.