### PR TITLE
Repurposed to testing global-mc

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ D = Activation(alpha \cdot op(A) \cdot op(B) + beta \cdot op(C) + bias)
 Where *op( )* refers to in-place operations, such as transpose and non-transpose, and *alpha* and
 *beta* are scalars.
 
-The activation function supports GELU, ReLU, and Swish (SiLU). the bias vector matches matrix D rows and
+The activation function supports GELU, ReLU, and Swish (SiLU). The bias vector matches matrix D rows and
 broadcasts to all D columns.
 
 The following table provides data type support. Note that fp8 and bf8 are only supported on the

--- a/tensilelite/Tensile/Activation.py
+++ b/tensilelite/Tensile/Activation.py
@@ -31,7 +31,7 @@ from .TensileInstructions import Module, TextBlock, HolderContainer, RegisterCon
                           TensileInstructions
 from .TensileInstructions.Enums import *
 from .TensileInstructions.Instructions import *
-from .Common import printExit, printWarning
+from Tensile.Common.Utilities import printExit, printWarning
 
 from dataclasses import dataclass, field
 

--- a/tensilelite/Tensile/BenchmarkStructs.py
+++ b/tensilelite/Tensile/BenchmarkStructs.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,11 +24,17 @@
 
 from copy import deepcopy
 import itertools
-from .Common import print1, print2, hasParam, printExit, \
-        defaultBenchmarkCommonParameters, validParameters, globalParameters, \
-        defaultBatchedBenchmarkFinalProblemSizes, defaultBenchmarkFinalProblemSizes
+
+from Tensile.Common.ValidParameters import checkParametersAreValid
+from Tensile.Common import print1, print2, hasParam, printExit
+from Tensile.Common.GlobalParameters import defaultBenchmarkCommonParameters, globalParameters, \
+                                            defaultBatchedBenchmarkFinalProblemSizes, \
+                                            defaultBenchmarkFinalProblemSizes
+from Tensile.Common.ValidParameters import validParameters
+from Tensile.SolutionStructs.Problem import ProblemType
+
 from .CustomKernels import getAllCustomKernelNames
-from .SolutionStructs import ProblemType, ProblemSizes, ActivationArgs, BiasTypeArgs, \
+from .SolutionStructs import ProblemSizes, ActivationArgs, BiasTypeArgs, \
         FactorDimArgs
 
 
@@ -41,26 +47,6 @@ def getDefaultsForMissingParameters(paramList, defaultParams):
                     or name == "ProblemSizes":
                 benchmarkParams[name] = value
     return benchmarkParams
-
-
-def checkParametersAreValid(param, validParams):
-    """Ensures paramaters in params exist and have valid values as specified by validParames"""
-    (name, values) = param
-    if name == "ProblemSizes":
-        return
-    elif name == "InternalSupportParams":
-        return
-
-    if name not in validParams:
-        printExit("Invalid parameter name: {}\nValid parameters are {}." \
-                .format(name, sorted(validParameters.keys())))
-
-    for value in values:
-        if validParams[name] != -1 and value not in validParams[name]:
-            msgBase = "Invalid parameter value: {} = {}\nValid values for {} are {}{}."
-            msgExt = " (only first 32 combos printed)\nRefer to Common.py for more info" \
-                    if len(validParams[name])>32 else ""
-            printExit(msgBase.format(name, value, name, validParams[name][:32], msgExt))
 
 
 def separateParameters(paramSetList):
@@ -92,9 +78,9 @@ def checkCDBufferAndStrides(problemType, problemSizes, isCEqualD):
 class BenchmarkProcess:
     """Representation of benchmarking parameters and resulting steps"""
 
-    def __init__(self, problemTypeConfig, problemSizeGroupConfig):
+    def __init__(self, problemTypeConfig, problemSizeGroupConfig, printIndexAssignmentInfo: bool):
         """Create from the two sections of a config for a BenchmarkProblem"""
-        self.problemType = ProblemType(problemTypeConfig)
+        self.problemType = ProblemType(problemTypeConfig, printIndexAssignmentInfo)
         self.isBatched = "Batched" in problemTypeConfig and problemTypeConfig["Batched"]
         print2("# BenchmarkProcess beginning {}".format(self.problemType))
 

--- a/tensilelite/Tensile/ClientExecutable.py
+++ b/tensilelite/Tensile/ClientExecutable.py
@@ -29,7 +29,8 @@ from typing import Optional
 from pathlib import Path
 
 from . import SOURCE_PATH
-from .Common import globalParameters, print2, ClientExecutionLock, ensurePath, CLIENT_BUILD_DIR
+from Tensile.Common import print2, ClientExecutionLock, ensurePath, CLIENT_BUILD_DIR
+from Tensile.Common.GlobalParameters import globalParameters
 
 class CMakeEnvironment:
     def __init__(self, sourceDir, buildDir, **options):
@@ -78,7 +79,7 @@ def clientExecutableEnvironment(builddir: Optional[str], cxxCompiler: str, cComp
 
 buildEnv = None
 
-def getClientExecutable(cxxCompiler: str, cCompiler: str, builddir):
+def getClientExecutable(cxxCompiler: str, cCompiler: str, builddir: Path):
     if "PrebuiltClient" in globalParameters:
         return globalParameters["PrebuiltClient"]
 

--- a/tensilelite/Tensile/ClientWriter.py
+++ b/tensilelite/Tensile/ClientWriter.py
@@ -30,13 +30,19 @@ import shutil
 from pathlib import Path
 from enum import Enum
 from glob import glob
+from typing import List
+
+from Tensile.SolutionStructs.Problem import ProblemType, ProblemSizesMock, ProblemSizesMockDummy
+from Tensile.SolutionStructs import ActivationArgs, BiasTypeArgs, FactorDimArgs
+from Tensile.Toolchain.Component import Assembler
 
 from . import ROOT_PATH
 from . import ClientExecutable
 from . import LibraryIO
-from .Common import globalParameters, ensurePath, print1, printExit, printWarning, ClientExecutionLock, isaToGfx, \
-  LIBRARY_LOGIC_DIR, LIBRARY_CLIENT_DIR
-from .SolutionStructs import ProblemType, ProblemSizesMock, ProblemSizesMockDummy, ActivationArgs, BiasTypeArgs, FactorDimArgs
+from Tensile.Common import ensurePath, print1, printExit, printWarning, ClientExecutionLock,\
+                           LIBRARY_LOGIC_DIR, LIBRARY_CLIENT_DIR, DepthUConfig
+from Tensile.Common.Architectures import isaToGfx
+from Tensile.Common.GlobalParameters import globalParameters
 from .TensileCreateLibrary import copyStaticFiles
 from .Contractions import FreeIndex, BatchIndex
 from .Contractions import ProblemType as ContractionsProblemType
@@ -79,7 +85,7 @@ class ClientLogLevel(Enum):
 ################################################################################
 # Main
 ################################################################################
-def main(config, cxxCompiler: str, cCompiler: str, outputPath: Path):
+def main(config, assembler: Assembler, cCompiler: str, isaInfoMap, outputPath: Path, deviceId: int, gfxName: str, useShortNames: bool=False):
 
   libraryLogicPath = ensurePath(outputPath / LIBRARY_LOGIC_DIR)
   clientLibraryPath = ensurePath(outputPath / LIBRARY_CLIENT_DIR)
@@ -97,15 +103,25 @@ def main(config, cxxCompiler: str, cCompiler: str, outputPath: Path):
   functions = []
   functionNames = []
 
-  createLibraryScript = getBuildClientLibraryScript(clientLibraryPath, libraryLogicPath, cxxCompiler)
+  createLibraryScript = getBuildClientLibraryScript(clientLibraryPath, libraryLogicPath, str(assembler.path), isaToGfx(list(isaInfoMap.keys())[0]), useShortNames)
   subprocess.run(shlex.split(createLibraryScript), cwd=clientLibraryPath)
   coList = glob(os.path.join(clientLibraryPath, "library/*.co"))
   yamlList = glob(os.path.join(clientLibraryPath, "library/*.yaml"))
 
   clientParametersPaths = []
+  splitGSU = False
+  printSolutionRejectionReason = False
+  printIndexAssignmentInfo = False
   for logicFileName in logicFiles:
     (scheduleName, _, problemType, _, exactLogic, newLibrary) \
-        = LibraryIO.parseLibraryLogicFile(logicFileName, cxxCompiler)
+        = LibraryIO.parseLibraryLogicFile(logicFileName, 
+                                          assembler, 
+                                          splitGSU,
+                                          printSolutionRejectionReason,
+                                          printIndexAssignmentInfo, 
+                                          DepthUConfig(),
+                                          isaInfoMap,
+                                          globalParameters["LazyLibraryLoading"])
     functions.append((scheduleName, problemType))
     functionNames.append("tensile_%s" % (problemType))
     problemSizes = ProblemSizesMock(exactLogic) if exactLogic else ProblemSizesMockDummy()
@@ -145,11 +161,13 @@ def main(config, cxxCompiler: str, cCompiler: str, outputPath: Path):
                                   factorDimArgs=factorDimArgs,
                                   activationArgs=activationArgs,
                                   icacheFlushArgs=icacheFlushArgs,
-                                  stepName=str(ProblemType(problemType)),
+                                  stepName=str(ProblemType(problemType, False)),
                                   stepBaseDir=str(clientLibraryPath),
                                   newLibrary=newLibrary,
-                                  configBase="ClientParameters_%s"%str(ProblemType(problemType)),
+                                  configBase="ClientParameters_%s"%str(ProblemType(problemType, False)),
                                   codeObjectFiles=coList,
+                                  deviceId=deviceId,
+                                  gfxName=gfxName,
                                   tileAwareSelection=False,
                                   libraryFile=yamlList[0]))
 
@@ -167,7 +185,7 @@ def main(config, cxxCompiler: str, cCompiler: str, outputPath: Path):
 
   forBenchmark = False
   enableTileSelection = False
-  returncode = runClient(libraryLogicPath, forBenchmark, enableTileSelection, cxxCompiler, cCompiler, clientLibraryPath, clientParametersPaths)
+  returncode = runClient(libraryLogicPath, forBenchmark, enableTileSelection, str(assembler.path), cCompiler, clientLibraryPath, clientParametersPaths)
 
   return returncode
 
@@ -200,7 +218,7 @@ def runClient(libraryLogicPath, forBenchmark, enableTileSelection, cxxCompiler: 
 
   return process.returncode
 
-def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler):
+def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler, targetGfx, useShortNames: bool=False):
   import io
   runScriptFile = io.StringIO()
 
@@ -209,7 +227,7 @@ def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler):
   if not globalParameters["LazyLibraryLoading"]:
     callCreateLibraryCmd += " --no-lazy-library-loading"
 
-  if globalParameters["ShortNames"]:
+  if useShortNames:
     callCreateLibraryCmd += " --short-file-names"
 
   if globalParameters.get("AsmDebug", False):
@@ -218,7 +236,7 @@ def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler):
   if globalParameters["KeepBuildTmp"]:
     callCreateLibraryCmd += " --keep-build-tmp"
 
-  callCreateLibraryCmd += " --architecture=" + globalParameters["Architecture"]
+  callCreateLibraryCmd += " --architecture=" + targetGfx
   callCreateLibraryCmd += " --code-object-version=" + globalParameters["CodeObjectVersion"]
   callCreateLibraryCmd += " --cxx-compiler=" + cxxCompiler
   callCreateLibraryCmd += " --library-format=" + globalParameters["LibraryFormat"]
@@ -231,17 +249,6 @@ def getBuildClientLibraryScript(buildPath, libraryLogicPath, cxxCompiler):
 
   return runScriptFile.getvalue()
 
-def writeBuildClientLibraryScript(path, libraryLogicPath, cxxCompiler):
-  filename = os.path.join(path, \
-    "build.%s" % ("bat" if os.name == "nt" else "sh") )
-  with open(filename, "w") as file:
-    file.write("#!/bin/bash\n\n")
-    file.write("set -ex\n")
-    file.write(getBuildClientLibraryScript(path, libraryLogicPath, cxxCompiler))
-
-  if os.name != "nt":
-    os.chmod(filename, 0o777)
-  return filename
 
 def writeRunScript(path, forBenchmark, enableTileSelection, cxxCompiler: str, cCompiler: str, buildDir, configPaths=None):
   if configPaths is None:
@@ -500,7 +507,7 @@ def pruneModeName(mode):
     if mode == 5: return 'Prune0X0X'
     if mode == 6: return 'Prune00XX'
 
-def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, libraryFile=None):
+def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, problemType, sourceDir, codeObjectFiles, resultsFileName, parametersFilePath, deviceId: int, gfxName: str, libraryFile=None):
 
     assert os.path.exists(sourceDir), f"sourceDir={sourceDir} does not exist"
 
@@ -513,9 +520,8 @@ def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs
           libraryFile = os.path.join(sourceDir, "library", libraryFilename)
         param("library-file", libraryFile)
 
-        currentGFXName = isaToGfx(globalParameters["CurrentISA"])
         for coFile in codeObjectFiles:
-            if 'gfx' not in coFile or currentGFXName in coFile:
+            if 'gfx' not in coFile or gfxName in coFile:
                 param("code-object", os.path.join(sourceDir,coFile))
 
         param('results-file', resultsFileName)
@@ -573,7 +579,7 @@ def writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs
         if globalParameters["DataInitValueActivationArgs"]:
           param('activation-additional-args', ','.join(map(str, globalParameters["DataInitValueActivationArgs"])))
 
-        param("device-idx",               globalParameters["Device"])
+        param("device-idx",               deviceId)
 
         param("init-seed",                globalParameters["DataInitSeed"])
 
@@ -658,6 +664,8 @@ def writeClientConfig(
       newLibrary,
       codeObjectFiles,
       tileAwareSelection,
+      deviceId: int,
+      gfxName: str,
       configBase = "ClientParameters",
       libraryFile = None
     ):
@@ -679,11 +687,11 @@ def writeClientConfig(
       resultsFileName = os.path.join(stepBaseDir, "../Data", stepName+".csv")
 
     newSolution = next(iter(newLibrary.solutions.values()))
-    writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, libraryFile)
+    writeClientConfigIni(forBenchmark, problemSizes, biasTypeArgs, factorDimArgs, activationArgs, icacheFlushArgs, newSolution.problemType, sourceDir, codeObjectFiles, resultsFileName, filename, deviceId, gfxName, libraryFile)
 
     return filename
 
-def CreateBenchmarkClientParametersForSizes(libraryRootPath, problemSizes, dataFilePath, configFile, problemTypeDict=None):
+def CreateBenchmarkClientParametersForSizes(libraryRootPath, problemSizes, dataFilePath, configFile, deviceId, gfxName, problemTypeDict=None):
 
     libraryPath = os.path.join(libraryRootPath, "library")
     libraryFiles = [os.path.join(libraryPath, f) for f in os.listdir(libraryPath)]
@@ -700,4 +708,4 @@ def CreateBenchmarkClientParametersForSizes(libraryRootPath, problemSizes, dataF
       problemTypeDict = metaData["ProblemType"]
       problemType = ContractionsProblemType.FromOriginalState(problemTypeDict)
 
-    writeClientConfigIni(True, problemSizes, "", "", "", "", problemType, libraryRootPath, codeObjectFiles, dataFilePath, configFile)
+    writeClientConfigIni(True, problemSizes, "", "", "", "", problemType, libraryRootPath, codeObjectFiles, dataFilePath, configFile, deviceId, gfxName)

--- a/tensilelite/Tensile/Common/Architectures.py
+++ b/tensilelite/Tensile/Common/Architectures.py
@@ -21,9 +21,11 @@
 ################################################################################
 
 import re
-from typing import Optional
+from subprocess import run, PIPE
+from typing import List, Optional
 
 from .Types import IsaVersion
+from .Utilities import locateExe
 
 # Translate GPU targets to filter filenames in Tensile_LOGIC directory
 architectureMap = {
@@ -57,6 +59,50 @@ architectureMap = {
     "gfx1201": "gfx1201",
 }
 
+gfxVariantMap = {
+    "gfx906": ["gfx906:xnack+", "gfx906:xnack-"],
+    "gfx908": ["gfx908:xnack+", "gfx908:xnack-"],
+    "gfx90a": ["gfx90a:xnack+", "gfx90a:xnack-"],
+    "gfx942": ["gfx942:xnack+", "gfx942:xnack-"],
+    "gfx950": ["gfx950:xnack+", "gfx950:xnack-"],
+}
+
+SUPPORTED_ISA = [
+    IsaVersion(8, 0, 3),
+    IsaVersion(9, 0, 0),
+    IsaVersion(9, 0, 6),
+    IsaVersion(9, 0, 8),
+    IsaVersion(9, 0, 10),
+    IsaVersion(9, 4, 2),
+    IsaVersion(9, 5, 0),
+    IsaVersion(10, 1, 0),
+    IsaVersion(10, 1, 1),
+    IsaVersion(10, 1, 2),
+    IsaVersion(10, 3, 0),
+    IsaVersion(11, 0, 0),
+    IsaVersion(11, 0, 1),
+    IsaVersion(11, 0, 2),
+    IsaVersion(12, 0, 0),
+    IsaVersion(12, 0, 1),
+]
+
+
+def isaToGfx(arch: IsaVersion) -> str:
+    """Converts an ISA version to a gfx architecture name.
+
+    Args:
+        arch: An object representing the major, minor, and step version of the ISA.
+
+    Returns:
+        The name of the GPU architecture (e.g., 'gfx906').
+    """
+    # Convert last digit to hex because reasons
+    name = str(arch[0]) + str(arch[1]) + ("%x" % arch[2])
+    return "gfx" + "".join(map(str, name))
+
+
+SUPPORTED_GFX = [isaToGfx(isa) for isa in SUPPORTED_ISA]
+
 
 def gfxToIsa(name: str) -> Optional[IsaVersion]:
     """Extracts the ISA version from a given gfx architecture name.
@@ -79,21 +125,7 @@ def gfxToIsa(name: str) -> Optional[IsaVersion]:
 
     ipart = ipart[:-1]
     major = int(ipart)
-    return tuple((major, minor, step))
-
-
-def isaToGfx(arch: IsaVersion) -> str:
-    """Converts an ISA version to a gfx architecture name.
-
-    Args:
-        arch: An object representing the major, minor, and step version of the ISA.
-
-    Returns:
-        The name of the GPU architecture (e.g., 'gfx906').
-    """
-    # Convert last digit to hex because reasons
-    name = str(arch[0]) + str(arch[1]) + ("%x" % arch[2])
-    return "gfx" + "".join(map(str, name))
+    return IsaVersion(major, minor, step)
 
 
 def gfxToSwCodename(gfxName: str) -> Optional[str]:
@@ -113,3 +145,64 @@ def gfxToSwCodename(gfxName: str) -> Optional[str]:
             if gfxName in archKey:
                 return architectureMap[archKey]
             return None
+
+
+def gfxToVariants(gfx: str) -> List[str]:
+    """Retrieves the list of variants for a given gfx architecture name.
+
+    Args:
+        gfx: The name of the GPU architecture (e.g., 'gfx906').
+
+    Returns:
+        List of variants for the GPU architecture.
+    """
+    return gfxVariantMap.get(gfx, [gfx])
+
+
+def cliArchsToIsa(cliArchs: str) -> List[IsaVersion]:
+    """Maps the requested gfx architectures to ISA numbers.
+
+    Args:
+        archs: str of ";" or "_" separated gfx architectures (e.g., gfx1100 or gfx90a;gfx1101).
+
+    Returns:
+        List of tuples
+    """
+    archs = cliArchs.split(";") if ";" in cliArchs else cliArchs.split("_")
+    return SUPPORTED_ISA if "all" in archs else [gfxToIsa(''.join(map(str, arch))) for arch in archs]
+
+
+def _detectGlobalCurrentISA(detectionTool, deviceId: int):
+    """
+    Returns returncode if detection failure
+    """
+    process = run([detectionTool], stdout=PIPE)
+    archList = []
+    for line in process.stdout.decode().split("\n"):
+        arch = gfxToIsa(line.strip())
+        if arch is not None:
+            if arch in SUPPORTED_ISA:
+                print(f"# Detected GPU {deviceId} with ISA: " + isaToGfx(arch))
+                archList.append(arch)
+    if process.returncode:
+        print(f"{detectionTool} exited with code {process.returncode}")
+    return archList[deviceId] if (len(archList) > 0 and process.returncode == 0) else process.returncode
+
+
+def detectGlobalCurrentISA(deviceId: int, enumerator: str):
+    """Returns the ISA version for a given device.
+
+    Given an integer ID for a device, the ISA version tuple
+    of the form (X, Y, Z) is computed using first amdgpu-arch.
+    If amdgpu-arch fails, rocm_agent_enumerator is used.
+
+    Args:
+        deviceID: an integer indicating the device to inspect.
+
+    Raises:
+        Exception if both tools fail to detect ISA.
+    """
+    result = _detectGlobalCurrentISA(enumerator, deviceId)
+    if not isinstance(result, IsaVersion):
+        raise Exception("Failed to detect currect ISA")
+    return result

--- a/tensilelite/Tensile/Common/Capabilities.py
+++ b/tensilelite/Tensile/Common/Capabilities.py
@@ -1,12 +1,37 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
 import subprocess
 from functools import lru_cache
-from typing import Tuple
+from typing import List, Dict
 
 from .Architectures import isaToGfx
+from .Types import IsaVersion, IsaInfo
 
 
 def _tryAssembler(
-    isaVersion: Tuple[int, int, int],
+    isaVersion: IsaVersion,
     assemblerPath: str,
     asmString: str,
     debug: bool = False,
@@ -177,7 +202,7 @@ def initArchCaps(isaVersion) -> dict:
     rv["SDWAWait"]           = (isaVersion in [(9,4,0), (9,4,1), (9,4,2), (9,5,0)])
     rv["VgprBank"]           = (isaVersion[0] in (10, 11, 12))
     rv["DSLow16NotPreserve"]       = isaVersion[0] == (12)
-    rv["WrokGroupIdFromTTM"] = isaVersion[0] == (12)
+    rv["WorkGroupIdFromTTM"] = isaVersion[0] == (12)
     rv["NoSDWA"]             = isaVersion[0] == (12)
     rv["VOP3ByteSel"]      = isaVersion[0] == (12)
     rv["HasFP8_OCP"]         = isaVersion[0] == (12)
@@ -224,3 +249,25 @@ def initAsmBugs(asmCaps) -> dict:
     rv["ExplicitNC"] = asmCaps["HasExplicitNC"]
 
     return rv
+
+def makeIsaInfoMap(targetIsas: List[IsaVersion], cxxCompiler: str) -> Dict[IsaVersion, IsaInfo]:
+    """Computes the supported capabilities for requested ISAs and compiler.
+
+    Given a list of ISAs and a compiler, the ASM, Arch, Register capabilities
+    and ASM bugs are computed and stored in a map.
+
+    Args:
+        targetIsas: A list of requested ISA versions to inspect.
+        cxxCompiler: A string path to a C++ compiler to use when computing capabilities.
+
+    Returns:
+        A map of ISA versions to capabilities.
+    """
+    isaInfoMap = {}
+    for v in targetIsas:
+        asmCaps = initAsmCaps(v, cxxCompiler, False)
+        archCaps = initArchCaps(v)
+        regCaps = initRegisterCaps(v, archCaps)
+        asmBugs = initAsmBugs(asmCaps)
+        isaInfoMap[v] = IsaInfo(asmCaps, archCaps, regCaps, asmBugs)
+    return isaInfoMap

--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -22,6 +22,7 @@
 #
 ################################################################################
 
+import itertools
 import math
 import os.path
 import subprocess
@@ -29,12 +30,15 @@ import sys
 import time
 from collections import OrderedDict
 from copy import deepcopy
+from typing import Dict
 
 from Tensile import __version__
 
-from .Architectures import gfxToIsa, isaToGfx
-from .Capabilities import initArchCaps, initAsmBugs, initAsmCaps
-from .Utilities import locateExe, versionIsCompatible
+from .Architectures import isaToGfx, SUPPORTED_ISA
+from .Types import IsaVersion, IsaInfo
+from .Utilities import locateExe, versionIsCompatible, print1, print2, printExit, printWarning, \
+     getVerbosity
+from .ValidParameters import validParameters
 
 startTime = time.time()
 
@@ -45,9 +49,6 @@ globalParameters["MinimumRequiredVersion"] = (
 globalParameters["PerformanceMetric"] = (
     "DeviceEfficiency"  # performance metric for benchmarking; one of {DeviceEfficiency, CUEfficiency}
 )
-globalParameters["PrintLevel"] = (
-    1  # how much info to print in generator. 0=none, 1=standard, 2=verbose
-)
 globalParameters["ClientLogLevel"] = (
     3  # the log level of client. 0=Error, 1=Terse, 2=Verbose, 3=Debug (Aligned with ResultReporter.hpp)
 )
@@ -57,9 +58,6 @@ globalParameters["PreciseKernelTime"] = (
     True  # T=On hip, use the timestamps for kernel start and stop rather than separate events.  Can provide more accurate kernel timing.  For GlobalSplitU kernels, recommend disabling this to provide consistent
 )
 # timing between GSU / non-GSU kernels
-globalParameters["CodeFromFiles"] = (
-    True  # if False byte arrays will be generated during Benchmarking phase as before
-)
 globalParameters["PinClocks"] = False  # T=pin gpu clocks and fan, F=don't
 globalParameters["HardwareMonitor"] = (
     True  # False: disable benchmarking client monitoring clocks using rocm-smi.
@@ -127,27 +125,11 @@ globalParameters["CpuThreads"] = (
 )  # How many CPU threads to use for kernel generation.  0=no threading, -1 == nproc, N=min(nproc,N).  TODO - 0 sometimes fails with a kernel name error?  0 does not check error codes correctly
 globalParameters["NumWarmups"] = 0
 
-# even if error occurs in kernel generation (ie due to resource overflow),
-# generate the kernel source anyway.  Tensile will also attempt to run
-# the kernel.  Useful to examine and debug overflow errors.
-globalParameters["ForceGenerateKernel"] = 0
-
-########################################
-# optimization knob controls
-########################################
-
-globalParameters["UnrollLoopEfficiencyEnable"] = (
-    False  # if True split(S) MAC&LDS in each unroll iteration into n smaller groups..
-)
-
 ########################################
 # less common
 ########################################
 globalParameters["CMakeBuildType"] = (
     "Release"  # whether benchmark clients and library client should be release or debug
-)
-globalParameters["PrintSolutionRejectionReason"] = (
-    False  # when a solution is marked as invalid, print why
 )
 globalParameters["LogicFormat"] = "yaml"  # set library backend (yaml, or json)
 globalParameters["LibraryFormat"] = "yaml"  # set library backend (yaml, or msgpack)
@@ -205,23 +187,12 @@ globalParameters["PruneSparseMode"] = (
 # build parameters
 globalParameters["CMakeCXXFlags"] = ""  # pass flags to cmake
 globalParameters["CMakeCFlags"] = ""  # pass flags to cmake
-globalParameters["DebugKernel"] = (
-    False  # assembly only, kernel gets buffer for debug "printing"; kernel writes data to memory, gets coppied to host and printed
-)
 globalParameters["AsanBuild"] = False  # build with asan
-globalParameters["SaveTemps"] = False  # Generate intermediate results of hip kernels
+#globalParameters["SaveTemps"] = False  # Generate intermediate results of hip kernels
 globalParameters["KeepBuildTmp"] = False  # If true, do not remove artifacts in build_tmp
 
 # debug for assembly
-globalParameters["EnableAsserts"] = False  # Enable assembly debug assert
-globalParameters["EnableDebugA"] = False  # Enable / Disable CheckValue1A
-globalParameters["EnableDebugB"] = False  # Enable / Disable CheckValue1B
-globalParameters["EnableDebugC"] = False  # Enable / Disable CheckValueC
-globalParameters["ExpectedValueC"] = 16.0  # Expected C Value when CheckValueC, debug for Alpha*A*B
-globalParameters["ForceCExpectedValue"] = (
-    False  # Force C to "DebugExpectedValueC", debug for global write
-)
-globalParameters["SplitGSU"] = False  # Split GSU kernel into GSU1 and GSUM
+#globalParameters["SplitGSU"] = False  # Split GSU kernel into GSU1 and GSUM
 
 # Tensor printing controls:
 globalParameters["PrintTensorA"] = 0  # Print TensorA after initialization
@@ -238,7 +209,6 @@ globalParameters["PrintTensorRef"] = (
 globalParameters["PrintTensorBias"] = 0  # Print TensorBias after initialization
 globalParameters["PrintTensorScaleAlphaVec"] = 0  # Print TensorScaleAlphaVec after initialization
 globalParameters["PrintTensorAmaxD"] = 0  # Print AmaxD after validation
-globalParameters["PrintIndexAssignments"] = 0  # Print the tensor index assignment info
 globalParameters["PrintWinnersOnly"] = False  # Only print the solutions which become the fastest
 globalParameters["PrintCodeCommands"] = (
     False  # print the commands used to generate the code objects (asm,link,hip-clang, etc)
@@ -252,35 +222,8 @@ globalParameters["DumpTensors"] = (
 
 # device selection
 globalParameters["Platform"] = 0  # select opencl platform
-globalParameters["Device"] = 0  # select hip device or opencl device within platform
 
 # shouldn't need to change
-globalParameters["DeviceLDS"] = 65536  # LDS bytes per CU, for computing occupancy
-globalParameters["MaxLDS"] = 65536  # max LDS a kernel should attempt to use
-globalParameters["ShortNames"] = (
-    False  # on windows kernel names can get too long; =True will convert solution/kernel names to serial ids
-)
-
-globalParameters["SupportedISA"] = [
-    (8, 0, 3),
-    (9, 0, 0),
-    (9, 0, 6),
-    (9, 0, 8),
-    (9, 0, 10),
-    (9, 4, 2),
-    (9, 5, 0),
-    (10, 1, 0),
-    (10, 1, 1),
-    (10, 1, 2),
-    (10, 3, 0),
-    (11, 0, 0),
-    (11, 0, 1),
-    (11, 0, 2),
-    (12, 0, 0),
-    (12, 0, 1),
-]  # assembly kernels writer supports these architectures
-
-globalParameters["NewClient"] = 2  # Old client deprecated: NewClient must be set to 2.
 globalParameters["ClientExecutionLockPath"] = (
     None  # Path for a file lock to ensure only one client is executed at once.  filelock module is required if this is enabled.
 )
@@ -292,20 +235,16 @@ globalParameters["LibraryUpdateComment"] = (
 )
 
 # internal, i.e., gets set during startup
-globalParameters["CurrentISA"] = (0, 0, 0)
-globalParameters["AMDGPUArchPath"] = None  # /opt/rocm/llvm/bin/amdgpu-arch
-globalParameters["ROCmAgentEnumeratorPath"] = None  # /opt/rocm/bin/rocm_agent_enumerator
 globalParameters["ROCmSMIPath"] = None  # /opt/rocm/bin/rocm-smi
 globalParameters["HipClangVersion"] = "0.0.0"
 
 # default runtime is selected based on operating system, user can override
 if os.name == "nt":
-    globalParameters["RuntimeLanguage"] = "HIP"  # "OCL"
+    globalParameters["RuntimeLanguage"] = "HIP"
 else:
     globalParameters["RuntimeLanguage"] = "HIP"
 
 globalParameters["CodeObjectVersion"] = "4"
-globalParameters["Architecture"] = "all"
 
 # perf model
 globalParameters["PerfModelL2ReadHits"] = 0.0
@@ -315,7 +254,7 @@ globalParameters["PerfModelReadEfficiency"] = 0.85
 
 # limitation for training
 globalParameters["MaxWorkspaceSize"] = 128 * 1024 * 1024  # max workspace for training (128MB)
-globalParameters["MinKForGSU"] = 32  # min K size to use GlobalSplitU algorithm (only for HPA now)
+#globalParameters["MinKForGSU"] = 32  # min K size to use GlobalSplitU algorithm (only for HPA now)
 
 # control if a solution is run for a given problem
 globalParameters["GranularityThreshold"] = 0.0
@@ -350,6 +289,7 @@ globalParameters["AsmDebug"] = (
 globalParameters["UseEffLike"] = True  # Set to False to use winnerGFlops as the performance metric
 
 # Save a copy - since pytest doesn't re-run this initialization code and YAML files can override global settings - odd things can happen
+# we should do this here...
 defaultGlobalParameters = deepcopy(globalParameters)
 
 
@@ -376,896 +316,6 @@ defaultInternalSupportParams = {
     # Use GG as G's backend
     "UseUniversalArgs": True,
 }
-
-
-################################################################################
-# Enumerate Valid Solution Parameters
-################################################################################
-validWorkGroups = []
-for numThreads in range(32, 1025, 32):
-    for nsg in [1, 2, 4, 8, 16, 32, 64, 96, 128, 256]:
-        for sg0 in range(1, numThreads // nsg + 1):
-            sg1 = numThreads // nsg // sg0
-            if sg0 * sg1 * nsg == numThreads:
-                workGroup = [sg0, sg1, nsg]
-                validWorkGroups.append(workGroup)
-
-validThreadTileSides = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] + list(
-    range(20, 256, 4)
-)
-validThreadTiles = []
-for i in validThreadTileSides:
-    for j in validThreadTileSides:
-        validThreadTiles.append([i, j])
-
-validActivationFormats = ("NCHW", "NHWC", "CNHW", "NCDHW", "NDHWC", "CNDHW")
-validWeightFormats = ("KCYX", "KYXC", "CKYX", "CYXK", "KCZYX", "CKZYX", "CZYXK")
-validMacroTileSides = [
-    1,
-    2,
-    4,
-    8,
-    16,
-    32,
-    64,
-    128,
-    256,
-    512,
-    1024,
-    6,
-    12,
-    24,
-    48,
-    96,
-    192,
-    384,
-    768,
-]
-validMacroTiles = []
-validISA = [(0, 0, 0)]
-validISA.extend(globalParameters["SupportedISA"])
-depthUs = list(range(2, 1024 + 1, 1))
-for i in validMacroTileSides:
-    for j in validMacroTileSides:
-        validMacroTiles.append([i, j])
-
-validMFMA = {}
-validMFMA["H"] = [[32, 32, 16, 1], [32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 32, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
-validMFMA["S"] = [[32, 32, 1, 2], [32, 32, 2, 1], [16, 16, 1, 4], [16, 16, 4, 1], [4, 4, 1, 16]]
-validMFMA["B"] = [[32, 32, 16, 1], [32, 32, 2, 2], [32, 32, 4, 1], [16, 16, 32, 1], [16, 16, 2, 4], [16, 16, 8, 1], [4, 4, 2, 16]]
-validMFMA["4xi8"] = [
-    [32, 32, 4, 2],
-    [32, 32, 8, 1],
-    [16, 16, 4, 4],
-    [16, 16, 16, 1],
-    [4, 4, 4, 16],
-    [32, 32, 16, 1],
-    [16, 16, 32, 1],
-]
-validMFMA["D"] = [[16, 16, 4, 1], [4, 4, 4, 4]]
-validMFMA["B1k"] = [[32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
-validMFMA["C"] = validMFMA["S"]
-validMFMA["Z"] = validMFMA["D"]
-validMFMA["I8"] = [
-    [32, 32, 4, 2],
-    [32, 32, 8, 1],
-    [16, 16, 4, 4],
-    [16, 16, 16, 1],
-    [4, 4, 4, 16],
-] + [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["X"] = [[32, 32, 4, 1], [16, 16, 8, 1]]
-validMFMA["F8"] = [[32, 32, 16, 1], [16, 16, 32, 1], [32, 32, 64, 1], [16, 16, 128, 1]]
-validMFMA["B8"] = validMFMA["F8"]
-validMFMA["F8B8"] = validMFMA["F8"]
-validMFMA["B8F8"] = validMFMA["F8"]
-validMFMA["F8N"] = [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["B8N"] = validMFMA["F8N"]
-validMFMA["F8B8N"] = validMFMA["F8N"]
-validMFMA["B8F8N"] = validMFMA["F8N"]
-validWMMA = [
-    [16, 16, 16, 1],
-]
-validTT = 32
-validMFMA["_format9"] = []
-
-for MFMA in [
-    validMFMA["H"],
-    validMFMA["S"],
-    validMFMA["B"],
-    validMFMA["D"],
-    validMFMA["X"],
-    validMFMA["F8"],
-    validWMMA,
-]:
-    for MI in MFMA:
-        for bm in range(int(math.log(MI[3], 2)) + 1):
-            for tt0 in range(1, validTT + 1):
-                for tt1 in range(1, validTT + 1):
-                    for wave_m in range(3):
-                        for wave_n in range(3):
-                            validMFMA["_format9"].append(
-                                [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
-                            )
-validMatrixInstructions = (
-    [[], [-1]]
-    + validMFMA["H"]
-    + validMFMA["S"]
-    + validMFMA["B"]
-    + validMFMA["D"]
-    + validMFMA["B1k"]
-    + validMFMA["X"]
-)
-validMatrixInstructions = validMatrixInstructions + validMFMA["_format9"]
-
-validSMFMA = {}
-validSMFMA["H"] = [[32, 32, 16, 1], [16, 16, 32, 1], [16, 16, 64, 1], [32, 32, 32, 1]]
-validSMFMA["B"] = [[32, 32, 16, 1], [16, 16, 32, 1], [16, 16, 64, 1], [32, 32, 32, 1]]
-validSMFMA["4xi8"] = [[32, 32, 32, 1], [16, 16, 64, 1], [16, 16, 128, 1], [32, 32, 64, 1]]
-validSMFMA["I8"] = validSMFMA["4xi8"]
-validSMFMA["F8"] = [[32, 32, 32, 1], [16, 16, 64, 1], [16, 16, 128, 1], [32, 32, 64, 1]]
-validSMFMA["B8"] = validSMFMA["F8"]
-validSMFMA["F8B8"] = validSMFMA["F8"]
-validSMFMA["B8F8"] = validSMFMA["F8"]
-validSMFMA["F8N"] = validSMFMA["F8"]
-validSMFMA["B8N"] = validSMFMA["F8"]
-validSMFMA["F8B8N"] = validSMFMA["F8N"]
-validSMFMA["B8F8N"] = validSMFMA["F8N"]
-validSMFMA["_format9"] = []
-for SMFMA in [validSMFMA["H"], validSMFMA["B"], validSMFMA["4xi8"], validSMFMA["F8N"]]:
-    for MI in SMFMA:
-        for bm in range(int(math.log(MI[3], 2)) + 1):
-            for tt0 in range(1, validTT + 1):
-                for tt1 in range(1, validTT + 1):
-                    for wave_m in range(3):
-                        for wave_n in range(3):
-                            validSMFMA["_format9"].append(
-                                [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
-                            )
-validSparseMatrixInstructions = validSMFMA["H"] + validSMFMA["B"] + validSMFMA["4xi8"]
-validMatrixInstructions = (
-    validMatrixInstructions + validSparseMatrixInstructions + validSMFMA["_format9"]
-)
-
-
-# The supported typed GEMM, each entry is (Ti, To, Tc).
-# DataType (Ti)        = The data-type of the input matrices: A/B
-# DestDataType (To)    = The data-type of the output matrices: C/D
-# ComputeDataType (Tc) = The data-type of computation: alpha/beta:
-# Cinternal: basically should == ComputeDataType
-
-# This is used in SolutionStruct.py::checkIfSupportedGEMMType()
-validGEMMTypes = [
-    ("H", "H", "H"),
-    ("S", "S", "S"),
-    ("D", "D", "D"),
-    ("C", "C", "C"),
-    ("Z", "Z", "Z"),
-    ("H", "H", "S"),
-    ("H", "S", "S"),
-    ("B", "B", "S"),
-    ("B", "S", "S"),
-    ("B", "H", "S"),
-    ("I8", "I", "I"),
-    ("4xi8", "I", "I"),
-    ("I8", "I8", "I"),
-    ("I8", "I", "S"),
-    ("I8", "I8", "S"),
-    ("I8", "H", "S"),
-    ("I8", "B", "S"),
-    ("F8", "S", "S"),
-    ("B8", "S", "S"),
-    ("F8B8", "S", "S"),
-    ("B8F8", "S", "S"),
-    ("F8", "H", "S"),
-    ("B8", "H", "S"),
-    ("F8B8", "H", "S"),
-    ("B8F8", "H", "S"),
-    ("B8", "B", "S"),
-    ("H", "F8", "S"),
-    ("F8", "B", "S"),
-    ("F8B8", "B", "S"),
-    ("B8F8", "B", "S"),  # in/out are both R8
-    ("F8", "F8", "S"),
-    ("B8", "B8", "S"),
-    ("F8B8", "B8", "S"),
-    ("B8F8", "B8", "S"),
-    ("F8", "B8", "S"),
-    ("B8", "F8", "S"),
-    ("F8B8", "F8", "S"),
-    ("B8F8", "F8", "S"),  # F8 NANOO
-    ("F8N", "S", "S"),
-    ("B8N", "S", "S"),
-    ("F8B8N", "S", "S"),
-    ("B8F8N", "S", "S"),
-    ("F8N", "H", "S"),
-    ("B8N", "H", "S"),
-    ("F8B8N", "H", "S"),
-    ("B8F8N", "H", "S"),
-    ("B8N", "B", "S"),
-    ("H", "F8N", "S"),
-    ("F8N", "B", "S"),
-    ("F8B8N", "B", "S"),
-    ("B8F8N", "B", "S"),  # in/out are both R8
-    ("F8N", "F8N", "S"),
-    ("B8N", "B8N", "S"),
-    ("F8B8N", "B8N", "S"),
-    ("B8F8N", "B8N", "S"),
-    ("F8N", "B8N", "S"),
-    ("B8N", "F8N", "S"),
-    ("F8B8N", "F8N", "S"),
-    ("B8F8N", "F8N", "S"),
-]
-
-# All HPA types are listed here (HPA=T). The name of the library logic files for these types is:
-# *_TiToTc_BH*.yaml where Ti, To, and Tc are the data types of A/B, C/D, and computation, respectively.
-# The name of the library logic files for non-HPA (HPA=F) types is: *_TiB*.yaml.
-HPATypes = [
-    ("H", "S", "S"),
-    ("H", "H", "S"),
-    ("B", "B", "S"),
-    ("B", "S", "S"),
-    ("B", "H", "S"),
-    ("I8", "I", "I"),
-    ("4xi8", "I", "I"),
-    ("I8", "I", "S"),
-    ("I8", "I8", "S"),
-    ("I8", "H", "S"),
-    ("I8", "B", "S"),
-    ("F8", "S", "S"),
-    ("B8", "S", "S"),
-    ("F8B8", "S", "S"),
-    ("B8F8", "S", "S"),
-    ("F8", "H", "S"),
-    ("B8", "H", "S"),
-    ("F8B8", "H", "S"),
-    ("B8F8", "H", "S"),
-    ("H", "F8", "S"),
-    ("F8", "B", "S"),
-    ("F8B8", "B", "S"),  # in/out are both R8
-    ("F8", "F8", "S"),
-    ("B8", "B8", "S"),
-    ("F8B8", "B8", "S"),
-    ("B8F8", "B8", "S"),
-    ("F8", "B8", "S"),
-    ("B8", "F8", "S"),
-    ("F8B8", "F8", "S"),
-    ("B8F8", "F8", "S"),
-    ("F8N", "S", "S"),
-    ("B8N", "S", "S"),
-    ("F8B8N", "S", "S"),
-    ("B8F8N", "S", "S"),
-    ("F8N", "H", "S"),
-    ("B8N", "H", "S"),
-    ("F8B8N", "H", "S"),
-    ("B8F8N", "H", "S"),
-    ("H", "F8N", "S"),
-    ("F8N", "B", "S"),
-    ("F8B8N", "B", "S"),  # in/out are both R8
-    ("F8N", "F8N", "S"),
-    ("B8N", "B8N", "S"),
-    ("F8B8N", "B8N", "S"),
-    ("B8F8N", "B8N", "S"),
-    ("F8N", "B8N", "S"),
-    ("B8N", "F8N", "S"),
-    ("F8B8N", "F8N", "S"),
-    ("B8F8N", "F8N", "S"),
-]
-
-validParameters = {
-    # 0: Global read is along parallel direction in thread level,
-    #     each load instruction stride whole threads.
-    #                         ----> perp
-    #       | [w0,  w0,  w1,w1,w2,w2,w3,w3,  w0,  w0, w1,w1,w2,w2,w3,w3]
-    #       | [ t0,t32] [                 ] [ t0,t32] [                ]
-    #  para | [ t1,t33] [  wave 1,2,3     ] [ t1,t33] [ wave 1,2,3     ]
-    #       | [ .., ..] [                 ] [ .., ..] [                ]
-    #       | [t31,t63] [                 ] [t31,t63] [                ]
-    #       V [-load_1]                      [-load_2]
-    #
-    # 1: Each wave load a block of memory,
-    #     each load instruction stride 64 threads.
-    #                         ----> perp
-    #         [ w0, w0,  w0, w0, w1,w1,w1,w1, w2,w2,w2,w2, w3,w3,w3,w3]
-    #       | [ t0,t32][ t0,t32]
-    #  para | [ t1,t33][ t1,t33]
-    #       | [ .., ..][ .., ..]
-    #       | [t31,t63][t31,t63]
-    #       V [-load_1][-load_2]
-    #
-    #
-    # 2: Each load instruction spread threads evenly in the perp direction
-    #                         ----> perp
-    #       |  [w0, w1, w2, w3, w0, w1, w2, w3, w0, w1, w2, w3, w0, w1, w2, w3]
-    #       |  [t0 ]           [t0 ]           [t32]           [t32]
-    #  para |  [t1 ]           [t1 ]           [t33]           [t33]
-    #       |  [.. ]           [.. ]           [.. ]           [.. ]
-    #       |  [t31]           [t31]           [t63]           [t63]
-    #       V [load_1]        [load_2]        [load_1]        [load_2]
-    #
-    "WaveSeparateGlobalReadA": [0, 1, 2],
-    "WaveSeparateGlobalReadB": [0, 1, 2],
-    # Add an unrolled loop and NGLL loop with swapped GRA and GRB order.
-    # which may change the tlb thrashing behavior.
-    "UnrollLoopSwapGlobalReadOrder": [0, 1],
-    # PrefetchGlobalRead = 1:
-    # Requires 2X LDS space, and VGPRs for buffering data on way into LDS
-    #   prefetch / double-buffer reads from global memory -> vgprs -> lds.
-    #
-    # PrefetchGlobalRead = 2:
-    # Do another prefetch while writing data from vgpr to lds.
-    #   prefetch / double-buffer reads from global memory -> vgprs --> lds.
-    #                                                              |-> prefetch reads
-    "PrefetchGlobalRead": [0, 1, 2],
-    # number of iteration prefetch local reads from lds to VGPRs buffer = PLR
-    "PrefetchLocalRead": list(range(128 + 1)),
-    # MatrixInstruction Only
-    # If set ClusterLocalRead, each iteration dedicated vgprBuffer for localRead
-    # So we can schedule these localReads to the front of the loop
-    "ClusterLocalRead": [0, 1],
-    # We use double LDS buffer when PrefetchGlobalRead.
-    # While it reads data from LDS[0]/[1], it prefetch global data and writes to LDS[1]/[0]
-    # If we can make sure all data are read from LDS to register before writing data to LDS, we can use 1 LDS buffer to save LDS memory.
-    # this can help to generate Kernel that LDS usage originally exceed MaxLDS if using double LDS buffer,
-    # or help to increase Occupancy.
-    #     1 means: Force to use 1 LDS Buffer even with PrefetchGlobalRead
-    #    -1 means: generator will use 1 LDS buffer only when LDS exceed MaxLDS
-    # Use case:
-    #    SIA2: 1LDSBuffer is set to 1 natively
-    #    SIA3: 1LDSBuffer works only when PGR=True
-    # TODO: optimize scheduling to support more cases.
-    "1LDSBuffer": [-1, 0, 1],
-    # Split the unroll summation into multiple sections and combine the sections
-    # GSU applies only to the unroll summation dimension
-    # Set to 0 to disable GSU, kernel code will be generated without GSU support
-    "GlobalSplitU": list(range(0, 1024 + 1)),
-    # choose how to do GlobalSplitU
-    # 1: use atomic operation to accumulate on one buffer
-    # 2: each GSU group write to each own buffer and accumulate by another kernel
-    # 3: each GSU group write to each own buffer and accumulate by same kernel
-    "GlobalSplitUAlgorithm": ["SingleBuffer", "MultipleBuffer", "MultipleBufferSingleKernel"],
-    # don't create a whole copy of the Unroll loop with loads removed - instead
-    # use buffer limits to suppress global loads and ignore unnecessary ds_reads
-    "SuppressNoLoadLoop": [False, True],
-    # For PrefetchGlobalRead=1, create a second copy of the unroll loop with
-    # the LDS pointer swaps expanded into inline constants for LDS read and write instructions
-    # This eliminates 4 vector XOR instructions used for pointer swap
-    "ExpandPointerSwap": [False, True],
-    # Schedule global reads and global read increments into LocalRead iterations
-    # Can reduce pressure on local read instruction dispatch queue
-    # 0=perform global reads at start of instruction loop
-    # 1=schedule into the local read instruction iterations
-    "ScheduleGlobalRead": [0, 1],
-    # Schedule local writes into LocalRead iterations.
-    # Can reduce pressure on local read instruction dispatch queue
-    "ScheduleLocalWrite": [0, 1],
-    # Scheduling algorithm to use for each iteration:
-    # 0 = minimal/no scheduling.  Global Read and increments, followed by local reads,
-    # followed by local writes, followed by MACs
-    "ScheduleIterAlg": [0, 1, 2, 3],
-    # For MatrixInstruction and SIA3, number of GlobalReadInstruction between mfma
-    # the purpose of this parameter is to control density of global read instruction scheduling
-    # Scheduling global read back to back can have better memory efficiency
-    # However, when full of vmem FIFO, it will block other instruction to be issued
-    # Range from 0.01 to 32
-    #         0.1 means 1 GR per 10 mfma
-    #           5 means 5 GR per 1 mfma
-    "GlobalReadPerMfma": [i / 100 for i in range(1, 3200)],
-    #
-    # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
-    # the purpose of this parameter is to control density of local write instruction scheduling
-    # In PGR1, we want to schedule local write more denser, so we can have more
-    #          latency to hide global read
-    # In PGR2, since LW is followed by GR, every LW has same whole loop latency
-    #          to hide global read. We want to schedule LW less denser, can
-    #          avoid full of vmem FIFO.
-    # Range from 0.01 to 32
-    #         0.1 means 1 LW per 10 mfma
-    #           5 means 5 LW per 1 mfma
-    # -1 will derived an optimized value internally
-    # -2 will derived an optimized value and override LWPM silently (debug only, not recommended)
-    "LocalWritePerMfma": [i / 100 for i in range(1, 3200)] + [-1],
-    # Interleave alpha scale calculation with beta loads and address calcs - rather
-    # than as a separate block of instructions
-    "InterleaveAlpha": [0, 1],
-    # Create a copy of NoLoadLoop which interleaves the stores with the final mac
-    # calculation and may perform other optimizations
-    # 0 = no interleave
-    # 1 = interleave one stores after required macs have completed execution
-    # 2 = interleave two stores after required macs have completed execution
-    "OptNoLoadLoop": [0, 1, 2],
-    "BufferLoad": [False, True],
-    "BufferStore": [False, True],
-    # Attempt to load directly from global memory into Vgpr.
-    # Assembly only
-    "DirectToVgprA": [False, True],
-    "DirectToVgprB": [False, True],
-    "DirectToVgprSparseMetadata": [False, True],
-    # Attempt to load directly from global memory into LDS.
-    # Assembly only
-    # Requires BufferLoad, assembler support for lds modifier on buffer
-    # loads (checked automatically), GlobalVectorWidth=1 (this is hw
-    # requirement) and A/B must not require any transpose.
-    # DirectToLds reduces load latency and eliminates the
-    # G2L registers used to stage data.  Also replaces the
-    # local write offset with an SGPR.
-    # For an 8x8 TT with PrefetchGlobalRead=1 this can save 33 VGPRs.
-    #    - Requirements for DirectToLds=1:
-    #      GlobalReadVectorWidth = 1/2/4 (GRVW * bpe must be 4 for now)
-    #      TransposeLDS = 1 for TLU=0 case
-    # DirectToLds support for x1 only for now
-    "DirectToLds": [False, True],
-    # Load options:
-    # (GRO = Global Read Offset)
-    # BufferLoad=0:
-    #  = Use flat instructions with 64 bit GRO for each load
-    #    + supports sizes up to 2^64
-    #    - uses many VGPR for addressing
-    #    - uses execmask+compares for edge detection
-    #    - generates extra LDS traffic (could convert flat->global load)
-    # BufferLoad=1:
-    #  = Use buffer load instructions with 32-bit offset
-    #    + Less VGPRS (32b offset vs 64-bit) needed for addressing
-    #    + Uses hardware buffer limit for edge detection
-    #    - Limited range - the bot-right corner of macro-tile (plus padding=GRVW
-    #        for shift-pointer, if ShiftPtr is required) must be within 2^32.
-    #      ShiftPtrPad = MayShift ? GRWV*BPE : 0
-    #      For TLU=1: Unroll*StrideA1 + ShiftPtrPad <= 2^32
-    #      For TLU=0: MT*StrideA1 + ShiftPtrPad <= 2^32
-    #      These conditions should be checked using Assert - TODO
-    #  = UseSgprForGRO=1:
-    #    + Attempt to use SGPR for Global Read Offsets.
-    #    + Use one VGPR base GRO + many SGPR GRO rather than many VGPR GRO.
-    #    + Each SGPR stores an offset from base GlobalReadOffset+0.
-    #    - Requirements for UseSgprForGRO=1:
-    #      - BufferLoad=1
-    #      - Use appropriate Assert*ElementMultiple or GRVW=1 to eliminate need for ShifPtr
-    #        (UseSgprForGRO does not support ShiftPtr since ShiftPtr needs to potentially shift GRO)
-    #  = KernelWriterAssembly also supports 64-bit 2D buffer size (see use64bPbcLimit)
-    #    - Requires 4 instructions to move scalar limit and a couple SGPR
-    #    - Enabled by default.  If the overhead matters we can add asserts/YAML parm to specialize
-    #  = UseInstOffsetForGRO=1:
-    #    + Attempt to use Instruction offset for Global Read Offsets.
-    #    + This feature avoid updating m0 for subsequent GRO(s) for directToLds feature
-    #    - Requirements for UseInstOffsetForGRO=1:
-    #      - BufferLoad=1
-    #      - DirectToLds=1
-    #  converting m0 update from LocalWriteAddrSGpr using  is usually win
-    # -1 attempt to use a heuristic to determine when the tile size will use too many SGPR and fall back to VGPR
-    "UseInstOffsetForGRO": [-1, 0, 1],
-    # Converting VGPR GRO into SGPR GRO is usually a win
-    # However, the mode may exhaust all available SGPR, in particular for large unroll
-    # -1 attempt to use a heuristic to determine when the tile size will use too many SGPR and fall back to VGPR
-    "UseSgprForGRO": [-1, 0, 1],
-    # Use a 64-bit shadow limit register to allow buffers larger than 2^32 bytes
-    "Use64bShadowLimit": [True, False],
-    # Assertion properties
-    # These provide information or assertions that the problem size meets certain requirements
-    # for sizes or alignments.  The kernel generator can use this information to produce
-    # a kernel which uses those assertions to produce a faster kernel.
-    #
-    # If modifying or adding Assertions also change ProblemProperties class in TensileTypes.h
-    # Kernel generator will assume that the summation size is some multiple of the element size
-    # and uses this to optimize the kernel.
-    # This can result in more efficient kernels, but requires runtime checking to ensure the specified
-    # summation value meets the requirements.
-    # (Recommended AF1EM value is 8 for half, 4 for single, 2 for double)
-    #
-    # Optimizations enabled by AssertSummationElementMultiple>1:
-    #  - If >=2 for half:
-    #     - Tail loop loads can be vectorized 2X to use dword
-    #     - Enables asm kernels on V20
-    #     - Can use DirectToLds for both unroll and tail loops
-    #  - Tail loop can be unrolled up to InnerUnroll amount if AssertSummationElementMultiple%InnerUnroll==0
-    #
-    # 1 indicates no assertion (since all sizes are multiples of 1)
-    "AssertSummationElementMultiple": [1, 2, 4, 8, 16, 32, 64, 128],
-    # Kernel generator will assume that the FreeIndex[0] size is some multiple of the element size
-    # and uses this to optimize the kernel.
-    # FreeIndex[0] is usually letter "I"
-    # (Recommended AF0EM value is 8 for half, 4 for single, 2 for double)
-    #
-    # Optimizations enabled by AssertFree0ElementMultiple>1:
-    # Load optimizations:
-    #  - For TLU=1 matrix, if AF1WM>=GLVW then can enable UseSgprForGRO
-    #      - Reduces registers used for address calculations
-    #      - Removes address shift/unshift code
-    #    - UseSgprForGRO will only be enabled if all matrices meet assertion requirements.
-    #
-    # Store Optimizations:
-    #  - Can vectorize stores in edge tiles.  Vector width can be up to AF0EM.
-    #   (since C matrix is always coalesced in Free0 index direction and this assertion guarantees the index element multiple)
-    #
-    # 1 indicates no assertion (since all sizes are multiples of 1)
-    "AssertFree0ElementMultiple": [1, 2, 4, 8, 16],
-    # Kernel generator will assume that the FreeIndex[1] size is some multiple of the element size
-    # and uses this to optimize the kernel.
-    # FreeIndex[1] is usually letter "J"
-    # (Recommended AF1EM value is 8 for half, 4 for single, 2 for double)
-    # Optimizations enabled by AssertFree1ElementMultiple>1:
-    #  - See above AssertFree0ElementMultiple "Load optimizations"
-    # 1 indicates no assertion (since all sizes are multiples of 1)
-    "AssertFree1ElementMultiple": [1, 2, 4, 8, 16],
-    # Assertions that require arithmetic intensity to be specified value.
-    # Arithmetic intensity measures the ratio of computation to memory bandwidth required for a problem.
-    # These predicates can be used to adjust solution selection compute-bound or memory-bound problems.
-    "AssertAIGreaterThanEqual": -1,
-    "AssertAILessThanEqual": -1,
-    # Stagger the start summation position of the tiles.
-    # Elements from the summation dimension are loaded at offsets rather than all starting at 0.
-    # StaggerU is the max 'clicks' of StaggerUStride bytes where each wg starts ; see StaggerUMapping
-    # for how the specific stagger for a given wg is determined.
-    #
-    # The tile assignment C are same as with StaggerOffset=0 ; the difference is the
-    # order that the summation elements are added.
-    # GRO will wrap back to the row start when the edge is reached.
-    #
-    # This can be effective for TLU=0 style matrices where the K dimension is a large power-of-2.
-    # In this case the start of each row of the tile is separated by an exact power-of-2
-    # which causes poor dram, cache, and tlb behavior.  V20 has 16 channels each 256 bytes wide.
-    # StaggerU adjusts the start position in the summation (aka 'U') dimension
-    # to avoid these conflicts.  Both A and B matrix start at the adjusted position.
-    # If >0 specifies the offset in multiples of the macro-tile "unroll" dim
-    #  - Higher values will spread traffic to more channels but provide less L2 re-use.
-    #  - StaggerU and WorkGroupMapping interact and should be tuned together -
-    #    The WGM controls how tiles are assigned in C matrix, while StaggerU controls where those
-    #    tiles start reading their summation dim parms.
-    #  - StaggerU requires BufferLoad==1 and is silently ignored if BufferLoad==0
-    "StaggerU": [0, 2, 4, 8, 16, 32, 64],
-    # Stride in bytes for each staggeru 'click'.
-    # 256 is recommended since this is the width of memory channel (on gfx803,gfx900,gf906) - so
-    # each click will start in a new memory channel and spread traffic among the 16 available channels.
-    # For example StaggerUStride=256 and StaggerU=8 will use 8 unique starting points
-    # in summation dimension, each offset by 256-bytes - provided the tensor dims are large
-    # enough to support this.
-    # StaggerUStride will be internally increased so it is an integer multiple of DepthU*BpeAB.
-    # (the implementation requires this - the unroll iteration accesses data in steps of
-    # DepthU*BPE
-    "StaggerUStride": [-1, 16, 32, 64, 128, 256, 512, 1024, 2048],
-    # How the tile assignment (wg0, wg1, wg2) controls the initial StaggerU offset:
-    # 0: Use wg0
-    # 1: Use wg1
-    # 2: Use wg2
-    # 3: Use wgSerial, wgSerial = wg0 + wg1 * nwg0 + wg2 * (nwg0 * nwg1)
-    # 4: Debug mode, offset each tile max allowed StaggerU.  This just moves hotspot
-    #    to a different bank since all workgroups still start at same point.
-    "StaggerUMapping": [0, 1, 2, 3, 4],
-    # GSU Workgroup Coalesced Ordering
-    # False: {(wg0,wg1,wg2,wgn)|(wg0,wg1,wg2,wgn)|...|(wg0,wg1,wg2,wgn)}
-    # True:  {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
-    "GlobalSplitUCoalesced": [False, True],
-    # GSU Workgroup Mapping
-    # False: wg issued order = {(wg0,wg1,wg2,wgn),(wg0,wg1,wg2,wgn)|...|(wg0,wg1,wg2,wgn)}
-    #   -> workgroups do the summation by tile -> slower GR but faster GW
-    # True:  wg issused oder = {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
-    #   -> workgroups split up the summation -> faster GR but slower GW
-    "GlobalSplitUWorkGroupMappingRoundRobin": [False, True],
-    # 0=don't use magic div (source only)
-    # 1=magic div alg #1.  Slightly faster but limited range (if magic number is 2^32)
-    # 2=magic div alg#2.  Slightly slower but handles all unsigned ints up to 2^32
-    "MagicDivAlg": [0, 1, 2],
-    # For Block Mapping type:
-    # 0   : Use hardware-assigned wg number with no remapping.
-    # N   : WG block width.  "Wrap" to a new wg1 "row" assignment after N WGs assigned in that row.
-    # Tensor C always mapped with first free coord as fastest moving
-    # (Elements in this dimension are sequential in memory.
-    #
-    # For 2D nonbatched Matrix this means index order is I, then J
-    # For 2D batched Matrix this means index order is I, then J, then K.
-    #
-    # Then for 2D case:
-    #   - If drawn in row-major format, I is the width and J is the height.
-    #   - WGM determines dimensions of the box used to assign tiles from C
-    #   - WGM is the height of the box (in the J dimension)
-    #   - Given WGM, the box width (in I dim) is determined by number of CUs
-    #   - The box always moves across matrixC in the fastest-moving "I" dim, then
-    #     wraps to next J.  TODO - might be useful to change this?
-    #
-    # Examples for 2D matrix:
-    # WGM=8:  on CU64 machine this is a square box
-    # WGM=1:  Short/Fat - this will cover maximum width in I dimension of C.  This matches hardware assigned mapping.
-    # WGM=64: Tall/Skinny - this will cover maximum width in J dimension of C.
-    #
-    # Formula for wgSerial:
-    # wgSerial = wg0 + (wg1 % WorkGroupMapping) * nwg0
-    "WorkGroupMapping": list(
-        range(-1024, 1024 + 1)
-    ),  # change a workgroup's id so that the all the workgroups on the gpu at a time are hitting L2 cache the best
-    "WorkGroupMappingXCC": [
-        1,
-        2,
-        4,
-        8,
-        16,
-        32,
-    ],  # change a workgroup's id so that contiguous workgroup can map on same XCC
-    # -1 : WorkGroupMappingXCCGroup will be set to CU_count at runtime. Please ensure that (CU_count % WGMXCC == 0).
-    "WorkGroupMappingXCCGroup": list(
-        range(-1, 1024)
-    ),  # change a workgroup's id so that contiguous workgroup can map on same XCC, remap workgroup in a group of WGMXCCG.
-    "MaxOccupancy": list(
-        range(1, 40 + 1)
-    ),  # wg / CU; if cache thrashing is hurting performance, this allocates extra lds to artificially limit occupancy
-    "WorkGroup": validWorkGroups,  # ( wg0 x wg1 x LocalSplitU ) dimensions of the workgroup which will operate on a tile and share lds
-    # ThreadTile: ( tt0 x tt1 ) dimensions of the C tile that each thread works on,
-    # TT=4 and VW=4 means a thread will work on a tight 4x4 tile of C, where VW=1 means the tile will work on 16 spread out values
-    # Generally, the VW determines the consecutive a WI will work on, then it will skip ahead SG0*VW elements to get to the next row of VGPR inputs
-    "ThreadTile": validThreadTiles,
-    "MacroTile": validMacroTiles,  # MT0 = wg0*tt0, MT1 = wg1*tt1
-    "WavefrontSize": [32, 64],
-    # MatrixInstruction: (M x N x K x B)
-    # XDLOPS tile definition, only valid for gfx908, gfx90a
-    # MxNxKxB specifies matrix instruction variants
-    #  MxNxB determines the shape of the C tile each instruction worked on
-    #      K determines the unroll depth
-    # If empty, do not use these instructions
-    #
-    # Alternative format: (M x N x K x B x MIBlockM x WaveTileM x WaveTileN x WaveM x WaveN)
-    # (Note: MxN means M-by-N in the following comments)
-    # MIBlockM determines how many blocks along M dimension for multi-block MI variants. Concrete examples:
-    #  - MI 16x16x1x4 (4-block variant) with MIBlockM=4 -> (16x16)*(4x1)=64x16 tile per instruction executed
-    #  - MI 32x32x1x2 (2-block variant) with MIBlockM=1 -> (32x32)*(1x2)=32x64 tile per instruction executed
-    # WaveTileM/N are dimensions of the C tile each wave works on, and is close to the concept of ThreadTile in classic VALU kernels
-    #  - WT 4x1 -> each wave executes 4x1 matrix instructions on the C tile of total area (4*MITileM)x(1*MITileN)
-    # WaveM/N are dimensions of waves spawned for one workgroup where each wave consists of 64 threads
-    #  - Wave2x2 -> a total of 4 waves in one workgroup of shape 2x2
-    # Putting it all together:
-    #  - [32, 32, 1, 2,  1,  4, 1,  2, 2]
-    #     ^^^^^^^^^^^^   ^   ^^^^   ^^^^
-    #      MatrixInst  BlkM   WT    Wave
-    #  - means (32x64) per MI * (4x1) per wave * (2x2) per workgroup = (32*4*2)x(64*1*2) = 256x128 macro tile
-    # Tensile will ignore the parameters ThreadTile and WorkGroup when the alternative format is used
-    "MatrixInstruction": validMatrixInstructions,
-    # StoreRemap: Optimize MatrixInstruction store patterns to enhance performance.
-    #             MI output data between each threads are along N dims.
-    #             But global memory is along M dim continuous.
-    #             That mean global write between each threads are not continuous.
-    #             Therefore, store performance for MI instruction is poor.
-    # How StoreRemap works in final store stage:
-    #             1. Put all thread output data into LDS.
-    #             2. All thread read data from LDS along M dims.
-    #                (match global Memory continuous direction)
-    #             3. All thread write out data into global memory.
-    # 0:   Disable StoreRemap (default)
-    # 1~8: Enable StoreRemap and set the global write vector width
-    # Suggest optimum value: fp32 = [2,4], fp16 or bf16 = [4,8] (dwordx2 and dowrdx4)
-    # -1:  Use dwordx2 if support SRVW, or set SRVW to 0
-    "StoreRemapVectorWidth": [-1, 0, 1, 2, 4, 8],
-    # SourceSwap: Optimizes MatrixInstruction store pattern by swapping mfma input order.
-    "SourceSwap": [False, True],
-    # Following parameters are designed for store scheduling.
-    # (store stands for load from C (with beta) and store to C/D)
-    #
-    # we want to hide store behind unroll loop
-    #   1. if we can launch 2 WorkGroups per CU (occupancy >= 2, large M/N)
-    #   2. if there are remaining global memory bandwidth in unroll loop (compute bound kernel)
-    #
-    # we can hide store behind the other WG's loop by lowering priority of store
-    #   priority of loop is the same as priority of store
-    #     WG0: ???????????????\__
-    #         |<-- loop --->|<-- store -->|end
-    #
-    #     WG1: ___________________________/????????????\__
-    #         |<--------- loop ------------------->|<-- store -->|end
-    #
-    #   priority of loop is higher than priority of store
-    #     WG0: ???????\____________________
-    #         |<-- loop --->|<------ store ----->|end
-    #
-    #     WG1: _____________/?????\__________________
-    #         |<------- loop -------->|<----- store ---->|end
-    "StorePriorityOpt": [False, True],
-    #
-    # If we issue store in short period of time, kernel will become from compute bound to memory bound
-    # 0 means issue instructions as many as possible if VGPR available
-    "NumElementsPerBatchStore": list(range(-1, 256)),
-    #
-    # add sync after per batch store in order to store contiguous elements
-    # add sleep after per batch store in order to distribute store over whole loops
-    # NOTE: this parameter is highly depends on size_k
-    # 0 means no sync and sleep
-    "StoreSyncOpt": list(range(0, 256)),
-    #
-    # There are index or address calculation between global instructions.
-    # issue global instruction b2b has better performance
-    "GroupLoadStore": [False, True],
-    # In order to remove the copying from Acc vgpr to Arch vgpr, only use Arch vgprs for v_mfma_xxx.
-    # Only support for kernel whose totalVgpr counts less than 256 and gcn that has control bit ACC_CD.
-    "MIArchVgpr": [False, True],
-    # StreamK (SK) kernels divide work evenly among CUs by splitting along MT and K dimensions.
-    # Total work units are calculated as (#MTs x #LoopIters) and divided among workgroups.
-    # In most cases each workgroup will calculate a partial tile that are accumulated in a fixup step in the same kernel
-    # 0 : Standard data-parallel kernel
-    # 1 : Basic StreamK
-    # 2 : Two-Tile StreamK (each WG completes an even number of sk iterations, followed by an even number of dp tiles)
-    # 3 : Two-Tile StreamK with DP before SK tiles
-    # StreamK kernels can adjust the number of CUs being used.
-    # Using fewer sometimes increases overall throughput by allowing other kernels to run in parallel.
-    # StreamK grid is controlled by setting these enviornment variables:
-    # TENSILE_STREAMK_FIXED_GRID lets you override the default grid size with a specific number
-    #   0 = override disabled (default)
-    # TENSILE_STREAMK_FULL_TILES sets the number of full tiles to be included in stream-k work
-    #   -1 = use prediction model for best performance (not yet implemented)
-    #   0 = only remainder tiles run in stream-k
-    #   1+ = remainder + 1 (or more) full grids of tiles run in stream-k (default=1)
-    # TENSILE_STREAMK_DYNAMIC_GRID selects dynamic grid mode, which automatically limits the number of CUs used:
-    #   0 = Off, always use all CUs.
-    #   1 = Only reduce CUs for small problems to number of output tiles when num_tiles < CU count.
-    #   2 = Also reduce CUs used for large sizes to improve data-parallel portion and reduce power.
-    #   3 = Analytically predict the best grid-size by weighing the cost of the fix-up step and the cost of processing MACs (default).
-    #       Note: dynamic grid coefficients currently apply to gfx942 variants
-    # TENSILE_STREAMK_MAX_CUS allows the user to manually set maximum number of CUs used, which could free up some CUs for
-    #   other operations to run in parallel with gemm.
-    # TENSILE_STREAMK_GRID_MULTIPLIER lets you set how many workgroups are created per CU being used.
-    #   1 = 1 WG per CU (default), for example. 2 will launch WGs = 2 x CU count.
-    # The priority of these environment variables is defined as follows:
-    # TENSILE_STREAMK_FIXED_GRID > TENSILE_STREAMK_DYNAMIC_GRID > TENSILE_STREAMK_MAX_CUS > TENSILE_STREAMK_GRID_MULTIPLIER
-    "StreamK": [0, 1, 2, 3],
-    # Determines if StreamK kernel uses atomics
-    # 0: uses workspace to store partial tiles, accumulate in deterministic fix-up step
-    # 1: uses atomics to accumulate partial tiles
-    "StreamKAtomic": [0, 1],
-    # Enables XCC-based remapping of workgroups, set the value to the number of XCCs
-    # for the device/configuration being used
-    # 0: uses default workgroup assignment
-    # 2+: remaps workgroups to be contiguous within an XCC for a given number of XCCs
-    "StreamKXCCMapping": [0] + list(range(2, 9)),
-    # Debug settings for stream-k kernels to disable parts of the kernel
-    #   Bit 0: Don't generate fixup code
-    #   Bit 1: Don't generate write to partials code
-    # Both parts can be disabled together
-    #   0 = Debug mode off, generate full kernel
-    #   1 = No fixup
-    #   2 = No partials
-    #   3 = Nofixup and no partials
-    "DebugStreamK": [0, 1, 2, 3],
-    # Controls desired width (#elements) for loads from global memory -> LDS.
-    # and eliminates the pointer unshift logic
-    # -1 : Set GlobalReadVectorWidth =  VectorWidth
-    # NOTE: for input bpe=32, max GRVW is 4  (to fit dwordx4) (FP32), min GRVW is 1 (dword)
-    #                 bpe=16, max GRVW is 8  (to fit dwordx4) (FP16), min GRVW is 2 (dword)
-    #                 bpe=8,  max GRVW is 16 (to fit dwordx4) (INT8), min GRVW is 4 (dword)
-    "GlobalReadVectorWidthA": [-2, -1, 1, 2, 3, 4, 6, 8, 16],
-    "GlobalReadVectorWidthB": [-2, -1, 1, 2, 3, 4, 6, 8, 16],
-    # Controls desired width (#elements) for loads from LDS -> VGPR.
-    # -1 : Set LocalReadVectorWidth =  VectorWidth
-    #  1 cannot be used for half type.
-    # used in combination with TransposeLDS=True
-    # in TransposeLDS=1 case, use wider load to fetch elements in summation dimension from LDS
-    # helps optimizing instruction scheduling between MFMA and nonMFMA instructions
-    # NOTE: for input bpe=32, max LRVW is 4  (to fit ds_read_b128) (FP32)
-    #                 bpe=16, max LRVW is 8  (to fit ds_read_b128) (FP16)
-    #                 bpe=8,  max LRVW is 16 (to fit ds_read_b128) (INT8)
-    "LocalReadVectorWidth": [-1, 1, 2, 4, 8, 16],
-    # threads should read/write/operate on this many contiguous elements from the C matrix.
-    # If VW=4 then thread0 will process 4 consec C elements, then thread1 next 4, etc.
-    # If the ThreadTile is > VectorWidth then thread0 will next operate on the 4 elements in C at (4*NumThreads)
-    # Typically the load vector width and store vector width are directly related to the VW.
-    # The global load width is closely related to the width of local stores so
-    # GlobalReadVectorWidth also controls local write width.
-    # Local read width also matches since VectorWidth consec elements must be read
-    # Typically matching 16 bytes is good choice since the stores will be optimally coalesced with 16 bytes/WI.
-    # Using a VW too large which results in >16bytes/thread isn't supported
-    # For MFMA non SourceSwap: this parameter didn't take effect
-    # -1 means set vw to largest localReadWidth according to MIWaveTile
-    "VectorWidthA": [-1, 1, 2, 3, 4, 6, 8],
-    "VectorWidthB": [-1, 1, 2, 3, 4, 6, 8],
-    # If 0, store 1 element per instruction.
-    # If 1, store vector-width elements per instruction.
-    # if -1, store vector-wide elements per instruction unless PBD would not generate a valid kernel
-    "VectorStore": [-1, 0, 1],
-    # Controls desired width (#elements) for stores from reg to global memory.
-    # When MatrixInstruciton == None, derived parameter gwvw takes precedence.
-    # -1 : Set StoreVectorWidth = VectorWidth
-    "StoreVectorWidth": [-1, 1, 2, 3, 4, 6, 8],
-    # when loading all the data from global into lds requires multiple load instructions, these parameters govern which
-    # loads will pull which rectangle of data from global into lds
-    # NLC=1 means one load along the coalesced dimension, which results in the most coalescing possible
-    # NLC=-1 looks for the largest number of reads along the coalesced dimension which results in the least ammount of coalescing;
-    # however in this case the stride between one load and another is a static value, therefore buffer loads only need one set of registers
-    # whereas the =1 case has a stride which is a multiple of a kernel argument and therefore needs one address per load in the perpendicular dimension
-    "NumLoadsCoalescedA": list(range(-1, 64 + 1)),
-    "NumLoadsCoalescedB": list(range(-1, 64 + 1)),
-    # DepthU, LocalSplitU (which is the 3rd number in WorkGroup), and LoopUnroll are closely related
-    # LoopUnroll=4 means there are 4 subiterations within the loop, 4 actual iterations written in the code.
-    # LocalSplit=2 means the workgroup is split up into 2 subgroups, and each subgroup is doing different parts of the summation.
-    # subgroup0 does k=0-3, 8-11... and subgroup1 does k=4-7, 12-15...
-    # So, each iteration through the summation loop, which has 4 actual subiterations, does 8 summation iterations, because each subgroup did 4;
-    # and when data is read from global memory the threads read 8 elements along the summation dimension.
-    # DepthU = LoopUnroll * LocalSplitU = 4*2 in this case
-    # it made more sense for the user to directly control LocalSplitU and DepthU, then derrive afterwards LoopUnroll=DepthU/LocalSplitU
-    # -1 : Only allow GLVW=1
-    # -2 : Only allow max(GLVWA,GLVWB) < VW ?
-    # -3 : Only allow min(GLVWA,GLVWB) < VW ?
-    "DepthU": depthUs,
-    # integer amount of padding to put into LDS, in 2016 this didn't seem to help performance, profilers were showing that channel conflicts weren't really hurting
-    # performance so this has been deprecated and probably doesn't work
-    # -1 means use same padding as the VectorWidth if TLU=0 else 0.  (Padding only helps when transpose is required)
-    # With MatrixInstruciton: -1 means max(GRVW,MIInput) if TLU=0
-    "LdsPadA": [-1, 0, 1, 2, 3, 4, 8, 16, 32, 48, 64],
-    "LdsPadB": [-1, 0, 1, 2, 3, 4, 8, 16, 32, 48, 64],
-    "LdsPadMetadata": [-1, 0, 1, 2, 3, 4, 8],
-    # Padding boundary for LDS. defines block-size for pad insertion. for every 'LdsBlockSizePerPad' bytes, LDS padding (pad value from LdsPad parameter)
-    # is added (readOffset aware of the pad and adjusts offset value based on this parameter value).
-    # Only support LdsBlockSizePerPad >= unrollDepth * BPE
-    # 0 means disable LdsBlockSizePerPad
-    "LdsBlockSizePerPadA": [-1, 0, 64, 128, 256, 512, 1024, 2048],
-    "LdsBlockSizePerPadB": [-1, 0, 64, 128, 256, 512, 1024, 2048],
-    "LdsBlockSizePerPadMetadata": [-1, 0, 64, 128, 256, 512, 1024, 2048],
-    # Transpose LDS format. Local store in coalesced dimension , same as optimized global fetch dimension . applicable only in TLU=0 case for miSIMD(s)
-    # -1 : keep LDS layout same as global fetch dimension for both A and B
-    #      set TLDS = 1 for NN,TN,TT
-    #      set TLDS = 0 for NT
-    # 0  : coalesced dimension of lds is tile dimension
-    # 1  : keep LDS layout same as global fetch dimension for both A and B for NN,TN,TT, but NT would be rejected
-    # 2  : coalesced dimension of lds is unroll dimension for both A and B
-    "TransposeLDS": [-1, 1, 0, 2],
-    # add gls or slc after global memory read/writes to change caching, not caching the writes is promising and improved performance a tiny bit
-    # 0: none, 1: glc, 2: slc, 3: glc slc
-    # For gfx942, sets sc0/sc1/nt bits
-    # 0: none, 1: sc0, 2: sc1, 3: sc0 sc1, 4: nt, 5: nt sc0, 6: nt sc1, 7: nt sc0 sc1
-    "NonTemporalE": list(range(0, 8)),
-    "NonTemporalD": list(range(0, 8)),
-    "NonTemporalC": list(range(0, 8)),
-    "NonTemporalA": list(range(0, 8)),
-    "NonTemporalB": list(range(0, 8)),
-    "NonTemporalWS": list(range(0, 8)),
-    "NonTemporalMetadata": list(range(0, 8)),
-    "NonTemporal": list(range(-1, 8)),
-    # Group together unroll iterations inside the unroll loop.
-    # For example, InnerUnroll=2 will fetch LDS for two unroll iterations
-    "InnerUnroll": [1, 2, 4, 8, 16, 32, 64],
-    # Enable CP preload kernel arguments feature
-    # It can reduce time of loading kernel arguments by s_load.
-    # It needs new complier and vbios to support this feature.
-    "PreloadKernArgs": [False, True],
-    # Kernels should be written in assembly or source
-    # if assembly, ISA will determine architecture
-    # if source, Runtime will determine language
-    # later on, we'll relax this to inner kernel languages and outer kernel languages, such as inline asm embedded in ocl or in llvm
-    "KernelLanguage": ["Assembly"],
-    "ISA": validISA,  # arch for assembly kernels
-    # Name of the custom kernel located at `CUSTOM_KERNEL_PATH`.
-    # a custom kernel is a user written assembly kernel with its associated configuration parameters included in a custom.config section
-    # inside the yaml block between the --- and ... markers.  These parameters are only used for information purposes, not kernel generation.
-    # Ex:
-    # custom.config:
-    #   ProblemType:
-    #     OperationType: GEMM
-    #     etc...
-    #   ThreadTile: [8, 8]
-    #   etc...
-    #
-    # Custom kernels can be included in a BenchmarkProblemSizeGroup by having their name (without file extension) listed under the "CustomKernels"
-    # category alongside InitialSolutionParameters, BenchmarkCommonParameters, etc...
-    "CustomKernelName": -1,
-    # Will allow a kernel to be accepted even when checks determine it's not viable.
-    # Intended for use with custom kernels which have confirmed to be correct
-    "NoReject": [False, True],
-    # Debug use only.
-    "ActivationFused": [False, True],
-    # True-  function call
-    # False- inline
-    "ActivationFuncCall": [False, True],
-    # Alternative implementation for activation function
-    # Currently only supports GSU == 1
-    "ActivationAlt": [False, True],
-    # Do workgroup reduction. Currently for DBias
-    "WorkGroupReduction": [False],
-    # 4:2 Structured Sparse A Matrix, 0=Non Sparse, 1=Sparse Matrix A, 2=Sparse Matrix B
-    "Sparse": [0, 1, 2],
-    # in mix mode F8 need to convert to F16, do this before(0) ds or after(1) ds
-    "ConvertAfterDS": [False, True],
-    # Force disable shadow init to release more sgpr in preloop
-    "ForceDisableShadowInit": [False, True],
-    # Enable LDS Transpose Instruction
-    "LDSTrInst": [False, True],
-    # False: Use LocalSplitU. Number of WorkGroup[2] WorkItems (wave or thread) will compute the same output elements (matrix D) along different 
-    #        unroll indices. The local sum from those WorkItems are reduced through LDS.
-    # True:  Use WaveSplitK. Number of WorkGroup[2] threads in the same wave compute the same output elements (matrix D) along different unroll indices.
-    #        The local sum from those threads are reduced through suffling using VALU instructions. Currently only support dot2 kernel.
-    "WaveSplitK": [False, True],
-}
-
 
 # same parameter for all solution b/c depends only on compiler
 defaultBenchmarkCommonParameters = [
@@ -1374,97 +424,7 @@ for paramDict in defaultBenchmarkCommonParameters:
         defaultSolution[key] = value[0]
 # other non-benchmark options for solutions
 
-################################################################################
-# Default Problem Type
-################################################################################
-defaultProblemType = {
-    # =GEMM uses TransposeA,B parameters and makes the problem type more readable for users
-    # =TensorContraction  requires specifying
-    "OperationType": "GEMM",  # GEMM, TensorContraction, ConvolutionForward, ConvolutionBackwardData, ConvolutionBackwardWeights
-    "DataType": 0,  # data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "DataTypeA": 0,  # A data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "DataTypeB": 0,  # B data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "DataTypeE": 0,  # E data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "DataTypeAmaxD": 0,  # AmaxD data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "DestDataType": 0,  # destination data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "ComputeDataType": 0,  # compute data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
-    "F32XdlMathOp": 0,  # reducing intermediate precision from f32 to a specific type, such as "x", as listed in SolutionStructs.py::DataType.
-    # in:f32, intermediate:xf32, out:f32. f32 = xf32(f32) * xf32(f32)
-    "UseBeta": True,  # =True use beta parameter (asm will check for B=0 and optimize the write for that), =False don't use beta parameter
-    "UseE": False,  # =True use output E to output gemm results before activation
-    "Gradient": False,  # =True set globalWriteElements to gradient mode
-    "UseBias": 0,  # =1 support bias vector on M direction, =2 support bias vector on N direction, =3 support bias vector on both M,N direction
-    "BiasSrc": "D",  # This parameter is used in gradient + bias. Support A, B, D.
-    "UseScaleAB": "",  # Support "", "Scalar", and "Vector"
-    "UseScaleCD": False,  # =True use scaleC, scaleD
-    "UseScaleAlphaVec": 0,  # =1 support alpha vector on M direction, =2 support bias vector on N direction, =3 support alpha vector on both M,N direction
-    "HighPrecisionAccumulate": False,  # f32 += f16*f16
-    "SilentHighPrecisionAccumulate": False,  # Keep kernel names the same for HPA mode.  Useful for testing.
-    "Sparse": 0,  # 4:2 Structured Sparse A Matrix, 0=Non Sparse, 1=Sparse Matrix A, 2=Sparse Matrix B
-    "ComplexConjugateA": False,  # complex data should be conjugated for "C" transpose case
-    "ComplexConjugateB": False,
-    "StochasticRounding": False,  # By default, IEEE RNE rounding
-    # for OperationType == GEMM
-    "TransposeA": False,  # =True means transA="T" or "C", =False means transA = "N"
-    "TransposeB": True,
-    "Batched": False,  # add batching dimension
-    "StridedBatched": True,  # use to select general batch or strided batch
-    "GroupedGemm": False,  # use to select general batch or strided batch
-    # for OperationType == TensorContraction
-    # - Indices < NumIndicesC are Free or Batch indices and appear in C and D
-    # - Indices which appear in both A and B, and are < NumIndicesC are batch.  A and B must have same number of batch indices.
-    # - Indices which appear in both A and B, and are >= NumIndicesC are summation. A and B must have same number of summation indices.
-    # - Indices which appear in A or B (but not both), are Free.  A and B may have different numbers of free indices.
-    # - Summation loops are nested from smallest index number to largest, with the largest summation index as the 'unroll' loop.
-    # - Memory order of C and D matrices is always 0..NumIndicesC-1, with 0 as the fastest-moving.
-    #   - By choosing index assignments the output can be 'transposed'.  For example if IA=[1,2] IB=[0,2] then 0 is the coalesced dim for C/D.
-    #   - Likewise batch index may be assigned between two free indices to control the output order, ie to write in CNHW format.
-    #   - For example : IA=[0,1,3] IB=[2,1,3].  0,2 are free indices;  1 is batch.
-    "IndexAssignmentsA": [0, 2],
-    "IndexAssignmentsB": [1, 2],
-    "NumIndicesC": 2,
-    # use initial strides for AB.
-    # This has some performance impact for the increased flexibility:
-    #   - Additional strides will be passed into the kernel and will occupy SGPR registers
-    #   - GlobalReadWidth must be 1 (since elements are not guaranteed to be adjacent in memory)
-    "UseInitialStridesAB": False,
-    # use initial strides for CD.
-    # This has some performance impact for the increased flexibility:
-    #   - Additional strides will be passed into the kernel and will occupy SGPR registers
-    #   - Additional multiply on the store address path
-    #   -VectorStore must be 0.  If VectorStore is -1, it will be silently set to 0 internally.
-    "UseInitialStridesCD": False,
-    "AllowNoFreeDims": False,  # allow A or B to specify no free dims
-    # (if false, A and B must have at least one free dim)
-    # (if true, A and B must have at least one free or batch dim)
-    # SetConstStride* sets the specified stride in the problem.
-    # These no longer generate predicates - see AssertStrideEqualA/B below
-    # List of pairs of [index, constValue].
-    # Index is a member of the global index assignments (not an offset into IndexAssignmentsA/B)
-    # EX: SetConstStrideA: [ [3, 1], [2, 4] ] sets
-    #     strideA for index3 to constant '1' and stride for index2 to constant '4'.
-    "SetConstStrideA": [],
-    "SetConstStrideB": [],
-    "SetConstStrideBias": [],
-    # Summation dimension indices
-    "MirrorDimsA": [],
-    "MirrorDimsB": [],
-    "MirrorDimsMetadata": [],
-    # for LD description
-    "NumIndicesLD": 4,
-    "IndexAssignmentsLD": [3, 4, 5, 6],  # order is LDD, LDC, LDA, LDB
-    # Tile aware solution selection
-    "TileAwareSelection": False,
-    # Activation
-    "Activation": False,
-    "ActivationNoGuard": False,
-    # AmaxD
-    "OutputAmaxD": False,
-    # For kernels putting arguments in workspaces instead of kernel arguments, they can choose to support user arguments input instead.
-    "SupportUserArgs": True,
-    "SwizzleTensorA": False,
-    "SwizzleTensorB": False,
-}
+
 
 defaultProblemSizes = [{"Range": [[2880], 0, 0]}]
 defaultBenchmarkFinalProblemSizes = [{"Range": [[64, 64, 64, 512], 0, 0]}]
@@ -1488,85 +448,10 @@ defaultAnalysisParameters = {
 
 
 ################################################################################
-# Printing
-# 0 - user wants no printing
-# 1 - user wants limited prints
-# 2 - user wants full prints
-################################################################################
-def print1(message):
-    if globalParameters["PrintLevel"] >= 1:
-        print(message)
-        sys.stdout.flush()
-
-
-def print2(message):
-    if globalParameters["PrintLevel"] >= 2:
-        print(message)
-        sys.stdout.flush()
-
-
-def printWarning(message):
-    print("Tensile::WARNING: %s" % message)
-    sys.stdout.flush()
-
-
-def printExit(message):
-    print("Tensile::FATAL: %s" % message)
-    sys.stdout.flush()
-    sys.exit(-1)
-
-
-################################################################################
 # Is query version compatible with current version
 # a yaml file is compatible with tensile if
 # tensile.major == yaml.major and tensile.minor.step > yaml.minor.step
 ################################################################################
-def detectGlobalCurrentISA_(detectionTool):
-    """
-    Returns returncode if detection failure
-    """
-    global globalParameters
-
-    if globalParameters["CurrentISA"] == (0, 0, 0) and detectionTool:
-        process = subprocess.run([detectionTool], stdout=subprocess.PIPE)
-        if os.name == "nt":
-            line = ""
-            for line_in in process.stdout.decode().splitlines():
-                if "gcnArchName" in line_in:
-                    line += line_in.split()[1]
-                    break  # detemine if hipinfo will support multiple arch
-            arch = gfxToIsa(line.strip())
-            if arch is not None:
-                if arch in globalParameters["SupportedISA"]:
-                    print1("# Detected local GPU with ISA: " + isaToGfx(arch))
-                    globalParameters["CurrentISA"] = arch
-        else:
-            archList = []
-            for line in process.stdout.decode().split("\n"):
-                arch = gfxToIsa(line.strip())
-                if arch is not None:
-                    if arch in globalParameters["SupportedISA"]:
-                        print1("# Detected local GPU with ISA: " + isaToGfx(arch))
-                        archList.append(arch)
-            if len(archList) > 0:
-                globalParameters["CurrentISA"] = archList[globalParameters["Device"]]
-        if process.returncode:
-            printWarning("%s exited with code %u" % (detectionTool, process.returncode))
-        return process.returncode
-    return 0
-
-
-def detectGlobalCurrentISA():
-    """
-    Returns returncode if detection failure
-    """
-    errorCode = detectGlobalCurrentISA_(globalParameters["AMDGPUArchPath"])
-    if errorCode:
-        printWarning("Attempting to detect ISA with rocm_agent_enumerator")
-        return detectGlobalCurrentISA_(globalParameters["ROCmAgentEnumeratorPath"])
-    return errorCode
-
-
 def restoreDefaultGlobalParameters():
     """
     Restores `globalParameters` back to defaults.
@@ -1580,44 +465,45 @@ def restoreDefaultGlobalParameters():
         globalParameters[key] = value
 
 
-def printTable(rows):
-    rows = list([[str(cell) for cell in row] for row in rows])
-    colWidths = list([max([len(cell) for cell in col]) for col in zip(*rows)])
+# hopefully the isaInfoMap keys only contain isas we plan to build and not all
+def printCapabilitiesTable(isaInfoMap: Dict[str, IsaInfo]):
+    """
+    Prints a capability table for the given parameters and ISA information map.
 
-    for row in rows:
-        for width, cell in zip(colWidths, row):
-            pad = " " * (width - len(cell))
-            print(pad, cell, sep="", end=" ")
-        print()
+    Args:
+        supportedIsas: The ISAs to show in the table.
+        isaInfoMap: The ISA information map containing assembler and architecture capabilities.
+    """
 
+    def printTable(rows):
+        rows = [[str(cell) for cell in row] for row in rows]
+        colWidths = [max(len(cell) for cell in col) for col in zip(*rows)]
 
-def printCapTable(parameters):
-    import itertools
+        for row in rows:
+            print(" ".join(cell.ljust(width) for cell, width in zip(row, colWidths)))
 
-    archs = [(0, 0, 0)] + parameters["SupportedISA"]
-    gfxNames = list(map(isaToGfx, archs))
+    def capRow(isaInfoMap, cap, capType):
+        return [cap] + [
+            "1" if cap in getattr(info, capType) and getattr(info, capType)[cap] else "-"
+            for info in isaInfoMap.values()
+        ]
 
-    headerRow = ["cap"] + gfxNames
+    gfxs = list(map(isaToGfx, isaInfoMap.keys()))
+    headerRow = ["Capability"] + gfxs
 
-    def capRow(caps, cap):
-        return [cap] + [("1" if cap in caps[arch] and caps[arch][cap] else "0") for arch in archs]
-
-    allAsmCaps = set(
-        itertools.chain(*[caps.keys() for arch, caps in parameters["AsmCaps"].items()])
+    allAsmCaps = sorted(
+        set(itertools.chain(*[info.asmCaps for info in isaInfoMap.values()])),
+        key=lambda k: (k.split("_")[-1], k),
     )
-    allAsmCaps = sorted(allAsmCaps, key=lambda k: (k.split("_")[-1], k))
-    asmCapRows = [capRow(parameters["AsmCaps"], cap) for cap in allAsmCaps]
+    asmCapRows = [capRow(isaInfoMap, cap, "asmCaps") for cap in allAsmCaps]
 
-    allArchCaps = set(
-        itertools.chain(*[caps.keys() for arch, caps in parameters["ArchCaps"].items()])
-    )
-    allArchCaps = sorted(allArchCaps)
-    archCapRows = [capRow(parameters["ArchCaps"], cap) for cap in allArchCaps]
+    allArchCaps = sorted(set(itertools.chain(*[info.archCaps for info in isaInfoMap.values()])))
+    archCapRows = [capRow(isaInfoMap, cap, "archCaps") for cap in allArchCaps]
 
     printTable([headerRow] + asmCapRows + archCapRows)
 
 
-def assignGlobalParameters(config, cxxCompiler=None):
+def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
     """
     Assign Global Parameters
     Each global parameter has a default parameter, and the user
@@ -1661,35 +547,10 @@ def assignGlobalParameters(config, cxxCompiler=None):
         globalParameters["CmakeCCompiler"] = os.environ.get("CMAKE_C_COMPILER")
 
     globalParameters["ROCmBinPath"] = os.path.join(globalParameters["ROCmPath"], "bin")
-
-    # ROCm AMD GPU Arch Path
-    # ROCm Agent Enumerator Path
-    if os.name == "nt":
-        globalParameters["AMDGPUArchPath"] = locateExe(
-            globalParameters["ROCmBinPath"], "hipinfo.exe"
-        )
-        globalParameters["ROCmAgentEnumeratorPath"] = locateExe(
-            globalParameters["ROCmBinPath"], "hipinfo.exe"
-        )
-    else:
-        globalParameters["AMDGPUArchPath"] = locateExe(
-            globalParameters["ROCmPath"], "llvm/bin/amdgpu-arch"
-        )
-        globalParameters["ROCmAgentEnumeratorPath"] = locateExe(
-            globalParameters["ROCmBinPath"], "rocm_agent_enumerator"
-        )
-
     globalParameters["ROCmSMIPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm-smi")
     globalParameters["ROCmLdPath"] = locateExe(
         os.path.join(globalParameters["ROCmPath"], "llvm/bin"), "ld.lld"
     )
-
-    globalParameters["ExtractKernelPath"] = locateExe(
-        os.path.join(globalParameters["ROCmPath"], "hip/bin"), "extractkernel"
-    )
-
-    if "AMDGPUArchPath" in config:
-        globalParameters["AMDGPUArchPath"] = config["AMDGPUArchPath"]
 
     if "AsanBuild" in config:
         globalParameters["AsanBuild"] = config["AsanBuild"]
@@ -1700,44 +561,11 @@ def assignGlobalParameters(config, cxxCompiler=None):
     if "CodeObjectVersion" in config:
         globalParameters["CodeObjectVersion"] = config["CodeObjectVersion"]
 
-    # read current gfx version
-    returncode = detectGlobalCurrentISA()
-    if globalParameters["CurrentISA"] == (0, 0, 0):
-        printWarning(
-            "Did not detect SupportedISA: %s; cannot benchmark assembly kernels."
-            % globalParameters["SupportedISA"]
-        )
-    if returncode:
-        if os.name == "nt":
-            globalParameters["CurrentISA"] = (9, 0, 6)
-            printWarning("Failed to detect ISA so forcing (gfx906) on windows")
+    if getVerbosity() >= 1:
+        printCapabilitiesTable(isaInfoMap)
 
-    # TODO Remove this when rocm-smi supports gfx950
-    if globalParameters["CurrentISA"] in [(9,5,0)]:
-        printWarning("HardwareMonitor currently disabled for gfx950")
-        globalParameters["HardwareMonitor"] = False
-
-    globalParameters["AsmCaps"] = {}
-    globalParameters["ArchCaps"] = {}
-    globalParameters["AsmBugs"] = {}
-
-    for v in globalParameters["SupportedISA"] + [(0, 0, 0)]:
-        globalParameters["AsmCaps"][v] = initAsmCaps(v, cxxCompiler, False)
-        globalParameters["ArchCaps"][v] = initArchCaps(v)
-        globalParameters["AsmBugs"][v] = initAsmBugs(globalParameters["AsmCaps"][v])
-
-    if globalParameters["PrintLevel"] >= 1:
-        printCapTable(globalParameters)
-
-    globalParameters["SupportedISA"] = list(
-        [
-            i
-            for i in globalParameters["SupportedISA"]
-            if globalParameters["AsmCaps"][i]["SupportedISA"]
-        ]
-    )
-
-    validParameters["ISA"] = [(0, 0, 0), *globalParameters["SupportedISA"]]
+    isaList = list(isaInfoMap.keys())
+    validParameters["ISA"] = [IsaVersion(0, 0, 0), *isaList]
 
     # For ubuntu platforms, call dpkg to grep the version of hip-clang.  This check is platform specific, and in the future
     # additional support for yum, dnf zypper may need to be added.  On these other platforms, the default version of
@@ -1765,6 +593,10 @@ def assignGlobalParameters(config, cxxCompiler=None):
 
     # The following keys may be present in the config, but are not (or no longer) global parameters.
     ignoreKeys = [
+        "Architecture",
+        "ShortNames",
+        "PrintLevel",
+        "Device",
         "UseCompression",
         "CxxCompiler",
         "CCompiler",
@@ -1796,38 +628,4 @@ def setupRestoreClocks():
 
     atexit.register(restoreClocks)
 
-
 setupRestoreClocks()
-
-
-def assignParameterWithDefault(destinationDictionary, key, sourceDictionary, defaultDictionary):
-    if key in sourceDictionary:
-        destinationDictionary[key] = deepcopy(sourceDictionary[key])
-    else:
-        destinationDictionary[key] = deepcopy(defaultDictionary[key])
-
-
-def checkParametersAreValid(param, validParams):
-    """Ensures paramaters in params exist and have valid values as specified by validParames"""
-    (name, values) = param
-    if name == "ProblemSizes":
-        return
-    elif name == "InternalSupportParams":
-        return
-
-    if name not in validParams:
-        printExit(
-            "Invalid parameter name: {}\nValid parameters are {}.".format(
-                name, sorted(validParameters.keys())
-            )
-        )
-
-    for value in values:
-        if validParams[name] != -1 and value not in validParams[name]:
-            msgBase = "Invalid parameter value: {} = {}\nValid values for {} are {}{}."
-            msgExt = (
-                " (only first 32 combos printed)\nRefer to Common.py for more info"
-                if len(validParams[name]) > 32
-                else ""
-            )
-            printExit(msgBase.format(name, value, name, validParams[name][:32], msgExt))

--- a/tensilelite/Tensile/Common/Types.py
+++ b/tensilelite/Tensile/Common/Types.py
@@ -1,9 +1,132 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+from dataclasses import dataclass
 from typing import NamedTuple, Tuple
 
-IsaVersion = Tuple[int, int, int]
+@dataclass
+class IsaInfo:
+    asmCaps: dict
+    archCaps: dict
+    regCaps: dict
+    asmBugs: dict
 
 
 class SemanticVersion(NamedTuple):
     major: int
     minor: int
     patch: int
+    
+IsaVersion = SemanticVersion
+
+
+class DepthUConfig(NamedTuple):
+    deviceLDS: int=65536
+    maxLDS: int=65536
+
+
+def makeDepthUConfig(config: dict) -> DepthUConfig:
+    deviceLDS  = maxLDS = 65536
+    if "DeviceLDS" in config:
+        deviceLDS = config["DeviceLDS"]
+    if "MaxLDS" in config:
+        maxLDS = config["MaxLDS"]
+    return DepthUConfig(deviceLDS, maxLDS)
+
+
+class DebugConfig(NamedTuple):
+    """
+    Members:
+        debugKernel: assembly only, kernel gets buffer for debug "printing"; 
+                     kernel writes data to memory, gets coppied to host and printed.
+        forceGenerateKernel: Even if error occurs in kernel generation (i.e. due to resource overflow),
+                             generate the kernel source anyway. Tensile will also attempt to run
+                             the kernel. Useful to examine and debug overflow errors.
+        printSolutionRejectionReason: Print why a solution is marked as invalid.
+        printIndexAssignmentInfo: Print the tensor index assignment info.
+
+    """
+    enableAsserts: bool=False
+    enableDebugA: bool=False
+    enableDebugB: bool=False
+    enableDebugC: bool=False
+    expectedValueC: float=16.0
+    forceCExpectedValue: bool=False
+    debugKernel: bool=False
+    forceGenerateKernel: bool=False
+    printSolutionRejectionReason: bool=False
+    splitGSU: bool=False
+    printIndexAssignmentInfo: bool=False
+
+
+def makeDebugConfig(config: dict) -> DebugConfig:
+
+    enableAsserts = False
+    enableDebugA = False
+    enableDebugB = False
+    enableDebugC = False
+    expectedValueC = 16.0
+    forceCExpectedValue = False
+    debugKernel = False
+    forceGenerateKernel = False
+    printSolutionRejectionReason = False
+    splitGSU = False
+    printIndexAssignmentInfo = False
+
+    if "EnableAsserts" in config:
+        enableAsserts = config["EnableAsserts"]
+    if "EnableDebugA" in config:
+        enableDebugA = config["EnableDebugA"]
+    if "EnableDebugB" in config:
+        enableDebugB = config["EnableDebugB"]
+    if "EnableDebugC" in config:
+        enableDebugC = config["EnableDebugC"]
+    if "ExpectedValueC" in config:
+        expectedValueC = config["ExpectedValueC"]
+    if "ForceCExpectedValue" in config:
+        forceCExpectedValue = config["ForceCExpectedValue"]
+    if "DebugKernel" in config:
+        debugKernel = config["DebugKernel"]
+    if "ForceGenerateKernel" in config:
+        forceGenerateKernel = config["ForceGenerateKernel"]
+    if "PrintSolutionRejectionReason" in config:
+        printSolutionRejectionReason = config["PrintSolutionRejectionReason"]
+    if "SplitGSU" in config:
+        splitGSU = config["SplitGSU"]
+    if "PrintIndexAssignmentInfo" in config:
+        printIndexAssignmentInfo = config["PrintIndexAssignmentInfo"]
+
+    return DebugConfig(
+               enableAsserts,
+               enableDebugA,
+               enableDebugB,
+               enableDebugC,
+               expectedValueC,
+               forceCExpectedValue,
+               debugKernel,
+               forceGenerateKernel,
+               printSolutionRejectionReason,
+               splitGSU,
+               printIndexAssignmentInfo,
+            )

--- a/tensilelite/Tensile/Common/ValidParameters.py
+++ b/tensilelite/Tensile/Common/ValidParameters.py
@@ -1,0 +1,860 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+import math
+from functools import lru_cache
+
+from .Architectures import SUPPORTED_ISA
+
+################################################################################
+# Enumerate Valid Solution Parameters
+################################################################################
+
+validThreadTileSides = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16] + list(
+    range(20, 256, 4)
+)
+validThreadTiles = []
+for i in validThreadTileSides:
+    for j in validThreadTileSides:
+        validThreadTiles.append([i, j])
+
+validActivationFormats = ("NCHW", "NHWC", "CNHW", "NCDHW", "NDHWC", "CNDHW")
+validWeightFormats = ("KCYX", "KYXC", "CKYX", "CYXK", "KCZYX", "CKZYX", "CZYXK")
+validMacroTileSides = [
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    6,
+    12,
+    24,
+    48,
+    96,
+    192,
+    384,
+    768,
+]
+validMacroTiles = []
+validISA = [(0, 0, 0)]
+validISA.extend(SUPPORTED_ISA)
+depthUs = list(range(2, 1024 + 1, 1))
+for i in validMacroTileSides:
+    for j in validMacroTileSides:
+        validMacroTiles.append([i, j])
+validTT = 32
+
+@lru_cache
+def makeValidWorkGroups():
+    validWorkGroups = []
+    for numThreads in range(32, 1025, 32):
+        for nsg in [1, 2, 4, 8, 16, 32, 64, 96, 128, 256]:
+            for sg0 in range(1, numThreads // nsg + 1):
+                sg1 = numThreads // nsg // sg0
+                if sg0 * sg1 * nsg == numThreads:
+                    workGroup = [sg0, sg1, nsg]
+                    validWorkGroups.append(workGroup)
+    return validWorkGroups
+
+def makeValidWMMA():
+    return [[16, 16, 16, 1]]
+
+@lru_cache
+def makeValidMFMA():
+    validMFMA = {}
+    validMFMA["H"] = [[32, 32, 16, 1], [32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 32, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
+    validMFMA["S"] = [[32, 32, 1, 2], [32, 32, 2, 1], [16, 16, 1, 4], [16, 16, 4, 1], [4, 4, 1, 16]]
+    validMFMA["B"] = [[32, 32, 16, 1], [32, 32, 2, 2], [32, 32, 4, 1], [16, 16, 32, 1], [16, 16, 2, 4], [16, 16, 8, 1], [4, 4, 2, 16]]
+    validMFMA["4xi8"] = [
+        [32, 32, 4, 2],
+        [32, 32, 8, 1],
+        [16, 16, 4, 4],
+        [16, 16, 16, 1],
+        [4, 4, 4, 16],
+        [32, 32, 16, 1],
+        [16, 16, 32, 1],
+    ]
+    validMFMA["D"] = [[16, 16, 4, 1], [4, 4, 4, 4]]
+    validMFMA["B1k"] = [[32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
+    validMFMA["C"] = validMFMA["S"]
+    validMFMA["Z"] = validMFMA["D"]
+    validMFMA["I8"] = [
+        [32, 32, 4, 2],
+        [32, 32, 8, 1],
+        [16, 16, 4, 4],
+        [16, 16, 16, 1],
+        [4, 4, 4, 16],
+    ] + [[32, 32, 16, 1], [16, 16, 32, 1]]
+    validMFMA["X"] = [[32, 32, 4, 1], [16, 16, 8, 1]]
+    validMFMA["F8"] = [[32, 32, 16, 1], [16, 16, 32, 1], [32, 32, 64, 1], [16, 16, 128, 1]]
+    validMFMA["B8"] = validMFMA["F8"]
+    validMFMA["F8B8"] = validMFMA["F8"]
+    validMFMA["B8F8"] = validMFMA["F8"]
+    validMFMA["F8N"] = [[32, 32, 16, 1], [16, 16, 32, 1]]
+    validMFMA["B8N"] = validMFMA["F8N"]
+    validMFMA["F8B8N"] = validMFMA["F8N"]
+    validMFMA["B8F8N"] = validMFMA["F8N"]
+    validMFMA["_format9"] = []
+
+    for MFMA in [
+        validMFMA["H"],
+        validMFMA["S"],
+        validMFMA["B"],
+        validMFMA["D"],
+        validMFMA["X"],
+        validMFMA["F8N"],
+        makeValidWMMA(),
+    ]:
+        for MI in MFMA:
+            for bm in range(int(math.log(MI[3], 2)) + 1):
+                for tt0 in range(1, validTT + 1):
+                    for tt1 in range(1, validTT + 1):
+                        for wave_m in range(3):
+                            for wave_n in range(3):
+                                validMFMA["_format9"].append(
+                                    [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
+                                )
+    return validMFMA
+
+@lru_cache
+def makeValidSMFMA():
+    validSMFMA = {}
+    validSMFMA["H"] = [[32, 32, 16, 1], [16, 16, 32, 1], [16, 16, 64, 1], [32, 32, 32, 1]]
+    validSMFMA["B"] = [[32, 32, 16, 1], [16, 16, 32, 1], [16, 16, 64, 1], [32, 32, 32, 1]]
+    validSMFMA["4xi8"] = [[32, 32, 32, 1], [16, 16, 64, 1], [16, 16, 128, 1], [32, 32, 64, 1]]
+    validSMFMA["I8"] = validSMFMA["4xi8"]
+    validSMFMA["F8"] = [[32, 32, 32, 1], [16, 16, 64, 1], [16, 16, 128, 1], [32, 32, 64, 1]]
+    validSMFMA["B8"] = validSMFMA["F8"]
+    validSMFMA["F8B8"] = validSMFMA["F8"]
+    validSMFMA["B8F8"] = validSMFMA["F8"]
+    validSMFMA["F8N"] = validSMFMA["F8"]
+    validSMFMA["B8N"] = validSMFMA["F8"]
+    validSMFMA["F8B8N"] = validSMFMA["F8N"]
+    validSMFMA["B8F8N"] = validSMFMA["F8N"]
+    validSMFMA["_format9"] = []
+    for SMFMA in [validSMFMA["H"], validSMFMA["B"], validSMFMA["4xi8"], validSMFMA["F8N"]]:
+        for MI in SMFMA:
+            for bm in range(int(math.log(MI[3], 2)) + 1):
+                for tt0 in range(1, validTT + 1):
+                    for tt1 in range(1, validTT + 1):
+                        for wave_m in range(3):
+                            for wave_n in range(3):
+                                validSMFMA["_format9"].append(
+                                    [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
+                                )
+    return validSMFMA
+
+@lru_cache
+def makeValidMatrixInstructions():
+    mfma = makeValidMFMA()
+    smfma = makeValidSMFMA()
+    validMatrixInstructions = (
+        [[], [-1]]
+        + mfma["H"]
+        + mfma["S"]
+        + mfma["B"]
+        + mfma["D"]
+        + mfma["B1k"]
+        + mfma["X"]
+        + smfma["H"]
+        + smfma["B"]
+        + smfma["4xi8"]
+    )
+    return validMatrixInstructions + mfma["_format9"] + smfma["_format9"]
+
+
+validParameters = { # we need to make sure this matches develop
+    # 0: Global read is along parallel direction in thread level,
+    #     each load instruction stride whole threads.
+    #                         ----> perp
+    #       | [w0,  w0,  w1,w1,w2,w2,w3,w3,  w0,  w0, w1,w1,w2,w2,w3,w3]
+    #       | [ t0,t32] [                 ] [ t0,t32] [                ]
+    #  para | [ t1,t33] [  wave 1,2,3     ] [ t1,t33] [ wave 1,2,3     ]
+    #       | [ .., ..] [                 ] [ .., ..] [                ]
+    #       | [t31,t63] [                 ] [t31,t63] [                ]
+    #       V [-load_1]                      [-load_2]
+    #
+    # 1: Each wave load a block of memory,
+    #     each load instruction stride 64 threads.
+    #                         ----> perp
+    #         [ w0, w0,  w0, w0, w1,w1,w1,w1, w2,w2,w2,w2, w3,w3,w3,w3]
+    #       | [ t0,t32][ t0,t32]
+    #  para | [ t1,t33][ t1,t33]
+    #       | [ .., ..][ .., ..]
+    #       | [t31,t63][t31,t63]
+    #       V [-load_1][-load_2]
+    #
+    #
+    # 2: Each load instruction spread threads evenly in the perp direction
+    #                         ----> perp
+    #       |  [w0, w1, w2, w3, w0, w1, w2, w3, w0, w1, w2, w3, w0, w1, w2, w3]
+    #       |  [t0 ]           [t0 ]           [t32]           [t32]
+    #  para |  [t1 ]           [t1 ]           [t33]           [t33]
+    #       |  [.. ]           [.. ]           [.. ]           [.. ]
+    #       |  [t31]           [t31]           [t63]           [t63]
+    #       V [load_1]        [load_2]        [load_1]        [load_2]
+    #
+    "WaveSeparateGlobalReadA": [0, 1, 2],
+    "WaveSeparateGlobalReadB": [0, 1, 2],
+    # Add an unrolled loop and NGLL loop with swapped GRA and GRB order.
+    # which may change the tlb thrashing behavior.
+    "UnrollLoopSwapGlobalReadOrder": [0, 1],
+    # PrefetchGlobalRead = 1:
+    # Requires 2X LDS space, and VGPRs for buffering data on way into LDS
+    #   prefetch / double-buffer reads from global memory -> vgprs -> lds.
+    #
+    # PrefetchGlobalRead = 2:
+    # Do another prefetch while writing data from vgpr to lds.
+    #   prefetch / double-buffer reads from global memory -> vgprs --> lds.
+    #                                                              |-> prefetch reads
+    "PrefetchGlobalRead": [0, 1, 2],
+    # number of iteration prefetch local reads from lds to VGPRs buffer = PLR
+    "PrefetchLocalRead": list(range(128 + 1)),
+    # MatrixInstruction Only
+    # If set ClusterLocalRead, each iteration dedicated vgprBuffer for localRead
+    # So we can schedule these localReads to the front of the loop
+    "ClusterLocalRead": [0, 1],
+    # We use double LDS buffer when PrefetchGlobalRead.
+    # While it reads data from LDS[0]/[1], it prefetch global data and writes to LDS[1]/[0]
+    # If we can make sure all data are read from LDS to register before writing data to LDS, we can use 1 LDS buffer to save LDS memory.
+    # this can help to generate Kernel that LDS usage originally exceed MaxLDS if using double LDS buffer,
+    # or help to increase Occupancy.
+    #     1 means: Force to use 1 LDS Buffer even with PrefetchGlobalRead
+    #    -1 means: generator will use 1 LDS buffer only when LDS exceed MaxLDS
+    # Use case:
+    #    SIA2: 1LDSBuffer is set to 1 natively
+    #    SIA3: 1LDSBuffer works only when PGR=True
+    # TODO: optimize scheduling to support more cases.
+    "1LDSBuffer": [-1, 0, 1],
+    # Split the unroll summation into multiple sections and combine the sections
+    # GSU applies only to the unroll summation dimension
+    # Set to 0 to disable GSU, kernel code will be generated without GSU support
+    "GlobalSplitU": list(range(0, 1024 + 1)),
+    # choose how to do GlobalSplitU
+    # 1: use atomic operation to accumulate on one buffer
+    # 2: each GSU group write to each own buffer and accumulate by another kernel
+    # 3: each GSU group write to each own buffer and accumulate by same kernel
+    "GlobalSplitUAlgorithm": ["SingleBuffer", "MultipleBuffer", "MultipleBufferSingleKernel"],
+    # don't create a whole copy of the Unroll loop with loads removed - instead
+    # use buffer limits to suppress global loads and ignore unnecessary ds_reads
+    "SuppressNoLoadLoop": [False, True],
+    # For PrefetchGlobalRead=1, create a second copy of the unroll loop with
+    # the LDS pointer swaps expanded into inline constants for LDS read and write instructions
+    # This eliminates 4 vector XOR instructions used for pointer swap
+    "ExpandPointerSwap": [False, True],
+    # Schedule global reads and global read increments into LocalRead iterations
+    # Can reduce pressure on local read instruction dispatch queue
+    # 0=perform global reads at start of instruction loop
+    # 1=schedule into the local read instruction iterations
+    "ScheduleGlobalRead": [0, 1],
+    # Schedule local writes into LocalRead iterations.
+    # Can reduce pressure on local read instruction dispatch queue
+    "ScheduleLocalWrite": [0, 1],
+    # Scheduling algorithm to use for each iteration:
+    # 0 = minimal/no scheduling.  Global Read and increments, followed by local reads,
+    # followed by local writes, followed by MACs
+    "ScheduleIterAlg": [0, 1, 2, 3],
+    # For MatrixInstruction and SIA3, number of GlobalReadInstruction between mfma
+    # the purpose of this parameter is to control density of global read instruction scheduling
+    # Scheduling global read back to back can have better memory efficiency
+    # However, when full of vmem FIFO, it will block other instruction to be issued
+    # Range from 0.01 to 32
+    #         0.1 means 1 GR per 10 mfma
+    #           5 means 5 GR per 1 mfma
+    "GlobalReadPerMfma": [i / 100 for i in range(1, 3200)],
+    #
+    # For MatrixInstruction and SIA3, number of LocalWriteInstruction between mfma
+    # the purpose of this parameter is to control density of local write instruction scheduling
+    # In PGR1, we want to schedule local write more denser, so we can have more
+    #          latency to hide global read
+    # In PGR2, since LW is followed by GR, every LW has same whole loop latency
+    #          to hide global read. We want to schedule LW less denser, can
+    #          avoid full of vmem FIFO.
+    # Range from 0.01 to 32
+    #         0.1 means 1 LW per 10 mfma
+    #           5 means 5 LW per 1 mfma
+    # -1 will derived an optimized value internally
+    # -2 will derived an optimized value and override LWPM silently (debug only, not recommended)
+    "LocalWritePerMfma": [i / 100 for i in range(1, 3200)] + [-1],
+    # Interleave alpha scale calculation with beta loads and address calcs - rather
+    # than as a separate block of instructions
+    "InterleaveAlpha": [0, 1],
+    # Create a copy of NoLoadLoop which interleaves the stores with the final mac
+    # calculation and may perform other optimizations
+    # 0 = no interleave
+    # 1 = interleave one stores after required macs have completed execution
+    # 2 = interleave two stores after required macs have completed execution
+    "OptNoLoadLoop": [0, 1, 2],
+    "BufferLoad": [False, True],
+    "BufferStore": [False, True],
+    # Attempt to load directly from global memory into Vgpr.
+    # Assembly only
+    "DirectToVgprA": [False, True],
+    "DirectToVgprB": [False, True],
+    "DirectToVgprSparseMetadata": [False, True],
+    # Attempt to load directly from global memory into LDS.
+    # Assembly only
+    # Requires BufferLoad, assembler support for lds modifier on buffer
+    # loads (checked automatically), GlobalVectorWidth=1 (this is hw
+    # requirement) and A/B must not require any transpose.
+    # DirectToLds reduces load latency and eliminates the
+    # G2L registers used to stage data.  Also replaces the
+    # local write offset with an SGPR.
+    # For an 8x8 TT with PrefetchGlobalRead=1 this can save 33 VGPRs.
+    #    - Requirements for DirectToLds=1:
+    #      GlobalReadVectorWidth = 1/2/4 (GRVW * bpe must be 4 for now)
+    #      TransposeLDS = 1 for TLU=0 case
+    # DirectToLds support for x1 only for now
+    "DirectToLds": [False, True],
+    # Load options:
+    # (GRO = Global Read Offset)
+    # BufferLoad=0:
+    #  = Use flat instructions with 64 bit GRO for each load
+    #    + supports sizes up to 2^64
+    #    - uses many VGPR for addressing
+    #    - uses execmask+compares for edge detection
+    #    - generates extra LDS traffic (could convert flat->global load)
+    # BufferLoad=1:
+    #  = Use buffer load instructions with 32-bit offset
+    #    + Less VGPRS (32b offset vs 64-bit) needed for addressing
+    #    + Uses hardware buffer limit for edge detection
+    #    - Limited range - the bot-right corner of macro-tile (plus padding=GRVW
+    #        for shift-pointer, if ShiftPtr is required) must be within 2^32.
+    #      ShiftPtrPad = MayShift ? GRWV*BPE : 0
+    #      For TLU=1: Unroll*StrideA1 + ShiftPtrPad <= 2^32
+    #      For TLU=0: MT*StrideA1 + ShiftPtrPad <= 2^32
+    #      These conditions should be checked using Assert - TODO
+    #  = UseSgprForGRO=1:
+    #    + Attempt to use SGPR for Global Read Offsets.
+    #    + Use one VGPR base GRO + many SGPR GRO rather than many VGPR GRO.
+    #    + Each SGPR stores an offset from base GlobalReadOffset+0.
+    #    - Requirements for UseSgprForGRO=1:
+    #      - BufferLoad=1
+    #      - Use appropriate Assert*ElementMultiple or GRVW=1 to eliminate need for ShifPtr
+    #        (UseSgprForGRO does not support ShiftPtr since ShiftPtr needs to potentially shift GRO)
+    #  = KernelWriterAssembly also supports 64-bit 2D buffer size (see use64bPbcLimit)
+    #    - Requires 4 instructions to move scalar limit and a couple SGPR
+    #    - Enabled by default.  If the overhead matters we can add asserts/YAML parm to specialize
+    #  = UseInstOffsetForGRO=1:
+    #    + Attempt to use Instruction offset for Global Read Offsets.
+    #    + This feature avoid updating m0 for subsequent GRO(s) for directToLds feature
+    #    - Requirements for UseInstOffsetForGRO=1:
+    #      - BufferLoad=1
+    #      - DirectToLds=1
+    #  converting m0 update from LocalWriteAddrSGpr using  is usually win
+    # -1 attempt to use a heuristic to determine when the tile size will use too many SGPR and fall back to VGPR
+    "UseInstOffsetForGRO": [-1, 0, 1],
+    # Converting VGPR GRO into SGPR GRO is usually a win
+    # However, the mode may exhaust all available SGPR, in particular for large unroll
+    # -1 attempt to use a heuristic to determine when the tile size will use too many SGPR and fall back to VGPR
+    "UseSgprForGRO": [-1, 0, 1],
+    # Use a 64-bit shadow limit register to allow buffers larger than 2^32 bytes
+    "Use64bShadowLimit": [True, False],
+    # Assertion properties
+    # These provide information or assertions that the problem size meets certain requirements
+    # for sizes or alignments.  The kernel generator can use this information to produce
+    # a kernel which uses those assertions to produce a faster kernel.
+    #
+    # If modifying or adding Assertions also change ProblemProperties class in TensileTypes.h
+    # Kernel generator will assume that the summation size is some multiple of the element size
+    # and uses this to optimize the kernel.
+    # This can result in more efficient kernels, but requires runtime checking to ensure the specified
+    # summation value meets the requirements.
+    # (Recommended AF1EM value is 8 for half, 4 for single, 2 for double)
+    #
+    # Optimizations enabled by AssertSummationElementMultiple>1:
+    #  - If >=2 for half:
+    #     - Tail loop loads can be vectorized 2X to use dword
+    #     - Enables asm kernels on V20
+    #     - Can use DirectToLds for both unroll and tail loops
+    #  - Tail loop can be unrolled up to InnerUnroll amount if AssertSummationElementMultiple%InnerUnroll==0
+    #
+    # 1 indicates no assertion (since all sizes are multiples of 1)
+    "AssertSummationElementMultiple": [1, 2, 4, 8, 16, 32, 64, 128],
+    # Kernel generator will assume that the FreeIndex[0] size is some multiple of the element size
+    # and uses this to optimize the kernel.
+    # FreeIndex[0] is usually letter "I"
+    # (Recommended AF0EM value is 8 for half, 4 for single, 2 for double)
+    #
+    # Optimizations enabled by AssertFree0ElementMultiple>1:
+    # Load optimizations:
+    #  - For TLU=1 matrix, if AF1WM>=GLVW then can enable UseSgprForGRO
+    #      - Reduces registers used for address calculations
+    #      - Removes address shift/unshift code
+    #    - UseSgprForGRO will only be enabled if all matrices meet assertion requirements.
+    #
+    # Store Optimizations:
+    #  - Can vectorize stores in edge tiles.  Vector width can be up to AF0EM.
+    #   (since C matrix is always coalesced in Free0 index direction and this assertion guarantees the index element multiple)
+    #
+    # 1 indicates no assertion (since all sizes are multiples of 1)
+    "AssertFree0ElementMultiple": [1, 2, 4, 8, 16],
+    # Kernel generator will assume that the FreeIndex[1] size is some multiple of the element size
+    # and uses this to optimize the kernel.
+    # FreeIndex[1] is usually letter "J"
+    # (Recommended AF1EM value is 8 for half, 4 for single, 2 for double)
+    # Optimizations enabled by AssertFree1ElementMultiple>1:
+    #  - See above AssertFree0ElementMultiple "Load optimizations"
+    # 1 indicates no assertion (since all sizes are multiples of 1)
+    "AssertFree1ElementMultiple": [1, 2, 4, 8, 16],
+    # Assertions that require arithmetic intensity to be specified value.
+    # Arithmetic intensity measures the ratio of computation to memory bandwidth required for a problem.
+    # These predicates can be used to adjust solution selection compute-bound or memory-bound problems.
+    "AssertAIGreaterThanEqual": -1,
+    "AssertAILessThanEqual": -1,
+    # Stagger the start summation position of the tiles.
+    # Elements from the summation dimension are loaded at offsets rather than all starting at 0.
+    # StaggerU is the max 'clicks' of StaggerUStride bytes where each wg starts ; see StaggerUMapping
+    # for how the specific stagger for a given wg is determined.
+    #
+    # The tile assignment C are same as with StaggerOffset=0 ; the difference is the
+    # order that the summation elements are added.
+    # GRO will wrap back to the row start when the edge is reached.
+    #
+    # This can be effective for TLU=0 style matrices where the K dimension is a large power-of-2.
+    # In this case the start of each row of the tile is separated by an exact power-of-2
+    # which causes poor dram, cache, and tlb behavior.  V20 has 16 channels each 256 bytes wide.
+    # StaggerU adjusts the start position in the summation (aka 'U') dimension
+    # to avoid these conflicts.  Both A and B matrix start at the adjusted position.
+    # If >0 specifies the offset in multiples of the macro-tile "unroll" dim
+    #  - Higher values will spread traffic to more channels but provide less L2 re-use.
+    #  - StaggerU and WorkGroupMapping interact and should be tuned together -
+    #    The WGM controls how tiles are assigned in C matrix, while StaggerU controls where those
+    #    tiles start reading their summation dim parms.
+    #  - StaggerU requires BufferLoad==1 and is silently ignored if BufferLoad==0
+    "StaggerU": [0, 2, 4, 8, 16, 32, 64],
+    # Stride in bytes for each staggeru 'click'.
+    # 256 is recommended since this is the width of memory channel (on gfx803,gfx900,gf906) - so
+    # each click will start in a new memory channel and spread traffic among the 16 available channels.
+    # For example StaggerUStride=256 and StaggerU=8 will use 8 unique starting points
+    # in summation dimension, each offset by 256-bytes - provided the tensor dims are large
+    # enough to support this.
+    # StaggerUStride will be internally increased so it is an integer multiple of DepthU*BpeAB.
+    # (the implementation requires this - the unroll iteration accesses data in steps of
+    # DepthU*BPE
+    "StaggerUStride": [-1, 16, 32, 64, 128, 256, 512, 1024, 2048],
+    # How the tile assignment (wg0, wg1, wg2) controls the initial StaggerU offset:
+    # 0: Use wg0
+    # 1: Use wg1
+    # 2: Use wg2
+    # 3: Use wgSerial, wgSerial = wg0 + wg1 * nwg0 + wg2 * (nwg0 * nwg1)
+    # 4: Debug mode, offset each tile max allowed StaggerU.  This just moves hotspot
+    #    to a different bank since all workgroups still start at same point.
+    "StaggerUMapping": [0, 1, 2, 3, 4],
+    # GSU Workgroup Coalesced Ordering
+    # False: {(wg0,wg1,wg2,wgn)|(wg0,wg1,wg2,wgn)|...|(wg0,wg1,wg2,wgn)}
+    # True:  {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
+    "GlobalSplitUCoalesced": [False, True],
+    # GSU Workgroup Mapping
+    # False: wg issued order = {(wg0,wg1,wg2,wgn),(wg0,wg1,wg2,wgn)|...|(wg0,wg1,wg2,wgn)}
+    #   -> workgroups do the summation by tile -> slower GR but faster GW
+    # True:  wg issused oder = {(wg0,wg0,wg0)|(wg1,wg1,wg1)|(wg2,wg2,wg2)|...|(wgn,wgn,wgn)}
+    #   -> workgroups split up the summation -> faster GR but slower GW
+    "GlobalSplitUWorkGroupMappingRoundRobin": [False, True],
+    # 0=don't use magic div (source only)
+    # 1=magic div alg #1.  Slightly faster but limited range (if magic number is 2^32)
+    # 2=magic div alg#2.  Slightly slower but handles all unsigned ints up to 2^32
+    "MagicDivAlg": [0, 1, 2],
+    # For Block Mapping type:
+    # 0   : Use hardware-assigned wg number with no remapping.
+    # N   : WG block width.  "Wrap" to a new wg1 "row" assignment after N WGs assigned in that row.
+    # Tensor C always mapped with first free coord as fastest moving
+    # (Elements in this dimension are sequential in memory.
+    #
+    # For 2D nonbatched Matrix this means index order is I, then J
+    # For 2D batched Matrix this means index order is I, then J, then K.
+    #
+    # Then for 2D case:
+    #   - If drawn in row-major format, I is the width and J is the height.
+    #   - WGM determines dimensions of the box used to assign tiles from C
+    #   - WGM is the height of the box (in the J dimension)
+    #   - Given WGM, the box width (in I dim) is determined by number of CUs
+    #   - The box always moves across matrixC in the fastest-moving "I" dim, then
+    #     wraps to next J.  TODO - might be useful to change this?
+    #
+    # Examples for 2D matrix:
+    # WGM=8:  on CU64 machine this is a square box
+    # WGM=1:  Short/Fat - this will cover maximum width in I dimension of C.  This matches hardware assigned mapping.
+    # WGM=64: Tall/Skinny - this will cover maximum width in J dimension of C.
+    #
+    # Formula for wgSerial:
+    # wgSerial = wg0 + (wg1 % WorkGroupMapping) * nwg0
+    "WorkGroupMapping": list(
+        range(-1024, 1024 + 1)
+    ),  # change a workgroup's id so that the all the workgroups on the gpu at a time are hitting L2 cache the best
+    "WorkGroupMappingXCC": [
+        1,
+        2,
+        4,
+        8,
+        16,
+        32,
+    ],  # change a workgroup's id so that contiguous workgroup can map on same XCC
+    # -1 : WorkGroupMappingXCCGroup will be set to CU_count at runtime. Please ensure that (CU_count % WGMXCC == 0).
+    "WorkGroupMappingXCCGroup": list(
+        range(-1, 1024)
+    ),  # change a workgroup's id so that contiguous workgroup can map on same XCC, remap workgroup in a group of WGMXCCG.
+    "MaxOccupancy": list(
+        range(1, 40 + 1)
+    ),  # wg / CU; if cache thrashing is hurting performance, this allocates extra lds to artificially limit occupancy
+    "WorkGroup": makeValidWorkGroups(),  # ( wg0 x wg1 x LocalSplitU ) dimensions of the workgroup which will operate on a tile and share lds
+    # ThreadTile: ( tt0 x tt1 ) dimensions of the C tile that each thread works on,
+    # TT=4 and VW=4 means a thread will work on a tight 4x4 tile of C, where VW=1 means the tile will work on 16 spread out values
+    # Generally, the VW determines the consecutive a WI will work on, then it will skip ahead SG0*VW elements to get to the next row of VGPR inputs
+    "ThreadTile": validThreadTiles,
+    "MacroTile": validMacroTiles,  # MT0 = wg0*tt0, MT1 = wg1*tt1
+    "WavefrontSize": [32, 64],
+    # MatrixInstruction: (M x N x K x B)
+    # XDLOPS tile definition, only valid for gfx908, gfx90a
+    # MxNxKxB specifies matrix instruction variants
+    #  MxNxB determines the shape of the C tile each instruction worked on
+    #      K determines the unroll depth
+    # If empty, do not use these instructions
+    #
+    # Alternative format: (M x N x K x B x MIBlockM x WaveTileM x WaveTileN x WaveM x WaveN)
+    # (Note: MxN means M-by-N in the following comments)
+    # MIBlockM determines how many blocks along M dimension for multi-block MI variants. Concrete examples:
+    #  - MI 16x16x1x4 (4-block variant) with MIBlockM=4 -> (16x16)*(4x1)=64x16 tile per instruction executed
+    #  - MI 32x32x1x2 (2-block variant) with MIBlockM=1 -> (32x32)*(1x2)=32x64 tile per instruction executed
+    # WaveTileM/N are dimensions of the C tile each wave works on, and is close to the concept of ThreadTile in classic VALU kernels
+    #  - WT 4x1 -> each wave executes 4x1 matrix instructions on the C tile of total area (4*MITileM)x(1*MITileN)
+    # WaveM/N are dimensions of waves spawned for one workgroup where each wave consists of 64 threads
+    #  - Wave2x2 -> a total of 4 waves in one workgroup of shape 2x2
+    # Putting it all together:
+    #  - [32, 32, 1, 2,  1,  4, 1,  2, 2]
+    #     ^^^^^^^^^^^^   ^   ^^^^   ^^^^
+    #      MatrixInst  BlkM   WT    Wave
+    #  - means (32x64) per MI * (4x1) per wave * (2x2) per workgroup = (32*4*2)x(64*1*2) = 256x128 macro tile
+    # Tensile will ignore the parameters ThreadTile and WorkGroup when the alternative format is used
+    # NOTE: MatrixInstruction is no longer validated through this structure, but is instead validated via the
+    #   ``TensileLogic`` program.
+    "MatrixInstruction": -1,
+    # StoreRemap: Optimize MatrixInstruction store patterns to enhance performance.
+    #             MI output data between each threads are along N dims.
+    #             But global memory is along M dim continuous.
+    #             That mean global write between each threads are not continuous.
+    #             Therefore, store performance for MI instruction is poor.
+    # How StoreRemap works in final store stage:
+    #             1. Put all thread output data into LDS.
+    #             2. All thread read data from LDS along M dims.
+    #                (match global Memory continuous direction)
+    #             3. All thread write out data into global memory.
+    # 0:   Disable StoreRemap (default)
+    # 1~8: Enable StoreRemap and set the global write vector width
+    # Suggest optimum value: fp32 = [2,4], fp16 or bf16 = [4,8] (dwordx2 and dowrdx4)
+    # -1:  Use dwordx2 if support SRVW, or set SRVW to 0
+    "StoreRemapVectorWidth": [-1, 0, 1, 2, 4, 8],
+    # SourceSwap: Optimizes MatrixInstruction store pattern by swapping mfma input order.
+    "SourceSwap": [False, True],
+    # Following parameters are designed for store scheduling.
+    # (store stands for load from C (with beta) and store to C/D)
+    #
+    # we want to hide store behind unroll loop
+    #   1. if we can launch 2 WorkGroups per CU (occupancy >= 2, large M/N)
+    #   2. if there are remaining global memory bandwidth in unroll loop (compute bound kernel)
+    #
+    # we can hide store behind the other WG's loop by lowering priority of store
+    #   priority of loop is the same as priority of store
+    #     WG0: ???????????????\__
+    #         |<-- loop --->|<-- store -->|end
+    #
+    #     WG1: ___________________________/????????????\__
+    #         |<--------- loop ------------------->|<-- store -->|end
+    #
+    #   priority of loop is higher than priority of store
+    #     WG0: ???????\____________________
+    #         |<-- loop --->|<------ store ----->|end
+    #
+    #     WG1: _____________/?????\__________________
+    #         |<------- loop -------->|<----- store ---->|end
+    "StorePriorityOpt": [False, True],
+    #
+    # If we issue store in short period of time, kernel will become from compute bound to memory bound
+    # 0 means issue instructions as many as possible if VGPR available
+    "NumElementsPerBatchStore": list(range(-1, 256)),
+    #
+    # add sync after per batch store in order to store contiguous elements
+    # add sleep after per batch store in order to distribute store over whole loops
+    # NOTE: this parameter is highly depends on size_k
+    # 0 means no sync and sleep
+    "StoreSyncOpt": list(range(0, 256)),
+    #
+    # There are index or address calculation between global instructions.
+    # issue global instruction b2b has better performance
+    "GroupLoadStore": [False, True],
+    # In order to remove the copying from Acc vgpr to Arch vgpr, only use Arch vgprs for v_mfma_xxx.
+    # Only support for kernel whose totalVgpr counts less than 256 and gcn that has control bit ACC_CD.
+    "MIArchVgpr": [False, True],
+    # StreamK (SK) kernels divide work evenly among CUs by splitting along MT and K dimensions.
+    # Total work units are calculated as (#MTs x #LoopIters) and divided among workgroups.
+    # In most cases each workgroup will calculate a partial tile that are accumulated in a fixup step in the same kernel
+    # 0 : Standard data-parallel kernel
+    # 1 : Basic StreamK
+    # 2 : Two-Tile StreamK (each WG completes an even number of sk iterations, followed by an even number of dp tiles)
+    # 3 : Two-Tile StreamK with DP before SK tiles
+    # StreamK kernels can adjust the number of CUs being used.
+    # Using fewer sometimes increases overall throughput by allowing other kernels to run in parallel.
+    # StreamK grid is controlled by setting these enviornment variables:
+    # TENSILE_STREAMK_FIXED_GRID lets you override the default grid size with a specific number
+    #   0 = override disabled (default)
+    # TENSILE_STREAMK_FULL_TILES sets the number of full tiles to be included in stream-k work
+    #   -1 = use prediction model for best performance (not yet implemented)
+    #   0 = only remainder tiles run in stream-k
+    #   1+ = remainder + 1 (or more) full grids of tiles run in stream-k (default=1)
+    # TENSILE_STREAMK_DYNAMIC_GRID selects dynamic grid mode, which automatically limits the number of CUs used:
+    #   0 = Off, always use all CUs.
+    #   1 = Only reduce CUs for small problems to number of output tiles when num_tiles < CU count.
+    #   2 = Also reduce CUs used for large sizes to improve data-parallel portion and reduce power.
+    #   3 = Analytically predict the best grid-size by weighing the cost of the fix-up step and the cost of processing MACs (default).
+    #       Note: dynamic grid coefficients currently apply to gfx942 variants
+    # TENSILE_STREAMK_MAX_CUS allows the user to manually set maximum number of CUs used, which could free up some CUs for
+    #   other operations to run in parallel with gemm.
+    # TENSILE_STREAMK_GRID_MULTIPLIER lets you set how many workgroups are created per CU being used.
+    #   1 = 1 WG per CU (default), for example. 2 will launch WGs = 2 x CU count.
+    # The priority of these environment variables is defined as follows:
+    # TENSILE_STREAMK_FIXED_GRID > TENSILE_STREAMK_DYNAMIC_GRID > TENSILE_STREAMK_MAX_CUS > TENSILE_STREAMK_GRID_MULTIPLIER
+    "StreamK": [0, 1, 2, 3],
+    # Determines if StreamK kernel uses atomics
+    # 0: uses workspace to store partial tiles, accumulate in deterministic fix-up step
+    # 1: uses atomics to accumulate partial tiles
+    "StreamKAtomic": [0, 1],
+    # Enables XCC-based remapping of workgroups, set the value to the number of XCCs
+    # for the device/configuration being used
+    # 0: uses default workgroup assignment
+    # 2+: remaps workgroups to be contiguous within an XCC for a given number of XCCs
+    "StreamKXCCMapping": [0] + list(range(2, 9)),
+    # Debug settings for stream-k kernels to disable parts of the kernel
+    #   Bit 0: Don't generate fixup code
+    #   Bit 1: Don't generate write to partials code
+    # Both parts can be disabled together
+    #   0 = Debug mode off, generate full kernel
+    #   1 = No fixup
+    #   2 = No partials
+    #   3 = Nofixup and no partials
+    "DebugStreamK": [0, 1, 2, 3],
+    # Controls desired width (#elements) for loads from global memory -> LDS.
+    # and eliminates the pointer unshift logic
+    # -1 : Set GlobalReadVectorWidth =  VectorWidth
+    # NOTE: for input bpe=32, max GRVW is 4  (to fit dwordx4) (FP32), min GRVW is 1 (dword)
+    #                 bpe=16, max GRVW is 8  (to fit dwordx4) (FP16), min GRVW is 2 (dword)
+    #                 bpe=8,  max GRVW is 16 (to fit dwordx4) (INT8), min GRVW is 4 (dword)
+    "GlobalReadVectorWidthA": [-2, -1, 1, 2, 3, 4, 6, 8, 16],
+    "GlobalReadVectorWidthB": [-2, -1, 1, 2, 3, 4, 6, 8, 16],
+    # Controls desired width (#elements) for loads from LDS -> VGPR.
+    # -1 : Set LocalReadVectorWidth =  VectorWidth
+    #  1 cannot be used for half type.
+    # used in combination with TransposeLDS=True
+    # in TransposeLDS=1 case, use wider load to fetch elements in summation dimension from LDS
+    # helps optimizing instruction scheduling between MFMA and nonMFMA instructions
+    # NOTE: for input bpe=32, max LRVW is 4  (to fit ds_read_b128) (FP32)
+    #                 bpe=16, max LRVW is 8  (to fit ds_read_b128) (FP16)
+    #                 bpe=8,  max LRVW is 16 (to fit ds_read_b128) (INT8)
+    "LocalReadVectorWidth": [-1, 1, 2, 4, 8, 16],
+    # threads should read/write/operate on this many contiguous elements from the C matrix.
+    # If VW=4 then thread0 will process 4 consec C elements, then thread1 next 4, etc.
+    # If the ThreadTile is > VectorWidth then thread0 will next operate on the 4 elements in C at (4*NumThreads)
+    # Typically the load vector width and store vector width are directly related to the VW.
+    # The global load width is closely related to the width of local stores so
+    # GlobalReadVectorWidth also controls local write width.
+    # Local read width also matches since VectorWidth consec elements must be read
+    # Typically matching 16 bytes is good choice since the stores will be optimally coalesced with 16 bytes/WI.
+    # Using a VW too large which results in >16bytes/thread isn't supported
+    # For MFMA non SourceSwap: this parameter didn't take effect
+    # -1 means set vw to largest localReadWidth according to MIWaveTile
+    "VectorWidthA": [-1, 1, 2, 3, 4, 6, 8],
+    "VectorWidthB": [-1, 1, 2, 3, 4, 6, 8],
+    # If 0, store 1 element per instruction.
+    # If 1, store vector-width elements per instruction.
+    # if -1, store vector-wide elements per instruction unless PBD would not generate a valid kernel
+    "VectorStore": [-1, 0, 1],
+    # Controls desired width (#elements) for stores from reg to global memory.
+    # When MatrixInstruciton == None, derived parameter gwvw takes precedence.
+    # -1 : Set StoreVectorWidth = VectorWidth
+    "StoreVectorWidth": [-1, 1, 2, 3, 4, 6, 8],
+    # when loading all the data from global into lds requires multiple load instructions, these parameters govern which
+    # loads will pull which rectangle of data from global into lds
+    # NLC=1 means one load along the coalesced dimension, which results in the most coalescing possible
+    # NLC=-1 looks for the largest number of reads along the coalesced dimension which results in the least ammount of coalescing;
+    # however in this case the stride between one load and another is a static value, therefore buffer loads only need one set of registers
+    # whereas the =1 case has a stride which is a multiple of a kernel argument and therefore needs one address per load in the perpendicular dimension
+    "NumLoadsCoalescedA": list(range(-1, 64 + 1)),
+    "NumLoadsCoalescedB": list(range(-1, 64 + 1)),
+    # DepthU, LocalSplitU (which is the 3rd number in WorkGroup), and LoopUnroll are closely related
+    # LoopUnroll=4 means there are 4 subiterations within the loop, 4 actual iterations written in the code.
+    # LocalSplit=2 means the workgroup is split up into 2 subgroups, and each subgroup is doing different parts of the summation.
+    # subgroup0 does k=0-3, 8-11... and subgroup1 does k=4-7, 12-15...
+    # So, each iteration through the summation loop, which has 4 actual subiterations, does 8 summation iterations, because each subgroup did 4;
+    # and when data is read from global memory the threads read 8 elements along the summation dimension.
+    # DepthU = LoopUnroll * LocalSplitU = 4*2 in this case
+    # it made more sense for the user to directly control LocalSplitU and DepthU, then derrive afterwards LoopUnroll=DepthU/LocalSplitU
+    # -1 : Only allow GLVW=1
+    # -2 : Only allow max(GLVWA,GLVWB) < VW ?
+    # -3 : Only allow min(GLVWA,GLVWB) < VW ?
+    "DepthU": depthUs,
+    # integer amount of padding to put into LDS, in 2016 this didn't seem to help performance, profilers were showing that channel conflicts weren't really hurting
+    # performance so this has been deprecated and probably doesn't work
+    # -1 means use same padding as the VectorWidth if TLU=0 else 0.  (Padding only helps when transpose is required)
+    # With MatrixInstruciton: -1 means max(GRVW,MIInput) if TLU=0
+    "LdsPadA": [-1, 0, 1, 2, 3, 4, 8, 16, 32, 48, 64],
+    "LdsPadB": [-1, 0, 1, 2, 3, 4, 8, 16, 32, 48, 64],
+    "LdsPadMetadata": [-1, 0, 1, 2, 3, 4, 8],
+    # Padding boundary for LDS. defines block-size for pad insertion. for every 'LdsBlockSizePerPad' bytes, LDS padding (pad value from LdsPad parameter)
+    # is added (readOffset aware of the pad and adjusts offset value based on this parameter value).
+    # Only support LdsBlockSizePerPad >= unrollDepth * BPE
+    # 0 means disable LdsBlockSizePerPad
+    "LdsBlockSizePerPadA": [-1, 0, 64, 128, 256, 512, 1024, 2048],
+    "LdsBlockSizePerPadB": [-1, 0, 64, 128, 256, 512, 1024, 2048],
+    "LdsBlockSizePerPadMetadata": [-1, 0, 64, 128, 256, 512, 1024, 2048],
+    # Transpose LDS format. Local store in coalesced dimension , same as optimized global fetch dimension . applicable only in TLU=0 case for miSIMD(s)
+    # -1 : keep LDS layout same as global fetch dimension for both A and B
+    #      set TLDS = 1 for NN,TN,TT
+    #      set TLDS = 0 for NT
+    # 0  : coalesced dimension of lds is tile dimension
+    # 1  : keep LDS layout same as global fetch dimension for both A and B for NN,TN,TT, but NT would be rejected
+    # 2  : coalesced dimension of lds is unroll dimension for both A and B
+    "TransposeLDS": [-1, 1, 0, 2],
+    # add gls or slc after global memory read/writes to change caching, not caching the writes is promising and improved performance a tiny bit
+    # 0: none, 1: glc, 2: slc, 3: glc slc
+    # For gfx942, sets sc0/sc1/nt bits
+    # 0: none, 1: sc0, 2: sc1, 3: sc0 sc1, 4: nt, 5: nt sc0, 6: nt sc1, 7: nt sc0 sc1
+    "NonTemporalE": list(range(0, 8)),
+    "NonTemporalD": list(range(0, 8)),
+    "NonTemporalC": list(range(0, 8)),
+    "NonTemporalA": list(range(0, 8)),
+    "NonTemporalB": list(range(0, 8)),
+    "NonTemporalWS": list(range(0, 8)),
+    "NonTemporalMetadata": list(range(0, 8)),
+    "NonTemporal": list(range(-1, 8)),
+    # Group together unroll iterations inside the unroll loop.
+    # For example, InnerUnroll=2 will fetch LDS for two unroll iterations
+    "InnerUnroll": [1, 2, 4, 8, 16, 32, 64],
+    # Enable CP preload kernel arguments feature
+    # It can reduce time of loading kernel arguments by s_load.
+    # It needs new complier and vbios to support this feature.
+    "PreloadKernArgs": [False, True],
+    # Kernels should be written in assembly or source
+    # if assembly, ISA will determine architecture
+    # if source, Runtime will determine language
+    # later on, we'll relax this to inner kernel languages and outer kernel languages, such as inline asm embedded in ocl or in llvm
+    "KernelLanguage": ["Assembly"],
+    # We set validParams["ISA"] in multiple places
+    "ISA": validISA,  # arch for assembly kernels
+    # Name of the custom kernel located at `CUSTOM_KERNEL_PATH`.
+    # a custom kernel is a user written assembly kernel with its associated configuration parameters included in a custom.config section
+    # inside the yaml block between the --- and ... markers.  These parameters are only used for information purposes, not kernel generation.
+    # Ex:
+    # custom.config:
+    #   ProblemType:
+    #     OperationType: GEMM
+    #     etc...
+    #   ThreadTile: [8, 8]
+    #   etc...
+    #
+    # Custom kernels can be included in a BenchmarkProblemSizeGroup by having their name (without file extension) listed under the "CustomKernels"
+    # category alongside InitialSolutionParameters, BenchmarkCommonParameters, etc...
+    "CustomKernelName": -1,
+    # Will allow a kernel to be accepted even when checks determine it's not viable.
+    # Intended for use with custom kernels which have confirmed to be correct
+    "NoReject": [False, True],
+    # Debug use only.
+    "ActivationFused": [False, True],
+    # True-  function call
+    # False- inline
+    "ActivationFuncCall": [False, True],
+    # Alternative implementation for activation function
+    # Currently only supports GSU == 1
+    "ActivationAlt": [False, True],
+    # Do workgroup reduction. Currently for DBias
+    "WorkGroupReduction": [False],
+    # 4:2 Structured Sparse A Matrix, 0=Non Sparse, 1=Sparse Matrix A, 2=Sparse Matrix B
+    "Sparse": [0, 1, 2],
+    # in mix mode F8 need to convert to F16, do this before(0) ds or after(1) ds
+    "ConvertAfterDS": [False, True],
+    # Force disable shadow init to release more sgpr in preloop
+    "ForceDisableShadowInit": [False, True],
+    # Enable LDS Transpose Instruction
+    "LDSTrInst": [False, True],
+    # False: Use LocalSplitU. Number of WorkGroup[2] WorkItems (wave or thread) will compute the same output elements (matrix D) along different 
+    #        unroll indices. The local sum from those WorkItems are reduced through LDS.
+    # True:  Use WaveSplitK. Number of WorkGroup[2] threads in the same wave compute the same output elements (matrix D) along different unroll indices.
+    #        The local sum from those threads are reduced through suffling using VALU instructions. Currently only support dot2 kernel.
+    "WaveSplitK": [False, True],
+}
+
+newMIValidParameters = {
+    "EnableF32XdlMathOp": [False, True],
+    'EnableMatrixInstruction': [False, True],
+    'ISA': -1,
+    'MFMA_BF16_1K': [False, True],
+    'MIBlock': -1,
+    'MIInputPerThread': -1,
+    'MIInputPerThreadA': -1,
+    'MIInputPerThreadB': -1,
+    'MIInputPerThreadMetadata': -1,
+    'MIWaveGroup': -1,
+    'MIWaveTile': -1,
+    'MatrixInstM': -1,
+    'MatrixInstN': -1,
+    'MatrixInstK': -1,
+    'MatrixInstB': -1,
+    'MatrixInstBM': -1,
+    'MatrixInstBN': -1,
+    'MatrixInstruction': -1,
+    'Sparse': -1,
+    'ThreadTile': -1,
+    'WavefrontSize': -1,
+    'WorkGroup': -1,
+}
+
+
+def checkParametersAreValid(param, validParams):
+    """Ensures paramaters in params exist and have valid values as specified by validParames"""
+    (name, values) = param
+    if name == "ProblemSizes":
+        return
+    elif name == "InternalSupportParams":
+        return
+
+    if name not in validParams:
+        raise Exception(
+            "Invalid parameter name: {}\nValid parameters are {}.".format(
+                name, sorted(validParameters.keys())
+            )
+        )
+
+    for value in values:
+        if validParams[name] != -1 and value not in validParams[name]:
+            msgBase = "Invalid parameter value: {} = {}\nValid values for {} are {}{}."
+            msgExt = (
+                " (only first 32 combos printed)\nRefer to Common.py for more info"
+                if len(validParams[name]) > 32
+                else ""
+            )
+            raise Exception(msgBase.format(name, value, name, validParams[name][:32], msgExt))

--- a/tensilelite/Tensile/Common/__init__.py
+++ b/tensilelite/Tensile/Common/__init__.py
@@ -1,10 +1,4 @@
-from .Architectures import *
-from .Capabilities import *
 from .Constants import *
-
-# Dunder variables are not exported via `*`
-from .GlobalParameters import *
-from .GlobalParameters import __version__
 from .Parallel import *
 from .Types import *
 from .Utilities import *

--- a/tensilelite/Tensile/Components/ComputeStoreVgprs.py
+++ b/tensilelite/Tensile/Components/ComputeStoreVgprs.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -20,7 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from ..Common import globalParameters, DataDirection, SemanticVersion
+from ..Common import DataDirection, SemanticVersion
 from ..Component import GlobalWriteComponents
 from ..SolutionStructs import Solution
 from ..Activation import ActivationModule, ActivationType

--- a/tensilelite/Tensile/Components/PackData.py
+++ b/tensilelite/Tensile/Components/PackData.py
@@ -30,7 +30,6 @@ from ..TensileInstructions import Module, SDWAModifiers, SelectBit, UnusedBit, \
                             VMovB32, VLShiftLeftB32
 
 from ..Component import PackData
-from ..Common import globalParameters
 
 def formatting(idx, inputPrefix, prefixOffset):
     if inputPrefix:

--- a/tensilelite/Tensile/Components/Signature.py
+++ b/tensilelite/Tensile/Components/Signature.py
@@ -23,7 +23,7 @@
 ################################################################################
 
 from ..Component import Signature
-from ..Common import globalParameters, DataDirection
+from ..Common import DataDirection
 from ..TensileInstructions import SignatureBase
 from ..TensileInstructions import SignatureValueKind as SVK
 from ..Activation import ActivationType
@@ -118,7 +118,7 @@ class SignatureDefault(Signature):
             kernArgReg -= 2 # strides
         kernArgReg += kernel["ProblemType"]["NumIndicesSummation"]
         kernArgReg += kernel["ProblemType"]["NumIndicesC"]
-        if globalParameters["DebugKernel"]:
+        if writer.debugConfig.debugKernel:
             kernArgReg += writer.states.rpga # debug buffer
         # kernArgBytes = kernArgReg * 4 # bytes/reg
 
@@ -159,7 +159,7 @@ class SignatureDefault(Signature):
             signature.addArg(             "SizesSum%u"%i, SVK.SIG_VALUE,               "u32")
             userArgumentsInfo.gemmArgumentSize += 4
 
-        if globalParameters["DebugKernel"]:
+        if writer.debugConfig.debugKernel:
             signature.addArg("AddressDbg", SVK.SIG_GLOBALBUFFER, "struct", "generic")
         signature.addArg(    "D", SVK.SIG_GLOBALBUFFER, dstValueType, "generic")
         signature.addArg(    "C", SVK.SIG_GLOBALBUFFER, dstValueType, "generic")

--- a/tensilelite/Tensile/Components/StreamK.py
+++ b/tensilelite/Tensile/Components/StreamK.py
@@ -1540,7 +1540,7 @@ class StreamKOff(StreamK):
     def graWorkGroup(self, writer, kernel, tPA, tPB):
         module = Module("StreamK Off graWorkGroup")
 
-        if writer.states.archCaps["WrokGroupIdFromTTM"]:
+        if writer.states.archCaps["WorkGroupIdFromTTM"]:
             module.add(SMovB32(dst=sgpr("WorkGroup0"), src="ttmp9", comment="workaround"))
             module.add(SAndB32(dst=sgpr("WorkGroup1"), src0=hex(0xFFFF), src1="ttmp7", comment="workaround"))
             module.add(SLShiftRightB32(dst=sgpr("WorkGroup2"), shiftHex=hex(0x10), src="ttmp7"))

--- a/tensilelite/Tensile/CustomKernels/CustomGSUs_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_MT128x16x128_MI16x16x1_44_Freesize_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/CustomGSUs_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_MT128x16x128_MI16x16x1_44_Freesize_gfx942.s
@@ -63,7 +63,27 @@ custom.config:
       Activation: True
       UseScaleAlphaVec: 1
       SupportUserArgs: False
-   MatrixInstruction: [16, 16, 16, 1, 1, 2,1, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [2, 1]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    DepthU: 128
    StaggerU: 4

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_shortname0_gfx942.s
@@ -59,7 +59,27 @@ custom.config:
       UseBias: 1
       Activation: True
       UseScaleAlphaVec: 1
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,1, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [8, 1]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    DepthU: 32
    StaggerU: 4

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_AS_SAB_SAV_shortname1_gfx942.s
@@ -59,7 +59,27 @@ custom.config:
       UseBias: 1
       Activation: True
       UseScaleAlphaVec: 1
-   MatrixInstruction: [16, 16, 16, 1, 1, 2,2, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [2, 2]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    DepthU: 64
    StaggerU: 4

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,10, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 10]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HHS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname0_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname10_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname11_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname12_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname13_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname14_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname15_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname16_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,10, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 10]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname17_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname18_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname19_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname1_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname20_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname2_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname3_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname4_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname5_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname6_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname7_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname8_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_F8NH_HSS_BH_Bias_GG_AS_SAB_SAV_UserArgs_shortname9_gfx942.s
@@ -64,7 +64,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HHS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname0_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname10_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname11_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname12_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname13_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname14_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,20, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 20]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname15_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname16_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,11, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 11]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname17_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname18_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 8,12, 2,2]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [2, 2]
+   MIWaveTile: [8, 12]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [32, 8, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname1_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname2_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname3_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,9, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 9]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 0
    ScheduleIterAlg: 3
    DepthU: 32

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname4_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname5_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname6_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname7_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,14, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 14]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname8_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Ailk_Bljk_HSS_BH_Bias_GG_AS_SAV_UserArgs_shortname9_gfx942.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm:   True
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4,16, 4,1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x224x64_MI16x16x1_SN_K1_MIWT4_14_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x224x64_MI16x16x1_SN_K1_MIWT4_14_DTVA.s
@@ -62,6 +62,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 16, 1, 1, 4, 14, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x224x64_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x224x64_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
@@ -62,6 +62,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 16, 1, 1, 4, 14, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x256x64_MI16x16x1_SN_K1_MIWT4_16_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x256x64_MI16x16x1_SN_K1_MIWT4_16_DTVA.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm: False
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4, 16, 4, 1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: True
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x256x64_MI16x16x1_SN_K1_MIWT4_16_WSGRB2_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_BBS_BH_Bias_AS_SAV_UserArgs_MT256x256x64_MI16x16x1_SN_K1_MIWT4_16_WSGRB2_DTVA.s
@@ -61,7 +61,27 @@ custom.config:
       Batched: True
       GroupedGemm: False
       SupportUserArgs: True
-   MatrixInstruction: [16, 16, 16, 1, 1, 4, 16, 4, 1]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: True
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [4, 16]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 64

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_DTVA.s
@@ -64,6 +64,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 32, 1, 1, 4, 14, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 128

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
@@ -1,4 +1,3 @@
-
 /******************************************/
 /* Begin Kernel                           */
 /******************************************/
@@ -64,6 +63,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 32, 1, 1, 4, 14, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 128
@@ -42787,3 +42787,4 @@ label_GW_End_1:
 label_KernelEnd:
 s_endpgm                                           // Kernel End
 label_ASM_End:  /// The end of the kernel
+>>>>>>> origin/develop

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x224x128_MI16x16x1_SN_K1_MIWT4_14_WSGRB2_DTVA.s
@@ -42787,4 +42787,3 @@ label_GW_End_1:
 label_KernelEnd:
 s_endpgm                                           // Kernel End
 label_ASM_End:  /// The end of the kernel
->>>>>>> origin/develop

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x256x128_MI16x16x1_SN_K1_MIWT4_16_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x256x128_MI16x16x1_SN_K1_MIWT4_16_DTVA.s
@@ -64,6 +64,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 32, 1, 1, 4, 16, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 128

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x256x128_MI16x16x1_SN_K1_MIWT4_16_WSGRB2_DTVA.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_F8NBS_BH_BiasSB_AS_SABV_SAV_UserArgs_MT256x256x128_MI16x16x1_SN_K1_MIWT4_16_WSGRB2_DTVA.s
@@ -64,6 +64,7 @@ custom.config:
       GroupedGemm: False
       SupportUserArgs: True
    MatrixInstruction: [16, 16, 32, 1, 1, 4, 16, 4, 1]
+   WavefrontSize: 64
    1LDSBuffer: 1
    ScheduleIterAlg: 3
    DepthU: 128

--- a/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_HHS_BH_UserArgs_MT128x16x128_MI16x16x1_SN_K1_MIWT2_1_triple_buffer.s
+++ b/tensilelite/Tensile/CustomKernels/Custom_Cijk_Alik_Bljk_HHS_BH_UserArgs_MT128x16x128_MI16x16x1_SN_K1_MIWT2_1_triple_buffer.s
@@ -56,7 +56,27 @@ custom.config:
       TransposeB: 0
       UseBeta: True
       Batched: True
-   MatrixInstruction: [16, 16,16, 1,  1,   2,1,  4,1 ]
+   EnableF32XdlMathOp: False
+   EnableMatrixInstruction: True
+   MFMA_BF16_1K: False
+   MIBlock: [16, 16, 16, 1, 1, 1]
+   MIInputPerThread: 4
+   MIInputPerThreadA: 4
+   MIInputPerThreadB: 4
+   MIInputPerThreadMetadata: 4
+   MIWaveGroup: [4, 1]
+   MIWaveTile: [2, 1]
+   MatrixInstB: 1
+   MatrixInstBM: 1
+   MatrixInstBN: 1
+   MatrixInstK: 16
+   MatrixInstM: 16
+   MatrixInstN: 16
+   MatrixInstruction: [16, 16, 16, 1]
+   Sparse: 0
+   ThreadTile: [1, 1]
+   WavefrontSize: 64
+   WorkGroup: [64, 4, 1]
    AssertFree0ElementMultiple: 16
    AssertFree1ElementMultiple: 1
    AssertSummationElementMultiple: 128

--- a/tensilelite/Tensile/GenerateSummations.py
+++ b/tensilelite/Tensile/GenerateSummations.py
@@ -36,8 +36,9 @@ from copy import deepcopy
 from . import LibraryIO
 
 from . import ClientWriter
-from .Common import assignGlobalParameters, ensurePath, globalParameters, \
-    printExit, isaToGfx, gfxToSwCodename
+from Tensile.Common import ensurePath, printExit
+from Tensile.Common.Architectures import isaToGfx, gfxToSwCodename, detectGlobalCurrentISA
+from Tensile.Common.GlobalParameters import assignGlobalParameters
 from .SolutionStructs import ProblemSizes
 from .Toolchain.Validators import ToolchainDefaults, validateToolchain
 
@@ -64,10 +65,12 @@ def GenerateSummations(userArgs):
 
     inputLogicPath = userArgs[0]
     outputPath = userArgs[1]
-    assignGlobalParameters({})
-    cxxCompiler, cCompiler = validateToolchain(ToolchainDefaults.CXX_COMPILER, ToolchainDefaults.C_COMPILER)
+    isaInfoMap = assignGlobalParameters({})
+    cxxCompiler, cCompiler, enumerator = validateToolchain(ToolchainDefaults.CXX_COMPILER, 
+                                                           ToolchainDefaults.C_COMPILER,
+                                                           ToolchainDefaults.DEVICE_ENUMERATOR)
 
-    currentISA = globalParameters["CurrentISA"]
+    currentISA = detectGlobalCurrentISA(0, enumerator)
     gfxName = isaToGfx(currentISA)
     commonName = gfxToSwCodename(gfxName)
 
@@ -93,7 +96,7 @@ def GenerateSummations(userArgs):
         # same as the initial logic with the summation model added. To preseve the original
         # logic we also read in the raw unaltered version of the logic and stage the content
         # to write the final logic.
-        logic    = LibraryIO.parseLibraryLogicFile(logicFileName, cxxCompiler)
+        logic    = LibraryIO.parseLibraryLogicFile(logicFileName, cxxCompiler, isaInfoMap)
         rawLogic = LibraryIO.rawLibraryLogic(logicFileName)
 
         # If we cannot read the logic file then skip it

--- a/tensilelite/Tensile/Hardware.py
+++ b/tensilelite/Tensile/Hardware.py
@@ -23,7 +23,7 @@
 ################################################################################
 
 from . import Properties
-from .Common import isaToGfx
+from Tensile.Common.Architectures import isaToGfx
 import copy
 
 class HardwarePredicate(Properties.Predicate):

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -32,12 +32,13 @@ from .KernelWriterModules import *
 from .TensilePass import TensilePass, TensilePassOptions
 from .Component import Component, LraTileProperties
 from .Components.Signature import UserArgumentsInfo
-from .CustomKernels import isCustomKernelConfig
 from .SolutionStructs import Solution, isPackedIndex
 from .AsmMemoryInstruction import MemoryInstruction
 from .Activation import ActivationModule
-from .Common import globalParameters, printWarning, roundUp, print2, printExit, DataDirection, SemanticVersion, \
-  INDEX_CHARS, MAX_FILENAME_LENGTH
+from .Common import printWarning, roundUp, print2, DebugConfig, DataDirection, \
+  INDEX_CHARS, IsaVersion
+from Tensile.SolutionStructs.Naming import getKernelName
+from Tensile.Toolchain.Component import Assembler
 
 import abc
 import os
@@ -349,6 +350,7 @@ class ExternClasses:
   activation: ActivationModule = ActivationModule()
   biasSumUnroll: Optional[Component.SumUnroll] = None
 
+
 ################################################################################
 # Kernel Writer
 ################################################################################
@@ -358,12 +360,18 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   # Init
   ##############################################################################
-  def __init__(self, kernelMinNaming, kernelSerialNaming, assembler: str, amdClangVersion: SemanticVersion):
+  def __init__(
+      self,
+      kernelMinNaming,
+      kernelSerialNaming,
+      assembler: Assembler,
+      debugConfig: DebugConfig,
+    ):
     self.kernelMinNaming = kernelMinNaming
     self.kernelSerialNaming = kernelSerialNaming
     self.assembler = assembler
-    self.amdClangVersion = amdClangVersion
     self.ti = None
+    self.debugConfig = debugConfig
 
     self.do = {}
     self.do["PreLoop"]     = True
@@ -393,7 +401,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     # Various debug flags and modes
     self.db = {}
-    self.db["EnableAsserts"]       = globalParameters["EnableAsserts"]  # Enable assertion codegen. Requires 2 SGPR.
+    self.db["EnableAsserts"]       = self.debugConfig.enableAsserts  # Enable assertion codegen. Requires 2 SGPR.
     self.db["DebugKernelMaxItems"] = 16  # Capture first N(=16) print values, ignore subsequent.  If -1, debug writing is faster but writing more than 16 values is undefined.
 
     # Chicken bit to add conservative synchronization at strategic points:
@@ -420,8 +428,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # Requires DataInitTypeAB=1.
     # Only works if the problem uses full tiles (no edges)
     # Mismatches will assert (generate GPUVM fault)
-    self.db["CheckValue1A"] = globalParameters["EnableDebugA"]
-    self.db["CheckValue1B"] = globalParameters["EnableDebugB"]
+    self.db["CheckValue1A"] = self.debugConfig.enableDebugA
+    self.db["CheckValue1B"] = self.debugConfig.enableDebugB
     self.db["CheckValue1Metadata"] = False
     # Check value in C matrix.
     # Caveats:
@@ -430,15 +438,15 @@ class KernelWriter(metaclass=abc.ABCMeta):
     #  - Only works if matrix is integral multiple of macro-tile (no edges) - check is dumb so doesn't know
     #    which work-items are outside the valid edge.
     #  - Does not work in OptNoLoadLoop
-    self.db["CheckValueC"]  = globalParameters["EnableDebugC"]
+    self.db["CheckValueC"]  = self.debugConfig.enableDebugC
     # value expected if CheckValueC is set. Use '.' for FP.
     # For example could be 16.0 if U=8 and alpha=2
-    self.db["ValueCExpectedValue"] = globalParameters["ExpectedValueC"]
+    self.db["ValueCExpectedValue"] = self.debugConfig.expectedValueC
 
     # Force an expected value for all C outputs.
     # May be useful for checking store path
     # See same caveats as CheckValueC
-    self.db["ForceExpectedValue"]  = globalParameters["ForceCExpectedValue"]
+    self.db["ForceExpectedValue"]  = self.debugConfig.forceCExpectedValue
 
     # Force VSerial value into the output, this will
     # not match reference but can be useful to see which work-items are
@@ -468,7 +476,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.db["PrintStoreRegisterDb"] = False
 
     self.dumpData = Dump("DebugKernelItems", "AddressDbg", self.db["DebugKernelMaxItems"], \
-      globalParameters["DebugKernel"])
+      self.debugConfig.debugKernel)
     self.labels = LabelManager()
 
     # KernelWriter values
@@ -560,7 +568,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # returns: a Module with the combined, optimally scheduled
   #  localReadCode + otherCode
   ##############################################################################
-  def makeSubIterSchedule(self, kernel, tPA, tPB, localReadCode, iteration, pointerLWCode, pointerLRCode, waitCode, macIterCode, \
+  def _makeSubIterSchedule(self, kernel, tPA, tPB, localReadCode, iteration, pointerLWCode, pointerLRCode, waitCode, macIterCode, \
       waitLWCode = Module(), syncCode = Module(), packCode = Module(), prevIterCode = Module(), NLLlast = False):
 
     iterCode = Module()
@@ -1732,17 +1740,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
             # (which is always just before the macs)
             lgkmcnt += localWrites
           else:
-            # if UnrollLoopEfficiencyEnable == True  use waitCode passed lgkmCnt
-            # else:
             # we need to wait for all preceding reads before the macs
             # so only opportunity for optimization is if the writes are at the end
-            if globalParameters["UnrollLoopEfficiencyEnable"]:
-              lgkmcnt = waitCode.lgkmcnt
+            if localReads:
+              lgkmcnt = 0 # reset to wait for all reads
             else:
-              if localReads:
-                lgkmcnt = 0 # reset to wait for all reads
-              else:
-                lgkmcnt = localWrites  # this only survives if writes are at the end
+              lgkmcnt = localWrites  # this only survives if writes are at the end
 
       waitCode.comment += " old=%u, new=%u newLW=%u newLR=%u" % (waitCode.lgkmcnt, lgkmcnt,localWrites,localReads)
       if iteration == 0:
@@ -2205,7 +2208,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
         tP = tensorParametersA if kernel["ProblemType"]["BiasSrc"] == "A" else tensorParametersB
         macIterCode.add(self.exclasses.biasSumUnroll.loopSum(self, kernel, tP, u, kernel["InnerUnroll"]))
 
-      subIterCode = self.makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
+      subIterCode = self._makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
                       u, pointerLWCode, pointerLRCode, waitCode, macIterCode, waitLWCode, syncCode, pack[luIdx], module, NLLlast)
       module.add(subIterCode)
       pack[luIdx] = Module()
@@ -2288,7 +2291,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
   # dsWriteBA is to do ds_write B first.
   # grBA is to do buffer_load B first.
   ##############################################################################
-  def loopBody( self, kernel, tensorParametersA, tensorParametersB, pack, lc, loopCopies, finalLoop, firstIter=False, dsWriteBA=False, grBA=False, isDTVGRSecondBuf=False, skipClose=False ):
+  def _loopBody( self, kernel, tensorParametersA, tensorParametersB, pack, lc, loopCopies, finalLoop, firstIter=False, dsWriteBA=False, grBA=False, isDTVGRSecondBuf=False, skipClose=False ):
     module = Module("loopBody")
     expand = kernel["ExpandPointerSwap"]
 
@@ -2604,13 +2607,15 @@ class KernelWriter(metaclass=abc.ABCMeta):
       ## 8x8 -> split into group of 16 MAC(s)
       ## supports only PLR=0
       ###############################################################################
-      if self.states.numItersPLR or (not globalParameters["UnrollLoopEfficiencyEnable"]):
-        subIterCode = self.makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
-                        u, pointerLWCode, pointerLRCode, waitCode, macIterCode, waitLWCode, syncCode, pack[luIdx], module)
-        module.add(subIterCode) # add scheduled "other", local reads, local writes
-        pack[luIdx] = Module()
-      else:
-        printExit("TensileLite does not support MAC instructions.")
+
+      # Is this test necessary because of the global variable this if was previously always true
+      # after removing the global variable it is always false...
+      # if self.states.numItersPLR:
+      subIterCode = self._makeSubIterSchedule(kernel, tensorParametersA, tensorParametersB, localReads, \
+                      u, pointerLWCode, pointerLRCode, waitCode, macIterCode, waitLWCode, syncCode, pack[luIdx], module)
+      module.add(subIterCode) # add scheduled "other", local reads, local writes
+      pack[luIdx] = Module()
+
     # close unrolled loop
     endStr = ""
     if loopCopies == 2:
@@ -2791,7 +2796,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       dsWriteBA = True if isULSGRO else False
       # second GR buffer check for DTV
       isDTVGRSecondBuf = True if isDTV else False
-      module.add(self.loopBody( kernel, tensorParametersA, tensorParametersB, pack, 0, loopCopies, False , dsWriteBA=dsWriteBA, isDTVGRSecondBuf=isDTVGRSecondBuf, skipClose=True))
+      module.add(self._loopBody( kernel, tensorParametersA, tensorParametersB, pack, 0, loopCopies, False , dsWriteBA=dsWriteBA, isDTVGRSecondBuf=isDTVGRSecondBuf, skipClose=True))
       loopLabelToNoGRloopAfterABLoop = Label("NoGRloopAfterABLoop", "" )
       loopCounter = self.loopCounter(kernel, self.states.unrollIdx)
       module.add(SSubU32(dst=loopCounter, src0=loopCounter, \
@@ -2803,14 +2808,14 @@ class KernelWriter(metaclass=abc.ABCMeta):
       module.add(SCBranchSCC1(labelName=loopLabelToNoGRloopAfterABLoop.getLabelName(), comment="exit LoopL" ))
       # grBA check for UnrollLoopSwapGlobalReadOrder
       grBA = True if isULSGRO else False
-      module.add(self.loopBody( kernel, tensorParametersA, tensorParametersB, pack, 1, loopCopies, True , grBA=grBA))
+      module.add(self._loopBody( kernel, tensorParametersA, tensorParametersB, pack, 1, loopCopies, True , grBA=grBA))
     else:
       for lc in range(0, loopCopies):
         # second GR buffer check for DTV
         isDTVGRSecondBuf = True if isDTV and lc == 0 else False
         # loop body code generation
         finalLoop = lc == loopCopies - 1
-        module.add(self.loopBody( kernel, tensorParametersA, tensorParametersB, pack, lc, loopCopies, finalLoop, isDTVGRSecondBuf=isDTVGRSecondBuf ))
+        module.add(self._loopBody( kernel, tensorParametersA, tensorParametersB, pack, lc, loopCopies, finalLoop, isDTVGRSecondBuf=isDTVGRSecondBuf ))
 
     module.addComment1("Before NLL: Check VGPR.checkin for INT8 LW")
 
@@ -3230,18 +3235,19 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   # Init Kernel
   ##############################################################################
-  def initKernel(self, kernel, tensorParametersA, tensorParametersB):
+  def _initKernel(self, kernel, tensorParametersA, tensorParametersB):
     assert kernel["KernelLanguage"] == "Assembly"
     self.language   = "ASM"
     # ISA version, such as 803
     version = tuple(kernel["ISA"])
     if self.ti == None:
       self.ti = TensileInstructions()
-    self.ti.init(version, self.assembler)
+    self.ti.init(version, str(self.assembler.path))
     self.ti.setKernelInfo(version, kernel["WavefrontSize"])
+    self.ti.getArchCaps
 
     self.consts = ConstValues()
-    self.states = StateValues(version=version, kernel=kernel, kernelName=self.getKernelName(kernel))
+    self.states = StateValues(version=version, kernel=kernel, kernelName=getKernelName(self.kernelMinNaming, self.debugConfig.splitGSU, kernel))
     self.vgprs  = StateVgprs()
     self.sgprs  = collections.OrderedDict()
     self.codes  = CodeModules()
@@ -3547,7 +3553,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     # Check if the address setup code for LWA and GRO causes register growth.
     # This is not an error condition but bears further investigation.
     # Realistically we just have the GlobalToLocal VGPRs, all else is growth.
-    self.states.preventVgprOverflowDuringNewTile = 0 and not globalParameters["ForceGenerateKernel"]
+    self.states.preventVgprOverflowDuringNewTile = 0 and not self.debugConfig.forceGenerateKernel
 
     # For Beta:
     # Rather than waiting for all loads to finish with s_waitcnt vmcnt(0), interleave
@@ -3990,7 +3996,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       else:
         numVgprGlobalReadIncsMetadata = 0
 
-    numVgprAddressDbg = self.states.rpga if globalParameters["DebugKernel"] else 0
+    numVgprAddressDbg = self.states.rpga if self.debugConfig.debugKernel else 0
 
     ####################################
     # num vgprs: c write address
@@ -4345,7 +4351,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.numActivationTypeArgSize = 0 # Will change to 1 if activationType == All
     self.states.numActivationArgSize = max(1, int(kernel["ProblemType"]["DestDataType"].numRegisters()))
     self.states.numactivationArgTotalSize = self.states.numActivationArgSize * kernel["ProblemType"]["ActivationType"].getAdditionalArgNum()
-    self.states.numSgprAddressDbg = self.states.rpga if globalParameters["DebugKernel"] else 0
+    self.states.numSgprAddressDbg = self.states.rpga if self.debugConfig.debugKernel else 0
 
     ####################################
     # num sgprs: global read increments
@@ -4417,7 +4423,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     self.defineSgpr("OrigLoopCounter", 1)
 
-    if globalParameters["DebugKernel"]:
+    if self.debugConfig.debugKernel:
       self.defineSgpr("AddressDbg", self.states.numSgprAddressDbg)
       self.defineSgpr("DebugKernelItems", 1)
 
@@ -4700,7 +4706,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # Special dependency cases
       if kernel["ProblemType"]["ComputeDataType"].isDouble():
         if kernel["MatrixInstruction"] == [4, 4, 4, 4]:
-          if kernel['ISA'] == [9,0,10]:
+          if kernel['ISA'] == IsaVersion(9,0,10):
             self.states.miDependency = 4
 
 
@@ -5361,49 +5367,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
   #
   ##############################################################################
 
-  def _shortenFileBase(self, kernel):
-    base = self.getKernelName(kernel)
-    if len(base) <= MAX_FILENAME_LENGTH:
-      return base
-
-    import hashlib
-    import base64
-
-    pivot = MAX_FILENAME_LENGTH * 3 // 4
-    firstPart = base[:pivot]
-    secondPart = base[pivot:]
-
-    secondHash = hashlib.sha256(secondPart.encode()).digest()
-    secondPart = base64.b64encode(secondHash, b'_-').decode()
-
-    return firstPart + secondPart
-
-
-  def _getCustomKernelSource(self, kernel, CustomKernelDirectory):
-    kernelName = self.getKernelFileBase(kernel)
-    with open(os.path.join(CustomKernelDirectory, (kernelName + ".s"))) as f:
-      hipccver = globalParameters['HipClangVersion'].split(".")
-      hipccMaj = int(hipccver[0])
-      hipccPatch = int(hipccver[2].split("-")[0])
-      if not (hipccMaj >= 6 and hipccPatch >= 32650):
-        code = []
-        for line in f.readlines():
-          if "amdhsa_user_sgpr_kernarg_preload" not in line:
-            code.append(line)
-        code = "".join(code)
-      else:
-        code = f.read()
-
-    self.tPA = tensorParametersA = {}
-    self.tPB = tensorParametersB = {}
-    self.states.kernel = kernel
-    self.states.language = "ASM"
-    self.states.version = tuple(kernel["ISA"]) if "ISA" in kernel else globalParameters["CurrentISA"]
-    if not globalParameters["AsmCaps"][self.states.version]["SupportedISA"]:
-      self.states.version = (9,0,0)
-      printWarning(f"ISA: {self.version} is not supported; overriding with {self.states.version}")
-
-    return code
 
   def _getKernelSource(self, kernel: Solution):
     """
@@ -5413,41 +5376,24 @@ class KernelWriter(metaclass=abc.ABCMeta):
     fileString = ""
     tensorParametersA = {}
     tensorParametersB = {}
-    self.initKernel(kernel, tensorParametersA, tensorParametersB)
+    self._initKernel(kernel, tensorParametersA, tensorParametersB)
     self.stringIdx = 0
     (error, kb) = self.kernelBody(kernel, tensorParametersA, tensorParametersB)
     fileString += str(kb)
 
     if error != 0:
-      if globalParameters["ForceGenerateKernel"]:
+      if self.debugConfig.forceGenerateKernel:
         printWarning("Generating kernel source resulted in error {}, but ForceGenerateKernel=1 so saving source".format(error))
       else:
         raise RuntimeError("Generating kernel source resulted in error {}".format(error))
     return fileString
 
 
-  ##############################################################################
-  # get kernel name
-  ##############################################################################
-  def getKernelFileBase(self, kernel):
-    if isCustomKernelConfig(kernel):
-      fileBase = kernel["CustomKernelName"]
-    elif globalParameters["ShortNames"]:
-      fileBase = Solution.getNameSerial(kernel, self.kernelSerialNaming)
-    else:
-      fileBase = self._shortenFileBase(kernel)
-    return fileBase
-
-  def getKernelName(self, kernel):
-    kernelName = Solution.getNameMin(kernel, self.kernelMinNaming, True)
-    return kernelName
-
   @abc.abstractmethod
   def getSourceFileString(self, kernel) -> Tuple[int, str]:
     """
     Returns a string suitable for placing in Kernels.cpp.  This means the actual kernel source in the case
-    of a source kernel, or an assembled code object byte array definition in the case of an assembly kernel,
-    or an empty string in the case that CodeFromFiles is true.
+    of a source kernel, or an assembled code object byte array definition in the case of an assembly kernel.
 
     In the case of an assembly kernel, this function has the side effect of creating the following files:
      * An assembly source file
@@ -5458,10 +5404,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
     pass
 
   def getHeaderFileString(self, kernel):
-    kernelName = self.getKernelName(kernel)
+    kernelName = getKernelName(self.kernelMinNaming, self.debugConfig.splitGSU, kernel)
     fileString = "" # CHeader
-    if not globalParameters["CodeFromFiles"]:
-      fileString += "extern const unsigned char %s_coba[]; // code object byte array\n" % kernelName
+    fileString += "extern const unsigned char %s_coba[]; // code object byte array\n" % kernelName
 
     return fileString
 

--- a/tensilelite/Tensile/KernelWriterActivationEnumHeader.py
+++ b/tensilelite/Tensile/KernelWriterActivationEnumHeader.py
@@ -22,7 +22,6 @@
 
 from copy import deepcopy
 
-from .Common import globalParameters, CHeader
 from .Activation import ActivationType
 from .KernelWriterBase import KernelWriterBase
 

--- a/tensilelite/Tensile/KernelWriterActivationFunction.py
+++ b/tensilelite/Tensile/KernelWriterActivationFunction.py
@@ -21,15 +21,16 @@
 ################################################################################
 
 from copy import deepcopy
+from typing import List
 
 from .TensileInstructions import TensileInstructions
-from .Common import globalParameters, gfxToIsa, isaToGfx
+from Tensile.Common.Architectures import isaToGfx, IsaVersion
 from .Activation import ActivationInline, ActivationType
 from .KernelWriterBase import KernelWriterBase
 
 class KernelWriterActivationFunction(KernelWriterBase):
 
-  def __init__(self, state, cxxCompiler: str):
+  def __init__(self, state, cxxCompiler: str, supportedISA: List[IsaVersion]):
     super().__init__()
     self.cxxCompiler = cxxCompiler
     self.state["ProblemType"] = deepcopy(state["ProblemType"])
@@ -46,16 +47,7 @@ class KernelWriterActivationFunction(KernelWriterBase):
     self.enumName = "Tensile::%sActivationType_%s"%(self.actGradientPrefix, \
                                                     self.state["ProblemType"]["ActivationComputeDataType"])
 
-    # Get supported archs
-    if ";" in globalParameters["Architecture"]:
-      self.supportedArchs = globalParameters["Architecture"].split(";")
-    else:
-      self.supportedArchs = globalParameters["Architecture"].split("_")
-    if "all" in self.supportedArchs:
-      self.supportedArchs = deepcopy(globalParameters['SupportedISA'])
-    else:
-      for idx, arch in enumerate(self.supportedArchs):
-        self.supportedArchs[idx] = gfxToIsa(''.join(map(str, arch)))
+    self.supportedArchs = supportedISA
 
     # derive parameter
     self.language = "HIP"
@@ -93,7 +85,7 @@ class KernelWriterActivationFunction(KernelWriterBase):
   def getInlineAsm(self, activation: ActivationInline, spaces: int, activationType: str):
     activationStrList = []
 
-    isa = tuple(self.state["Kernel"]["ISA"])
+    isa = self.state["Kernel"]["ISA"]
     if not self._tf.isInit():
       self._tf.init(isa, self.cxxCompiler)
     self._tf.setKernelInfo(isa, self.state["Kernel"]["WavefrontSize"])

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -41,20 +41,21 @@ from .TensileInstructions.Instructions import *
 from .TensilePass import getActivationFunctionModuleName, getActivationBranchModuleName
 from .TensileInstructions.Containers import HWRegContainer
 from .Component import Component
-from .KernelWriter import KernelWriter, ConstValues, StateValues, StateVgprs, CodeModules
 from .KernelWriterModules import *
 from .SolutionStructs import isPackedIndex
 from .AsmStoreState import StoreState, VectorDataTypes
 from .AsmMemoryInstruction import MemoryInstruction
 from .Activation import ActivationType
 from .CustomKernels import isCustomKernelConfig
-from .Common import globalParameters, print2, printExit, printWarning, roundUp, ensurePath, INDEX_CHARS, DataDirection, SemanticVersion
-from dataclasses import dataclass
+from Tensile.Common import print2, printExit, printWarning, INDEX_CHARS, DebugConfig, DataDirection
+from Tensile.KernelWriter import KernelWriter
+from Tensile.SolutionStructs.Naming import getKernelFileBase
+from Tensile.Toolchain.Component import Assembler
 
 from math import ceil, log, floor
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import NamedTuple, Tuple
+from typing import NamedTuple, Tuple, Dict
 
 import os
 import subprocess
@@ -82,10 +83,41 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   # Init
   ##############################################################################
-  def __init__(self, kernelMinNaming, kernelSerialNaming, assembler: str, amdClangVersion: SemanticVersion):
-    super(KernelWriterAssembly, self).__init__(kernelMinNaming, kernelSerialNaming, assembler, amdClangVersion)
+  def __init__(
+      self,
+      kernelMinNaming,
+      kernelSerialNaming,
+      assembler: Assembler,
+      debugConfig: DebugConfig,
+    ):
+    super(KernelWriterAssembly, self).__init__(kernelMinNaming, kernelSerialNaming, assembler, debugConfig)
 
-  def getSourceFileString(self, kernel) -> Tuple[int, str]:
+
+  def _getCustomKernelSource(self, useShortNames, kernel, CustomKernelDirectory):
+    kernelName = getKernelFileBase(useShortNames, self.debugConfig.splitGSU, self.kernelMinNaming, self.kernelSerialNaming, kernel)
+    with open(os.path.join(CustomKernelDirectory, (kernelName + ".s"))) as f:
+      rocmVersion = self.assembler.rocm_version
+      if not (rocmVersion.major >= 6 and rocmVersion.patch >= 32650):
+        code = []
+        for line in f.readlines():
+          if "amdhsa_user_sgpr_kernarg_preload" not in line:
+            code.append(line)
+        code = "".join(code)
+      else:
+        code = f.read()
+
+    self.tPA = {}
+    self.tPB = {}
+    self.states.kernel = kernel
+    self.states.language = "ASM"
+    self.states.version = kernel["ISA"]
+
+    return code
+
+
+  def getSourceFileString(self,
+                          kernel,
+                          useShortNames: bool=False) -> Tuple[int, str]:
     assert kernel["KernelLanguage"] == "Assembly"
     # Skip if .o files will have already been built for this file
     if kernel.duplicate:
@@ -93,7 +125,7 @@ class KernelWriterAssembly(KernelWriter):
       return (0, "") # should this be an non zero number
 
     try:
-      code = self._getCustomKernelSource(kernel, CUSTOM_KERNEL_PATH) if isCustomKernelConfig(kernel) else self._getKernelSource(kernel)
+      code = self._getCustomKernelSource(useShortNames, kernel, CUSTOM_KERNEL_PATH) if isCustomKernelConfig(kernel) else self._getKernelSource(kernel)
       errcode = 0
     except RuntimeError as e:
       printWarning(f"Failed to generate assembly source code for {kernel}: {e}")
@@ -487,16 +519,10 @@ class KernelWriterAssembly(KernelWriter):
          or kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat():
         module.add(self.defineSgpr("PackKForV0", 1))
         module.add(self.defineSgpr("PackKForV1", 1))
-        if kernel["StreamK"] != 0:
-          self.states.nonPostLoopSgpr.append("PackKForV0")
-          self.states.nonPostLoopSgpr.append("PackKForV1")
         if (self.states.lrvwTileA > 2 or self.states.lrvwTileB > 2 or self.states.lrvwTileMetadata > 2) and \
             (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
           module.add(self.defineSgpr("PackKForV2", 1))
           module.add(self.defineSgpr("PackKForV3", 1))
-          if kernel["StreamK"] != 0:
-            self.states.nonPostLoopSgpr.append("PackKForV2")
-            self.states.nonPostLoopSgpr.append("PackKForV3")
 
     if kernel["ProblemType"]["StochasticRounding"]:
       module.add(self.defineSgpr("RNDSeed", 1))
@@ -797,7 +823,7 @@ class KernelWriterAssembly(KernelWriter):
 
     module.add(RegSet("v", "vgprSerial", self.states.startVgprSerial))
 
-    if globalParameters["DebugKernel"]:
+    if self.debugConfig.debugKernel:
       module.add(RegSet("v", "vgprAddressDbg", \
           self.states.startVgprAddressDbg))
     #module.addComment0("Occu: %u waves/simd" % self.numWavesPerSimd )
@@ -1255,7 +1281,7 @@ class KernelWriterAssembly(KernelWriter):
       else:
         msg = "unknown"
 
-      if globalParameters["PrintSolutionRejectionReason"]:
+      if self.debugConfig.printSolutionRejectionReason:
         printWarning("%s overflowed resources.  errorCode=%d, msg=\"%s\", vgprs=%u, sgprs=%u" \
           % (self.states.kernelName, self.states.overflowedResources, msg, \
           self.vgprPool.size(), self.sgprPool.size()))
@@ -1313,7 +1339,7 @@ class KernelWriterAssembly(KernelWriter):
   def getKernelArgLoadModule(self, kernel, sgprStartIdx, numsOfLoad, preloadNum):
     kernelArgs = Module("load arguments")
     kernelArgs.addComment1("Load Kernel Args")
-    if globalParameters["DebugKernel"]:
+    if self.debugConfig.debugKernel:
       kernelArgs.add(self.argLoader.loadKernArg("AddressDbg", "KernArgAddress", dword=2))
     self.argLoader.resetOffset()
     kernelArgs.addModuleAsFlatItems(self.argLoader.loadAllKernArg(sgprStartIdx, "KernArgAddress", numsOfLoad, preloadNum))
@@ -2049,7 +2075,7 @@ class KernelWriterAssembly(KernelWriter):
 
     ########################################
     # Debug Buffer
-    if globalParameters["DebugKernel"]:
+    if self.debugConfig.debugKernel:
       module.addComment1("Debug Buffer")
 
       # nwg0 FIXME use NumWorkGroups0
@@ -4447,7 +4473,7 @@ class KernelWriterAssembly(KernelWriter):
               numVgprValuPackA *= 2
           else:
             numVgprValuPackA = self.states.a.numVgprValuPerBlock * kernel["InnerUnroll"] * self.states.numVgprBufferPackA * (int(4/tensorParametersA["bpeDS"]) - 1)
-        
+
         vgprBaseA = self.vgprPool.checkOutAligned(numValuA + numVgprValuPackA, 2)
         imodA.add(RegSet("v", "vgprValuA_X0_I0_BASE", vgprBaseA))
         if numVgprValuPackA > 0:
@@ -4523,7 +4549,7 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   # Using wider load instructions to improve the GR efficiency in tail loop.
   # If loading size is smaller than a dword(32bit), it will return 0 instead.
-  # Need to call buffer_load_d16 to load the data which is out of boundary. 
+  # Need to call buffer_load_d16 to load the data which is out of boundary.
   ##############################################################################
   def tailLoopGlobalRead(self, kernel, tPA, tPB, doA, doB):
     imod = Module("tailLoopGlobalRead")
@@ -4763,7 +4789,7 @@ class KernelWriterAssembly(KernelWriter):
         if doA and kernel["DirectToLds%s"%tPA["tensorChar"]]:
           imod.add(SMovB32(dst=mgpr(0), src=hex(kernel["LdsNumBytes"]), \
               comment="Restore LDS clamp at %u bytes HERE"%(kernel["LdsNumBytes"])))
-         
+
         imod.add(SCmpEQU32(src0=sgpr(tmpSgprKB), src1=0, \
                            comment="Valid loading size per thread is multiples of 4 bytes"))
 
@@ -5576,7 +5602,7 @@ class KernelWriterAssembly(KernelWriter):
 
     # Write bias A, B data to LDS
     if kernel["ProblemType"]["Gradient"] and kernel["ProblemType"]["UseBias"] and (kernel["ProblemType"]["BiasSrc"] == "A" or kernel["ProblemType"]["BiasSrc"] == "B"):
-      
+
       tP = tPA if kernel["ProblemType"]["BiasSrc"] == "A" else tPB
       module.add(self.exclasses.biasSumUnroll.storeSumLDS(self, kernel, tP))
 
@@ -7697,17 +7723,17 @@ class KernelWriterAssembly(KernelWriter):
       if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
         if tP["is_sparse"]:
             globalReadGuardKBody(tP["tpsMetadata"])
-  
+
       if self.db["ConservativeWaitCnt"] & 0x1:
           module.add(SBarrier(comment="debug"))
           module.add(SWaitCnt(lgkmcnt=0, vmcnt=0, vscnt=0, comment=""))
           module.add(SBarrier(comment="debug"))
-  
+
       # TODO - can remove one of these m0 restores if A and B both TLU
       if kernel["DirectToLds%s"%tP["tensorChar"]]:
         module.add(SMovB32(dst=mgpr(0), src=hex(kernel["LdsNumBytes"]), \
             comment="Restore LDS clamp at %u bytes HERE"%(kernel["LdsNumBytes"])))
-  
+
       if not kernel["BufferLoad"]:
         self.vgprPool.checkIn(maxAddrVgpr)
         self.vgprPool.checkIn(bpeVgpr)
@@ -7898,7 +7924,7 @@ class KernelWriterAssembly(KernelWriter):
     tc = tP["tensorChar"]
     problemType = self.states.kernel["ProblemType"]
     imod = StructuredModule("globalReadDo%s_%u"%(tc,mode))
-    if not self.do["GlobalRead%s"%tP["tensorChar"]]: 
+    if not self.do["GlobalRead%s"%tP["tensorChar"]]:
       return imod
 
     # sizeK % LOCAL_DEPTHU
@@ -8061,7 +8087,7 @@ class KernelWriterAssembly(KernelWriter):
                 else:
                   g2lIdxM = i * max(loadWidth * tP["bpeRatio"], 1)
                   destVgpr = destVgprPrefix + "+%u"%((g2lIdx+eccOffset+tP["shiftGR"]) if not tP["isM"] else g2lIdxM)
-                  self.vgprs.globalReadRegisters[tc].append(g2lIdx+eccOffset+tP["shiftGR"] if not tP["isM"] else g2lIdxM) 
+                  self.vgprs.globalReadRegisters[tc].append(g2lIdx+eccOffset+tP["shiftGR"] if not tP["isM"] else g2lIdxM)
                   if tP["isM"]:
                     assert(graIdx <= self.states.m.numVgprG2LAllocated)
 
@@ -10419,7 +10445,7 @@ class KernelWriterAssembly(KernelWriter):
     useBiasBackup      = self.states.useBias
     betasBackup    = betas
     edgesBackup    = edges
-    gsuLimit = 1 if noGSUBranch or globalParameters["SplitGSU"] else 2
+    gsuLimit = 1 if noGSUBranch or self.debugConfig.splitGSU else 2
     if gsuLimit > 1:
       gsuLabel = Label(label=self.labels.getNameInc("GSU"), comment="")
       with self.allocTmpSgpr(1) as tmpSgprGSU:
@@ -11938,7 +11964,7 @@ class KernelWriterAssembly(KernelWriter):
         addrScaleAVec, addrScaleBVec, addrScaleAlphaVec, biasLocalBarrierInit, \
         tmpVgpr, tmpVgprDynamic, cvtVgprStruct, activationSetPCStruct, activationTypeStr, \
         batchElementSgprs, tmpSgpr, codeAccVgprRead, codeMulAlpha, packdata, self, factorDim, \
-        self.amdClangVersion)
+        self.assembler.version)
 
   ##############################################################################
   def openPrefetchGlobalRead2(self, kernel):

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -519,10 +519,16 @@ class KernelWriterAssembly(KernelWriter):
          or kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat():
         module.add(self.defineSgpr("PackKForV0", 1))
         module.add(self.defineSgpr("PackKForV1", 1))
+        if kernel["StreamK"] != 0:
+          self.states.nonPostLoopSgpr.append("PackKForV0")
+          self.states.nonPostLoopSgpr.append("PackKForV1")
         if (self.states.lrvwTileA > 2 or self.states.lrvwTileB > 2 or self.states.lrvwTileMetadata > 2) and \
             (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
           module.add(self.defineSgpr("PackKForV2", 1))
           module.add(self.defineSgpr("PackKForV3", 1))
+          if kernel["StreamK"] != 0:
+            self.states.nonPostLoopSgpr.append("PackKForV2")
+            self.states.nonPostLoopSgpr.append("PackKForV3")
 
     if kernel["ProblemType"]["StochasticRounding"]:
       module.add(self.defineSgpr("RNDSeed", 1))

--- a/tensilelite/Tensile/KernelWriterBetaOnly.py
+++ b/tensilelite/Tensile/KernelWriterBetaOnly.py
@@ -24,7 +24,7 @@
 
 from copy import deepcopy
 
-from .Common import globalParameters, CHeader, INDEX_CHARS
+from Tensile.Common import INDEX_CHARS
 from .TensileInstructions import DataType
 from .KernelWriterBase import KernelWriterBase
 

--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -23,12 +23,14 @@
 ################################################################################
 
 from pathlib import Path
-from .Common import print1, print2, HR, printExit, defaultAnalysisParameters, globalParameters, \
-  assignParameterWithDefault, startTime, ProgressBar, printWarning, ensurePath, \
-  LIBRARY_LOGIC_DIR, BENCHMARK_DATA_DIR
-from .SolutionStructs import Solution
+from typing import Dict
 from . import LibraryIO
 from . import SolutionSelectionLibrary
+from Tensile.Common import print1, print2, HR, printExit, \
+  assignParameterWithDefault, ProgressBar, printWarning, ensurePath, \
+  LIBRARY_LOGIC_DIR, BENCHMARK_DATA_DIR, getVerbosity, IsaInfo, DepthUConfig
+from Tensile.Common.GlobalParameters import defaultAnalysisParameters, globalParameters, startTime
+from Tensile.SolutionStructs.Naming import getMinNaming, getNameMin, getNameFull
 
 from copy import deepcopy
 from sys import stdout
@@ -42,7 +44,7 @@ import math
 ################################################################################
 # Analyze Problem Type
 ################################################################################
-def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryLogicPath):
+def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryLogicPath, splitGSU: bool):
   print2(HR)
   print1("# Analyzing: %s" % problemType)
 
@@ -70,21 +72,21 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
     solutions = problemSizeGroup[4]
     problemSizesList.append(problemSizes)
     solutionsList.append(solutions)
-    solutionMinNaming = Solution.getMinNaming(solutions)
+    solutionMinNaming = getMinNaming(solutions)
     print1("# Read: %s" % (solutionsFileName))
     print2("# ProblemSizes: %s" % problemSizes)
     print2("# Solutions:")
     solutionIdx = 0
     for solution in solutions:
-      print2("#  (%u) %s" % (solutionIdx, Solution.getNameMin(solution, \
-          solutionMinNaming)))
+      print2("#  (%u) %s" % (solutionIdx, getNameMin(solution, \
+          solutionMinNaming, splitGSU)))
       solutionIdx += 1
     print2(HR)
 
   ######################################
   # Create Logic Analyzer
   logicAnalyzer = LogicAnalyzer( problemType, problemSizesList, solutionsList, \
-      dataFileNameList, inputParameters)
+      dataFileNameList, inputParameters, splitGSU)
 
   selectionSolutionsIdsList = None
   selectionSolutions = None
@@ -107,7 +109,7 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
     printExit("Bad KeepLogic=%u"%globalParameters["KeepLogic"])
 
   # print raw data
-  if globalParameters["PrintLevel"] >= 2:
+  if getVerbosity() >= 2:
     line = "After Removals:\n"
     numOther = 1
     for size in logicAnalyzer.numProblemSizes:
@@ -126,9 +128,9 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
   for i in range(0, len(logicAnalyzer.solutions)):
     s = logicAnalyzer.solutions[i]
     s["SolutionIndex"] = i
-    s["SolutionNameMin"] = Solution.getNameMin(s, solutionMinNaming)
-    s["KernelNameMin"]   = Solution.getNameMin(s, solutionMinNaming, True)
-    print1("(%2u) %s : %s" % (i, Solution.getNameMin(s, solutionMinNaming), Solution.getNameFull(s)))
+    s["SolutionNameMin"] = getNameMin(s, solutionMinNaming, splitGSU)
+    s["KernelNameMin"]   = getNameMin(s, solutionMinNaming, splitGSU, True)
+    print1("(%2u) %s : %s" % (i, getNameMin(s, solutionMinNaming, splitGSU), getNameFull(s, splitGSU)))
 
   if enableTileSelection:
     validSelectionSolutions = SolutionSelectionLibrary.analyzeSolutionSelection(problemType, selectionFileNameList, \
@@ -160,8 +162,8 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
       (validSolution, validSolutionInfo) = validSelectionSolution
       selectionSolutionIndex = solutionsStartIndex + i
       selectionSolutionsIds.add(selectionSolutionIndex)
-      validSolution["SolutionNameMin"] = Solution.getNameMin(validSolution, solutionMinNaming)
-      validSolution["KernelNameMin"]   = Solution.getNameMin(validSolution, solutionMinNaming, True)
+      validSolution["SolutionNameMin"] = getNameMin(validSolution, solutionMinNaming, splitGSU)
+      validSolution["KernelNameMin"]   = getNameMin(validSolution, solutionMinNaming, splitGSU, True)
       validSolution["Ideals"] = validSolutionInfo
       selectionSolutions.append(validSolution)
 
@@ -250,10 +252,11 @@ class LogicAnalyzer:
   # ENTRY: Init
   ##############################################################################
   def __init__(self, problemType, problemSizesList, solutionsList, \
-      dataFileNameList, inputParameters):
+      dataFileNameList, inputParameters, splitGSU: bool):
 
     # parameters
     self.parameters = inputParameters
+    self.splitGSU = splitGSU
 
     # problem type
     self.problemType = problemType
@@ -290,12 +293,12 @@ class LogicAnalyzer:
         self.solutionGroupMap[solutionGroupIdx][solutionIdx] = sIdx
         progressBar.increment()
     self.numSolutions = len(self.solutions)
-    self.solutionMinNaming = Solution.getMinNaming(self.solutions)
+    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(Solution.getNameMin(solution, \
-          self.solutionMinNaming))
+      self.solutionNames.append(getNameMin(solution, \
+          self.solutionMinNaming, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
           solution["MacroTile1"]))
     self.flopsPerMac = self.problemType["DataType"].flopsPerMac()
@@ -688,7 +691,7 @@ class LogicAnalyzer:
           currentIndexRange[self.indexOrder[2]][0], \
           currentIndexRange[self.indexOrder[3]][0])
     tab = self.tab[cii]
-    if globalParameters["PrintLevel"] == 1:
+    if getVerbosity() == 1:
       stdout.write("\n%s"%tab)
     currentIndex = self.indexOrder[currentIndexIndex]
     print2("%senRule(%s)" % (tab, currentIndexRange))
@@ -714,7 +717,7 @@ class LogicAnalyzer:
           print2("%sSingleProblem & LastIndex :: winnerIdx<0; returning" % (tab) )
           return None
         ruleList.append([-1, winnerIdx])
-        if globalParameters["PrintLevel"] == 1:
+        if getVerbosity() == 1:
           stdout.write("%")
 
       ########################################
@@ -730,7 +733,7 @@ class LogicAnalyzer:
           return None
         rule = [ -1, nextRule ]
         ruleList.append(rule)
-        if globalParameters["PrintLevel"] == 1:
+        if getVerbosity() == 1:
           stdout.write("%")
 
     else:
@@ -783,7 +786,7 @@ class LogicAnalyzer:
         initialRule = [ currentIndexRange[currentIndex][0], nextRule ]
       ruleList.append(initialRule)
       print2("%sMultiProblem::InitialRuleList=%s" % (tab, ruleList))
-      if globalParameters["PrintLevel"] == 1:
+      if getVerbosity() == 1:
         stdout.write("#")
 
       ########################################
@@ -808,7 +811,7 @@ class LogicAnalyzer:
           if winnerIdx < 0:
             ruleList[len(ruleList)-1][0] = problemIndex # NO_UPDATE
             print2("%sUpdating range b/c None" % tab)
-            if globalParameters["PrintLevel"] == 1:
+            if getVerbosity() == 1:
               stdout.write(" ")
             continue
           else:
@@ -821,7 +824,7 @@ class LogicAnalyzer:
           if nextRule == None:
             ruleList[len(ruleList)-1][0] = problemIndex # NO_UPDATE
             print2("%sUpdating b/c None" % tab)
-            if globalParameters["PrintLevel"] == 1:
+            if getVerbosity() == 1:
               stdout.write(" ")
             continue
           else:
@@ -832,7 +835,7 @@ class LogicAnalyzer:
         if candidateRule[1] == priorRule[1]:
           print2("%sCandidateRule==PriorRule; just updating prior" % (tab))
           ruleList[len(ruleList)-1][0] = problemIndex # NO_UPDATE
-          if globalParameters["PrintLevel"] == 1:
+          if getVerbosity() == 1:
             stdout.write(" ")
           continue
 
@@ -872,14 +875,14 @@ class LogicAnalyzer:
           if True: # or candidateRuleScore < priorRuleScore:
             ruleList.append(candidateRule)
             print2("%sAppending b/c Different" % tab)
-            if globalParameters["PrintLevel"] == 1:
+            if getVerbosity() == 1:
               stdout.write("#")
 
           ########################################
           # prior wins
           else:
             print2("%sPrior Rule Wins" % tab)
-            if globalParameters["PrintLevel"] == 1:
+            if getVerbosity() == 1:
               stdout.write(".")
             ruleList[len(ruleList)-1][0] = problemIndex # NO_UPDATE
 
@@ -1117,12 +1120,12 @@ class LogicAnalyzer:
     for i in range(0, oldNumSolutions):
       if i != removeSolutionIdx:
         self.solutions.append(oldSolutions[i])
-    self.solutionMinNaming = Solution.getMinNaming(self.solutions)
+    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(Solution.getNameMin(solution, \
-          self.solutionMinNaming))
+      self.solutionNames.append(getNameMin(solution, \
+          self.solutionMinNaming, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
           solution["MacroTile1"]))
     self.numSolutions = len(self.solutions)
@@ -1168,12 +1171,12 @@ class LogicAnalyzer:
       else:
         removeSolutionIdxList.append(i)
 
-    self.solutionMinNaming = Solution.getMinNaming(self.solutions)
+    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(Solution.getNameMin(solution, \
-          self.solutionMinNaming))
+      self.solutionNames.append(getNameMin(solution, \
+          self.solutionMinNaming, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
           solution["MacroTile1"]))
     self.numSolutions = len(self.solutions)
@@ -1429,8 +1432,17 @@ class LogicAnalyzer:
     return serial
 
 
-
-def generateLogic(config, benchmarkDataPath, libraryLogicPath, cxxCompiler: str):
+def generateLogic(
+    config,
+    benchmarkDataPath,
+    libraryLogicPath,
+    cxxCompiler: str,
+    splitGSU: bool,
+    printSolutionRejectionReason: bool,
+    printIndexAssignmentInfo: bool,
+    depthUConfig: DepthUConfig,
+    isaInfoMap: Dict[str, IsaInfo]
+  ):
 
   libraryLogicPath = ensurePath(libraryLogicPath)
 
@@ -1473,7 +1485,15 @@ def generateLogic(config, benchmarkDataPath, libraryLogicPath, cxxCompiler: str)
         printExit("%s doesn't exist for %s" % (dataFileName, fileBase) )
       if not os.path.exists(solutionsFileName):
         printExit("%s doesn't exist for %s" % (solutionsFileName, fileBase) )
-      (problemSizes, solutions) = LibraryIO.parseSolutionsFile(solutionsFileName, cxxCompiler)
+      (problemSizes, solutions) = LibraryIO.parseSolutionsFile(
+                                      solutionsFileName,
+                                      cxxCompiler,
+                                      splitGSU,
+                                      printSolutionRejectionReason,
+                                      printIndexAssignmentInfo,
+                                      depthUConfig,
+                                      isaInfoMap
+                                  )
       if len(solutions) == 0:
         printExit("%s doesn't contains any solutions." % (solutionsFileName) )
       problemType = solutions[0]["ProblemType"]
@@ -1483,7 +1503,7 @@ def generateLogic(config, benchmarkDataPath, libraryLogicPath, cxxCompiler: str)
           dataFileName, solutionsFileName, selectionFileName, solutions) )
 
   for problemType in problemTypes:
-    logicTuple = analyzeProblemType(problemType, problemTypes[problemType], analysisParameters, libraryLogicPath)
+    logicTuple = analyzeProblemType(problemType, problemTypes[problemType], analysisParameters, libraryLogicPath, splitGSU)
 
     filename = os.path.join(libraryLogicPath, \
         "{}_{}".format(analysisParameters["ScheduleName"], str(problemType)))
@@ -1546,7 +1566,26 @@ def read_max_freq():
 ###
 ################################################################################
 ################################################################################
-def main(config, cxxCompiler: str, outputPath: Path):
+def main(
+      config,
+      cxxCompiler: str,
+      outputPath: Path,
+      splitGSU: bool,
+      printSolutionRejectionReason: bool,
+      printIndexAssignmentInfo: bool,
+      depthUConfig: DepthUConfig,
+      isaInfoMap: Dict[str, IsaInfo]
+    ):
   benchmarkDataPath = outputPath / BENCHMARK_DATA_DIR
   libraryLogicPath = outputPath / LIBRARY_LOGIC_DIR
-  generateLogic(config, benchmarkDataPath, libraryLogicPath, cxxCompiler)
+  generateLogic(
+    config,
+    benchmarkDataPath,
+    libraryLogicPath,
+    cxxCompiler,
+    splitGSU,
+    printSolutionRejectionReason,
+    printIndexAssignmentInfo,
+    depthUConfig,
+    isaInfoMap
+  )

--- a/tensilelite/Tensile/Ops/AMaxGenerator.py
+++ b/tensilelite/Tensile/Ops/AMaxGenerator.py
@@ -32,8 +32,8 @@ import subprocess
 import collections
 from contextlib import contextmanager
 import Tensile.TensileInstructions as ti
-from Tensile.Common import detectGlobalCurrentISA, restoreDefaultGlobalParameters, \
-    assignGlobalParameters, isaToGfx, gfxToIsa, globalParameters
+from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxToIsa
+from Tensile.Common.GlobalParameters import restoreDefaultGlobalParameters, assignGlobalParameters
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
@@ -848,8 +848,8 @@ if __name__ == '__main__':
     if any([not i for i in (arch, toolchain_path, isa)]):
         restoreDefaultGlobalParameters()
         assignGlobalParameters({})
-        detectGlobalCurrentISA()
-        isa = globalParameters['CurrentISA']
+        enumerator = validateToolchain(ToolchainDefaults.DEVICE_ENUMERATOR)
+        isa = detectGlobalCurrentISA(0, enumerator)
         arch = isaToGfx(isa)
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 

--- a/tensilelite/Tensile/Ops/LayerNormGenerator.py
+++ b/tensilelite/Tensile/Ops/LayerNormGenerator.py
@@ -32,8 +32,8 @@ import subprocess
 import collections
 from contextlib import contextmanager
 import Tensile.TensileInstructions as ti
-from Tensile.Common import detectGlobalCurrentISA, restoreDefaultGlobalParameters, \
-    assignGlobalParameters, isaToGfx, gfxToIsa, globalParameters
+from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxToIsa
+from Tensile.Common.GlobalParameters import assignGlobalParameters, restoreDefaultGlobalParameters
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def kernel_header(name: str, gfx_arch: str, vgpr: int, sgpr: int, lds: int):
@@ -925,8 +925,8 @@ if __name__ == '__main__':
     if any([not i for i in (arch, toolchain_path, isa)]):
         restoreDefaultGlobalParameters()
         assignGlobalParameters({})
-        detectGlobalCurrentISA()
-        isa = globalParameters['CurrentISA']
+        enumerator = validateToolchain(ToolchainDefaults.DEVICE_ENUMERATOR)
+        isa = detectGlobalCurrentISA(0, enumerator)
         arch = isaToGfx(isa)
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 

--- a/tensilelite/Tensile/Ops/SoftmaxGenerator.py
+++ b/tensilelite/Tensile/Ops/SoftmaxGenerator.py
@@ -31,8 +31,8 @@ import json
 import subprocess
 from contextlib import contextmanager
 import Tensile.TensileInstructions as ti
-from Tensile.Common import detectGlobalCurrentISA, restoreDefaultGlobalParameters, \
-    assignGlobalParameters, isaToGfx, gfxToIsa, globalParameters
+from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx, gfxToIsa
+from Tensile.Common.GlobalParameters import restoreDefaultGlobalParameters, assignGlobalParameters
 from Tensile.Toolchain.Validators import ToolchainDefaults, validateToolchain
 
 def record_num_calls(f):
@@ -692,8 +692,8 @@ if __name__ == '__main__':
     if any([not i for i in (arch, toolchain_path, isa)]):
         restoreDefaultGlobalParameters()
         assignGlobalParameters({})
-        detectGlobalCurrentISA()
-        isa = globalParameters['CurrentISA']
+        enumerator = validateToolchain(ToolchainDefaults.DEVICE_ENUMERATOR)
+        isa = detectGlobalCurrentISA(0, enumerator)
         arch = isaToGfx(isa)
         toolchain_path = validateToolchain(ToolchainDefaults.CXX_COMPILER)
 

--- a/tensilelite/Tensile/SolutionSelectionLibrary.py
+++ b/tensilelite/Tensile/SolutionSelectionLibrary.py
@@ -1,6 +1,6 @@
 ################################################################################
 #
-# Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+# Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
 #
 ################################################################################
 
-from .SolutionStructs import Solution
+from Tensile.SolutionStructs.Naming import getNameMin
 
 import csv
 
@@ -89,8 +89,9 @@ def updateValidSolutions(validSolutions, analyzerSolutions, solutionMinNaming):
     (validSolution, validSolutionInfo) = validSelectionSolution
     selectionSolutionIndex = solutionsStartIndex + i
     selectionSolutionsIds.add(selectionSolutionIndex)
-    validSolution["SolutionNameMin"] = Solution.getNameMin(validSolution, solutionMinNaming)
-    validSolution["KernelNameMin"]   = Solution.getNameMin(validSolution, solutionMinNaming, True)
+    splitGSU = False # this is a reminder that we need to add this in to the function signature
+    validSolution["SolutionNameMin"] = getNameMin(validSolution, solutionMinNaming, splitGSU)
+    validSolution["KernelNameMin"]   = getNameMin(validSolution, solutionMinNaming, splitGSU, True)
     validSolution["Ideals"] = validSolutionInfo
     selectionSolutions.append(validSolution)
 

--- a/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -1,0 +1,284 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+from copy import deepcopy
+from functools import lru_cache
+from typing import List
+
+from Tensile.Common.Constants import MAX_FILENAME_LENGTH
+from Tensile.Common.ValidParameters import validParameters
+
+from .Problem import ProblemType
+
+########################################
+# create a dictionary with booleans on whether to include parameter in name
+def getMinNaming(objs: list):
+  nonCKObjs = [obj for obj in objs if not ("CustomKernelName" in obj and obj["CustomKernelName"])]
+  # early return
+  if len(nonCKObjs) == 0:
+    return {}
+  # determine keys
+  requiredParameters = {}
+  if hasattr(nonCKObjs[0], "_state"):
+    keys = list(nonCKObjs[0]._state.keys())
+  else:
+    keys = list(nonCKObjs[0].keys())
+  # only 1, rather than name being nothing, it'll be everything
+  if len(nonCKObjs) == 1:
+    for key in keys:
+      if key in list(validParameters.keys()):
+        requiredParameters[key] = False
+  else:
+    for key in keys:
+      required = False
+      if key in list(validParameters.keys()):
+        for i in range(1, len(nonCKObjs)):
+          if nonCKObjs[0][key] != nonCKObjs[i][key]:
+            required = True
+            break
+      if required:
+        requiredParameters[key] = True
+      else:
+        requiredParameters[key] = False
+  requiredParameters["GlobalSplitU"] = True
+  requiredParameters["WorkGroupMapping"] = True
+  if "MatrixInstM" in nonCKObjs[0]._state:
+    # Use MIWaveGroup and MIWaveTile instead of WG and MT
+    requiredParameters["MIWaveTile"]  = True
+    requiredParameters["ThreadTile"]  = False
+  requiredParameters["ProblemType"]       = False # always prepended
+  requiredParameters["MacroTile0"]        = False # always prepended
+  requiredParameters["MacroTile1"]        = False # always prepended
+  requiredParameters["DepthU"]            = False # always prepended
+  requiredParameters["MatrixInstruction"] = False # always prepended
+  requiredParameters["MatrixInstM"]       = False # always prepended
+  requiredParameters["MatrixInstN"]       = False # always prepended
+  requiredParameters["MatrixInstK"]       = False # always prepended
+  requiredParameters["MatrixInstB"]       = False # always prepended
+  requiredParameters["MatrixInstBM"]      = False # always prepended
+  requiredParameters["MatrixInstBN"]      = False # always prepended
+  requiredParameters["CustomKernelName"]  = False # Will not affect naming
+  requiredParameters["Kernel"]            = True  # distinguish kernels from solutions
+                                                  # for single-source compilation
+  return requiredParameters
+
+
+def getKeyNoInternalArgs(state, splitGSU: bool):
+  state_copy = deepcopy(state)
+  state_copy["ProblemType"]["GroupedGemm"] = False
+  if splitGSU:
+    state_copy["GlobalSplitU"] = "M" if (state_copy["GlobalSplitU"] > 1) else state_copy["GlobalSplitU"]
+  elif state["GlobalSplitU"] > 0:
+    state_copy["GlobalSplitU"] = "M"
+  state_copy["WorkGroupMapping"] = "M"
+  state_copy["WorkGroupMappingXCC"] = "M"
+  state_copy["WorkGroupMappingXCCGroup"] = "M"
+  state_copy["StaggerU"] = "M"
+  state_copy["StaggerUStride"] = "M"
+  state_copy["StaggerUMapping"] = "M"
+  state_copy["GlobalSplitUCoalesced"] = "M"
+  state_copy["GlobalSplitUWorkGroupMappingRoundRobin"] = "M"
+  return state_copy
+
+
+def getNameFull(state, splitGSU: bool):
+  requiredParameters = {}
+  for key in state:
+    if key in list(validParameters.keys()):
+      requiredParameters[key] = True
+  if "MatrixInstM" in state:
+    # Use MIWaveGroup and MIWaveTile instead of WG and MT
+    requiredParameters["MIWaveTile"]  = True
+    requiredParameters["ThreadTile"]  = False
+  return getNameMin(state, requiredParameters, splitGSU)
+
+
+@lru_cache(maxsize=None)
+def getParameterNameAbbreviation( name: str ):
+  return ''.join(c for c in name if c.isupper())
+
+@ lru_cache(maxsize=None)
+def getPrimitiveParameterValueAbbreviation(key, value):
+  if isinstance(value, str):
+    return getParameterNameAbbreviation(value)
+  elif isinstance(value, bool):
+    return "1" if value else "0"
+  elif isinstance(value, int):
+    if value >= 0:
+      return "%u" % value
+    else: # -1 -> n1
+      return "n%01u" % abs(value)
+  elif isinstance(value, ProblemType): # will need to deal with this
+    return str(value)
+  elif isinstance(value, float):
+    val1 = int(value)
+    val2 = int(round(value*100)) - int(value)*100
+    if val2 > 0:
+      s =  "%dp%s" % (val1,str(val2).zfill(2))
+    else:
+      s = "%d" % (val1)
+    return s
+
+
+def getParameterValueAbbreviation(key, value):
+  if key == "ISA":
+    return f"{value[0]}{value[1]}{value[2]:x}"
+  compositieTypes = (dict, list, tuple,)
+  if not isinstance(value, compositieTypes):
+    return getPrimitiveParameterValueAbbreviation(key, value)
+  elif isinstance(value, tuple):
+    return ''.join(str(v) for v in value)
+  elif isinstance(value, list):
+    return '_'.join(getParameterValueAbbreviation(key, v) for v in value)
+  elif isinstance(value, dict):
+    return "_".join(f"{pos:d}{k:d}" for pos,k in value.items())
+  else:
+    raise Exception(f"Parameter {key}={value} is new object type ({type(value)})")
+
+
+def getNameMin(state, requiredParameters, splitGSU: bool, ignoreInternalArgs = False):
+  if "CustomKernelName" in state and state["CustomKernelName"]:
+    return state["CustomKernelName"]
+
+  components = []
+  backup = state["ProblemType"]["GroupedGemm"]
+  if ignoreInternalArgs:
+    state["ProblemType"]["GroupedGemm"] = False
+  if "ProblemType" in state:
+    components.append(f'{str(state["ProblemType"])}')
+    # name += str(state["ProblemType"]) + "_"
+  if ignoreInternalArgs:
+    state["ProblemType"]["GroupedGemm"] = backup
+  if "MacroTile0" in state \
+      and "MacroTile1" in state \
+      and "DepthU" in state:
+    components.append(f'{getParameterNameAbbreviation("MacroTile")}{state["MacroTile0"]}x{state["MacroTile1"]}x{state["DepthU"]}')
+  if "MatrixInstM" in state:
+    components.append(f'{getParameterNameAbbreviation("MatrixInstruction")}{state["MatrixInstM"]}x{state["MatrixInstN"]}x{state["MatrixInstB"]}')
+  backup = state["GlobalSplitU"]
+  if ignoreInternalArgs:
+    if splitGSU:
+      state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
+    elif state["GlobalSplitU"] > 0:
+      requiredParameters["GlobalSplitU"] = False
+    requiredParameters["WorkGroupMapping"] = False
+    requiredParameters["WorkGroupMappingXCC"] = False
+    requiredParameters["WorkGroupMappingXCCGroup"] = False
+    requiredParameters["StaggerU"] = False
+    requiredParameters["StaggerUStride"] = False
+    requiredParameters["StaggerUMapping"] = False
+    requiredParameters["GlobalSplitUCoalesced"] = False
+    requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
+  useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
+  if 'MatrixInstM' in state:
+    requiredParameters["MIWaveTile"] = True
+    requiredParameters["ThreadTile"] = False
+  else:
+    requiredParameters["MIWaveTile"] = False
+    requiredParameters["ThreadTile"] = True
+  components.append('SN')
+  for key in sorted(state.keys()):
+    if key in requiredParameters and key[0] != '_':
+      if requiredParameters[key] and key != "CustomKernelName":
+        components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
+  state["GlobalSplitU"] = backup
+  requiredParameters["GlobalSplitU"] = True
+  requiredParameters["WorkGroupMapping"] = True
+  requiredParameters["WorkGroupMappingXCC"] = True
+  requiredParameters["WorkGroupMappingXCCGroup"] = True
+  requiredParameters["StaggerU"] = True
+  requiredParameters["StaggerUStride"] = True
+  requiredParameters["StaggerUMapping"] = True
+  requiredParameters["GlobalSplitUCoalesced"] = True
+  requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
+  requiredParameters["MIWaveTile"] = useWaveTile
+  requiredParameters["ThreadTile"] = useThreadTile
+  return '_'.join(components)
+
+
+def getSerialNaming(objs):
+  data = {}
+  for obj in objs:
+    for paramName in sorted(obj.keys()):
+      if paramName in validParameters.keys():
+        paramValue = obj[paramName]
+        if paramName in data:
+          if paramValue not in data[paramName]:
+            data[paramName].append(paramValue)
+        else:
+          data[paramName] = [ paramValue ]
+  maxObjs = 1
+  for paramName in data:
+    if not isinstance(data[paramName][0], dict):
+      data[paramName] = sorted(data[paramName])
+    maxObjs *= len(data[paramName])
+  numDigits = len(str(maxObjs))
+  return [ data, numDigits ]
+
+
+def getNameSerial(state, serialNaming):
+  data = serialNaming[0]
+  numDigits = serialNaming[1]
+  serial = 0
+  multiplier = 1
+  for paramName in sorted(state.keys()):
+    if paramName in list(validParameters.keys()):
+      paramValue = state[paramName]
+      paramData = data[paramName]
+      paramNameMultiplier = len(paramData)
+      if paramValue in paramData:
+        paramValueIdx = paramData.index(paramValue)
+      serial += paramValueIdx * multiplier
+      multiplier *= paramNameMultiplier
+  name = "%s%0*u" % ("S" if hasattr(state, "_state") else "K", \
+      numDigits, serial)
+  return name
+
+
+def shortenFileBase(kernelMinNaming, splitGSU, kernel):
+  base = getKernelName(kernelMinNaming, splitGSU, kernel)
+  if len(base) <= MAX_FILENAME_LENGTH:
+    return base
+  import hashlib
+  import base64
+  pivot = MAX_FILENAME_LENGTH * 3 // 4
+  firstPart = base[:pivot]
+  secondPart = base[pivot:]
+  secondHash = hashlib.sha256(secondPart.encode()).digest()
+  secondPart = base64.b64encode(secondHash, b'_-').decode()
+  return firstPart + secondPart
+
+
+def getKernelFileBase(useShortNames: bool, splitGSU: bool, kernelMinNaming, kernelSerialNaming, kernel):
+  if "CustomKernelName" in kernel and kernel["CustomKernelName"]:
+    fileBase = kernel["CustomKernelName"]
+  elif useShortNames:
+    fileBase = getNameSerial(kernel, kernelSerialNaming)
+  else:
+    fileBase = shortenFileBase(kernelMinNaming, splitGSU, kernel)
+  return fileBase
+
+
+def getKernelName(kernelMinNaming, splitGSU, kernel):
+  kernelName = getNameMin(kernel, kernelMinNaming, splitGSU, True)
+  return kernelName

--- a/tensilelite/Tensile/SolutionStructs/Problem.py
+++ b/tensilelite/Tensile/SolutionStructs/Problem.py
@@ -1103,9 +1103,9 @@ def getBiasDataTypeListDefault(problem: ProblemType) -> List[DataType]:
   bList = []
   for d in ["DataType", "ComputeDataType", "DestDataType"]:
     dtype = DataType(problem[d])
-    # filter out int8, because it is not supported by bias datatype
+    # filter out int8/f8/b8, because it is not supported by bias datatype
     # TODO
-    if not dtype.isInt8():
+    if not dtype.isInt8() and not dtype.is8bitFloat():
       bList.append(dtype)
 
   biasDataTypeList = list(set(bList))

--- a/tensilelite/Tensile/SolutionStructs/Problem.py
+++ b/tensilelite/Tensile/SolutionStructs/Problem.py
@@ -1,0 +1,1115 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+from collections import OrderedDict
+from collections.abc import Mapping
+
+from typing import List
+
+from Tensile.TensileInstructions.Base import fastdeepcopy as deepcopy
+from Tensile.Activation import ActivationType
+from Tensile.TensileInstructions.DataType import DataType
+from Tensile.Common.Constants import INDEX_CHARS
+from Tensile.Common.Utilities import assignParameterWithDefault, printWarning, print2, print1, printExit
+
+
+
+
+class ProblemSizeRange:
+
+  def __init__(self, problemType, config):
+    self.totalIndices = 1+max(problemType["IndexAssignmentsA"]) + problemType["NumIndicesLD"]
+    if len(config) < self.totalIndices:
+      for i in range(len(config), self.totalIndices):
+        if i < self.totalIndices - problemType["NumIndicesLD"]:
+          config.append(0)
+        else:
+          config.append([0])
+
+    self.indexMax = []
+    self.indexIsSized = []
+    self.indicesSized = []
+    self.indicesMapped = []
+    for i in range(0, self.totalIndices):
+      dim = deepcopy(config[i])
+      if isinstance(dim, list):
+        if len(dim) == 1:
+          self.indicesSized.append([dim[0], 1, 0, dim[0]])
+        elif len(dim) == 2:
+          self.indicesSized.append([dim[0], dim[0], 0, dim[1]])
+        elif len(dim) == 3:
+          self.indicesSized.append([dim[0], dim[1], 0, dim[2]])
+        elif len(dim) == 4:
+          self.indicesSized.append([dim[0], dim[1], dim[2], dim[3]])
+        else:
+          printExit("dimension[%u] config (%s) has %u descriptors rather than 1-4."
+              % ( i, dim, len(dim) ))
+        self.indexIsSized.append(True)
+        self.indexMax.append(self.indicesSized[len(self.indicesSized)-1][3])
+
+      elif isinstance(dim, int):
+        self.indicesMapped.append(dim)
+        self.indexIsSized.append(False)
+        self.indexMax.append(self.indicesSized[self.indicesMapped[ \
+            len(self.indicesMapped)-1]][3])
+
+    # max num elements in each tensor
+    self.maxNumElements = [ 1, 1, 1 ]
+    for i in range(0, problemType["NumIndicesC"]):
+      self.maxNumElements[0] *= self.indexMax[i]
+    for i in problemType["IndexAssignmentsA"]:
+      self.maxNumElements[1] *= self.indexMax[i]
+    for i in problemType["IndexAssignmentsB"]:
+      self.maxNumElements[2] *= self.indexMax[i]
+
+    self.totalProblemSizes = 1
+    self.numProblemSizes = [] # per index
+    self.problemSizeToIndex = []
+    self.problemIndexToSize = []
+    sizedIdx = 0
+    for i in range(0, len(self.indexIsSized)):
+      self.problemSizeToIndex.append({})
+      self.problemIndexToSize.append({})
+      if self.indexIsSized[i]:
+        self.numProblemSizes.append(0)
+        index = self.indicesSized[sizedIdx]
+        sizedIdx += 1
+        currentSize = index[0]
+        currentIncrement = index[1]
+        while currentSize <= index[3]:
+          currentSize += currentIncrement
+          currentIncrement += index[2]
+          self.numProblemSizes[i] += 1
+      else:
+        self.numProblemSizes.append(1)
+      self.totalProblemSizes *= self.numProblemSizes[i]
+
+    ########################################
+    # enumerate problem sizes
+    currentSizedIndexSizes = []
+    currentSizedIndexIncrements = []
+    for i in range(0, len(self.indicesSized)):
+      currentSizedIndexSizes.append(self.indicesSized[i][0])
+      currentSizedIndexIncrements.append(self.indicesSized[i][1])
+
+    # iterate over all problem sizes
+    self.problemSizes = []
+    moreProblemSizes = True
+    problemIdx = 0
+    problemSize = [0]*self.totalIndices
+    while moreProblemSizes:
+      #/ convert current sized and mapped indices to full sizes
+      currentSizedIdx = 0
+      currentMappedIdx = 0
+      for i in range(0, self.totalIndices):
+        if self.indexIsSized[i]:
+          problemSize[i] = currentSizedIndexSizes[currentSizedIdx]
+          currentSizedIdx+=1
+        else:
+          problemSize[i] = problemSize[self.indicesMapped[currentMappedIdx]]
+          currentMappedIdx+=1
+      self.problemSizes.append(tuple(problemSize))
+
+      #/ increment sizes for next benchmark
+      currentSizedIndexSizes[0] += currentSizedIndexIncrements[0]
+      currentSizedIndexIncrements[0] += self.indicesSized[0][2]
+      for i in range(1, len(self.indicesSized)+1):
+        # if prior index past max, reset to min and increment next index
+        if currentSizedIndexSizes[i-1] > self.indicesSized[i-1][3]:
+          #/ reset prior index
+          currentSizedIndexSizes[i-1] = self.indicesSized[i-1][0]
+          currentSizedIndexIncrements[i-1] = self.indicesSized[i-1][1]
+          # increment next index
+          if i >= len(self.indicesSized):
+            moreProblemSizes = False
+          else:
+            currentSizedIndexSizes[i] += currentSizedIndexIncrements[i]
+            currentSizedIndexIncrements[i] += self.indicesSized[i][2]
+
+      problemIdx+=1
+
+  ########################################
+  # YAML format
+  def __str__(self):
+    state = "[ "
+    sizedIdx = 0
+    mappedIdx = 0
+    for i in range(0, len(self.indexIsSized)):
+      if self.indexIsSized[i]:
+        indices = self.indicesSized[sizedIdx]
+        state += "[ %u, %u, %u, %u ]" \
+            % (indices[0], indices[1], indices[2], indices[3])
+        sizedIdx += 1
+      else:
+        indices = self.indicesSized[self.indicesMapped[mappedIdx]]
+        state += str(self.indicesMapped[mappedIdx])
+        mappedIdx += 1
+      if i < len(self.indexIsSized)-1:
+        state += ", "
+    state += " ]"
+    return state
+
+class Problem:
+  """ Problem sizes, strides, padding and other info"""
+  def __init__(self, sizes=None, stridesA=None, stridesB=None, stridesC=None, stridesD=None, count=None):
+    self.sizes = tuple(sizes) if sizes else None
+    self.stridesA = tuple(stridesA) if stridesA else None
+    self.stridesB = tuple(stridesB) if stridesB else None
+    self.stridesC = tuple(stridesC) if stridesC else None
+    self.stridesD = tuple(stridesD) if stridesD else None
+
+    self.count = count
+
+  def __str__(self):
+    rv= "{ sizes:" + str(list(self.sizes))
+    if self.stridesA:
+      rv += ", stridesA:" + str(list(self.stridesA))
+    if self.stridesB:
+      rv += ", stridesB:" + str(list(self.stridesB))
+    if self.stridesC:
+      rv += ", stridesC:" + str(list(self.stridesC))
+    if self.stridesD:
+      rv += ", stridesD:" + str(list(self.stridesD))
+    rv += " }"
+    return rv
+
+class ExactList(Problem):
+  def __init__(self, e, problemType):
+    if len(e) == problemType["TotalIndices"]:
+      if -1 in e:
+        printExit("ExactSize %s contains -1" % (e))
+      if problemType["OperationType"] == "GEMM":
+        e += [-1, -1, -1, -1]
+        e = ExactList.convertLeadingDims(problemType, tuple(e))
+      sizes=e
+
+    elif len(e) == (problemType["TotalIndices"] + problemType["NumIndicesLD"]):
+      sizes = ExactList.convertLeadingDims(problemType, tuple(e))
+    else:
+      printExit("ExactSize %s doesn't match indices of ProblemType %s, totalIndices=%d, len e=%d, NumIndicesLD = %d" \
+          % (e, problemType, problemType["TotalIndices"], len(e), problemType["NumIndicesLD"]) )
+
+    # TODO- pass strides here, remove calls to convertLeadingDims
+    Problem.__init__(self, sizes=sizes)
+
+  def __str__(self):
+    return str(list(self.sizes))
+
+  @staticmethod
+  def convertLeadingDims(problemType, problemSize, stridesA = None, stridesB = None, stridesC = None, stridesD = None):
+    # FIXME-problem: refactor to eliminate max, pass strides in strideB parm rather than hacked
+    # onto the end of the sizes list
+    predStridesD = stridesD is not None and stridesD[1] != -1
+    predStridesC = stridesC is not None and stridesC[1] != -1
+    predStridesA = stridesA is not None and stridesA[1] != -1
+    predStridesB = stridesB is not None and stridesB[1] != -1
+    return problemSize[:problemType["NumIndicesC"]+1] + \
+           (max(problemSize[0], problemSize[problemType["IndexAssignmentsLD"][0]]) if not predStridesD else stridesD[1], ) + \
+           (max(problemSize[0], problemSize[problemType["IndexAssignmentsLD"][1]]) if not predStridesC else stridesC[1], ) + \
+           (max(problemSize[problemType["IndexAssignmentsLD"][2]],
+                problemSize[problemType["IndexAssignmentsA"][0]]) if not predStridesA else stridesA[1], ) + \
+           (max(problemSize[problemType["IndexAssignmentsLD"][3]],
+                problemSize[problemType["IndexAssignmentsB"][0]]) if not predStridesB else stridesB[1], )
+
+
+class ExactDict(Problem):
+  AllowedFields = [ 'count', 'sizes', 'stridesA', 'stridesB', 'stridesC', 'stridesD' ]
+
+  def __init__(self, e, problemType):
+    Problem.__init__(self)
+
+    for f in e:
+      if f in ExactDict.AllowedFields:
+        setattr(self, f, e[f])
+      else:
+        raise RuntimeError ("specified field '%s' is not a valid Exact dict field"%f)
+
+    if problemType:
+      if "OperationType" in problemType and problemType["OperationType"] == "GEMM":
+        sizesTuple = tuple(self.sizes + [-1, -1, -1, -1])
+        self.sizes = ExactList.convertLeadingDims(problemType, sizesTuple, self.stridesA, self.stridesB, self.stridesC, self.stridesD)
+
+    if problemType:
+      if "OperationType" in problemType and problemType["OperationType"] == "GEMM":
+        if len(self.sizes) != (problemType["TotalIndices"] + problemType["NumIndicesLD"]):
+        # FIXME-ExactDict size descriptor still (but preferrably not so) uses 8-tuple for GEMM problems
+          raise RuntimeError ("specified size=%s does not have enough indices for problem (expected %d, got %d)" \
+                % (self.sizes, problemType["TotalIndices"]+problemType["NumIndicesLD"], len(self.sizes)))
+      elif len(self.sizes) != problemType["TotalIndices"]:
+        raise RuntimeError ("specified size=%s does not have enough indices for problem (expected %d, got %d)" \
+                % (self.sizes, problemType["TotalIndices"], len(self.sizes)))
+
+
+################################################################################
+# ProblemSizes
+################################################################################
+"""
+Adapter class for class `ProblemSizes`. It satisfies the implicit usage requirement
+of ClientWriter.writeClientConfig() by converting ExactLogic to list of `Problem` objects
+"""
+class ProblemSizesMock:
+  def __init__(self, exactLogic):
+    self.problems = [Problem(problem) for problem, solution in exactLogic]
+
+class ProblemSizesMockDummy:
+  def __init__(self):
+    self.problems = [Problem(sizes=[128, 128, 1, 512])]
+
+class ProblemSizes:
+
+  ########################################
+  def __init__(self, problemType, config):
+    self.problemType = problemType
+    self.ranges = []
+    self.exacts = []
+    self.minStrides = None
+    if config:
+      for dictionary in config:
+        for sizeTypeKey in dictionary:
+          #print ("PROBLEM parsed:", sizeTypeKey, dictionary[sizeTypeKey])
+          if sizeTypeKey == "Range":
+            psr = ProblemSizeRange(problemType, dictionary[sizeTypeKey])
+            self.ranges.append( psr )
+          elif sizeTypeKey == "Exact":
+            e= dictionary[sizeTypeKey]
+            if isinstance(e,list):
+              self.exacts.append(ExactList(e, problemType))
+            elif isinstance(e,dict):
+              self.exacts.append(ExactDict(e, problemType))
+            else:
+              printExit("Unsupported Exact type==%s"%type(e))
+          elif sizeTypeKey == "MinStride":
+            e = dictionary[sizeTypeKey]
+            if len(e) != problemType["TotalIndices"]:
+              printExit("MinStride %s doesn't match indices of ProblemType %s" \
+                  % (e, problemType) )
+            if self.minStrides:
+              printExit("Only one MinStride command is allowed in a ProblemsSizes definition.  Previous minStrides:%s, New minstride:%s" \
+                  % (self.minStrides, e) )
+
+            self.minStrides=(tuple(e))
+          else:
+            printExit("ProblemSize Type %s not supported"%sizeTypeKey)
+
+    if not self.minStrides:
+      # set harmless default mins of 0
+      self.minStrides = ([0]* problemType["TotalIndices"])
+
+    # not the ideal spot, but convert leading dims that are below the minimum size
+    if problemType["OperationType"] == "GEMM":
+      for i in range(0, len(self.ranges)):
+        self.ranges[i].problemSizes[:] = \
+          [ExactList.convertLeadingDims(self.problemType, problemSize) for problemSize in self.ranges[i].problemSizes]
+
+    self.problems = OrderedDict()
+    for sizeRange in self.ranges:
+      for rangeSize in sizeRange.problemSizes:
+        self.problems.update({Problem(rangeSize) : 1})
+    for e in self.exacts:
+        self.problems.update({e : 1})
+    self.problems =  list(self.problems.keys())
+    self.totalProblemSizes = len(self.problems)
+
+    # max sizes
+    self.maxD = 0
+    self.maxC = 0
+    self.maxA = 0
+    self.maxB = 0
+    for problem in self.problems:
+      problemSize = problem.sizes # FIXME-problem.   This should use problem.strides*
+
+      sizeLdd = problemSize[self.problemType["IndexAssignmentsLD"][0]] if problemType["OperationType"] == "GEMM" else problemSize[0]
+      sizeD = max(self.minStrides[0], sizeLdd)
+      for i in range(1, problemType["NumIndicesC"]):
+        sizeD *= max(self.minStrides[i], problemSize[i])
+
+      sizeLdc = problemSize[self.problemType["IndexAssignmentsLD"][1]] if problemType["OperationType"] == "GEMM" else problemSize[0]
+      sizeC = max(self.minStrides[0], sizeLdc)
+      for i in range(1, problemType["NumIndicesC"]):
+        sizeC *= max(self.minStrides[i], problemSize[i])
+
+      sizeLda = problemSize[self.problemType["IndexAssignmentsLD"][2]] \
+                if problemType["OperationType"] == "GEMM" \
+                else problemSize[self.problemType["IndexAssignmentsA"][0]]
+      sizeA = max(self.minStrides[self.problemType["IndexAssignmentsA"][0]], sizeLda)
+      for i in self.problemType["IndexAssignmentsA"][1:]:
+        sizeA *= max(self.minStrides[i], problemSize[i])
+
+      sizeLdb = problemSize[self.problemType["IndexAssignmentsLD"][3]] \
+                if problemType["OperationType"] == "GEMM" \
+                else problemSize[self.problemType["IndexAssignmentsB"][0]]
+      sizeB = max(self.minStrides[self.problemType["IndexAssignmentsB"][0]], sizeLdb)
+      for i in self.problemType["IndexAssignmentsB"][1:]:
+        sizeB *= max(self.minStrides[i], problemSize[i])
+
+      self.maxD = max(self.maxD, sizeD)
+      self.maxC = max(self.maxC, sizeC)
+      self.maxA = max(self.maxA, sizeA)
+      self.maxB = max(self.maxB, sizeB)
+
+  def __str__(self):
+    s = "ProblemSizes\n"
+    for sizeRange in self.ranges:
+      s += "  %s" % sizeRange
+    return s
+
+################################################################################
+# ProblemType
+# name of solution should begin with name of problemType, and arguments can be listed out explicitly
+
+################################################################################
+# Default Problem Type
+################################################################################
+_defaultProblemType = {
+    # =GEMM uses TransposeA,B parameters and makes the problem type more readable for users
+    # =TensorContraction  requires specifying
+    "OperationType": "GEMM",  # GEMM, TensorContraction, ConvolutionForward, ConvolutionBackwardData, ConvolutionBackwardWeights
+    "DataType": 0,  # data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "DataTypeA": 0,  # A data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "DataTypeB": 0,  # B data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "DataTypeE": 0,  # E data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "DataTypeAmaxD": 0,  # AmaxD data type can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "DestDataType": 0,  # destination data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "ComputeDataType": 0,  # compute data types can specified by a variety of ways, such as "s", as listed in SolutionStructs.py::DataType
+    "F32XdlMathOp": 0,  # reducing intermediate precision from f32 to a specific type, such as "x", as listed in SolutionStructs.py::DataType.
+    # in:f32, intermediate:xf32, out:f32. f32 = xf32(f32) * xf32(f32)
+    "UseBeta": True,  # =True use beta parameter (asm will check for B=0 and optimize the write for that), =False don't use beta parameter
+    "UseE": False,  # =True use output E to output gemm results before activation
+    "Gradient": False,  # =True set globalWriteElements to gradient mode
+    "UseBias": 0,  # =1 support bias vector on M direction, =2 support bias vector on N direction, =3 support bias vector on both M,N direction
+    "BiasSrc": "D",  # This parameter is used in gradient + bias. Support A, B, D.
+    "UseScaleAB": "",  # Support "", "Scalar", and "Vector"
+    "UseScaleCD": False,  # =True use scaleC, scaleD
+    "UseScaleAlphaVec": 0,  # =1 support alpha vector on M direction, =2 support bias vector on N direction, =3 support alpha vector on both M,N direction
+    "HighPrecisionAccumulate": False,  # f32 += f16*f16
+    "SilentHighPrecisionAccumulate": False,  # Keep kernel names the same for HPA mode.  Useful for testing.
+    "Sparse": 0,  # 4:2 Structured Sparse A Matrix, 0=Non Sparse, 1=Sparse Matrix A, 2=Sparse Matrix B
+    "ComplexConjugateA": False,  # complex data should be conjugated for "C" transpose case
+    "ComplexConjugateB": False,
+    "StochasticRounding": False,  # By default, IEEE RNE rounding
+    # for OperationType == GEMM
+    "TransposeA": False,  # =True means transA="T" or "C", =False means transA = "N"
+    "TransposeB": True,
+    "Batched": False,  # add batching dimension
+    "StridedBatched": True,  # use to select general batch or strided batch
+    "GroupedGemm": False,  # use to select general batch or strided batch
+    # for OperationType == TensorContraction
+    # - Indices < NumIndicesC are Free or Batch indices and appear in C and D
+    # - Indices which appear in both A and B, and are < NumIndicesC are batch.  A and B must have same number of batch indices.
+    # - Indices which appear in both A and B, and are >= NumIndicesC are summation. A and B must have same number of summation indices.
+    # - Indices which appear in A or B (but not both), are Free.  A and B may have different numbers of free indices.
+    # - Summation loops are nested from smallest index number to largest, with the largest summation index as the 'unroll' loop.
+    # - Memory order of C and D matrices is always 0..NumIndicesC-1, with 0 as the fastest-moving.
+    #   - By choosing index assignments the output can be 'transposed'.  For example if IA=[1,2] IB=[0,2] then 0 is the coalesced dim for C/D.
+    #   - Likewise batch index may be assigned between two free indices to control the output order, ie to write in CNHW format.
+    #   - For example : IA=[0,1,3] IB=[2,1,3].  0,2 are free indices;  1 is batch.
+    "IndexAssignmentsA": [0, 2],
+    "IndexAssignmentsB": [1, 2],
+    "NumIndicesC": 2,
+    # use initial strides for AB.
+    # This has some performance impact for the increased flexibility:
+    #   - Additional strides will be passed into the kernel and will occupy SGPR registers
+    #   - GlobalReadWidth must be 1 (since elements are not guaranteed to be adjacent in memory)
+    "UseInitialStridesAB": False,
+    # use initial strides for CD.
+    # This has some performance impact for the increased flexibility:
+    #   - Additional strides will be passed into the kernel and will occupy SGPR registers
+    #   - Additional multiply on the store address path
+    #   -VectorStore must be 0.  If VectorStore is -1, it will be silently set to 0 internally.
+    "UseInitialStridesCD": False,
+    "AllowNoFreeDims": False,  # allow A or B to specify no free dims
+    # (if false, A and B must have at least one free dim)
+    # (if true, A and B must have at least one free or batch dim)
+    # SetConstStride* sets the specified stride in the problem.
+    # These no longer generate predicates - see AssertStrideEqualA/B below
+    # List of pairs of [index, constValue].
+    # Index is a member of the global index assignments (not an offset into IndexAssignmentsA/B)
+    # EX: SetConstStrideA: [ [3, 1], [2, 4] ] sets
+    #     strideA for index3 to constant '1' and stride for index2 to constant '4'.
+    "SetConstStrideA": [],
+    "SetConstStrideB": [],
+    "SetConstStrideBias": [],
+    # Summation dimension indices
+    "MirrorDimsA": [],
+    "MirrorDimsB": [],
+    "MirrorDimsMetadata": [],
+    # for LD description
+    "NumIndicesLD": 4,
+    "IndexAssignmentsLD": [3, 4, 5, 6],  # order is LDD, LDC, LDA, LDB
+    # Tile aware solution selection
+    "TileAwareSelection": False,
+    # Activation
+    "Activation": False,
+    "ActivationNoGuard": False,
+    # AmaxD
+    "OutputAmaxD": False,
+    # For kernels putting arguments in workspaces instead of kernel arguments, they can choose to support user arguments input instead.
+    "SupportUserArgs": True,
+    "SwizzleTensorA": False,
+    "SwizzleTensorB": False,
+}
+
+# The supported typed GEMM, each entry is (Ti, To, Tc).
+# DataType (Ti)        = The data-type of the input matrices: A/B
+# DestDataType (To)    = The data-type of the output matrices: C/D
+# ComputeDataType (Tc) = The data-type of computation: alpha/beta:
+# Cinternal: basically should == ComputeDataType
+# This is used in _checkIfSupportedGEMMType()
+_validGEMMTypes = [
+    ("H", "H", "H"),
+    ("S", "S", "S"),
+    ("D", "D", "D"),
+    ("C", "C", "C"),
+    ("Z", "Z", "Z"),
+    ("H", "H", "S"),
+    ("H", "S", "S"),
+    ("B", "B", "S"),
+    ("B", "S", "S"),
+    ("B", "H", "S"),
+    ("I8", "I", "I"),
+    ("4xi8", "I", "I"),
+    ("I8", "I8", "I"),
+    ("I8", "I", "S"),
+    ("I8", "I8", "S"),
+    ("I8", "H", "S"),
+    ("I8", "B", "S"),
+    ("F8", "S", "S"),
+    ("B8", "S", "S"),
+    ("F8B8", "S", "S"),
+    ("B8F8", "S", "S"),
+    ("F8", "H", "S"),
+    ("B8", "H", "S"),
+    ("F8B8", "H", "S"),
+    ("B8F8", "H", "S"),
+    ("B8", "B", "S"),
+    ("H", "F8", "S"),
+    ("F8", "B", "S"),
+    ("F8B8", "B", "S"),
+    ("B8F8", "B", "S"),  # in/out are both R8
+    ("F8", "F8", "S"),
+    ("B8", "B8", "S"),
+    ("F8B8", "B8", "S"),
+    ("B8F8", "B8", "S"),
+    ("F8", "B8", "S"),
+    ("B8", "F8", "S"),
+    ("F8B8", "F8", "S"),
+    ("B8F8", "F8", "S"),  # F8 NANOO
+    ("F8N", "S", "S"),
+    ("B8N", "S", "S"),
+    ("F8B8N", "S", "S"),
+    ("B8F8N", "S", "S"),
+    ("F8N", "H", "S"),
+    ("B8N", "H", "S"),
+    ("F8B8N", "H", "S"),
+    ("B8F8N", "H", "S"),
+    ("B8N", "B", "S"),
+    ("H", "F8N", "S"),
+    ("F8N", "B", "S"),
+    ("F8B8N", "B", "S"),
+    ("B8F8N", "B", "S"),  # in/out are both R8
+    ("F8N", "F8N", "S"),
+    ("B8N", "B8N", "S"),
+    ("F8B8N", "B8N", "S"),
+    ("B8F8N", "B8N", "S"),
+    ("F8N", "B8N", "S"),
+    ("B8N", "F8N", "S"),
+    ("F8B8N", "F8N", "S"),
+    ("B8F8N", "F8N", "S"),
+]
+
+
+# All HPA types are listed here (HPA=T). The name of the library logic files for these types is:
+# *_TiToTc_BH*.yaml where Ti, To, and Tc are the data types of A/B, C/D, and computation, respectively.
+# The name of the library logic files for non-HPA (HPA=F) types is: *_TiB*.yaml.
+_HPATypes = [
+    ("H", "S", "S"),
+    ("H", "H", "S"),
+    ("B", "B", "S"),
+    ("B", "S", "S"),
+    ("B", "H", "S"),
+    ("I8", "I", "I"),
+    ("4xi8", "I", "I"),
+    ("I8", "I", "S"),
+    ("I8", "I8", "S"),
+    ("I8", "H", "S"),
+    ("I8", "B", "S"),
+    ("F8", "S", "S"),
+    ("B8", "S", "S"),
+    ("F8B8", "S", "S"),
+    ("B8F8", "S", "S"),
+    ("F8", "H", "S"),
+    ("B8", "H", "S"),
+    ("F8B8", "H", "S"),
+    ("B8F8", "H", "S"),
+    ("H", "F8", "S"),
+    ("F8", "B", "S"),
+    ("F8B8", "B", "S"),  # in/out are both R8
+    ("F8", "F8", "S"),
+    ("B8", "B8", "S"),
+    ("F8B8", "B8", "S"),
+    ("B8F8", "B8", "S"),
+    ("F8", "B8", "S"),
+    ("B8", "F8", "S"),
+    ("F8B8", "F8", "S"),
+    ("B8F8", "F8", "S"),
+    ("F8N", "S", "S"),
+    ("B8N", "S", "S"),
+    ("F8B8N", "S", "S"),
+    ("B8F8N", "S", "S"),
+    ("F8N", "H", "S"),
+    ("B8N", "H", "S"),
+    ("F8B8N", "H", "S"),
+    ("B8F8N", "H", "S"),
+    ("H", "F8N", "S"),
+    ("F8N", "B", "S"),
+    ("F8B8N", "B", "S"),  # in/out are both R8
+    ("F8N", "F8N", "S"),
+    ("B8N", "B8N", "S"),
+    ("F8B8N", "B8N", "S"),
+    ("B8F8N", "B8N", "S"),
+    ("F8N", "B8N", "S"),
+    ("B8N", "F8N", "S"),
+    ("F8B8N", "F8N", "S"),
+    ("B8F8N", "F8N", "S"),
+]
+
+
+class ProblemType(Mapping):
+  ########################################
+
+  @classmethod
+  def FromDefaultConfig(printIndexAssignmentInfo: bool):
+    return ProblemType(_defaultProblemType, printIndexAssignmentInfo)
+
+  def __init__(self, config, printIndexAssignmentInfo: bool):
+    self.state = {}
+
+    for key in _defaultProblemType:
+      assignParameterWithDefault(self.state, key, config, _defaultProblemType)
+
+    # adjusting all data types
+    if "DataType" in config:
+      self["DataType"]  = DataType(config["DataType"])
+      self["DataTypeA"] = self["DataType"]
+      self["DataTypeB"] = self["DataType"]
+    else:
+      raise Exception("NO data type specified")
+      self["DataType"]  = DataType(0)
+      self["DataTypeA"] = DataType(0)
+      self["DataTypeB"] = DataType(0)
+
+    if "DataTypeA" in config:
+      self["DataTypeA"] = DataType(config["DataTypeA"])
+
+    if "DataTypeB" in config:
+      self["DataTypeB"] = DataType(config["DataTypeB"])
+
+    if "DestDataType" in config:
+      self["DestDataType"] = DataType(config["DestDataType"])
+    else:
+      if "DataType" in config:
+        self["DestDataType"] = DataType(config["DataType"])
+      else:
+        raise Exception("NO dest data type or data type specified")
+        self["DataType"] = DataType(0)
+
+    self["DataTypeE"] = self["DestDataType"]
+    if "DataTypeE" in config:
+      self["DataTypeE"] = DataType(config["DataTypeE"])
+
+    if "ComputeDataType" in config:
+      self["ComputeDataType"] = DataType(config["ComputeDataType"])
+    else:
+      if "DestDataType" in config:
+        self["ComputeDataType"] = DataType(config["DestDataType"])
+      else:
+        if "DataType" in config:
+          self["ComputeDataType"] = DataType(config["DataType"])
+        else:
+          raise Exception("NO compute data type, or dest data type, or data type specified")
+          self["DataType"] = DataType(0)
+
+    # Just like DataTypeE is DestDataType by default; DataTypeAmaxD if ComputeDataType by default.
+    # So far we don't have to set it in config yamls
+    self["DataTypeAmaxD"] = self["ComputeDataType"]
+    if "DataTypeAmaxD" in config:
+      self["DataTypeAmaxD"] = DataType(config["DataTypeAmaxD"])
+
+    if self["Sparse"]:
+      self["DataTypeMetadata"] = DataType("I8")
+
+    if "F32XdlMathOp" in config:
+        self["F32XdlMathOp"] = DataType(config["F32XdlMathOp"])
+    else:
+        self["F32XdlMathOp"] = DataType(0)
+
+    # Modifying ComputeDataType for HHH+HPA: if (HHH+HPA), convert it to HHS_BH by setting ComputeDataType to S.
+    if self["ComputeDataType"].isHalf() and self["DataType"].isHalf() and self["HighPrecisionAccumulate"]:
+      printWarning("Inconsistent DataTypes: DataType == f16, DestType == f16, ComputeDataType == f16, but HPA == True (HHH+HPA, no such a type); Converting HHH+HPA to HHS_BH by setting compute data type to f32.")
+      self["ComputeDataType"] = DataType('s')
+
+    # Modifying ComputeDataType for BBB+HPA: if (BBB+HPA), convert it to BBS_BH by setting ComputeDataType to S.
+    if self["ComputeDataType"].isBFloat16() and self["DataType"].isBFloat16() and self["HighPrecisionAccumulate"]:
+      printWarning("Inconsistent DataTypes: DataType == bf16, DestType == bf16, ComputeDataType == bf16, but HPA == True (BBB+HPA, no such a type); Converting BBB+HPA to BBS_BH by setting compute data type to f32.")
+      self["ComputeDataType"] = DataType('s')
+
+    # Modifying ComputeDataType for I8I8I_BH: if (I8I8I8+HPA), convert it to I8I8I_BH by setting ComputeDataType to i.
+    if self["ComputeDataType"].isInt8() and DataType(config["DataType"]).isInt8() and self["HighPrecisionAccumulate"]:
+      print2("DataType == i8 and HPA == True; setting compute data type to int32")
+      self["ComputeDataType"] = DataType('i')
+
+    if self["OperationType"] == "GEMM":
+      self._checkIfSupportedGEMMType()
+      self.initGEMM()
+    else:
+      raise Exception("Unsupported OperationType = %s" % self["OperationType"])
+
+    self.state["AssignedDerivedParameters"] = False
+    ProblemType.assignDerivedParameters(self.state, printIndexAssignmentInfo)
+
+    for tc in ('A', 'B'):
+      for sc in self["SetConstStride%s"%tc] :
+          (anchorDim, stride) = sc[:2]
+          if anchorDim not in self.state["IndexAssignments%s"%tc]:
+              raise Exception("SetConstStride%s=%s anchorDim=%u is not in IndexAssignments%s"%(tc, sc, anchorDim, tc))
+
+    # Bias
+    # If compute data type is not equal to dest data type, tensile will run conversion kernel.
+    # In this case we don't need to apply bias in beta only kernel.
+    if "UseBias" in config:
+      if self["ComputeDataType"] != self["DestDataType"]:
+        self["BetaOnlyUseBias"] = False
+      else:
+        self["BetaOnlyUseBias"] = True if self["UseBias"] > 0 else False
+      if "BiasDataTypeList" in config:
+        self["BiasDataTypeList"] = [DataType(btype) for btype in config["BiasDataTypeList"]]
+        self["BiasDataTypeList"].sort() # Make name unique
+      else:
+        self["BiasDataTypeList"] = getBiasDataTypeListDefault(self)
+    else:
+      self["BetaOnlyUseBias"] = False
+      self["BiasDataTypeList"] = []
+
+    # Activation
+    # Currently, ActivationType supports only 'all' and 'hipblaslt_all', and is active only when the Activation configuration is set to True.
+    # Otherwise, ActivationType will be set to 'none'.
+    if "Activation" in config:
+      typeStr = config.get("ActivationType", 'none')
+      if typeStr not in ['all', 'hipblaslt_all']:
+        typeStr = 'none'
+    else:
+      typeStr = 'none'
+    self["ActivationType"] = ActivationType(typeStr)
+    if "ActivationComputeDataType" in config:
+      self["ActivationComputeDataType"] = DataType(config["ActivationComputeDataType"])
+    else:
+      self["ActivationComputeDataType"] = self["ComputeDataType"]
+
+    if self["ActivationType"] != 'none':
+      # This is a dummy guard in case we currently don't have a converter to convert data from compute type to activation compute type
+      if self["ActivationComputeDataType"] not in [self["ComputeDataType"], self["DestDataType"]]:
+        printWarning("TensileLite currently only supports ActivationComputeDataType (%s) = ComputeDataType (%s) or DestDataType (%s). \
+                      ActivationComputeDataType will be set to ComputeDataType automatically."%(self["ActivationComputeDataType"].toChar(), \
+                                                                                                self["ComputeDataType"], \
+                                                                                                self["DestDataType"]))
+        self["ActivationComputeDataType"] = self["ComputeDataType"]
+      if (self["ActivationComputeDataType"].numRegisters() != self["ComputeDataType"].numRegisters()) and \
+        (self["DataType"].numRegisters() < self["DestDataType"].numRegisters()):
+        printWarning("TensileLite only supports ActivationComputeDataType = ComputeDataType if DestDataType > DataType. \
+                      ActivationComputeDataType will be set to ComputeDataType automatically.")
+        self["ActivationComputeDataType"] = self["ComputeDataType"]
+
+    if "UseE" in config:
+      if config["UseE"]:
+        if self["ActivationType"] == 'none':
+          printWarning("Use E is disabled cause Activation is set to False.")
+          self["UseE"] = False
+        else:
+          self["UseE"] = config["UseE"]
+      else:
+        self["UseE"] = config["UseE"]
+
+    if "Gradient" in config:
+      if config["Gradient"]:
+        if (not self["UseBias"]) and self["ActivationType"] == 'none':
+          printWarning("Gradient is disabled cause bias and activation are both disabled.")
+          self["Gradient"] = False
+        if self["ActivationType"] != 'none' and self["UseE"] == False:
+          printWarning("Use E is enabled cause Activation is enabled.")
+          self["UseE"] = True
+        elif self["ActivationType"] != 'none' and self["UseE"] == False:
+          printWarning("Use E is disabled cause Activation is disabled.")
+          self["UseE"] = False
+        # if self["UseScaleAlphaVec"]:
+        #   printWarning("Use scaleAlphaVec is disabled cause Gradient is enabled.")
+        #   self["UseScaleAlphaVec"] = False
+      self["Gradient"] = config["Gradient"]
+
+    # Need gradient info
+    biasSrcList = ["A", "B", "D"]
+    if "BiasSrc" in config:
+      if not self["Gradient"] and config["BiasSrc"] != "D":
+        printWarning("BiasSrc is set to D cause Gradient is disabled.")
+        self["BiasSrc"] = "D"
+      elif self["Gradient"]:
+        # # Currently only supports D :)
+        # if config["BiasSrc"] != "D":
+        #   raise Exception("BiasSrc currently only supports D.")
+        if config["BiasSrc"] not in biasSrcList:
+          raise Exception("BiasSrc only supports A, B, D.")
+
+    if "ActivationNoGuard" in config:
+      self["ActivationNoGuard"] = config["ActivationNoGuard"]
+      if self["ActivationNoGuard"]:
+        if self["ActivationType"] == 'none':
+          printWarning("ActivationNoGuard is set to False cause Acivation is off.")
+          self["ActivationNoGuard"] = False
+        if (not self["Gradient"]):
+          printWarning("ActivationNoGuard is set to False cause Gradient is off.")
+          self["ActivationNoGuard"] = False
+
+  ################################################################################
+   # Function checkIfSupportedGEMMType:
+  #   Assures 3 data-types are valid, supported and well-assigned
+  #   See the discussion in ValidParameters.py for validGEMMTypes
+  ################################################################################
+  def _checkIfSupportedGEMMType(self):
+    inType = self["DataType"]
+    outType = self["DestDataType"]
+    computeType = self["ComputeDataType"]
+
+    gemmType = ( inType.toChar(), outType.toChar(), computeType.toChar() )
+    if gemmType not in _validGEMMTypes:
+      raise Exception("This typed-GEMM (Ti, To, Tc) = (%s, %s, %s) is not supported yet."%(gemmType[0], gemmType[1], gemmType[2]))
+
+  ########################################
+  def initGEMM(self):
+    sumIdx = 3 if self["Batched"] else 2
+    self["IndexAssignmentsA"] = [0, sumIdx] # N
+    self["IndexAssignmentsB"] = [sumIdx, 1] # N
+    if self.state["Sparse"] == 2:
+      self["IndexAssignmentsMetadata"] = [sumIdx, 1] # N (ref B)
+    else:
+      self["IndexAssignmentsMetadata"] = [sumIdx, 0] # T (ref A)
+    if self["TransposeA"]:
+      self["IndexAssignmentsA"] = [sumIdx, 0] # T
+    if self["TransposeB"]:
+      self["IndexAssignmentsB"] = [1, sumIdx] # T
+    if self["Batched"]:
+      self["IndexAssignmentsA"].append(2)
+      self["IndexAssignmentsB"].append(2)
+      self["IndexAssignmentsMetadata"].append(2)
+      self["NumIndicesC"] = 3
+    else:
+      self["NumIndicesC"] = 2
+
+    self["NumIndicesLD"] = 4
+    self["IndexAssignmentsLD"][0] = self["NumIndicesC"] + 1
+    for i in range(1, len(self["IndexAssignmentsLD"])):
+      self["IndexAssignmentsLD"][i] = self["IndexAssignmentsLD"][i-1] + 1
+
+  ########################################
+  def isGEMM(self):
+    return self.operationType == 0
+
+  ########################################
+  # determine d0, d1, dU
+  @staticmethod
+  def assignDerivedParameters(state, printIndexAssignmentInfo: bool=False):
+    if "AssignedDerivedParameters" in state:
+      if state["AssignedDerivedParameters"]:
+        return
+    state["AssignedDerivedParameters"] = False
+
+    state["TotalIndices"] = max(max(state["IndexAssignmentsA"])+1, \
+        max(state["IndexAssignmentsB"])+1)
+
+    # determine num free, batch
+    state["IndicesFree"] = []
+    state["IndicesBatch"] = []
+    state["IndicesSummation"] = []
+
+    for i in range(0, state["NumIndicesC"]):
+      inA = i in state["IndexAssignmentsA"]
+      inB = i in state["IndexAssignmentsB"]
+      if inA and inB:
+        state["IndicesBatch"].append(i)
+
+      elif inA or inB:
+        state["IndicesFree"].append(i)
+      else:
+        raise Exception("invalid index %u (inC but not (inA or inB))" % i)
+
+    # determine num summation
+    for i in range(state["NumIndicesC"], state["TotalIndices"]):
+      inA = i in state["IndexAssignmentsA"]
+      inB = i in state["IndexAssignmentsB"]
+      if inA and inB:
+        state["IndicesSummation"].append(i)
+      else:
+        raise Exception("invalid index %u (expected summation but not (inA and inB))" % i)
+    # print index assignments
+    if printIndexAssignmentInfo:
+      print("IndicesFree:  %s" % state["IndicesFree"])
+      print("IndicesBatch: %s" % state["IndicesBatch"])
+      print("IndicesSum:   %s" % state["IndicesSummation"])
+      print("IndexAssignmentsA:   %s" % state["IndexAssignmentsA"])
+      print("IndexAssignmentsB:   %s" % state["IndexAssignmentsB"])
+      print("NumIndicesC:  %s" % state["NumIndicesC"])
+
+    for k in ('IndexAssignmentsA','IndexAssignmentsB'):
+      if len(state[k]) != len(set(state[k])):
+        raise Exception("duplicate index in %s=%s"% (k,state[k]))
+
+    state["NumIndicesFree"] = len(state["IndicesFree"])
+    state["NumIndicesBatch"] = len(state["IndicesBatch"])
+    state["NumIndicesSummation"] = len(state["IndicesSummation"])
+    if not state["AllowNoFreeDims"] and state["NumIndicesFree"] < 2 :
+      raise Exception("Tensile requires >= 2 free indices or set AllowNoFreeDims; FreeIndices=%s."% state["IndicesFree"])
+
+    # by default, unroll index will be the last/inner summation index
+    state["IndexUnroll"] = state["IndicesSummation"][len(state["IndicesSummation"])-1]
+    for i in range(0, len(state["IndexAssignmentsA"])):
+      if state["IndexAssignmentsA"][i] == state["IndexUnroll"]:
+        state["IndexUnrollA"] = i
+        break
+    for i in range(0, len(state["IndexAssignmentsB"])):
+      if state["IndexAssignmentsB"][i] == state["IndexUnroll"]:
+        state["IndexUnrollB"] = i
+        break
+    for i in range(0, len(state["IndexAssignmentsMetadata"])):
+      if state["IndexAssignmentsMetadata"][i] == state["IndexUnroll"]:
+        state["IndexUnrollM"] = i
+        break
+    #print2("IndexUnrollA: %u" % state["IndexUnrollA"])
+    #print2("IndexUnrollB: %u" % state["IndexUnrollB"])
+
+    # assign d0, d1
+    if state["AllowNoFreeDims"]:
+      dimList = state["IndicesFree"] + state["IndicesBatch"]
+    else:
+      dimList = state["IndicesFree"]
+    state["Index01A"] = [i for i in state["IndexAssignmentsA"] if i in dimList][0]
+    state["Index01B"] = [i for i in state["IndexAssignmentsB"] if i in dimList][0]
+    #print2("Index01A: %u" % state["Index01A"])
+    #print2("Index01B: %u" % state["Index01B"])
+    # Store code is optimized for 0 as the fastest-moving in memory
+    # whichever has lower stride in C (lower value), is 0, other is 1
+    if state["Index01A"] < state["Index01B"]:
+      state["Index0"]  = state["Index01A"]
+      state["Index1"]  = state["Index01B"]
+      state["Tensor0"] = 0
+      state["Tensor1"] = 1
+      state["TileA"] = 0
+      state["TileB"] = 1
+    else:
+      state["Index0"]  = state["Index01B"]
+      state["Index1"]  = state["Index01A"]
+      state["Tensor0"] = 1
+      state["Tensor1"] = 0
+      state["TileA"] = 1
+      state["TileB"] = 0
+
+    # generalize transpose
+    strideIdxA = state["IndexAssignmentsA"].index(state["Index01A"])
+    strideIdxB = state["IndexAssignmentsB"].index(state["Index01B"])
+    unrollIdxA = state["IndexAssignmentsA"].index(state["IndexUnroll"])
+    unrollIdxB = state["IndexAssignmentsB"].index(state["IndexUnroll"])
+    state["TLUA"] = strideIdxA < unrollIdxA
+    state["TLUB"] = strideIdxB < unrollIdxB
+    #state["TLUB"] = True # hack
+
+    if printIndexAssignmentInfo:
+      print("TLUA:  %s (stridePosA(%d) <? unrollIdxA(%d)" % \
+			(state["TLUA"], strideIdxA, unrollIdxA))
+      print("TLUB:  %s (stridePosB(%d) <? unrollIdxB(%d)" % \
+	  		(state["TLUB"], strideIdxB, unrollIdxB))
+      print("Index01A:  %s" % state["Index01A"])
+      print("Index01B:  %s" % state["Index01B"])
+    #unrollDimStrideGreaterThanTileDimStrideA = TLUA = !transA = fast
+    #!unrollDimStrideLessThanTileDimStrideB   = TLUB =  transB = fast
+    state["AssignedDerivedParameters"] = True
+
+    if state["Sparse"]:
+      state["Index01Metadata"] = [i for i in state["IndexAssignmentsMetadata"] if i in dimList][0]
+      strideIdxM = state["IndexAssignmentsMetadata"].index(state["Index01Metadata"])
+      unrollIdxM = state["IndexAssignmentsMetadata"].index(state["IndexUnroll"])
+      state["TLUMetadata"] = strideIdxM < unrollIdxM
+      if printIndexAssignmentInfo:
+        print("TLUMetadata:  %s (stridePosM(%d) <? unrollIdxM(%d)" % \
+          (state["TLUMetadata"], strideIdxM, unrollIdxM))
+        print("Index01Metadata:  %s" % state["Index01Metadata"])
+
+  ########################################
+  def __str__(self):
+    indexChars = INDEX_CHARS
+    # C dimensions
+    name = "C"
+    for i in range(0, self["NumIndicesC"]):
+      name += indexChars[i].lower()
+    # A dimensions
+    name += "_A"
+    for i in self["IndexAssignmentsA"]:
+      name += indexChars[i] if i in self["MirrorDimsA"] else indexChars[i].lower()
+    if self["ComplexConjugateA"]:
+      name += "C"
+    # B dimensions
+    name += "_B"
+    for i in self["IndexAssignmentsB"]:
+      name += indexChars[i] if i in self["MirrorDimsB"] else indexChars[i].lower()
+    if self["ComplexConjugateB"]:
+      name += "C"
+
+    # DataTypes
+    if self["DataType"] != self["DataTypeA"] or self["DataType"] != self["DataTypeB"]:
+      name += "_"
+      name += self["DataTypeA"].toChar() + self["DataTypeB"].toChar()
+    name += "_"
+    name += self["DataType"].toChar() # Type of A/B
+
+    # Special condition for some newly supported kernels:
+    #   HHS, HSS, BSS and I8II kernels, use a clearer naming _TiToTc_
+    # TODO: Distinguish all kernels by _TiToTc_ to be more consistent with rocblas
+    gemmType = (self["DataType"].toChar(),self["DestDataType"].toChar(),self["ComputeDataType"].toChar() )
+    if gemmType in _HPATypes:
+      name += self["DestDataType"].toChar()    # Type of C/D
+      name += self["ComputeDataType"].toChar() # Type of Alpha/Beta
+      name += "_"
+
+    if not self["F32XdlMathOp"].isSingle() and self["DataType"].isSingle():
+      name += "_M"
+      name += self["F32XdlMathOp"].toChar()
+      name += "_"
+
+    if self["SwizzleTensorA"]:
+      name += "STA_"
+
+    if self["SwizzleTensorB"]:
+      name += "STB_"
+
+    # Other
+    if self["UseBeta"]: name += "B"
+    if self["HighPrecisionAccumulate"] and not self["SilentHighPrecisionAccumulate"]: name += "H"
+    if self["UseInitialStridesAB"]: name += "I"
+    if self["UseInitialStridesCD"]: name += "Ic"
+    if self["UseBias"]:
+      name += "_Bias"
+      if self["BiasDataTypeList"] != getBiasDataTypeListDefault(self):
+        for i in self["BiasDataTypeList"]:
+          name += i.toChar()
+      if self["BiasSrc"] and self["Gradient"]: # Show bias src if gradient = True
+        name += "_BiasSrc%s"%self["BiasSrc"]
+
+    factorDim = max(self["UseScaleAlphaVec"], self["UseBias"])
+    if factorDim > 1 :
+        name += "_FD%s"%("N" if factorDim == 2 else "MN")
+
+    if self["UseE"]:
+      if self["Gradient"]:
+        name += "_Grad%s"%self["DataTypeE"].toChar()
+      else:
+        name += "_Aux%s"%self["DataTypeE"].toChar() # Not showing aux types
+    if self["OutputAmaxD"]:
+      name += "_AmaxD"
+    if self["Sparse"]:
+      if self["Sparse"] == 2:
+        name += "_SPB"
+      else:
+        name += "_SPA"
+
+    # precision and other
+    # name += "_SB" if self["StridedBatched"] else "_GB"
+    if self["GroupedGemm"]:
+      name += "_GG"
+    else:
+      name += "" if self["StridedBatched"] else "_GB" # legacy
+
+    # Activation Naming
+    if self["ActivationType"] != 'none':
+      if self["ActivationType"] == 'all':
+        name += "_A"
+      elif self["ActivationType"] == 'hipblaslt_all':
+        name += "_HA"
+      else:
+        name += "_%s"%str(self["ActivationType"]).upper()
+      name += self["ActivationComputeDataType"].toChar()
+    if self["ActivationNoGuard"]: name += "NG"
+
+    if self["UseScaleAB"] == "Scalar": name += "_SAB"
+    elif self["UseScaleAB"] == "Vector": name += "_SABV"
+    if self["UseScaleCD"]: name += "_SCD"
+    if self["UseScaleAlphaVec"]: name += "_SAV"
+
+    if self["SupportUserArgs"]: name += "_UserArgs"
+
+    return name
+
+  def keys(self):
+    return list(self.state.keys())
+  def __len__(self):
+    return len(self.state)
+  def __iter__(self):
+    return iter(self.state)
+  def __getitem__(self, key):
+    return self.state[key]
+  def __setitem__(self, key, value):
+    self.state[key] = value
+  def __repr__(self):
+    return self.__str__()
+  def getAttributes(self):
+    return self.state
+  def __hash__(self):
+    return hash(str(self))
+  def __eq__(self, other):
+    return isinstance(other, ProblemType) and self.getAttributes() == other.getAttributes()
+  def __ne__(self, other):
+    result = self.__eq__(other)
+    if result is NotImplemented:
+      return result
+    return not result
+
+  def get(self, key, default=None):
+    try:
+      return self.state[key]
+    except:
+      return default
+
+################################################################################
+# Bias Type
+################################################################################
+
+def getBiasDataTypeListDefault(problem: ProblemType) -> List[DataType]:
+  bList = []
+  for d in ["DataType", "ComputeDataType", "DestDataType"]:
+    dtype = DataType(problem[d])
+    # filter out int8, because it is not supported by bias datatype
+    # TODO
+    if not dtype.isInt8():
+      bList.append(dtype)
+
+  biasDataTypeList = list(set(bList))
+  biasDataTypeList.sort() # Make name unique
+  return biasDataTypeList
+
+

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -22,923 +22,44 @@
 #
 ################################################################################
 
-from .TensileInstructions import DataType, roundUpToNearestMultiple
-from .TensileInstructions.Base import fastdeepcopy as deepcopy
-
-from .KernelWriterBetaOnly import KernelWriterBetaOnly
-from .KernelWriterConversion import KernelWriterConversion
-from .KernelWriterActivationEnumHeader import KernelWriterActivationEnumHeader
-from .KernelWriterActivationFunction import KernelWriterActivationFunction
-from .KernelWriterActivationOnly import KernelWriterActivationOnly
-from .KernelWriterReduction import KernelWriterReduction
-
-from .AsmStoreState import VectorDataTypes
-from .Activation import ActivationType
-
-from .CustomKernels import isCustomKernelConfig
-
-from .Common import assignParameterWithDefault, \
-                    defaultProblemType, defaultSolution, \
-                    defaultInternalSupportParams, \
-                    globalParameters, internalParameters, \
-                    print2, printExit, printWarning, \
-                    validMFMA, validSMFMA, validParameters, \
-                    validGEMMTypes, HPATypes, roundUp, validWMMA, INDEX_CHARS
-
-from collections import OrderedDict
-from collections.abc import Mapping
-from enum import Enum
-from functools import lru_cache
-from typing import List
-
 import collections
 import math
-import operator
-import sys
 
-########################################
-# Print a reject message :
-def reject(state, *args):
-  if state and "NoReject" in state and state["NoReject"]:
-    return
+from enum import Enum
+from typing import List, Dict
 
-  if globalParameters["PrintSolutionRejectionReason"]:
-    sys.stdout.write("\nreject: ")
-    for a in args:
-      print(a)
-    #traceback.print_stack(None, 2)
-    solutionIndex = state["SolutionIndex"] if (state != None and "SolutionIndex" in state) else -1
-    if solutionIndex != -1:
-      # If we have valid solutionIndex, this means we are during TensileCreateLibrary stage
-      # In this stage, all solutions in the logic should be valid
-      # So if any rejection happens, print the warning for further check
-      # This will be done only when --global-parameters=PrintSolutionRejectionReason=True
-      solutionNameMin = state["SolutionNameMin"] if ("SolutionNameMin" in state) else None
-      # if we don't have SolutionNameMin, we simply use the problemTypeName
-      solutionNameMin = str(state["ProblemType"]) if (solutionNameMin == None) else solutionNameMin
-      print("!! Warning: Any rejection of a LibraryLogic is not expected, please check. \
-        SolutionIndex: %d (or SolutionName/ProblemType: %s)"%(solutionIndex, solutionNameMin))
-  if state != None:
-    state["Valid"] = False
+from Tensile.TensileInstructions import DataType, roundUpToNearestMultiple
+from Tensile.TensileInstructions.Base import fastdeepcopy as deepcopy
+from Tensile.KernelWriterBetaOnly import KernelWriterBetaOnly
+from Tensile.KernelWriterConversion import KernelWriterConversion
+from Tensile.KernelWriterActivationEnumHeader import KernelWriterActivationEnumHeader
+from Tensile.KernelWriterActivationFunction import KernelWriterActivationFunction
+from Tensile.KernelWriterActivationOnly import KernelWriterActivationOnly
+from Tensile.KernelWriterReduction import KernelWriterReduction
+from Tensile.Activation import ActivationType
+from Tensile.AsmStoreState import VectorDataTypes
+from Tensile.Common import assignParameterWithDefault, IsaInfo, \
+                    print2, printExit, printWarning, \
+                    roundUp, INDEX_CHARS, IsaVersion, SemanticVersion, \
+                    DepthUConfig
+from Tensile.Common.GlobalParameters import defaultSolution, \
+                                            defaultInternalSupportParams, \
+                                            internalParameters
+from Tensile.SolutionStructs.Naming import getNameFull
+from Tensile.SolutionStructs.Problem import ProblemType
+from Tensile.Toolchain.Component import Assembler
 
-# print a labled variable
-def pvar(state, field):
-  return field + "=" + str(state[field])
-
-def roundupRatio(dividend, divisor):
-  return int(math.ceil(float(dividend) / float(divisor)))
+from .Utilities import reject, roundupRatio, pvar
 
 class Fbs(Enum):
   Free=0     # Expect to be free dimension
   Batch=1    # Expect to be batch dimension
   Sum=2      # Expect to be summation dimension
 
-################################################################################
-# ProblemType
-# name of solution should begin with name of problemType, and arguments can be listed out explicitly
-class ProblemType(Mapping):
-  ########################################
-  def __init__(self, config):
-    self.state = {}
-
-    for key in defaultProblemType:
-      assignParameterWithDefault(self.state, key, config, defaultProblemType)
-
-    # adjusting all data types
-    if "DataType" in config:
-      self["DataType"]  = DataType(config["DataType"])
-      self["DataTypeA"] = self["DataType"]
-      self["DataTypeB"] = self["DataType"]
-    else:
-      printExit("NO data type specified")
-      self["DataType"]  = DataType(0)
-      self["DataTypeA"] = DataType(0)
-      self["DataTypeB"] = DataType(0)
-
-    if "DataTypeA" in config:
-      self["DataTypeA"] = DataType(config["DataTypeA"])
-
-    if "DataTypeB" in config:
-      self["DataTypeB"] = DataType(config["DataTypeB"])
-
-    if "DestDataType" in config:
-      self["DestDataType"] = DataType(config["DestDataType"])
-    else:
-      if "DataType" in config:
-        self["DestDataType"] = DataType(config["DataType"])
-      else:
-        printExit("NO dest data type or data type specified")
-        self["DataType"] = DataType(0)
-
-    self["DataTypeE"] = self["DestDataType"]
-    if "DataTypeE" in config:
-      self["DataTypeE"] = DataType(config["DataTypeE"])
-
-    if "ComputeDataType" in config:
-      self["ComputeDataType"] = DataType(config["ComputeDataType"])
-    else:
-      if "DestDataType" in config:
-        self["ComputeDataType"] = DataType(config["DestDataType"])
-      else:
-        if "DataType" in config:
-          self["ComputeDataType"] = DataType(config["DataType"])
-        else:
-          printExit("NO compute data type, or dest data type, or data type specified")
-          self["DataType"] = DataType(0)
-
-    # Just like DataTypeE is DestDataType by default; DataTypeAmaxD if ComputeDataType by default.
-    # So far we don't have to set it in config yamls
-    self["DataTypeAmaxD"] = self["ComputeDataType"]
-    if "DataTypeAmaxD" in config:
-      self["DataTypeAmaxD"] = DataType(config["DataTypeAmaxD"])
-
-    if self["Sparse"]:
-      self["DataTypeMetadata"] = DataType("I8")
-
-    if "F32XdlMathOp" in config:
-        self["F32XdlMathOp"] = DataType(config["F32XdlMathOp"])
-    else:
-        self["F32XdlMathOp"] = DataType(0)
-
-    # Modifying ComputeDataType for HHH+HPA: if (HHH+HPA), convert it to HHS_BH by setting ComputeDataType to S.
-    if self["ComputeDataType"].isHalf() and self["DataType"].isHalf() and self["HighPrecisionAccumulate"]:
-      printWarning("Inconsistent DataTypes: DataType == f16, DestType == f16, ComputeDataType == f16, but HPA == True (HHH+HPA, no such a type); Converting HHH+HPA to HHS_BH by setting compute data type to f32.")
-      self["ComputeDataType"] = DataType('s')
-
-    # Modifying ComputeDataType for BBB+HPA: if (BBB+HPA), convert it to BBS_BH by setting ComputeDataType to S.
-    if self["ComputeDataType"].isBFloat16() and self["DataType"].isBFloat16() and self["HighPrecisionAccumulate"]:
-      printWarning("Inconsistent DataTypes: DataType == bf16, DestType == bf16, ComputeDataType == bf16, but HPA == True (BBB+HPA, no such a type); Converting BBB+HPA to BBS_BH by setting compute data type to f32.")
-      self["ComputeDataType"] = DataType('s')
-
-    # Modifying ComputeDataType for I8I8I_BH: if (I8I8I8+HPA), convert it to I8I8I_BH by setting ComputeDataType to i.
-    if self["ComputeDataType"].isInt8() and DataType(config["DataType"]).isInt8() and self["HighPrecisionAccumulate"]:
-      print2("DataType == i8 and HPA == True; setting compute data type to int32")
-      self["ComputeDataType"] = DataType('i')
-
-    if self["OperationType"] == "GEMM":
-      self.checkIfSupportedGEMMType()
-      self.initGEMM()
-    else:
-      printExit("Unsupported OperationType = %s" % self["OperationType"])
-
-    self.state["AssignedDerivedParameters"] = False
-    ProblemType.assignDerivedParameters(self.state)
-
-    for tc in ('A', 'B'):
-      for sc in self["SetConstStride%s"%tc] :
-          (anchorDim, stride) = sc[:2]
-          if anchorDim not in self.state["IndexAssignments%s"%tc]:
-              printExit("SetConstStride%s=%s anchorDim=%u is not in IndexAssignments%s"%(tc, sc, anchorDim, tc))
-
-    # Bias
-    # If compute data type is not equal to dest data type, tensile will run conversion kernel.
-    # In this case we don't need to apply bias in beta only kernel.
-    if "UseBias" in config:
-      if self["ComputeDataType"] != self["DestDataType"]:
-        self["BetaOnlyUseBias"] = False
-      else:
-        self["BetaOnlyUseBias"] = True if self["UseBias"] > 0 else False
-      if "BiasDataTypeList" in config:
-        self["BiasDataTypeList"] = [DataType(btype) for btype in config["BiasDataTypeList"]]
-        self["BiasDataTypeList"].sort() # Make name unique
-      else:
-        self["BiasDataTypeList"] = getBiasDataTypeListDefault(self)
-    else:
-      self["BetaOnlyUseBias"] = False
-      self["BiasDataTypeList"] = []
-
-    # Activation
-    # Currently, ActivationType supports only 'all' and 'hipblaslt_all', and is active only when the Activation configuration is set to True.
-    # Otherwise, ActivationType will be set to 'none'.
-    if "Activation" in config:
-      typeStr = config.get("ActivationType", 'none')
-      if typeStr not in ['all', 'hipblaslt_all']:
-        typeStr = 'none'
-    else:
-      typeStr = 'none'
-    self["ActivationType"] = ActivationType(typeStr)
-    if "ActivationComputeDataType" in config:
-      self["ActivationComputeDataType"] = DataType(config["ActivationComputeDataType"])
-    else:
-      self["ActivationComputeDataType"] = self["ComputeDataType"]
-
-    if self["ActivationType"] != 'none':
-      # This is a dummy guard in case we currently don't have a converter to convert data from compute type to activation compute type
-      if self["ActivationComputeDataType"] not in [self["ComputeDataType"], self["DestDataType"]]:
-        printWarning("TensileLite currently only supports ActivationComputeDataType (%s) = ComputeDataType (%s) or DestDataType (%s). \
-                      ActivationComputeDataType will be set to ComputeDataType automatically."%(self["ActivationComputeDataType"].toChar(), \
-                                                                                                self["ComputeDataType"], \
-                                                                                                self["DestDataType"]))
-        self["ActivationComputeDataType"] = self["ComputeDataType"]
-      if (self["ActivationComputeDataType"].numRegisters() != self["ComputeDataType"].numRegisters()) and \
-        (self["DataType"].numRegisters() < self["DestDataType"].numRegisters()):
-        printWarning("TensileLite only supports ActivationComputeDataType = ComputeDataType if DestDataType > DataType. \
-                      ActivationComputeDataType will be set to ComputeDataType automatically.")
-        self["ActivationComputeDataType"] = self["ComputeDataType"]
-
-    if "UseE" in config:
-      if config["UseE"]:
-        if self["ActivationType"] == 'none':
-          printWarning("Use E is disabled cause Activation is set to False.")
-          self["UseE"] = False
-        else:
-          self["UseE"] = config["UseE"]
-      else:
-        self["UseE"] = config["UseE"]
-
-    if "Gradient" in config:
-      if config["Gradient"]:
-        if (not self["UseBias"]) and self["ActivationType"] == 'none':
-          printWarning("Gradient is disabled cause bias and activation are both disabled.")
-          self["Gradient"] = False
-        if self["ActivationType"] != 'none' and self["UseE"] == False:
-          printWarning("Use E is enabled cause Activation is enabled.")
-          self["UseE"] = True
-        elif self["ActivationType"] != 'none' and self["UseE"] == False:
-          printWarning("Use E is disabled cause Activation is disabled.")
-          self["UseE"] = False
-        # if self["UseScaleAlphaVec"]:
-        #   printWarning("Use scaleAlphaVec is disabled cause Gradient is enabled.")
-        #   self["UseScaleAlphaVec"] = False
-      self["Gradient"] = config["Gradient"]
-
-    # Need gradient info
-    biasSrcList = ["A", "B", "D"]
-    if "BiasSrc" in config:
-      if not self["Gradient"] and config["BiasSrc"] != "D":
-        printWarning("BiasSrc is set to D cause Gradient is disabled.")
-        self["BiasSrc"] = "D"
-      elif self["Gradient"]:
-        # # Currently only supports D :)
-        # if config["BiasSrc"] != "D":
-        #   printExit("BiasSrc currently only supports D.")
-        if config["BiasSrc"] not in biasSrcList:
-          printExit("BiasSrc only supports A, B, D.")
-
-    if "ActivationNoGuard" in config:
-      self["ActivationNoGuard"] = config["ActivationNoGuard"]
-      if self["ActivationNoGuard"]:
-        if self["ActivationType"] == 'none':
-          printWarning("ActivationNoGuard is set to False cause Acivation is off.")
-          self["ActivationNoGuard"] = False
-        if (not self["Gradient"]):
-          printWarning("ActivationNoGuard is set to False cause Gradient is off.")
-          self["ActivationNoGuard"] = False
-
-  ################################################################################
-   # Function checkIfSupportedGEMMType:
-  #   Assures 3 data-types are valid, supported and well-assigned
-  #   See the discussion on Common.py for validGEMMTypes
-  ################################################################################
-  def checkIfSupportedGEMMType(self):
-    inType = self["DataType"]
-    outType = self["DestDataType"]
-    computeType = self["ComputeDataType"]
-
-    gemmType = ( inType.toChar(), outType.toChar(), computeType.toChar() )
-    if gemmType not in validGEMMTypes:
-      printExit("This typed-GEMM (Ti, To, Tc) = (%s, %s, %s) is not supported yet."%(gemmType[0],gemmType[1],gemmType[2]))
-
-  ########################################
-  def initGEMM(self):
-    sumIdx = 3 if self["Batched"] else 2
-    self["IndexAssignmentsA"] = [0, sumIdx] # N
-    self["IndexAssignmentsB"] = [sumIdx, 1] # N
-    if self.state["Sparse"] == 2:
-      self["IndexAssignmentsMetadata"] = [sumIdx, 1] # N (ref B)
-    else:
-      self["IndexAssignmentsMetadata"] = [sumIdx, 0] # T (ref A)
-    if self["TransposeA"]:
-      self["IndexAssignmentsA"] = [sumIdx, 0] # T
-    if self["TransposeB"]:
-      self["IndexAssignmentsB"] = [1, sumIdx] # T
-    if self["Batched"]:
-      self["IndexAssignmentsA"].append(2)
-      self["IndexAssignmentsB"].append(2)
-      self["IndexAssignmentsMetadata"].append(2)
-      self["NumIndicesC"] = 3
-    else:
-      self["NumIndicesC"] = 2
-
-    self["NumIndicesLD"] = 4
-    self["IndexAssignmentsLD"][0] = self["NumIndicesC"] + 1
-    for i in range(1, len(self["IndexAssignmentsLD"])):
-      self["IndexAssignmentsLD"][i] = self["IndexAssignmentsLD"][i-1] + 1
-
-  ########################################
-  def isGEMM(self):
-    return self.operationType == 0
-
-  ########################################
-  # determine d0, d1, dU
-  @staticmethod
-  def assignDerivedParameters(state):
-    if "AssignedDerivedParameters" in state:
-      if state["AssignedDerivedParameters"]:
-        return
-    state["AssignedDerivedParameters"] = False
-
-    state["TotalIndices"] = max(max(state["IndexAssignmentsA"])+1, \
-        max(state["IndexAssignmentsB"])+1)
-
-    # determine num free, batch
-    state["IndicesFree"] = []
-    state["IndicesBatch"] = []
-    state["IndicesSummation"] = []
-
-    for i in range(0, state["NumIndicesC"]):
-      inA = i in state["IndexAssignmentsA"]
-      inB = i in state["IndexAssignmentsB"]
-      if inA and inB:
-        state["IndicesBatch"].append(i)
-
-      elif inA or inB:
-        state["IndicesFree"].append(i)
-      else:
-        printExit("invalid index %u (inC but not (inA or inB))" % i)
-
-    # determine num summation
-    for i in range(state["NumIndicesC"], state["TotalIndices"]):
-      inA = i in state["IndexAssignmentsA"]
-      inB = i in state["IndexAssignmentsB"]
-      if inA and inB:
-        state["IndicesSummation"].append(i)
-      else:
-        printExit("invalid index %u (expected summation but not (inA and inB))" % i)
-    # print index assignments
-    if globalParameters["PrintIndexAssignments"]:
-      print("IndicesFree:  %s" % state["IndicesFree"])
-      print("IndicesBatch: %s" % state["IndicesBatch"])
-      print("IndicesSum:   %s" % state["IndicesSummation"])
-      print("IndexAssignmentsA:   %s" % state["IndexAssignmentsA"])
-      print("IndexAssignmentsB:   %s" % state["IndexAssignmentsB"])
-      print("NumIndicesC:  %s" % state["NumIndicesC"])
-
-    for k in ('IndexAssignmentsA','IndexAssignmentsB'):
-      if len(state[k]) != len(set(state[k])):
-        printExit("duplicate index in %s=%s"% (k,state[k]))
-
-    state["NumIndicesFree"] = len(state["IndicesFree"])
-    state["NumIndicesBatch"] = len(state["IndicesBatch"])
-    state["NumIndicesSummation"] = len(state["IndicesSummation"])
-    if not state["AllowNoFreeDims"] and state["NumIndicesFree"] < 2 :
-      printExit("Tensile requires >= 2 free indices or set AllowNoFreeDims; FreeIndices=%s."% state["IndicesFree"])
-
-    # by default, unroll index will be the last/inner summation index
-    state["IndexUnroll"] = state["IndicesSummation"][len(state["IndicesSummation"])-1]
-    for i in range(0, len(state["IndexAssignmentsA"])):
-      if state["IndexAssignmentsA"][i] == state["IndexUnroll"]:
-        state["IndexUnrollA"] = i
-        break
-    for i in range(0, len(state["IndexAssignmentsB"])):
-      if state["IndexAssignmentsB"][i] == state["IndexUnroll"]:
-        state["IndexUnrollB"] = i
-        break
-    for i in range(0, len(state["IndexAssignmentsMetadata"])):
-      if state["IndexAssignmentsMetadata"][i] == state["IndexUnroll"]:
-        state["IndexUnrollM"] = i
-        break
-    #print2("IndexUnrollA: %u" % state["IndexUnrollA"])
-    #print2("IndexUnrollB: %u" % state["IndexUnrollB"])
-
-    # assign d0, d1
-    if state["AllowNoFreeDims"]:
-      dimList = state["IndicesFree"] + state["IndicesBatch"]
-    else:
-      dimList = state["IndicesFree"]
-    state["Index01A"] = [i for i in state["IndexAssignmentsA"] if i in dimList][0]
-    state["Index01B"] = [i for i in state["IndexAssignmentsB"] if i in dimList][0]
-    #print2("Index01A: %u" % state["Index01A"])
-    #print2("Index01B: %u" % state["Index01B"])
-    # Store code is optimized for 0 as the fastest-moving in memory
-    # whichever has lower stride in C (lower value), is 0, other is 1
-    if state["Index01A"] < state["Index01B"]:
-      state["Index0"]  = state["Index01A"]
-      state["Index1"]  = state["Index01B"]
-      state["Tensor0"] = 0
-      state["Tensor1"] = 1
-      state["TileA"] = 0
-      state["TileB"] = 1
-    else:
-      state["Index0"]  = state["Index01B"]
-      state["Index1"]  = state["Index01A"]
-      state["Tensor0"] = 1
-      state["Tensor1"] = 0
-      state["TileA"] = 1
-      state["TileB"] = 0
-
-    # generalize transpose
-    strideIdxA = state["IndexAssignmentsA"].index(state["Index01A"])
-    strideIdxB = state["IndexAssignmentsB"].index(state["Index01B"])
-    unrollIdxA = state["IndexAssignmentsA"].index(state["IndexUnroll"])
-    unrollIdxB = state["IndexAssignmentsB"].index(state["IndexUnroll"])
-    state["TLUA"] = strideIdxA < unrollIdxA
-    state["TLUB"] = strideIdxB < unrollIdxB
-    #state["TLUB"] = True # hack
-
-    if globalParameters["PrintIndexAssignments"]:
-      print("TLUA:  %s (stridePosA(%d) <? unrollIdxA(%d)" % \
-			(state["TLUA"], strideIdxA, unrollIdxA))
-      print("TLUB:  %s (stridePosB(%d) <? unrollIdxB(%d)" % \
-	  		(state["TLUB"], strideIdxB, unrollIdxB))
-      print("Index01A:  %s" % state["Index01A"])
-      print("Index01B:  %s" % state["Index01B"])
-    #unrollDimStrideGreaterThanTileDimStrideA = TLUA = !transA = fast
-    #!unrollDimStrideLessThanTileDimStrideB   = TLUB =  transB = fast
-    state["AssignedDerivedParameters"] = True
-
-    if state["Sparse"]:
-      state["Index01Metadata"] = [i for i in state["IndexAssignmentsMetadata"] if i in dimList][0]
-      strideIdxM = state["IndexAssignmentsMetadata"].index(state["Index01Metadata"])
-      unrollIdxM = state["IndexAssignmentsMetadata"].index(state["IndexUnroll"])
-      state["TLUMetadata"] = strideIdxM < unrollIdxM
-      if globalParameters["PrintIndexAssignments"]:
-        print("TLUMetadata:  %s (stridePosM(%d) <? unrollIdxM(%d)" % \
-          (state["TLUMetadata"], strideIdxM, unrollIdxM))
-        print("Index01Metadata:  %s" % state["Index01Metadata"])
-
-  ########################################
-  def __str__(self):
-    indexChars = INDEX_CHARS
-    # C dimensions
-    name = "C"
-    for i in range(0, self["NumIndicesC"]):
-      name += indexChars[i].lower()
-    # A dimensions
-    name += "_A"
-    for i in self["IndexAssignmentsA"]:
-      name += indexChars[i] if i in self["MirrorDimsA"] else indexChars[i].lower()
-    if self["ComplexConjugateA"]:
-      name += "C"
-    # B dimensions
-    name += "_B"
-    for i in self["IndexAssignmentsB"]:
-      name += indexChars[i] if i in self["MirrorDimsB"] else indexChars[i].lower()
-    if self["ComplexConjugateB"]:
-      name += "C"
-
-    # DataTypes
-    if self["DataType"] != self["DataTypeA"] or self["DataType"] != self["DataTypeB"]:
-      name += "_"
-      name += self["DataTypeA"].toChar() + self["DataTypeB"].toChar()
-    name += "_"
-    name += self["DataType"].toChar() # Type of A/B
-
-    # Special condition for some newly supported kernels:
-    #   HHS, HSS, BSS and I8II kernels, use a clearer naming _TiToTc_
-    # TODO: Distinguish all kernels by _TiToTc_ to be more consistent with rocblas
-    gemmType = (self["DataType"].toChar(),self["DestDataType"].toChar(),self["ComputeDataType"].toChar() )
-    if gemmType in HPATypes:
-      name += self["DestDataType"].toChar()    # Type of C/D
-      name += self["ComputeDataType"].toChar() # Type of Alpha/Beta
-      name += "_"
-
-    if not self["F32XdlMathOp"].isSingle() and self["DataType"].isSingle():
-      name += "_M"
-      name += self["F32XdlMathOp"].toChar()
-      name += "_"
-
-    if self["SwizzleTensorA"]:
-      name += "STA_"
-
-    if self["SwizzleTensorB"]:
-      name += "STB_"
-
-    # Other
-    if self["UseBeta"]: name += "B"
-    if self["HighPrecisionAccumulate"] and not self["SilentHighPrecisionAccumulate"]: name += "H"
-    if self["UseInitialStridesAB"]: name += "I"
-    if self["UseInitialStridesCD"]: name += "Ic"
-    if self["UseBias"]:
-      name += "_Bias"
-      if self["BiasDataTypeList"] != getBiasDataTypeListDefault(self):
-        for i in self["BiasDataTypeList"]:
-          name += i.toChar()
-      if self["BiasSrc"] and self["Gradient"]: # Show bias src if gradient = True
-        name += "_BiasSrc%s"%self["BiasSrc"]
-
-    factorDim = max(self["UseScaleAlphaVec"], self["UseBias"])
-    if factorDim > 1 :
-        name += "_FD%s"%("N" if factorDim == 2 else "MN")
-
-    if self["UseE"]:
-      if self["Gradient"]:
-        name += "_Grad%s"%self["DataTypeE"].toChar()
-      else:
-        name += "_Aux%s"%self["DataTypeE"].toChar() # Not showing aux types
-    if self["OutputAmaxD"]:
-      name += "_AmaxD"
-    if self["Sparse"]:
-      if self["Sparse"] == 2:
-        name += "_SPB"
-      else:
-        name += "_SPA"
-
-    # precision and other
-    # name += "_SB" if self["StridedBatched"] else "_GB"
-    if self["GroupedGemm"]:
-      name += "_GG"
-    else:
-      name += "" if self["StridedBatched"] else "_GB" # legacy
-
-    # Activation Naming
-    if self["ActivationType"] != 'none':
-      if self["ActivationType"] == 'all':
-        name += "_A"
-      elif self["ActivationType"] == 'hipblaslt_all':
-        name += "_HA"
-      else:
-        name += "_%s"%str(self["ActivationType"]).upper()
-      name += self["ActivationComputeDataType"].toChar()
-    if self["ActivationNoGuard"]: name += "NG"
-
-    if self["UseScaleAB"] == "Scalar": name += "_SAB"
-    elif self["UseScaleAB"] == "Vector": name += "_SABV"
-    if self["UseScaleCD"]: name += "_SCD"
-    if self["UseScaleAlphaVec"]: name += "_SAV"
-
-    if self["SupportUserArgs"]: name += "_UserArgs"
-
-    return name
-
-  def keys(self):
-    return list(self.state.keys())
-  def __len__(self):
-    return len(self.state)
-  def __iter__(self):
-    return iter(self.state)
-  def __getitem__(self, key):
-    return self.state[key]
-  def __setitem__(self, key, value):
-    self.state[key] = value
-  def __repr__(self):
-    return self.__str__()
-  def getAttributes(self):
-    return self.state
-  def __hash__(self):
-    return hash(str(self))
-  def __eq__(self, other):
-    return isinstance(other, ProblemType) and self.getAttributes() == other.getAttributes()
-  def __ne__(self, other):
-    result = self.__eq__(other)
-    if result is NotImplemented:
-      return result
-    return not result
-
-  def get(self, key, default=None):
-    try:
-      return self.state[key]
-    except:
-      return default
-
-
-
-################################################################################
-# ProblemSizeRange
-################################################################################
-class ProblemSizeRange:
-
-  ########################################
-  def __init__(self, problemType, config):
-    self.totalIndices = 1+max(problemType["IndexAssignmentsA"]) + problemType["NumIndicesLD"]
-    if len(config) < self.totalIndices:
-      for i in range(len(config), self.totalIndices):
-        if i < self.totalIndices - problemType["NumIndicesLD"]:
-          config.append(0)
-        else:
-          config.append([0])
-
-    self.indexMax = []
-    self.indexIsSized = []
-    self.indicesSized = []
-    self.indicesMapped = []
-    for i in range(0, self.totalIndices):
-      dim = deepcopy(config[i])
-      if isinstance(dim, list):
-        if len(dim) == 1:
-          self.indicesSized.append([dim[0], 1, 0, dim[0]])
-        elif len(dim) == 2:
-          self.indicesSized.append([dim[0], dim[0], 0, dim[1]])
-        elif len(dim) == 3:
-          self.indicesSized.append([dim[0], dim[1], 0, dim[2]])
-        elif len(dim) == 4:
-          self.indicesSized.append([dim[0], dim[1], dim[2], dim[3]])
-        else:
-          printExit("dimension[%u] config (%s) has %u descriptors rather than 1-4."
-              % ( i, dim, len(dim) ))
-        self.indexIsSized.append(True)
-        self.indexMax.append(self.indicesSized[len(self.indicesSized)-1][3])
-
-      elif isinstance(dim, int):
-        self.indicesMapped.append(dim)
-        self.indexIsSized.append(False)
-        self.indexMax.append(self.indicesSized[self.indicesMapped[ \
-            len(self.indicesMapped)-1]][3])
-
-    # max num elements in each tensor
-    self.maxNumElements = [ 1, 1, 1 ]
-    for i in range(0, problemType["NumIndicesC"]):
-      self.maxNumElements[0] *= self.indexMax[i]
-    for i in problemType["IndexAssignmentsA"]:
-      self.maxNumElements[1] *= self.indexMax[i]
-    for i in problemType["IndexAssignmentsB"]:
-      self.maxNumElements[2] *= self.indexMax[i]
-
-    self.totalProblemSizes = 1
-    self.numProblemSizes = [] # per index
-    self.problemSizeToIndex = []
-    self.problemIndexToSize = []
-    sizedIdx = 0
-    for i in range(0, len(self.indexIsSized)):
-      self.problemSizeToIndex.append({})
-      self.problemIndexToSize.append({})
-      if self.indexIsSized[i]:
-        self.numProblemSizes.append(0)
-        index = self.indicesSized[sizedIdx]
-        sizedIdx += 1
-        currentSize = index[0]
-        currentIncrement = index[1]
-        while currentSize <= index[3]:
-          currentSize += currentIncrement
-          currentIncrement += index[2]
-          self.numProblemSizes[i] += 1
-      else:
-        self.numProblemSizes.append(1)
-      self.totalProblemSizes *= self.numProblemSizes[i]
-
-    ########################################
-    # enumerate problem sizes
-    currentSizedIndexSizes = []
-    currentSizedIndexIncrements = []
-    for i in range(0, len(self.indicesSized)):
-      currentSizedIndexSizes.append(self.indicesSized[i][0])
-      currentSizedIndexIncrements.append(self.indicesSized[i][1])
-
-    # iterate over all problem sizes
-    self.problemSizes = []
-    moreProblemSizes = True
-    problemIdx = 0
-    problemSize = [0]*self.totalIndices
-    while moreProblemSizes:
-      #/ convert current sized and mapped indices to full sizes
-      currentSizedIdx = 0
-      currentMappedIdx = 0
-      for i in range(0, self.totalIndices):
-        if self.indexIsSized[i]:
-          problemSize[i] = currentSizedIndexSizes[currentSizedIdx]
-          currentSizedIdx+=1
-        else:
-          problemSize[i] = problemSize[self.indicesMapped[currentMappedIdx]]
-          currentMappedIdx+=1
-      self.problemSizes.append(tuple(problemSize))
-
-      #/ increment sizes for next benchmark
-      currentSizedIndexSizes[0] += currentSizedIndexIncrements[0]
-      currentSizedIndexIncrements[0] += self.indicesSized[0][2]
-      for i in range(1, len(self.indicesSized)+1):
-        # if prior index past max, reset to min and increment next index
-        if currentSizedIndexSizes[i-1] > self.indicesSized[i-1][3]:
-          #/ reset prior index
-          currentSizedIndexSizes[i-1] = self.indicesSized[i-1][0]
-          currentSizedIndexIncrements[i-1] = self.indicesSized[i-1][1]
-          # increment next index
-          if i >= len(self.indicesSized):
-            moreProblemSizes = False
-          else:
-            currentSizedIndexSizes[i] += currentSizedIndexIncrements[i]
-            currentSizedIndexIncrements[i] += self.indicesSized[i][2]
-
-      problemIdx+=1
-
-  ########################################
-  # YAML format
-  def __str__(self):
-    state = "[ "
-    sizedIdx = 0
-    mappedIdx = 0
-    for i in range(0, len(self.indexIsSized)):
-      if self.indexIsSized[i]:
-        indices = self.indicesSized[sizedIdx]
-        state += "[ %u, %u, %u, %u ]" \
-            % (indices[0], indices[1], indices[2], indices[3])
-        sizedIdx += 1
-      else:
-        indices = self.indicesSized[self.indicesMapped[mappedIdx]]
-        state += str(self.indicesMapped[mappedIdx])
-        mappedIdx += 1
-      if i < len(self.indexIsSized)-1:
-        state += ", "
-    state += " ]"
-    return state
-
-class Problem:
-  """ Problem sizes, strides, padding and other info"""
-  def __init__(self, sizes=None, stridesA=None, stridesB=None, stridesC=None, stridesD=None, count=None):
-    self.sizes = tuple(sizes) if sizes else None
-    self.stridesA = tuple(stridesA) if stridesA else None
-    self.stridesB = tuple(stridesB) if stridesB else None
-    self.stridesC = tuple(stridesC) if stridesC else None
-    self.stridesD = tuple(stridesD) if stridesD else None
-
-    self.count = count
-
-  def __str__(self):
-    rv= "{ sizes:" + str(list(self.sizes))
-    if self.stridesA:
-      rv += ", stridesA:" + str(list(self.stridesA))
-    if self.stridesB:
-      rv += ", stridesB:" + str(list(self.stridesB))
-    if self.stridesC:
-      rv += ", stridesC:" + str(list(self.stridesC))
-    if self.stridesD:
-      rv += ", stridesD:" + str(list(self.stridesD))
-    rv += " }"
-    return rv
-
-class ExactList(Problem):
-  def __init__(self, e, problemType):
-    if len(e) == problemType["TotalIndices"]:
-      if -1 in e:
-        printExit("ExactSize %s contains -1" % (e))
-      if problemType["OperationType"] == "GEMM":
-        e += [-1, -1, -1, -1]
-        e = ExactList.convertLeadingDims(problemType, tuple(e))
-      sizes=e
-
-    elif len(e) == (problemType["TotalIndices"] + problemType["NumIndicesLD"]):
-      sizes = ExactList.convertLeadingDims(problemType, tuple(e))
-    else:
-      printExit("ExactSize %s doesn't match indices of ProblemType %s, totalIndices=%d, len e=%d, NumIndicesLD = %d" \
-          % (e, problemType, problemType["TotalIndices"], len(e), problemType["NumIndicesLD"]) )
-
-    # TODO- pass strides here, remove calls to convertLeadingDims
-    Problem.__init__(self, sizes=sizes)
-
-  def __str__(self):
-    return str(list(self.sizes))
-
-  @staticmethod
-  def convertLeadingDims(problemType, problemSize, stridesA = None, stridesB = None, stridesC = None, stridesD = None):
-    # FIXME-problem: refactor to eliminate max, pass strides in strideB parm rather than hacked
-    # onto the end of the sizes list
-    predStridesD = stridesD is not None and stridesD[1] != -1
-    predStridesC = stridesC is not None and stridesC[1] != -1
-    predStridesA = stridesA is not None and stridesA[1] != -1
-    predStridesB = stridesB is not None and stridesB[1] != -1
-    return problemSize[:problemType["NumIndicesC"]+1] + \
-           (max(problemSize[0], problemSize[problemType["IndexAssignmentsLD"][0]]) if not predStridesD else stridesD[1], ) + \
-           (max(problemSize[0], problemSize[problemType["IndexAssignmentsLD"][1]]) if not predStridesC else stridesC[1], ) + \
-           (max(problemSize[problemType["IndexAssignmentsLD"][2]],
-                problemSize[problemType["IndexAssignmentsA"][0]]) if not predStridesA else stridesA[1], ) + \
-           (max(problemSize[problemType["IndexAssignmentsLD"][3]],
-                problemSize[problemType["IndexAssignmentsB"][0]]) if not predStridesB else stridesB[1], )
-
-
-class ExactDict(Problem):
-  AllowedFields = [ 'count', 'sizes', 'stridesA', 'stridesB', 'stridesC', 'stridesD' ]
-
-  def __init__(self, e, problemType):
-    Problem.__init__(self)
-
-    for f in e:
-      if f in ExactDict.AllowedFields:
-        setattr(self, f, e[f])
-      else:
-        raise RuntimeError ("specified field '%s' is not a valid Exact dict field"%f)
-
-    if problemType:
-      if "OperationType" in problemType and problemType["OperationType"] == "GEMM":
-        sizesTuple = tuple(self.sizes + [-1, -1, -1, -1])
-        self.sizes = ExactList.convertLeadingDims(problemType, sizesTuple, self.stridesA, self.stridesB, self.stridesC, self.stridesD)
-
-    if problemType:
-      if "OperationType" in problemType and problemType["OperationType"] == "GEMM":
-        if len(self.sizes) != (problemType["TotalIndices"] + problemType["NumIndicesLD"]):
-        # FIXME-ExactDict size descriptor still (but preferrably not so) uses 8-tuple for GEMM problems
-          raise RuntimeError ("specified size=%s does not have enough indices for problem (expected %d, got %d)" \
-                % (self.sizes, problemType["TotalIndices"]+problemType["NumIndicesLD"], len(self.sizes)))
-      elif len(self.sizes) != problemType["TotalIndices"]:
-        raise RuntimeError ("specified size=%s does not have enough indices for problem (expected %d, got %d)" \
-                % (self.sizes, problemType["TotalIndices"], len(self.sizes)))
-
-
-################################################################################
-# ProblemSizes
-################################################################################
-"""
-Adapter class for class `ProblemSizes`. It satisfies the implicit usage requirement
-of ClientWriter.writeClientConfig() by converting ExactLogic to list of `Problem` objects
-"""
-class ProblemSizesMock:
-  def __init__(self, exactLogic):
-    self.problems = [Problem(problem) for problem, solution in exactLogic]
-
-class ProblemSizesMockDummy:
-  def __init__(self):
-    self.problems = [Problem(sizes=[128, 128, 1, 512])]
-
-class ProblemSizes:
-
-  ########################################
-  def __init__(self, problemType, config):
-    self.problemType = problemType
-    self.ranges = []
-    self.exacts = []
-    self.minStrides = None
-    if config:
-      for dictionary in config:
-        for sizeTypeKey in dictionary:
-          #print ("PROBLEM parsed:", sizeTypeKey, dictionary[sizeTypeKey])
-          if sizeTypeKey == "Range":
-            psr = ProblemSizeRange(problemType, dictionary[sizeTypeKey])
-            self.ranges.append( psr )
-          elif sizeTypeKey == "Exact":
-            e= dictionary[sizeTypeKey]
-            if isinstance(e,list):
-              self.exacts.append(ExactList(e, problemType))
-            elif isinstance(e,dict):
-              self.exacts.append(ExactDict(e, problemType))
-            else:
-              printExit("Unsupported Exact type==%s"%type(e))
-          elif sizeTypeKey == "MinStride":
-            e = dictionary[sizeTypeKey]
-            if len(e) != problemType["TotalIndices"]:
-              printExit("MinStride %s doesn't match indices of ProblemType %s" \
-                  % (e, problemType) )
-            if self.minStrides:
-              printExit("Only one MinStride command is allowed in a ProblemsSizes definition.  Previous minStrides:%s, New minstride:%s" \
-                  % (self.minStrides, e) )
-
-            self.minStrides=(tuple(e))
-          else:
-            printExit("ProblemSize Type %s not supported"%sizeTypeKey)
-
-    if not self.minStrides:
-      # set harmless default mins of 0
-      self.minStrides = ([0]* problemType["TotalIndices"])
-
-    # not the ideal spot, but convert leading dims that are below the minimum size
-    if problemType["OperationType"] == "GEMM":
-      for i in range(0, len(self.ranges)):
-        self.ranges[i].problemSizes[:] = \
-          [ExactList.convertLeadingDims(self.problemType, problemSize) for problemSize in self.ranges[i].problemSizes]
-
-    self.problems = OrderedDict()
-    for sizeRange in self.ranges:
-      for rangeSize in sizeRange.problemSizes:
-        self.problems.update({Problem(rangeSize) : 1})
-    for e in self.exacts:
-        self.problems.update({e : 1})
-    self.problems =  list(self.problems.keys())
-    self.totalProblemSizes = len(self.problems)
-
-    # max sizes
-    self.maxD = 0
-    self.maxC = 0
-    self.maxA = 0
-    self.maxB = 0
-    for problem in self.problems:
-      problemSize = problem.sizes # FIXME-problem.   This should use problem.strides*
-
-      sizeLdd = problemSize[self.problemType["IndexAssignmentsLD"][0]] if problemType["OperationType"] == "GEMM" else problemSize[0]
-      sizeD = max(self.minStrides[0], sizeLdd)
-      for i in range(1, problemType["NumIndicesC"]):
-        sizeD *= max(self.minStrides[i], problemSize[i])
-
-      sizeLdc = problemSize[self.problemType["IndexAssignmentsLD"][1]] if problemType["OperationType"] == "GEMM" else problemSize[0]
-      sizeC = max(self.minStrides[0], sizeLdc)
-      for i in range(1, problemType["NumIndicesC"]):
-        sizeC *= max(self.minStrides[i], problemSize[i])
-
-      sizeLda = problemSize[self.problemType["IndexAssignmentsLD"][2]] \
-                if problemType["OperationType"] == "GEMM" \
-                else problemSize[self.problemType["IndexAssignmentsA"][0]]
-      sizeA = max(self.minStrides[self.problemType["IndexAssignmentsA"][0]], sizeLda)
-      for i in self.problemType["IndexAssignmentsA"][1:]:
-        sizeA *= max(self.minStrides[i], problemSize[i])
-
-      sizeLdb = problemSize[self.problemType["IndexAssignmentsLD"][3]] \
-                if problemType["OperationType"] == "GEMM" \
-                else problemSize[self.problemType["IndexAssignmentsB"][0]]
-      sizeB = max(self.minStrides[self.problemType["IndexAssignmentsB"][0]], sizeLdb)
-      for i in self.problemType["IndexAssignmentsB"][1:]:
-        sizeB *= max(self.minStrides[i], problemSize[i])
-
-      self.maxD = max(self.maxD, sizeD)
-      self.maxC = max(self.maxC, sizeC)
-      self.maxA = max(self.maxA, sizeA)
-      self.maxB = max(self.maxB, sizeB)
-
-  def __str__(self):
-    s = "ProblemSizes\n"
-    for sizeRange in self.ranges:
-      s += "  %s" % sizeRange
-    return s
 
 ################################################################################
 # Factor Type
 ################################################################################
-
 class FactorDimArgs:
 
   ########################################
@@ -956,23 +77,6 @@ class FactorDimArgs:
   def __str__(self):
     s = "FactorDimArgs\n"
     return s
-
-################################################################################
-# Bias Type
-################################################################################
-
-def getBiasDataTypeListDefault(problem: ProblemType) -> List[DataType]:
-  bList = []
-  for d in ["DataType", "ComputeDataType", "DestDataType"]:
-    dtype = DataType(problem[d])
-    # filter out int8/f8/b8, because it is not supported by bias datatype
-    # TODO
-    if not dtype.isInt8() and not dtype.is8bitFloat():
-      bList.append(dtype)
-
-  biasDataTypeList = list(set(bList))
-  biasDataTypeList.sort() # Make name unique
-  return biasDataTypeList
 
 class BiasTypeArgs:
 
@@ -1052,19 +156,33 @@ def isExtractableIndex(ks, index, tc='x'):
 ################################################################################
 class Solution(collections.abc.Mapping):
 
-  ########################################
-  def __init__(self, config, cxxCompiler: str, srcName: str = ""):
+  ########################################   # need to be sure PSRR is passing to all fxns
+  def __init__(
+    self,
+    config,
+    splitGSU: bool,
+    printSolutionRejectionReason: bool,
+    printIndexAssignmentInfo: bool,
+    depthUConfig: DepthUConfig,
+    assembler: Assembler,
+    isaInfoMap: Dict[IsaVersion, IsaInfo],
+    srcName: str = ""
+  ):
+
     self._name = None
-    self.cxxCompiler = cxxCompiler
+    self.assembler = assembler
+    self.isaInfoMap = isaInfoMap
     self.srcName = srcName
+    self.splitGSU = splitGSU
     config = config
+    targetIsas = list(isaInfoMap.keys())
 
     self._state = {}
     # problem type
     if "ProblemType" in config:
-      self["ProblemType"] = ProblemType(config["ProblemType"])
+      self["ProblemType"] = ProblemType(config["ProblemType"], printIndexAssignmentInfo)
     else:
-      self["ProblemType"] = ProblemType(defaultProblemType)
+      self["ProblemType"] = ProblemType.FromDefaultConfig(printIndexAssignmentInfo)
 
     if "InternalSupportParams" in config:
       self["InternalSupportParams"] = {}
@@ -1073,30 +191,27 @@ class Solution(collections.abc.Mapping):
     else:
       self["InternalSupportParams"] = defaultInternalSupportParams
 
-
-    # assign parameters with defaults
+    # Assign solution state from config, filling missing from the defaultSolution
     for key in defaultSolution:
       assignParameterWithDefault(self._state, key, config, defaultSolution)
+
     if 'ISA' not in self._state:
       if 'ISA' in config:
-        if not globalParameters["AsmCaps"][tuple(config['ISA'])]["SupportedISA"]:
-          defaultIsa = [9,0,0]
-          print("warning: ISA:", config['ISA'], " is not supported; overriding with ", defaultIsa)
-          self._state['ISA'] = defaultIsa
-        else:
-          self._state['ISA'] = config['ISA']
+        # The ISA is expected to be defined when calling from TensileCreateLibrary
+        isa = config['ISA']
+        isa = IsaVersion(isa[0], isa[1], isa[2])
+        assert self.isaInfoMap[isa].asmCaps["SupportedISA"]
+        self._state['ISA'] = IsaVersion(isa[0], isa[1], isa[2])
       else:
-        # Assembly by default
-        self._state['ISA'] = list(globalParameters["CurrentISA"])
-        if 'KernelLanguage' in config:
-          if config['KernelLanguage'] != 'Assembly':
-            self._state['ISA'] = [0,0,0]
+        # When calling from Tensile, the ISA is typically not defined.
+        printWarning(f"ISA not set on config using {targetIsas[0]}.")
+        self._state['ISA'] = targetIsas[0]
 
     if "CodeObjectVersion" not in self._state:
       if "CodeObjectVersion" in config:
         self._state["CodeObjectVersion"] = str(config["CodeObjectVersion"])
       else:
-        self._state["CodeObjectVersion"] = str(globalParameters["CodeObjectVersion"])
+        self._state["CodeObjectVersion"] = self.assembler.code_object_version
     # assign parameters without defaults
     for key in config:
       if (key != "ProblemType" or key != "InternalSupportParams") and key not in self._state:
@@ -1107,9 +222,18 @@ class Solution(collections.abc.Mapping):
       self["AssignedProblemIndependentDerivedParameters"] = False
     if "AssignedDerivedParameters" not in self._state:
       self["AssignedDerivedParameters"] = False
-    Solution.assignDerivedParameters(self._state)
-    self._name = config["CustomKernelName"] if isCustomKernelConfig(config) else None
-    self.initHelperKernelObjects()
+    Solution.assignDerivedParameters(
+      self._state,
+      splitGSU,
+      printSolutionRejectionReason,
+      printIndexAssignmentInfo,
+      isaInfoMap,
+      assembler.rocm_version,
+      depthUConfig,
+    )
+    self._name = config["CustomKernelName"] if "CustomKernelName" in config and config["CustomKernelName"] else None
+
+    self.initHelperKernelObjects(targetIsas)
 
   # these keys are copied from ProblemType to internal that may be overridden
   InternalKeys = ["UseSgprForGRO","VectorStore"]
@@ -1127,11 +251,11 @@ class Solution(collections.abc.Mapping):
 
   ########################################
   # create Helper Kernels
-  def initHelperKernelObjects(self):
+  def initHelperKernelObjects(self, supportedISA: List[IsaVersion]):
     self.initBetaOnlyKernelObjects()
-    self.initConversionKernelObjects()
+    self.initConversionKernelObjects(supportedISA)
     self.initActivationEnumHeaderObjects()
-    self.initActivationFunctionObjects()
+    self.initActivationFunctionObjects(supportedISA)
     self.initActivationOnlyKernelObjects()
     self.initReductionKernelObjects()
 
@@ -1161,7 +285,7 @@ class Solution(collections.abc.Mapping):
 
   ########################################
   # create Conversion Kernels
-  def initConversionKernelObjects(self):
+  def initConversionKernelObjects(self, supportedArchs: List[tuple]):
     self.conversionKernelObjects = []
     load_vector_width = [1, 2] if self["ProblemType"]["DataType"].isDouble() else [1, 2, 4]
     genPGRPostKernels = True
@@ -1188,7 +312,7 @@ class Solution(collections.abc.Mapping):
             state["UnrollOnly"] = unrollOnly
             state["_GlobalAccumulation"] = self["_GlobalAccumulation"]
             state["ActivationFused"] = self["ActivationFused"]
-            self.conversionKernelObjects.append(KernelWriterConversion(state, vw))
+            self.conversionKernelObjects.append(KernelWriterConversion(state, vw, supportedArchs, self.isaInfoMap))
           for btype in typeList:
             state = {}
             state["ProblemType"] = deepcopy(self["ProblemType"])
@@ -1201,7 +325,7 @@ class Solution(collections.abc.Mapping):
             state["UnrollOnly"] = unrollOnly
             state["_GlobalAccumulation"] = self["_GlobalAccumulation"]
             state["ActivationFused"] = self["ActivationFused"]
-            self.conversionKernelObjects.append(KernelWriterConversion(state, vw))
+            self.conversionKernelObjects.append(KernelWriterConversion(state, vw, supportedArchs, self.isaInfoMap))
         else:
           state = {}
           state["ProblemType"] = deepcopy(self["ProblemType"])
@@ -1212,7 +336,7 @@ class Solution(collections.abc.Mapping):
           state["UnrollOnly"] = unrollOnly
           state["_GlobalAccumulation"] = self["_GlobalAccumulation"]
           state["ActivationFused"] = self["ActivationFused"]
-          self.conversionKernelObjects.append(KernelWriterConversion(state, vw))
+          self.conversionKernelObjects.append(KernelWriterConversion(state, vw, supportedArchs, self.isaInfoMap))
 
   def initActivationEnumHeaderObjects(self):
     self.activationEnumHeaderObjects = []
@@ -1223,7 +347,7 @@ class Solution(collections.abc.Mapping):
       state["KernelLanguage"] = "Source"
       self.activationEnumHeaderObjects.append(KernelWriterActivationEnumHeader(state))
 
-  def initActivationFunctionObjects(self):
+  def initActivationFunctionObjects(self, supportedISA: List[IsaVersion]):
     self.activationFunctionObjects = []
     if self["ProblemType"]["ActivationType"] in ['all', 'hipblaslt_all']:
       state = {}
@@ -1231,7 +355,9 @@ class Solution(collections.abc.Mapping):
       state["ProblemType"]["GroupedGemm"] = False
       state["KernelLanguage"] = "Source"
       state["Kernel"] = {"WavefrontSize": self["WavefrontSize"], "ISA": tuple(self["ISA"])}
-      self.activationFunctionObjects.append(KernelWriterActivationFunction(state, self.cxxCompiler))
+      if not isinstance(supportedISA, list):
+        raise Exception(f"{type(supportedISA)}")
+      self.activationFunctionObjects.append(KernelWriterActivationFunction(state, str(self.assembler.path), supportedISA))
 
   def initActivationOnlyKernelObjects(self):
     self.activationOnlyKernelObjects = []
@@ -1277,19 +403,19 @@ class Solution(collections.abc.Mapping):
     return self.conversionKernelObjects
 
   @staticmethod
-  def getMIOutputInfo(state):
+  def getMIOutputInfo(state, isaInfoMap: Dict[str, IsaInfo]):
     outputVectorWidth = 4
     RegsPerOut = 1
 
     isa = tuple(state["ISA"])
-    if globalParameters["AsmCaps"][isa]['HasMFMA']:
+    if isaInfoMap[isa].asmCaps['HasMFMA']:
       if state["ProblemType"]["DataType"].MIOutputTypeNameAbbrev() == 'f64':
         outputVectorWidth, RegsPerOut = 1, 2
       else:
         outputVectorWidth, RegsPerOut = 4, 1
-    elif globalParameters["AsmCaps"][isa]['HasWMMA_V1']:
+    elif isaInfoMap[isa].asmCaps['HasWMMA_V1']:
         outputVectorWidth, RegsPerOut = 1, 1
-    elif globalParameters["AsmCaps"][isa]['HasWMMA_V2']:
+    elif isaInfoMap[isa].asmCaps['HasWMMA_V2']:
         outputVectorWidth, RegsPerOut = 8, 1
     else:
       print("WARNING: unexpect code flow")
@@ -1299,11 +425,7 @@ class Solution(collections.abc.Mapping):
   ########################################
   # assign tile sizes
   @staticmethod
-  def assignProblemIndependentDerivedParameters(state):
-
-    if globalParameters["NewClient"] != 2:
-      print("WARNING: Old client deprecated, NewClient parameter being set to 2.")
-      globalParameters["NewClient"] = 2
+  def assignProblemIndependentDerivedParameters(state, printRejectionReason: bool, isaInfoMap: Dict[str, IsaInfo]):
 
     if "AssignedProblemIndependentDerivedParameters" in state:
       if state["AssignedProblemIndependentDerivedParameters"]:
@@ -1313,12 +435,13 @@ class Solution(collections.abc.Mapping):
       state["Valid"] = True
 
     if (not state["ProblemType"]["StridedBatched"]) and (not state["ProblemType"]['Batched']):
-      reject(state, "General Batched GEMM only support Batched Problem")
+      reject(state, printRejectionReason, "General Batched GEMM only support Batched Problem")
 
     if (not state["ProblemType"]["StridedBatched"]) and (state["ProblemType"]["OperationType"] != 'GEMM'):
-      reject(state, "General Batched GEMM only support GEMM OperationType")
+      reject(state, printRejectionReason, "General Batched GEMM only support GEMM OperationType")
 
-    Solution.MatrixInstructionToMIParameters(state)
+    ### ---> This is where we previously called matrixInstructionToMIParameters
+
     EnableMatrixInstruction = state["EnableMatrixInstruction"] if "EnableMatrixInstruction" in state else None
     if EnableMatrixInstruction == None:
       if  ("MIBlock" in state and len(state["MIBlock"]) == 6) \
@@ -1329,7 +452,7 @@ class Solution(collections.abc.Mapping):
           and ("ThreadTile" in state and len(state["ThreadTile"]) == 2) :
         EnableMatrixInstruction = False
       else:
-        reject(state, "EnableMatrixInstruction undetermined")
+        reject(state, printRejectionReason, "EnableMatrixInstruction undetermined")
 
     if EnableMatrixInstruction == True:
       state["MatrixInstM"]         = state["MIBlock"][0]
@@ -1342,7 +465,7 @@ class Solution(collections.abc.Mapping):
       state["LocalSplitU"] = state["WorkGroup"][2]
       state["NumWaveSplitK"] = 1
       
-      state["MIOutputVectorWidth"], state["MIRegPerOut"] = Solution.getMIOutputInfo(state)
+      state["MIOutputVectorWidth"], state["MIRegPerOut"] = Solution.getMIOutputInfo(state, isaInfoMap)
 
       if state["MatrixInstM"] == 4:
         state["ThreadTile0"] = state["MIWaveTile"][0] * state["MIOutputVectorWidth"]
@@ -1373,7 +496,7 @@ class Solution(collections.abc.Mapping):
     if "SubGroup0" in state and "SubGroup1" in state and "LocalSplitU" in state and "NumWaveSplitK" in state:
       state["NumThreads"] = state["SubGroup0"] * state["SubGroup1"] * state["LocalSplitU"] * state["NumWaveSplitK"]
       if (state["NumThreads"] % state['WavefrontSize']) != 0:
-        reject(state, f"size of WorkGroup {state['NumThreads']} should be multiple of WavefrontSize {state['WavefrontSize']}")
+        reject(state, printRejectionReason, f"size of WorkGroup {state['NumThreads']} should be multiple of WavefrontSize {state['WavefrontSize']}")
 
     # macro tile sizes
     if "SubGroup0" in state and "ThreadTile0" in state:
@@ -1383,11 +506,11 @@ class Solution(collections.abc.Mapping):
     if "MacroTile" in state:
       if state["MacroTile0"] != state["MacroTile"][0] \
           or state["MacroTile1"] != state["MacroTile"][1]:
-        reject(state, "MacroTile mismatch")
+        reject(state, printRejectionReason, "MacroTile mismatch")
 
     # dot2: currently only support fp16 with HPA on gfx942
     state["UseDotInstruction"] = (not state["EnableMatrixInstruction"]) and state["ProblemType"]["DataType"].isHalf() \
-      and state["ProblemType"]["HighPrecisionAccumulate"] and (globalParameters["CurrentISA"] == (9,4,2))
+      and state["ProblemType"]["HighPrecisionAccumulate"] and (state["ISA"] == IsaVersion(9,4,2))
     if state["UseDotInstruction"]:
       # need modification for dot4 or dot8
       state["NumDotElements"] = 2
@@ -1399,7 +522,7 @@ class Solution(collections.abc.Mapping):
     state["tailLoopOptA"] = True
     state["tailLoopOptB"] = True
 
-    if (tuple(state["ISA"]) != (9, 4, 2)) or \
+    if (state["ISA"] != (9, 4, 2)) or \
        (state["ProblemType"]["Sparse"]) or \
        (state["UseDotInstruction"]):
       state["tailLoopOptA"] = False
@@ -1433,12 +556,12 @@ class Solution(collections.abc.Mapping):
   #  state[GlobalReadVectorWidth*]
   #  state[NumLoads*] # only used in SolutionStructs, with classic alg
   @staticmethod
-  def setGlobalReadVectorWidth(state, tc, totalVectors, grvw):
+  def setGlobalReadVectorWidth(state, tc, totalVectors, grvw, printRejectionReason: bool):
     validDepthU = True
     if grvw not in [1,2,4,8,16,32]:
       validDepthU = False
     if totalVectors % state["NumThreads"] != 0:
-      reject(None, "totalVectors%s %u %% NumThreads %u != 0" \
+      reject(None, printRejectionReason, "totalVectors%s %u %% NumThreads %u != 0" \
           % (tc, totalVectors, state["NumThreads"]))
       validDepthU = False
 
@@ -1461,7 +584,7 @@ class Solution(collections.abc.Mapping):
   #   state[LSCA]
   #   state[LSPA]
   @staticmethod
-  def setGlobalLoadTileDimClassic(state, tc, numLoads, totalVectorsCoalesced, totalElementsPerp, depthU):
+  def setGlobalLoadTileDimClassic(state, tc, numLoads, totalVectorsCoalesced, totalElementsPerp, depthU, printRejectionReason: bool):
 
     if state["WaveSeparateGlobalRead%s"%tc]:
       totalElementsPerp = roundupRatio(totalElementsPerp, state["NumThreads"] // state["WavefrontSize"])
@@ -1490,7 +613,7 @@ class Solution(collections.abc.Mapping):
           foundValid = True
           break
       if not foundValid:
-        reject(state, "%s: No NumLoadsCoalesced=1 found"%tc)
+        reject(state, printRejectionReason, "%s: No NumLoadsCoalesced=1 found"%tc)
         return False
 
     # nlc = -1
@@ -1506,29 +629,29 @@ class Solution(collections.abc.Mapping):
           foundValid = True
           break
       if not foundValid:
-        reject(state, "%s: No NumLoadsCoalesced=-1 found"%tc)
+        reject(state, printRejectionReason, "%s: No NumLoadsCoalesced=-1 found"%tc)
         return False
 
     # nlc = other
     else:
       if state["NumLoadsCoalesced%s"%tc] > state["NumLoads%s"%tc]:
-        reject(state, "%s nlc > numLoads"%tc)
+        reject(state, printRejectionReason, "%s nlc > numLoads"%tc)
         return False
 
       state["NumLoadsPerpendicular%s"%tc] = state["NumLoads%s"%tc] \
           // state["NumLoadsCoalesced%s"%tc]
 
       if state["NumLoads%s"%tc] % state["NumLoadsCoalesced%s"%tc] != 0:
-        reject(state, "%s: numLoads %u %% numLoadsCoalesced %u != 0" \
+        reject(state, printRejectionReason, "%s: numLoads %u %% numLoadsCoalesced %u != 0" \
             % (tc, state["NumLoads%s"%tc], state["NumLoadsCoalesced%s"%tc]))
         return False
 
       if totalVectorsCoalesced % state["NumLoadsCoalesced%s"%tc] != 0 :
-        reject(state, "%s: totalVectorsCoalesced %u %% numLoadsPara %u != 0" \
+        reject(state, printRejectionReason, "%s: totalVectorsCoalesced %u %% numLoadsPara %u != 0" \
               % (tc, totalVectorsCoalesced, state["NumLoadsCoalesced%s"%tc]))
         return False
       if totalElementsPerp % state["NumLoadsPerpendicular%s"%tc] != 0:
-        reject(state, "%s: totalElementsPerp %u %% numLoadsPerp %u != 0" \
+        reject(state, printRejectionReason, "%s: totalElementsPerp %u %% numLoadsPerp %u != 0" \
               % (tc, totalElementsPerp, state["NumLoadsPerpendicular%s"%tc]))
         return False
 
@@ -1547,289 +670,32 @@ class Solution(collections.abc.Mapping):
     return True
 
 
-  ########################################
-  # Sets the Global Read Tile dims (para, perp)
-  # This information controls which threads read which addresses from global mem)
-  # Output from this function:
-  #   state[NumLoadsCoalesced*]
-  #   state[NumLoadsPerpendicular*]
-  #   state[LSC*]
-  #   state[LSP*]
-  #   state[GlobalReadVectorWidth]
-  #
-  # LSC and LSP define the shape of the PerLoadTile, measured in elements.
-  #   LSC*LSP is the elements loaded by a single instruction across all
-  #   threads in the group.
-  #   LSC is the number of elements loaded in the para(coalesced) dimension
-  #   LSP is the number of elements loaded in the perp(noncoalesced) dimension
-  #   PerLoadTile is always rectangular.
-  #   When BufferLoad=1, the area (LSC*LSP) can be larger than NumThreads.
-  #   In this case, some threads will generate a dummy OOB GRO.
-  #   Related fields:
-  #     LVC = LSC/GRVW  (LVCA = LSCA/GLVWA)
-  #     LVP = LSP/GRVW  (LVPA = LSPA/GLVWA)
-  #
-  # NumLoadsCoalesced and NumLoadsPerpendicular define the number of times the
-  #   PerLoadTile is loaded in each dimension to fetch the LoadTile
-  # LoadTile = (LSC * NumLoadsCoalesced) * (LSP * NumLoadsPerpendicular).
-  #   For Fractional, the LoadTile can be larger than the MacroTile. Buffer
-  #   loads will clip any OOB references to 0 and will also avoid writing these
-  #   into LDS.
-
-  # Fractional load algorithm:
-  #  - Each load instruction loads one or more (complete) rows of the load tile.
-  #     - Each row is LSC elements wide
-  #     - Rows are complete and do not wrap. This allows a single base GRO VGPR
-  #       to be used for all loads in the tile.
-  #     - Some work-items in the load may not perform useful work. These WI will
-  #       set their GRO to a large OOB number so as to do no harm
-  #     - Some G2L registers space may be unused as well.
-  #     - The 'used' message at the bottom of this routine computes and prints the
-  #       wasted register space.
-  #     - The wasted space is removed when the data is written to LDS- the LWO
-  #       for work-items beyond the valid ones are set to safely write to OOB locations.
-
-  #     - In cases where each load is loading multiple rows (multiple lines of lsc
-  #       elements), the last load is allowed to load fewer lines than the others.
-  #       The KernelWriterAssembly will modify the LWO for the last load.  This allows
-  #       flexibility in the unroll factors for example.
-  @staticmethod
-  def setGlobalLoadTileDimFractional(state, tc, depthU):
-
-    assert(depthU > 0)
-    dbFract = 0
-
-    # parDim, perpDim define the LoadTile and are measured in elements
-    if state["ProblemType"]["TLU%s"%tc]:
-      parDim  = state["MacroTile%s"%tc]
-      perpDim = depthU
-    else:
-      parDim  = depthU
-      perpDim = state["MacroTile%s"%tc]
-
-    if dbFract:
-        print("\ninfo: %s Fractional MT%u_%u_%u Par=%u Perp=%u WG%02u_%02u_%02u NumThreads=%u GRWV%s=%u" \
-          % (tc, state["MacroTile0"], state["MacroTile1"], depthU, \
-            parDim, perpDim, \
-            state["WorkGroup"][0], state["WorkGroup"][1], state["LocalSplitU"], \
-            state["NumThreads"], tc, state["GlobalReadVectorWidth%s"%tc]))
-
-    # Try to find a GRVW which is smaller than the LSC and also does not force
-    # the LSC to wrap - both of these conditions can be tested with lsc % grvw ==0.
-    # Each iteration divides GRWV by 2 which provides finer granularity
-    # and a possible opportunity to handle the lsc
-    grvw = state["GlobalReadVectorWidth%s"%tc]
-    minGrvw = 2 if state["ProblemType"]["DataType"].isHalf() and \
-                globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"] else 1
-    # TODO- check this for int8 and fractional load
-    # minGrvw = 4 if state["ProblemType"]["DataType"].isInt8() and \
-    #             globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"] else 1
-    bestVw = -1
-    while grvw >= minGrvw:
-      # Per instruction across the entire group:
-      elementsLoadedPerInst = state["NumThreads"]*grvw
-      mik = 1
-      if (state["DirectToVgpr%s"%tc] and state["ProblemType"]["TLU%s"%tc]):
-        mik = state["MatrixInstK"] * state["LocalSplitU"] // state["MIInputPerThread"]
-        elementsLoadedPerInst //= mik
-      # LSC, LSP - #elements loaded along specified dim with each load
-      if parDim >= elementsLoadedPerInst:
-        # entire work-group can work on (part) of the same row
-        state["LSC%s"%tc] = elementsLoadedPerInst
-        state["LSP%s"%tc] = mik if state["ProblemType"]["TLU%s"%tc] else state["MatrixInstK"]
-        state["NumLoadsCoalesced%s"%tc] = roundupRatio(parDim , state["LSC%s"%tc])
-        state["NumLoadsPerpendicular%s"%tc] = 1
-      else:
-        # work-group exceeds read dimension so wraps to multiple rows
-        state["LSC%s"%tc] = parDim
-        state["LSP%s"%tc] = min(perpDim, elementsLoadedPerInst // parDim)
-        state["NumLoadsCoalesced%s"%tc] = 1
-        state["NumLoadsPerpendicular%s"%tc] = roundupRatio(perpDim , state["LSP%s"%tc])
-
-      # Vector loads can't wrap to next P dim, so LSC must be divisible by vector elements;
-      if dbFract:
-        print("  lsc search : lsc(%u) %% grvw(%u) = %u (?0)" % (state["LSC%s"%tc], grvw, state["LSC%s"%tc] % grvw))
-      if state["LSC%s"%tc] % grvw == 0:
-        bestVw = grvw
-        # Try to shrink GRVW if possible while keeping same LSC and LSP:
-        # For example, avoid cases where we use a GRVW=4 with many empty addresses
-        # when a GRVW=1 will do instead.
-        validElementsLoadedPerInst = state["LSC%s"%tc] * state["LSP%s"%tc]
-        grvw //= 2
-        while grvw >= minGrvw:
-          elementsLoadedPerInst = state["NumThreads"]*grvw//mik
-          if elementsLoadedPerInst < validElementsLoadedPerInst:
-            break # Went too far, not enough load elements at this VW
-          if state["LSC%s"%tc] % grvw == 0:
-            if dbFract:
-              print("  stepdown success (valid)elementsLoadedPerInst=", validElementsLoadedPerInst, "/", elementsLoadedPerInst, "grvw=", grvw, "lsc=", state["LSC%s"%tc])
-            bestVw = grvw
-          grvw //= 2
-        break
-
-      # TODO - could have this generate dwordx3 loads in addition, step down by 1 instead of div2
-      # Would need to change asm code gen to generate x3
-      grvw //= 2
-      # end-- while loop
-
-    if bestVw == -1:
-      if dbFract:
-        print ("reject fractional - no acceptable tile dim? GlobalReadVectorWidth%s"%tc, \
-         state["GlobalReadVectorWidth%s"%tc])
-      return False  # could not find a solution, perhaps only possible for half ?
-
-    state["GlobalReadVectorWidth%s"%tc] = bestVw
-    if bestVw != state["GlobalReadVectorWidth%s"%tc]:
-      if dbFract:
-        print("  reducing GlobalReadVectorWidth%s from %u to %u" \
-            % (tc, state["GlobalReadVectorWidth%s"%tc], bestVw))
-
-    # How many loads per threads in each dimension.
-    # threads which are outside the global read tile bounds will be clipped
-    # in the assembly code generator.
-    # Multiply the LSC*GRVW
-    state["NumLoadsCoalesced%s"%tc] = roundupRatio(parDim, state["LSC%s"%tc])
-    state["NumLoadsPerpendicular%s"%tc] = roundupRatio(perpDim , state["LSP%s"%tc])
-
-    nlc = state["NumLoadsCoalesced%s"%tc]
-    nlp = state["NumLoadsPerpendicular%s"%tc]
-
-    # LoadTile must at least cover the MacroTile:
-    assert(nlc*state["LSC%s"%tc] >= parDim)
-    assert(nlp*state["LSP%s"%tc] >= perpDim)
-
-    perpOverhang = perpDim % state["LSP%s"%tc]
-    state["fractionalPerpOverhang%s"%tc] = perpOverhang
-    if dbFract:
-      # how many threads compute Global Read Offsets (GRO) that are not used
-      print("  PerLoadTile=%ux%u elements Loads/WI=%ux%u LoadTile/WI=%ux%u (MT=%ux%u), %u/%u = %.1f%% WI GRO used %s" \
-          % (state["LSC%s"%tc], state["LSP%s"%tc], \
-             nlc, nlp, \
-             nlc*state["LSC%s"%tc], nlp*state["LSP%s"%tc], \
-             parDim, perpDim, \
-             parDim*perpDim, \
-             nlc*nlp*state["NumThreads"]*state["GlobalReadVectorWidth%s"%tc], \
-             float(parDim*perpDim), \
-             float(nlc*nlp*state["NumThreads"]*state["GlobalReadVectorWidth%s"%tc]) * 100.0) \
-             )
-
-      for p in range(0,nlp):
-        elementWidth = 4
-        if p != nlp-1:
-          perp = state["LSP%s"%tc]
-        else:
-          perp = perpOverhang if perpOverhang else state["LSP%s"%tc]
-
-        validElements = state["LSC%s"%tc] * perp
-        print("  buffer_load_element_x%u %ux%ux%u bytes,  %u/%u valid GRO" %\
-              (state["GlobalReadVectorWidth%s"%tc], \
-              state["LSC%s"%tc], perp, \
-              elementWidth, \
-              validElements//state["GlobalReadVectorWidth%s"%tc],
-              state["NumThreads"]))
-
-    return True
-
-
-  @staticmethod
-  def MatrixInstructionToMIParameters(state):
-    isa = tuple(state["ISA"])
-    if len(state["MatrixInstruction"]) == 9:
-      mi                          = state["MatrixInstruction"]
-      state["MatrixInstruction"]  = [state["MatrixInstruction"][0],state["MatrixInstruction"][1],state["MatrixInstruction"][2],state["MatrixInstruction"][3]]
-
-      waves                       = mi[7]* mi[8]
-      miwg0                       = mi[4] * mi[0] * mi[7]
-      state["WorkGroup"][0]       = miwg0
-      state["WorkGroup"][1]       = waves*state["WavefrontSize"] // state["WorkGroup"][0]
-      state["ThreadTile"][0]      = 1  # dummy
-      state["ThreadTile"][1]      = 1  # dummy
-
-      state["MFMA_BF16_1K"] = False
-      if not state["ProblemType"]["Sparse"]:
-        miDataType = state["ProblemType"]["DataType"] if (not state["EnableF32XdlMathOp"]) else state["ProblemType"]["F32XdlMathOp"]
-        if globalParameters["AsmCaps"][isa]["HasMFMA"]:
-          if not (miDataType.toChar() in validMFMA and \
-            state["MatrixInstruction"] in validMFMA[miDataType.toChar()]):
-            if miDataType.isBFloat16() and \
-              state["MatrixInstruction"] in validMFMA["B1k"]:
-              state["MFMA_BF16_1K"] = True
-            else:
-              reject(state, "MatrixInstruction %s not valid for DataType %s" % (state["MatrixInstruction"], miDataType))
-        elif globalParameters["AsmCaps"][isa]["HasWMMA"]:
-          if state["MatrixInstruction"] not in validWMMA:
-            reject(state, "MatrixInstruction %s not valid for DataType %s" % (state["MatrixInstruction"], state["ProblemType"]["DataType"]))
-      else:
-        if not (state["ProblemType"]["DataType"].toChar() in validSMFMA and \
-          state["MatrixInstruction"] in validSMFMA[state["ProblemType"]["DataType"].toChar()]):
-          reject(state, "Sparse MatrixInstruction %s not valid for DataType %s" % (state["MatrixInstruction"], state["ProblemType"]["DataType"]))
-
-      # set EnableMatrixInstruction
-      state["EnableMatrixInstruction"] = True
-
-      # set MIBlock
-      MIBlock_BM = miwg0 // mi[0]
-      MIBlock_BM = min(MIBlock_BM, mi[3])
-      MIBlock_BN = mi[3] // MIBlock_BM
-
-      state["MIBlock"]    = [32, 32, 2, 1, 1, 1]
-      state["MIBlock"][0] = mi[0]
-      state["MIBlock"][1] = mi[1]
-      state["MIBlock"][2] = mi[2]
-      state["MIBlock"][3] = mi[3]
-      state["MIBlock"][4] = MIBlock_BM
-      state["MIBlock"][5] = MIBlock_BN
-
-      # set MIWaveGroup
-      state['MIWaveGroup']     = [1, 1]
-      state['MIWaveGroup'][0]  = min((miwg0 // mi[0]) // MIBlock_BM, waves)
-      state['MIWaveGroup'][1]  = waves // state['MIWaveGroup'][0]
-
-      # set MIWaveTile
-      state['MIWaveTile']      = [1, 1]
-      state['MIWaveTile'][0]   = mi[5]
-      state['MIWaveTile'][1]   = mi[6]
-      # set MIInputPerThread
-      isa = tuple(state["ISA"])
-      state['MIInputPerThread'] = state["MatrixInstruction"][0] * state["MatrixInstruction"][2] * state["MatrixInstruction"][3] // state["WavefrontSize"]
-      if (not globalParameters["AsmCaps"][isa]['HasMFMA']) and globalParameters["AsmCaps"][isa]['HasWMMA']:
-        if state['ISA'][0] == 10 or state['ISA'][0] == 11:
-          state['MIInputPerThread'] = state["MatrixInstruction"][2]
-      sparseA = False if not state["ProblemType"]["Sparse"] else False if state["ProblemType"]["Sparse"] == 2 else True
-      sparseB = False if not state["ProblemType"]["Sparse"] else True if state["ProblemType"]["Sparse"] == 2 else False
-      state['MIInputPerThreadA'] = state['MIInputPerThread'] if not sparseA else state['MIInputPerThread']//2
-      state['MIInputPerThreadB'] = state['MIInputPerThread'] if not sparseB else state['MIInputPerThread']//2
-      state['MIInputPerThreadMetadata'] = state['MIInputPerThread'] if not state["ProblemType"]["Sparse"] else state['MIInputPerThread']//8
-    elif state["MatrixInstruction"] != [] and len(state["MatrixInstruction"]) == 4:
-      state["EnableMatrixInstruction"] = True
-    else:
-      state["EnableMatrixInstruction"] = False
 
 
   ##############################################
   # check and calculate Wave Separate Global Read
   @staticmethod
-  def checkAndAssignWaveSeparateGlobalRead(state, tc):
+  def checkAndAssignWaveSeparateGlobalRead(state, tc, printRejectionReason: bool):
     # check can we use WaveSeparateGlobalRead
     numOfWaves = state["NumThreads"] // state["WavefrontSize"]
     if state["WaveSeparateGlobalRead%s"%tc]:
       if state["ProblemType"]["TLU%s"%tc] and (state["_DepthU%s"%tc] > 0) and (state["_DepthU%s"%tc] % numOfWaves != 0):
-        reject(state, "didn't support WaveSeparateGlobalRead when DepthU is not multiple of wave %u in TLU%s" % (state["_DepthU%s"%tc], tc))
+        reject(state, printRejectionReason, "didn't support WaveSeparateGlobalRead when DepthU is not multiple of wave %u in TLU%s" % (state["_DepthU%s"%tc], tc))
       if not state["ProblemType"]["TLU%s"%tc] and (state["MacroTile%s" % tc] % numOfWaves != 0):
-        reject(state, "didn't support WaveSeparateGlobalRead when MacroTile is not multiple of wave %u in TLU%s" % (state["MacroTile%s"%tc], tc))
+        reject(state, printRejectionReason, "didn't support WaveSeparateGlobalRead when MacroTile is not multiple of wave %u in TLU%s" % (state["MacroTile%s"%tc], tc))
 
 
   ########################################
   # determine can we use VgprForLocalReadPacking
   @staticmethod
-  def isVgprForLocalReadPackingDoable(state):
+  def isVgprForLocalReadPackingDoable(state, isaInfoMap: Dict[str, IsaInfo]):
     isa = tuple(state["ISA"])
     doable = True
     # MatrixInstruction only
     if not state["EnableMatrixInstruction"]:
       doable = False
     # only for HasEccHalf
-    if not globalParameters["ArchCaps"][isa]["HasEccHalf"]:
+    if not isaInfoMap[isa].archCaps["HasEccHalf"]:
       doable = False
     # only for PLR>=1 (except for DTVA+B)
     if state["PrefetchLocalRead"] < 1 and not (state["DirectToVgprA"] and state["DirectToVgprB"]):
@@ -1850,19 +716,19 @@ class Solution(collections.abc.Mapping):
   ########################################
   # determine can we use DirectToVgpr
   @staticmethod
-  def isDirectToVgprDoable(state, tc):
+  def isDirectToVgprDoable(state, tc, printRejectionReason: bool, isaInfoMap: Dict[str, IsaInfo]):
     MIindex = 0 if tc == 'A' else 1
     numBytes = state["ProblemType"]["DataType"].numBytes()
     numBytesGR = state["ProblemType"]["DataType%s"%tc].numBytes()
     # With MatrixInstruction only
     if not state["EnableMatrixInstruction"] :
-      reject(state, "DirectToVgpr is for MatrixInstruction only")
+      reject(state, printRejectionReason, "DirectToVgpr is for MatrixInstruction only")
       return False
 
     # disable the following combinations for initial implementation
     # TODO: enable them
     if state["LocalSplitU"] != 1 and (not state["ProblemType"]["TLU%c"%tc]):
-      reject(state, "DirectToVgpr + LSU + TLU=False has not been enabled yet(tentative)")
+      reject(state, printRejectionReason, "DirectToVgpr + LSU + TLU=False has not been enabled yet(tentative)")
       return False
 
     if state["DirectToVgprA"] and state["DirectToVgprB"]:
@@ -1873,42 +739,42 @@ class Solution(collections.abc.Mapping):
       state["PrefetchLocalRead"] = 0
       # So far, DTVA + DTVB does not perform well (waitcnt is not ideal).
       # Disable it for now (TODO: improve waitcnt and re-enable)
-      reject(state, "DirectToVgprA + DirectToVgprB disabled")
+      reject(state, printRejectionReason, "DirectToVgprA + DirectToVgprB disabled")
       return False
 
     # DTV + input type conversion
     if state["ProblemType"]["DataType%s"%tc] != state["ProblemType"]["DataType"]:
       if not state["ConvertAfterDS"]:
-        reject(state, "DirectToVgpr%s + input conversion + ConvertAfterDS=False not supported"%(tc))
+        reject(state, printRejectionReason, "DirectToVgpr%s + input conversion + ConvertAfterDS=False not supported"%(tc))
         return False
 
     # check if the DataType can support DirectToVgpr
     if not Solution.isDirectToVgprSupportDataType(state):
-      reject(state, "no DirectToVgpr support for this input data type")
+      reject(state, printRejectionReason, "no DirectToVgpr support for this input data type")
       return False
 
     # Does not work with TLU = False and PrefetchLocalRead = 0
     if (not state["ProblemType"]["TLU%c"%tc]) and state["PrefetchLocalRead"] == 0:
-      reject(state, "DirectToVgpr%c does not supports TLU%c = False and PrefetchLocalRead = 0"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU%c = False and PrefetchLocalRead = 0"%(tc, tc))
       return False
 
     # Does not work with TLU = False and CGEMM/DGEMM/DGEMM (not supported)
     if (not state["ProblemType"]["TLU%c"%tc]) and (state["ProblemType"]["DataType"].isDouble() or \
         state["ProblemType"]["DataType"].isComplex()):
-      reject(state, "DirectToVgpr%c does not supports TLU%c = False + S/C/D/ZGEMM"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU%c = False + S/C/D/ZGEMM"%(tc, tc))
       return False
 
     if numBytesGR * state["GlobalReadVectorWidth%c"%tc] < 4:
       # no support for DTV + numBytesGR * GlobalReadVectorWidth< 4
-      reject(state, "DirectToVgpr%c does not support TLU%c + numByte * GlobalReadVectorWidth%c < 4"%(tc, tc, tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not support TLU%c + numByte * GlobalReadVectorWidth%c < 4"%(tc, tc, tc))
       return False
 
     if numBytes < 4:
       # numBytes < 4 case
       if state["ProblemType"]["TLU%c"%tc]:
         # use pack logic (with v_perm) same as local read (only if VgprForLocalReadPacking is doable)
-        if not Solution.isVgprForLocalReadPackingDoable(state):
-          reject(state, "Does not meet the requirement for DirectToVgpr%c + TLU%c + numByte < 4"%(tc, tc))
+        if not Solution.isVgprForLocalReadPackingDoable(state, isaInfoMap):
+          reject(state, printRejectionReason, "Does not meet the requirement for DirectToVgpr%c + TLU%c + numByte < 4"%(tc, tc))
           return False
         # force ClusterLocalRead=1 for DTV + pack
         state["ClusterLocalRead"] = 1
@@ -1916,7 +782,7 @@ class Solution(collections.abc.Mapping):
       # numBytes >= 4 case
       if state["ProblemType"]["TLU%c"%tc] and state["MIInputPerThread"] > 1:
         # no support for numBytes >= 4 + MIInputPerThread > 1
-        reject(state, "DirectToVgpr%c does not support TLU%c+ numByte >= 4 + MIInputPerThread > 1"%(tc, tc))
+        reject(state, printRejectionReason, "DirectToVgpr%c does not support TLU%c+ numByte >= 4 + MIInputPerThread > 1"%(tc, tc))
         return False
 
     # MatrixInstBM,BN check
@@ -1924,52 +790,52 @@ class Solution(collections.abc.Mapping):
     #  for B, MatrixInstBM should be 1
     # This is to limit the number of Vgpr
     if tc == 'A' and not (state['MatrixInstBN'] == 1):
-      reject(state, "MatrixInstBN should be 1 for DirectToVgprA. Current value is %d"%(state['MatrixInstBN']))
+      reject(state, printRejectionReason, "MatrixInstBN should be 1 for DirectToVgprA. Current value is %d"%(state['MatrixInstBN']))
       return False
     if tc == 'B' and not (state['MatrixInstBM'] == 1):
-      reject(state, "MatrixInstBM should be 1 for DirectToVgprB. Current value is %d"%(state['MatrixInstBM']))
+      reject(state, printRejectionReason, "MatrixInstBM should be 1 for DirectToVgprB. Current value is %d"%(state['MatrixInstBM']))
       return False
 
     # Does not work with WaveSeparateGlobalRead
     if state["WaveSeparateGlobalRead%c"%tc]:
-      reject(state, "DirectToVgpr%c does not supports WaveSeparateGlobalRead%c"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports WaveSeparateGlobalRead%c"%(tc, tc))
       return False
 
     # Does not work with TLU + VectorWidth != GlobalReadVectorWidth (VW = 2 + GRVW = 1 or VW = 1 + GRVW = 2 does not work)
     if state["ProblemType"]["TLU%c"%tc] and state["VectorWidth%s"%tc] != state["GlobalReadVectorWidth%c"%tc]:
-      reject(state, "DirectToVgpr%c does not supports TLU + VectorWidth%s(=%u) != GlobalReadVectorWidth%c(%u)"%(tc, tc, state["VectorWidth%s"%tc], tc, state["GlobalReadVectorWidth%c"%tc]))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU + VectorWidth%s(=%u) != GlobalReadVectorWidth%c(%u)"%(tc, tc, state["VectorWidth%s"%tc], tc, state["GlobalReadVectorWidth%c"%tc]))
       return False
 
     # Does not work with TLU=False and NumLoadsCoalesced != DepthU//(MatrixInstK*GRVW*LSU//MIInputPerThread)
     if (not state["ProblemType"]["TLU%c"%tc]) and \
         state["NumLoadsCoalesced%c"%tc] != state["DepthU"] // (state["MatrixInstK"] * state["GlobalReadVectorWidth%c"%tc] * state["LocalSplitU"] // state["MIInputPerThread"]):
-      reject(state, "DirectToVgpr%c does not supports TLU=False and NumLoadsCoalesced%c != DepthU//(MatrixInstK*GlobalReadVectorWidth*LocalSplitU//MIInputPerThread(=%u))"%(tc, tc, state["MIInputPerThread"]))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU=False and NumLoadsCoalesced%c != DepthU//(MatrixInstK*GlobalReadVectorWidth*LocalSplitU//MIInputPerThread(=%u))"%(tc, tc, state["MIInputPerThread"]))
       return False
 
     # TLU=False case, need GlobalReadVectorWidth == LocalReadVectorWidth
     if (not state["ProblemType"]["TLU%c"%tc]) and \
        state["GlobalReadVectorWidth%c"%tc] != state["LocalReadVectorWidth"]:
-      reject(state, "DirectToVgpr%c does not supports TLU=False GlobalReadVectorWidth%c(%u) != LocalReadVectorWidth(%u)"%(tc, tc, state["GlobalReadVectorWidth%c"%tc], state["LocalReadVectorWidth"]))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU=False GlobalReadVectorWidth%c(%u) != LocalReadVectorWidth(%u)"%(tc, tc, state["GlobalReadVectorWidth%c"%tc], state["LocalReadVectorWidth"]))
       return False
 
     # Does not work with SIA<3
     if state["ScheduleIterAlg"] < 3:
-      reject(state, "DirectToVgpr%c does not supports ScheduleIterAlg < 3"%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports ScheduleIterAlg < 3"%(tc))
       return False
 
     # Does not work with InnerUnroll>1
     if state["InnerUnroll"]>1:
-      reject(state, "DirectToVgpr%c does not supports InnerUnroll>1"%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports InnerUnroll>1"%(tc))
       return False
 
     # Reject TLU = UnrollMajorLDS
     if state["ProblemType"]["TLU%c"%tc] == state["UnrollMajorLDS%c"%tc]:
-      reject(state, "DirectToVgpr%c does not supports TLU%c = UnrollMajorLDS%c"%(tc, tc, tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports TLU%c = UnrollMajorLDS%c"%(tc, tc, tc))
       return False
 
     # does not work with UnrollLoopSwapGlobalReadOrder
     if state["UnrollLoopSwapGlobalReadOrder"]:
-      reject(state, "DirectToVgpr%c does not supports UnrollLoopSwapGlobalReadOrder"%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports UnrollLoopSwapGlobalReadOrder"%(tc))
       return False
 
     # does not work with PGR2 + EPS
@@ -1979,17 +845,17 @@ class Solution(collections.abc.Mapping):
 
     # does not work with Sparse
     if state["ProblemType"]["Sparse"]:
-      reject(state, "DirectToVgpr%c does not supports Sparse"%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports Sparse"%(tc))
       return False
 
     # for DTVA/DTVB, does not work with PGR0
     if state["PrefetchGlobalRead"] == 0:
-      reject(state, "DirectToVgpr%c does not supports PrefetchGlobalRead == 0."%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports PrefetchGlobalRead == 0."%(tc))
       return False
 
     # for DTVA, does not work with NN and TLDS0
     if tc == 'A' and state["TransposeLDS"] == 0 and (not state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
-      reject(state, "DirectToVgpr%c does not supports NN case with TransposeLDS == 0."%(tc))
+      reject(state, printRejectionReason, "DirectToVgpr%c does not supports NN case with TransposeLDS == 0."%(tc))
       return False
 
     # for DTVA, does not work with TT and Tail-loop
@@ -2010,13 +876,13 @@ class Solution(collections.abc.Mapping):
   ########################################
   # determine can we use DirectToLds
   @staticmethod
-  def isDirectToLdsDoable(state, tc):
+  def isDirectToLdsDoable(state, tc, isaInfoMap, printRejectionReason: bool):
 
     numBytes = state["ProblemType"]["DataType"].numBytes()
-    isa = tuple(state["ISA"])
+    isa = state["ISA"]
 
     # x4 support for directToLds
-    canDTLx4 = globalParameters["AsmCaps"][isa]["HasDirectToLdsx4"]
+    canDTLx4 = isaInfoMap[isa].asmCaps["HasDirectToLdsx4"]
 
     # numelements_perlane = 4/numBytes
     # TN with transposeLDS feature should work as long as state["AssertSummationElementMultiple"] % (numelements_perlane*2) = 0
@@ -2036,91 +902,91 @@ class Solution(collections.abc.Mapping):
 
     # x2 DTL is not supported
     if numBytesPerLoad == 8:
-      reject(state, "can't use DirectToLds with b64 buffer load")
+      reject(state, printRejectionReason, "can't use DirectToLds with b64 buffer load")
       return False
 
     if numBytesPerLoad == 16 and not canDTLx4:
-      reject(state, "b128 DirectToLds not supported")
+      reject(state, printRejectionReason, "b128 DirectToLds not supported")
       return False
 
     # so far MFMA only (TODO: enable non MFMA case)
     if not state["EnableMatrixInstruction"]:
-      reject(state, "DirectToLds is for MatrixInstruction only for now (tentative)")
+      reject(state, printRejectionReason, "DirectToLds is for MatrixInstruction only for now (tentative)")
       return False
 
     # so far, DirectToLds does not work with StreamK (TODO: enable StreamK case)
     if state["StreamK"]:
-      reject(state, "DirectToLds does not support StreamK (tentative)")
+      reject(state, printRejectionReason, "DirectToLds does not support StreamK (tentative)")
       return False
 
     # ToDo: Review def of lrvw and this check
     # DTL + LocalReadVectorWidth > MIInputPerThread does not work
     # Need support for TailLoop
-    if not state["ProblemType"]["Sparse"] and (not globalParameters["AsmCaps"][isa]["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
+    if not state["ProblemType"]["Sparse"] and (not isaInfoMap[isa].asmCaps["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
       if state["LocalReadVectorWidth"] > state["MIInputPerThread"]:
-        reject(state, "DirectToLds does not work with LocalReadVectorWidth > MIInputPerThread")
+        reject(state, printRejectionReason, "DirectToLds does not work with LocalReadVectorWidth > MIInputPerThread")
         return False
 
-    if not state["ProblemType"]["Sparse"] and (not globalParameters["AsmCaps"][isa]["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
+    if not state["ProblemType"]["Sparse"] and (not isaInfoMap[isa].asmCaps["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
       if state["ProblemType"]["DataType"].isBFloat16() and state["AssertSummationElementMultiple"] % (2 * state["GlobalReadVectorWidth%c"%tc]) != 0:
-        reject(state, "can't use DirectToLds for BF16 with AssertSummationElementMultiple %u" % state["AssertSummationElementMultiple"])
+        reject(state, printRejectionReason, "can't use DirectToLds for BF16 with AssertSummationElementMultiple %u" % state["AssertSummationElementMultiple"])
         return False
 
     if state["NumThreads"] % state["WavefrontSize"] != 0:
-      reject(state, "can't use DirectToLds for NumThreads % WavefrontSize != 0")
+      reject(state, printRejectionReason, "can't use DirectToLds for NumThreads % WavefrontSize != 0")
       return False
 
     if state["ProblemType"]["TLU%c"%tc] == state["UnrollMajorLDS%c" % tc]:
-      reject(state, "can't use DirectToLds for TLU%c == UnrollMajorLDS%c"%(tc, tc))
+      reject(state, printRejectionReason, "can't use DirectToLds for TLU%c == UnrollMajorLDS%c"%(tc, tc))
       return False
 
     # avoid picking x2&x4 for precisions < f32/f64 in [ProblemType][TLU] == TRUE
     if not state["EnableMatrixInstruction"]:
       if state["GlobalReadVectorWidth%c"%tc] * numBytesAB * state["WavefrontSize"] > 256:
-        reject(state, "can't use DirectToLds for not EnableMatrixInstruction and GlobalReadVectorWidth%c * bpe%c * WavefrontSize > 256"%(tc,tc))
+        reject(state, printRejectionReason, "can't use DirectToLds for not EnableMatrixInstruction and GlobalReadVectorWidth%c * bpe%c * WavefrontSize > 256"%(tc,tc))
         return False
 
     if state["WaveSeparateGlobalRead%c" % tc]:
       if state["LSC%c"%tc] * state["LSP%c"%tc] * numBytesAB != state["WavefrontSize"] * state["GlobalReadVectorWidth%c"%tc] * numBytesAB:
-        reject(state, "can't use DirectToLds for LSC%c and LSP%c * bpe!= WavefrontSize * GlobalReadVectorWidth%c * bpe%c > 4"%(tc, tc, tc, tc))
+        reject(state, printRejectionReason, "can't use DirectToLds for LSC%c and LSP%c * bpe!= WavefrontSize * GlobalReadVectorWidth%c * bpe%c > 4"%(tc, tc, tc, tc))
         return False
     else:
       if state["LSC%c"%tc] * state["LSP%c"%tc] * numBytesAB != state["NumThreads"] * state["GlobalReadVectorWidth%c"%tc] * numBytesAB:
-        reject(state, "can't use DirectToLds for LSC%c and LSP%c * bpe != NumThreads * GlobalReadVectorWidth%c * bpe%c > 4"%(tc, tc, tc, tc))
+        reject(state, printRejectionReason, "can't use DirectToLds for LSC%c and LSP%c * bpe != NumThreads * GlobalReadVectorWidth%c * bpe%c > 4"%(tc, tc, tc, tc))
         return False
 
     # so far, DirectToLds does not work well with PGR=2
     # performance is not good and a lot of ds_read for DTL can cause scheduling issue(need fix)
     if state["PrefetchGlobalRead"] == 2:
-      reject(state, "can't use DirectToLds for PrefetchGlobalRead == 2")
+      reject(state, printRejectionReason, "can't use DirectToLds for PrefetchGlobalRead == 2")
       return False
 
     # so far, DirectToLds does not work with LRVW=2
     if state["LocalReadVectorWidth"] == 2:
-      reject(state, "can't use DirectToLds for LocalReadVectorWidth == 2")
+      reject(state, printRejectionReason, "can't use DirectToLds for LocalReadVectorWidth == 2")
       return False
 
     # Does not work with (NumLoadsCoalesced>1 and UseInstOffsetForGRO) + DGEMM
     if state["ProblemType"]["DataType"].isDouble() and \
       (state["NumLoadsCoalesced%c"%tc] > 1 and state["UseInstOffsetForGRO"]):
-      reject(state, "DirectToLds%c does not supports NumLoadsCoalesced%c > 1 and UseInstOffsetForGRO for dgemm"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToLds%c does not supports NumLoadsCoalesced%c > 1 and UseInstOffsetForGRO for dgemm"%(tc, tc))
       return False
 
     # Does not work with NumLoadsCoalesced>1 + ZGEMM
     if state["ProblemType"]["DataType"].isDoubleComplex() and state["NumLoadsCoalesced%c"%tc] > 1:
-      reject(state, "DirectToLds%c does not supports NumLoadsCoalesced%c > 1 for zgemm"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToLds%c does not supports NumLoadsCoalesced%c > 1 for zgemm"%(tc, tc))
       return False
 
     # Does not work with PrefetchGlobalRead=2 and PrefetchLocalRead=1 (cannot schedule DTL global read after local read)
     if state["PrefetchGlobalRead"] == 2 and state["PrefetchLocalRead"] == 1:
-      reject(state, "DirectToLds%c does not work with PrefetchGlobalRead=2 and PrefetchLocalRead=1"%(tc))
+      reject(state, printRejectionReason, "DirectToLds%c does not work with PrefetchGlobalRead=2 and PrefetchLocalRead=1"%(tc))
       return False
 
     # DirectToLds does not work if MacroTile is not power of 2
     # LDS offset swap/rotate logic works only when MacroTile is power of 2
     mt = state["MacroTile%c"%tc]
     if mt & (mt - 1) != 0:
-      reject(state, "can't use DirectToLds if MacroTile%s is not power of 2"%tc)
+      reject(state, printRejectionReason, "can't use DirectToLds if MacroTile%s is not power of 2"%tc)
       return False
 
     # DirectToLds does not work with TLU=False and bpe > bpr and DepthU//NumLoadsCoalesced < 8
@@ -2129,7 +995,7 @@ class Solution(collections.abc.Mapping):
     # current offset swap logic does not work
     if (not state["ProblemType"]["TLU%c"%tc]) and state["ProblemType"]["DataType"].numRegisters() > 1 and \
        state["_DepthU%s"%tc] // state["NumLoadsCoalesced%c"%tc] < 8:
-      reject(state, "DirectToLds%c does not work with TLU=False and bpe > bpr and DepthU//NumLoadsCoalesced%c < 8"%(tc, tc))
+      reject(state, printRejectionReason, "DirectToLds%c does not work with TLU=False and bpe > bpr and DepthU//NumLoadsCoalesced%c < 8"%(tc, tc))
       return False
 
     return True
@@ -2152,15 +1018,27 @@ class Solution(collections.abc.Mapping):
   ########################################
   # assign all derived parameters
   @staticmethod
-  def assignDerivedParameters(state):
-    state["EnableF32XdlMathOp"] = False #ignore the F32 xDL MathOp by default.
+  def assignDerivedParameters(
+    state,
+    splitGSU: bool,
+    printRejectionReason: bool,
+    printIndexAssignmentInfo: bool,
+    isaInfoMap,
+    rocmVersion: SemanticVersion,
+    depthUConfig: DepthUConfig
+  ):
+    # NOTE: This entry should instead should already be set on the solution within the logic
+    # files. This code will be removed once all logic files are updated to contain both
+    # the keys "EnableF32XdlMathOp" and "F32XdlMathOp".
+    state["EnableF32XdlMathOp"] = False 
+    #ignore the F32 xDL MathOp by default.
     #enable F32 xDL MathOp only when the input type is f32.
     if "F32XdlMathOp" in state["ProblemType"] \
        and (not state["ProblemType"]["F32XdlMathOp"].isSingle()) \
        and (state["ProblemType"]["DataType"].isSingle()):
       state["EnableF32XdlMathOp"] = True
 
-    Solution.assignProblemIndependentDerivedParameters(state)
+    Solution.assignProblemIndependentDerivedParameters(state, printRejectionReason, isaInfoMap)
 
     if "AssignedDerivedParameters" in state:
       if state["AssignedDerivedParameters"]:
@@ -2184,7 +1062,7 @@ class Solution(collections.abc.Mapping):
     elif state["GlobalSplitUAlgorithm"] == 'MultipleBuffer':
       state["_GlobalAccumulation"] = 'MultipleBuffer'
     elif state["GlobalSplitUAlgorithm"] == 'MultipleBufferSingleKernel':
-      if (not globalParameters["SplitGSU"]):
+      if (not splitGSU):
         state["_GlobalAccumulation"] = 'MultipleBufferSingleKernel'
       else:
         if state["GlobalSplitU"] > 1:
@@ -2200,32 +1078,32 @@ class Solution(collections.abc.Mapping):
       state["GlobalSplitU"] = 0 # Cannot enable both Stream-K and GSU
       state["GlobalSplitUAlgorithm"] = "MultipleBuffer" # Set default Algorithm
       if state["ProblemType"]["DataType"].isDouble():
-        reject(state, "Type {} for DataType not yet supported with StreamK".format(state["ProblemType"]["DataType"].toChar()))
+        reject(state, printRejectionReason, "Type {} for DataType not yet supported with StreamK".format(state["ProblemType"]["DataType"].toChar()))
       if state["MIWaveGroup"][0] * state["MIWaveGroup"][1] != 4:
-        reject(state, "Stream-K requries MIWaveGroup0*MIWaveGroup1=4")
+        reject(state, printRejectionReason, "Stream-K requries MIWaveGroup0*MIWaveGroup1=4")
       if not state["EnableMatrixInstruction"]:
-        reject(state, "Stream-K requires MatrixInstruction")
-      if globalParameters["AsmCaps"][isa]["HasWMMA"]:
-        reject(state, "Stream-K untested with WMMA")
+        reject(state, printRejectionReason, "Stream-K requires MatrixInstruction")
+      if isaInfoMap[isa].asmCaps["HasWMMA"]:
+        reject(state, printRejectionReason, "Stream-K untested with WMMA")
       # if state["PersistentKernel"]:
-      #   reject(state, "Cannot enable both Stream-K and PersistentKernel")
+      #   reject(state, printRejectionReason, "Cannot enable both Stream-K and PersistentKernel")
       if not state["ProblemType"]["StridedBatched"]:
-        reject(state, "General batch not supported with Stream-K")
+        reject(state, printRejectionReason, "General batch not supported with Stream-K")
       if state["ProblemType"]["GroupedGemm"]:
-        reject(state, "Grouped gemm not yet supported with Stream-K")
+        reject(state, printRejectionReason, "Grouped gemm not yet supported with Stream-K")
       if state["ScheduleGlobalRead"] != 1:
-        reject(state, "ScheduleGlobalRead not supported with Stream-K")
+        reject(state, printRejectionReason, "ScheduleGlobalRead not supported with Stream-K")
       if state["ScheduleLocalWrite"] != 1:
-        reject(state, "ScheduleLocalWrite not supported with Stream-K")
+        reject(state, printRejectionReason, "ScheduleLocalWrite not supported with Stream-K")
       if state["ScheduleIterAlg"] != 2 and state["ScheduleIterAlg"] != 3:
-        reject(state, "ScheduleIterAlg not supported with Stream-K")
+        reject(state, printRejectionReason, "ScheduleIterAlg not supported with Stream-K")
       if state["StreamKAtomic"] == 1:
         if not state["ProblemType"]["DataType"].isSingle():
-          reject(state, "Atomic Stream-K currently only tested for SGEMM")
+          reject(state, printRejectionReason, "Atomic Stream-K currently only tested for SGEMM")
         if not state["BufferStore"]:
-          reject(state, "Atomic Stream-K requires BufferStore")
+          reject(state, printRejectionReason, "Atomic Stream-K requires BufferStore")
         if state["LocalSplitU"] > 1:
-          reject(state, "Atomic Stream-K not working with LocalSplitU")
+          reject(state, printRejectionReason, "Atomic Stream-K not working with LocalSplitU")
       if not state["Valid"]:
         return
     else:
@@ -2245,28 +1123,28 @@ class Solution(collections.abc.Mapping):
     if state["VectorStore"] == -1:
         state["_VectorStore"] = 1 # default, may be changed if needed to generate a valid kernel
 
-    ProblemType.assignDerivedParameters(state["ProblemType"])
+    ProblemType.assignDerivedParameters(state["ProblemType"], printIndexAssignmentInfo)
     if not state["Valid"]:
       print2("in assignDerivedParameters, state['Valid'] = False")
       return
 
-    if not globalParameters["AsmCaps"][isa]["HasNTModifier"]:
+    if not isaInfoMap[isa].asmCaps["HasNTModifier"]:
       # force to disable nt flag if it is not supported by arch
       for ch in ["", "A", "B", "C", "D", "E", "WS", "Metadata"]:
         if state["NonTemporal%s"%ch] >= 4:
           state["NonTemporal%s"%ch] -= 4
 
-    if state["WavefrontSize"] == 32 and not globalParameters["ArchCaps"][isa]["HasWave32"]:
-      reject(state, "WavefrontSize=32 not supported for ISA {}".format(isa))
+    if state["WavefrontSize"] == 32 and not isaInfoMap[isa].archCaps["HasWave32"]:
+      reject(state, printRejectionReason, "WavefrontSize=32 not supported for ISA {}".format(isa))
       return
 
     if state["WavefrontSize"] == 32 and state["KernelLanguage"] == "Source":
-      reject(state, "WavefrontSize=32 not yet supported for source kernels.")
+      reject(state, printRejectionReason, "WavefrontSize=32 not yet supported for source kernels.")
       return
 
     if state["EnableMatrixInstruction"]:
-      if not (globalParameters["AsmCaps"][isa]["HasMFMA"] or globalParameters["AsmCaps"][isa]["HasWMMA"]):
-        reject(state, f"isa {isa} doesn't support matrix instruction")
+      if not (isaInfoMap[isa].asmCaps["HasMFMA"] or isaInfoMap[isa].asmCaps["HasWMMA"]):
+        reject(state, printRejectionReason, f"isa {isa} doesn't support matrix instruction")
         return
       if not (state["ProblemType"]["DataType"].isSingle() \
               or state["ProblemType"]["DataType"].isDouble() \
@@ -2275,62 +1153,62 @@ class Solution(collections.abc.Mapping):
               or state["ProblemType"]["DataType"].isComplex() \
               or state["ProblemType"]["DataType"].is8bitFloat() \
               or state["ProblemType"]["DataType"].isInt8()):
-        reject(state, "didn't support Matrix Instruction with type %s" % str(state["ProblemType"]["DataType"]))
+        reject(state, printRejectionReason, "didn't support Matrix Instruction with type %s" % str(state["ProblemType"]["DataType"]))
         return
-      if (not globalParameters["AsmCaps"][isa]["HasMFMA"] and globalParameters["AsmCaps"][isa]["HasWMMA"] and (state["WavefrontSize"] == 64)):
+      if (not isaInfoMap[isa].asmCaps["HasMFMA"] and isaInfoMap[isa].asmCaps["HasWMMA"] and (state["WavefrontSize"] == 64)):
          print2("!! Warning: WMMA only well tune on WGP mode, wave size = 32")
-      #  reject(state, "WMMA only suppport on WGP mode, wave size = 32")
+      #  reject(state, printRejectionReason, "WMMA only suppport on WGP mode, wave size = 32")
       #  return
       if not state["MIBlock"] or len(state["MIBlock"]) != 6:
-        reject(state, "invalid MIBlock")
+        reject(state, printRejectionReason, "invalid MIBlock")
         return
       if not state["MIWaveGroup"] or len(state["MIWaveGroup"]) != 2:
-        reject(state, "invalid MIWaveGroup")
+        reject(state, printRejectionReason, "invalid MIWaveGroup")
         return
       if not state["MIWaveTile"] or len(state["MIWaveTile"]) != 2:
-        reject(state, "invalid MIWaveTile")
+        reject(state, printRejectionReason, "invalid MIWaveTile")
         return
-      if globalParameters["AsmCaps"][isa]["HasMFMA"]:
+      if isaInfoMap[isa].asmCaps["HasMFMA"]:
         if not state["ProblemType"]["HighPrecisionAccumulate"] \
            and state["ProblemType"]["DataType"].numRegisters() < 1 :
-          reject(state, "Matrix instructions for half, bf16 (or i8) types are natively accumulated" + \
+          reject(state, printRejectionReason, "Matrix instructions for half, bf16 (or i8) types are natively accumulated" + \
            " in fp32 (or i32) precision. Please add the following config:" + \
            "\n - HighPrecisionAccumulate: True")
           return
-      if globalParameters["AsmCaps"][isa]["HasWMMA"]:
+      if isaInfoMap[isa].asmCaps["HasWMMA"]:
         if state["ProblemType"]["DataType"].numRegisters() >=1:
-          reject(state, "WMMA only support half, bf16 and i8 type")
+          reject(state, printRejectionReason, "WMMA only support half, bf16 and i8 type")
           return
       if state["InterleaveAlpha"]:
-        reject(state, "Matrix instruction doesn't support InterleaveAlpha")
+        reject(state, printRejectionReason, "Matrix instruction doesn't support InterleaveAlpha")
         return
       if state["ProblemType"]["DataType"].isInt8():
         if isa[:2] == (9, 4):
           if tuple(state["MatrixInstruction"])[:3] in ((32, 32, 8), (16, 16, 16)):
-            reject(state, "v_mfma_i32_32x32x8 and v_mfma_i32_16x16x16 have been deprecated in gfx94x")
+            reject(state, printRejectionReason, "v_mfma_i32_32x32x8 and v_mfma_i32_16x16x16 have been deprecated in gfx94x")
             return
       if state["ProblemType"]["ComputeDataType"].isDouble():
         # See [4,4,4,4] snop for more info
-        if state["MatrixInstruction"] == [4,4,4,4] and (not state['ISA'] == [9,0,10]) and state["ScheduleIterAlg"] == 3:
-          reject(state, "Currently Matrix instructions [4,4,4,4] is disabled.")
+        if state["MatrixInstruction"] == [4,4,4,4] and (not state['ISA'] == IsaVersion(9,0,10)) and state["ScheduleIterAlg"] == 3:
+          reject(state, printRejectionReason, "Currently Matrix instructions [4,4,4,4] is disabled.")
           return
     else:
       if not state["ProblemType"]["HighPrecisionAccumulate"] \
          and state["ProblemType"]["ComputeDataType"].numRegisters() > state["ProblemType"]["DataType"].numRegisters() :
-        reject(state, "For non-MI Kernel, if sizeof(ComputeDataType) > sizeof(DataType), " + \
+        reject(state, printRejectionReason, "For non-MI Kernel, if sizeof(ComputeDataType) > sizeof(DataType), " + \
          "Please add the following config:" + \
          "\n - HighPrecisionAccumulate: True")
         return
       if state["ProblemType"]["Sparse"]:
-        reject(state, "Sparse A problem is only supported by SMFMA MI kernel.")
+        reject(state, printRejectionReason, "Sparse A problem is only supported by SMFMA MI kernel.")
         return
 
       if state["ThreadTile0"] > 16 or state["ThreadTile1"] > 16:
-        reject(state, "Invalid value for ThreadTile")
+        reject(state, printRejectionReason, "Invalid value for ThreadTile")
         return
 
       if state["ScheduleIterAlg"] == 2 or state["ScheduleIterAlg"] == 3:
-        reject(state, "SIA2 and SIA3 only support MatrixInstruction")
+        reject(state, printRejectionReason, "SIA2 and SIA3 only support MatrixInstruction")
         return
 
     if state["ProblemType"]["Tensor0"]==0:
@@ -2355,7 +1233,7 @@ class Solution(collections.abc.Mapping):
         state["MIWaveTileB"] = state["MIWaveTile"][0]
 
     if state["ProblemType"]["Sparse"] == 2 and state["DirectToVgprSparseMetadata"]:
-      reject(state, "Sparse B does not supprot DirectToVgprSparseMetadata")
+      reject(state, printRejectionReason, "Sparse B does not supprot DirectToVgprSparseMetadata")
       return
 
 
@@ -2408,7 +1286,7 @@ class Solution(collections.abc.Mapping):
     for (tc,batchMask) in (('A', 0x1), ('B', 0x2)):
       freeDims = [i for i in problemType["IndexAssignments%s"%tc] if i in problemType["IndicesFree"]]
       if not freeDims:
-        reject(state, "tensor%s contains no free indices.")
+        reject(state, printRejectionReason, "tensor%s contains no free indices.")
         return False
 
     # Determine which indices will be packed together as this impacts several different parms (sizes, magic numbers, etc)
@@ -2459,11 +1337,11 @@ class Solution(collections.abc.Mapping):
       state["DirectToLds"] = False
       state["_UseSgprForGRO"] = False
       if state["PrefetchGlobalRead"] == 2:
-        reject(state, "BufferLoad=0 does not support PrefetchGlobalRead=2")
+        reject(state, printRejectionReason, "BufferLoad=0 does not support PrefetchGlobalRead=2")
         return
 
       if problemType["UseBias"]:
-        reject(state, "BufferLoad=0 does not support UseBias due to no suppress no load.")
+        reject(state, printRejectionReason, "BufferLoad=0 does not support UseBias due to no suppress no load.")
         return
 
     #These modes only work under certain conditions, apply them here:
@@ -2539,9 +1417,9 @@ class Solution(collections.abc.Mapping):
 
     numBytes = state["ProblemType"]["DataType"].numBytes()
     isa = tuple(state["ISA"])
-    state["enableLDSTrA"] = state["LDSTrInst"] and globalParameters["AsmCaps"][isa]["HasLDSTr"] and numBytes == 2 \
+    state["enableLDSTrA"] = state["LDSTrInst"] and isaInfoMap[isa].asmCaps["HasLDSTr"] and numBytes == 2 \
             and not state["UnrollMajorLDSA"] and not state["DirectToVgprA"]
-    state["enableLDSTrB"] = state["LDSTrInst"] and globalParameters["AsmCaps"][isa]["HasLDSTr"] and numBytes == 2 \
+    state["enableLDSTrB"] = state["LDSTrInst"] and isaInfoMap[isa].asmCaps["HasLDSTr"] and numBytes == 2 \
             and not state["UnrollMajorLDSB"] and not state["DirectToVgprB"]
 
     if state["enableLDSTrA"]:
@@ -2555,15 +1433,15 @@ class Solution(collections.abc.Mapping):
       return
 
     # if state["EnableMatrixInstruction"] and not state["SourceSwap"] and (state["VectorWidthA"] > 1 or state["VectorWidthB"] > 1):
-    #   reject(state, "not implement VectorWidth without SourceSwap")
+    #   reject(state, printRejectionReason, "not implement VectorWidth without SourceSwap")
 
     # TT0,1 both must be multiples of VW, b/c of rC, rA, rB
     if state["EnableMatrixInstruction"]:
       if (state["MIWaveTile"][0] % state["VectorWidthA"]) != 0:
-        reject(state, "MIWaveTile0(%u) should be multiple of VectorWidthA(%u)" % (state["MIWaveTile"][0], state["VectorWidthA"]))
+        reject(state, printRejectionReason, "MIWaveTile0(%u) should be multiple of VectorWidthA(%u)" % (state["MIWaveTile"][0], state["VectorWidthA"]))
         return
       if (state["MIWaveTile"][1] % state["VectorWidthB"]) != 0:
-        reject(state, "MIWaveTile0(%u) should be multiple of VectorWidthB(%u)" % (state["MIWaveTile"][1], state["VectorWidthB"]))
+        reject(state, printRejectionReason, "MIWaveTile0(%u) should be multiple of VectorWidthB(%u)" % (state["MIWaveTile"][1], state["VectorWidthB"]))
         return
 
     if len(problemType["IndicesSummation"]) > 1:
@@ -2575,18 +1453,18 @@ class Solution(collections.abc.Mapping):
     if state["KernelLanguage"] == "Assembly" \
       and state["ProblemType"]["DataType"].isHalf():
 
-      if globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"]:
+      if isaInfoMap[state["ISA"]].archCaps["HasEccHalf"]:
         if not state["ProblemType"]["HighPrecisionAccumulate"] and state["AssertFree0ElementMultiple"] % 2 != 0:
           # beta-on-edge has AF0EM requirement except for HPA kernels
-          reject(state, "Archs with HasEccHalf require AF0EM%2==0 except for HPA kernels")
+          reject(state, printRejectionReason, "Archs with HasEccHalf require AF0EM%2==0 except for HPA kernels")
           return
 
     if state["ConvertAfterDS"]:
         if (state["ProblemType"]["DataType"].isHalf() == False):
-            reject(state, "ConvertAfterDS only support DataType half")
+            reject(state, printRejectionReason, "ConvertAfterDS only support DataType half")
             return
         if (state["ProblemType"]["DataTypeA"].isAnyFloat8() == False) and (state["ProblemType"]["DataTypeB"].isAnyFloat8() == False):
-            reject(state, "one of DataTypeA or DataTypeB need to be float8/float8_fnuz")
+            reject(state, printRejectionReason, "one of DataTypeA or DataTypeB need to be float8/float8_fnuz")
             return
 
     # DepthU == -1?
@@ -2607,7 +1485,20 @@ class Solution(collections.abc.Mapping):
         state[backup[0]] = backup[1]
       state["ValidDepthU"] = True
       state["DepthU"]      = depthuList[index[0]]
-      Solution.depthUIteration(state, index, depthuList, problemType, isa, bufferLoad, packedC0, packedC1)
+      Solution.depthUIteration(
+        state,
+        index,
+        depthuList,
+        problemType,
+        isa,
+        bufferLoad,
+        packedC0,
+        packedC1,
+        printRejectionReason,
+        isaInfoMap,
+        rocmVersion,
+        depthUConfig,
+      )
       if state["Valid"] or (state["ValidDepthU"] and (not state["Valid"])):
         break
       index[0] += 1
@@ -2615,8 +1506,21 @@ class Solution(collections.abc.Mapping):
         break
     if "ValidDepthU" in state:
       del state["ValidDepthU"]
- 
-  def depthUIteration(state, index, depthuList, problemType, isa, bufferLoad, packedC0, packedC1):
+
+  def depthUIteration(
+      state,
+      index,
+      depthuList,
+      problemType,
+      isa,
+      bufferLoad,
+      packedC0,
+      packedC1,
+      printRejectionReason: bool,
+      isaInfoMap: Dict[IsaVersion, IsaInfo],
+      rocmVersion: SemanticVersion,
+      depthUConfig: DepthUConfig
+    ):
     ########################################
     # Auto search for DepthU starts here
     # Activates when DepthU == -1
@@ -2650,15 +1554,15 @@ class Solution(collections.abc.Mapping):
       state["_DepthUB"] = depthUB# internal
       state["_DepthUMetadata"] = depthUM# internal
 
-      Solution.checkAndAssignWaveSeparateGlobalRead(state, 'A')
-      Solution.checkAndAssignWaveSeparateGlobalRead(state, 'B')
+      Solution.checkAndAssignWaveSeparateGlobalRead(state, 'A', printRejectionReason)
+      Solution.checkAndAssignWaveSeparateGlobalRead(state, 'B', printRejectionReason)
       if state["ProblemType"]["Sparse"]:
         if state["ProblemType"]["Sparse"] == 2:
           if not state["DirectToVgprSparseMetadata"]:
-            Solution.checkAndAssignWaveSeparateGlobalRead(state, 'Metadata')
+            Solution.checkAndAssignWaveSeparateGlobalRead(state, 'Metadata', printRejectionReason)
         else:
           if not state["DirectToVgprSparseMetadata"]:
-            Solution.checkAndAssignWaveSeparateGlobalRead(state, 'Metadata')
+            Solution.checkAndAssignWaveSeparateGlobalRead(state, 'Metadata', printRejectionReason)
 
       # Set up stagger shift:
       bpeAB = int(4*state["ProblemType"]["DataType"].numRegisters())
@@ -2676,12 +1580,12 @@ class Solution(collections.abc.Mapping):
       except ValueError: # i.e., StaggerUStride == 0
           staggerStrideShift = 0
       if staggerStrideShift < 0:
-        reject(state, "StaggerUStride=%u is less than size of DepthU=%u * BytesPerElement=%u" \
+        reject(state, printRejectionReason, "StaggerUStride=%u is less than size of DepthU=%u * BytesPerElement=%u" \
           % (state["StaggerUStride"], state["DepthU"], bpeAB))
       #print "staggerStrideShift=", staggerStrideShift, "depthu=", state["DepthU"]
       state["_staggerStrideShift"] = staggerStrideShift
 
-      def calcLdsPad(lrvw: int) -> int:
+      def calcLdsPad(lrvw: int, isaInfoMap: Dict[str, IsaInfo]) -> int:
         ldsPadA = state["LdsPadA"]
         ldsPadB = state["LdsPadB"]
         optPadA = optPadB = lrvw
@@ -2693,7 +1597,7 @@ class Solution(collections.abc.Mapping):
           else:
             optPadA //= 2
             readRegsA //= 2
-        if (not globalParameters["AsmCaps"][isa]['HasWMMA']) and (readRegsA > 4 or readRegsB > 4):
+        if (not isaInfoMap[isa].asmCaps['HasWMMA']) and (readRegsA > 4 or readRegsB > 4):
           reject(state, "LocalReadVectorWidth results in attemping to read LDS larger than b128, reject")
           return
         if state["EnableMatrixInstruction"]:
@@ -2875,12 +1779,12 @@ class Solution(collections.abc.Mapping):
         else:
           if state["ProblemType"]["Sparse"] and state["MIInputPerThread"] * state["ProblemType"]["DataType"].numBytes() > 16:
             if state["LocalReadVectorWidth"] < state["MIInputPerThread"] // 2:
-              reject(state, "LocalReadVectorWidth < %u" %(state["MIInputPerThread"] // 2))
-          elif not state["ProblemType"]["Sparse"] and (not globalParameters["AsmCaps"][isa]["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
+              reject(state, printRejectionReason, "LocalReadVectorWidth < %u" %(state["MIInputPerThread"] // 2))
+          elif not state["ProblemType"]["Sparse"] and (not isaInfoMap[isa].asmCaps["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
             if state["LocalReadVectorWidth"] < state["MIInputPerThread"]:
-              reject(state, "LocalReadVectorWidth < %u" %(state["MIInputPerThread"]))
+              reject(state, printRejectionReason, "LocalReadVectorWidth < %u" %(state["MIInputPerThread"]))
           if state["LocalReadVectorWidth"] > state["MIInputPerThread"] and not state["TransposeLDS"]:
-            reject(state, "LocalReadVectorWidth require Transpose LDS")
+            reject(state, printRejectionReason, "LocalReadVectorWidth require Transpose LDS")
 
         if autoLRVW:
           if state["LocalReadVectorWidth"] // state["MIInputPerThread"] > 1:
@@ -2888,10 +1792,10 @@ class Solution(collections.abc.Mapping):
               # if only have 1 iteration with wider local read, reduce LRVW to have better scheduling (at least 2 iterations)
               state["LocalReadVectorWidth"] //= 2
           if state["LocalReadVectorWidth"] // state["MIInputPerThread"] > 1:
-            padA, padB, padM = calcLdsPad(state["LocalReadVectorWidth"])
+            padA, padB, padM = calcLdsPad(state["LocalReadVectorWidth"], isaInfoMap)
             ldsBlockSizePerPadA, ldsBlockSizePerPadB = calcLdsBlockSizePerPad(state["LocalReadVectorWidth"])
             ldsNumBytesA, ldsNumBytesAlignedA, ldsNumBytesB, ldsNumBytesAlignedB, ldsNumBytesMetadata, ldsNumBytesAlignedMetadata = calcLdsNumBytes(padA, ldsBlockSizePerPadA, padB, ldsBlockSizePerPadB)
-            if (ldsNumBytesAlignedA + ldsNumBytesAlignedB) > globalParameters["MaxLDS"]:
+            if (ldsNumBytesAlignedA + ldsNumBytesAlignedB) > depthUConfig.maxLDS:
               state["LocalReadVectorWidth"] //= 2
       else:
         if state["UseDotInstruction"]:
@@ -2925,7 +1829,7 @@ class Solution(collections.abc.Mapping):
             if state["MatrixInstBM"] == 1 and state["MIWaveTile"][0] == 1 and state["MIWaveGroup"][0] == 1 and state["ProblemType"]["TLUA"]:
               state["GlobalReadVectorWidthA"] = 1
             else:
-              reject(state, "GRVWA=-2 is set for skinny MT")
+              reject(state, printRejectionReason, "GRVWA=-2 is set for skinny MT")
           elif state["GlobalReadVectorWidthA"] == -1:
             if state["ProblemType"]["SwizzleTensorA"]:
               state["GlobalReadVectorWidthA"] = state["MIInputPerThreadA"] * calSwizzleK(state, "A")
@@ -2963,7 +1867,7 @@ class Solution(collections.abc.Mapping):
             if state["MatrixInstBN"] == 1 and state["MIWaveTile"][1] == 1 and state["MIWaveGroup"][1] == 1 and state["ProblemType"]["TLUB"]:
               state["GlobalReadVectorWidthB"] = 1
             else:
-              reject(state, "GRVWB=-2 is set for skinny MT")
+              reject(state, printRejectionReason, "GRVWB=-2 is set for skinny MT")
           elif state["GlobalReadVectorWidthB"] == -1:
             if state["ProblemType"]["SwizzleTensorB"]:
               state["GlobalReadVectorWidthB"] = state["MIInputPerThreadB"] * calSwizzleK(state, "B")
@@ -2996,34 +1900,34 @@ class Solution(collections.abc.Mapping):
       for tc in ("A", "B",):
         if state["ProblemType"][f"SwizzleTensor{tc}"]:
           if not state["EnableMatrixInstruction"]:
-            reject(state, f"Tensor {tc} swizzling supports MI only")
+            reject(state, printRejectionReason, f"Tensor {tc} swizzling supports MI only")
           # Print rejection reason instead of force set
           # 16 means bytes of buffer_load_dwordx4
           SwizzlePackK = calSwizzleK(state, tc)
           if state[f"GlobalReadVectorWidth{tc}"] != state[f"MIInputPerThread{tc}"] * SwizzlePackK:
             GRVW_TC = state[f"GlobalReadVectorWidth{tc}"]
             MIInPerThread = state[f"MIInputPerThread{tc}"]
-            reject(state, f"SwizzleTensor{tc} doesn't support GRVW{tc} ({GRVW_TC}) != MIInputPerThread{tc} ({MIInPerThread}) * {SwizzlePackK}")
+            reject(state, printRejectionReason, f"SwizzleTensor{tc} doesn't support GRVW{tc} ({GRVW_TC}) != MIInputPerThread{tc} ({MIInPerThread}) * {SwizzlePackK}")
           # TODO- increasing VW might have better perf. But it'll change the swizzling pattern.
           if state[f"VectorWidth{tc}"] != 1:
             VW_TC = state[f"VectorWidth{tc}"]
-            reject(state, f"SwizzleTensor{tc} requires VectorWidth{tc} ({VW_TC}) == 1")
+            reject(state, printRejectionReason, f"SwizzleTensor{tc} requires VectorWidth{tc} ({VW_TC}) == 1")
 
       if state["ProblemType"]["SwizzleTensorA"]:
         if not state["DirectToVgprA"]:
-          reject(state, f"Tensor A swizzling requires DirectToVgprA")
+          reject(state, printRejectionReason, f"Tensor A swizzling requires DirectToVgprA")
         if not state["ProblemType"]["TransposeA"]:
-          reject(state, f"Tensor A swizzling supports TN or TT only")
+          reject(state, printRejectionReason, f"Tensor A swizzling supports TN or TT only")
 
       if state["ProblemType"]["SwizzleTensorB"]:
         if not state["DirectToVgprB"]:
-          reject(state, f"Tensor B swizzling requires DirectToVgprB")
+          reject(state, printRejectionReason, f"Tensor B swizzling requires DirectToVgprB")
         if state["ProblemType"]["TransposeB"]:
-          reject(state, f"Tensor B swizzling supports TN or NN only")
+          reject(state, printRejectionReason, f"Tensor B swizzling supports TN or NN only")
 
         # TODO- NN fails validation due to DTVB + Tail-Loop is not working correctly
         if not (state["ProblemType"]["TransposeA"] and not state["ProblemType"]["TransposeB"]):
-          reject(state, f"Tensor B swizzling supports TN only")
+          reject(state, printRejectionReason, f"Tensor B swizzling supports TN only")
 
       # Force GRVW the same when UnrollLoopSwapGlobalReadOrder = 1.
       if genGRVWA and state["UnrollLoopSwapGlobalReadOrder"] == 1:
@@ -3033,15 +1937,15 @@ class Solution(collections.abc.Mapping):
 
       # reject - VW too big
       if (state["VectorWidthA"] * state["ProblemType"]["DataType"].numBytes()) > 16:
-        reject(state, "VWA * DataType.numBytes() > 16")
+        reject(state, printRejectionReason, "VWA * DataType.numBytes() > 16")
       if (state["VectorWidthB"] * state["ProblemType"]["DataType"].numBytes()) > 16:
-        reject(state, "VWB * DataType.numBytes() > 16")
+        reject(state, printRejectionReason, "VWB * DataType.numBytes() > 16")
 
       # reject - GRVW too big
       if (state["GlobalReadVectorWidthA"] * state["ProblemType"]["DataTypeA"].numBytes()) > 16:
-        reject(state, "GRVWA * DataTypeA.numBytes() > 16")
+        reject(state, printRejectionReason, "GRVWA * DataTypeA.numBytes() > 16")
       if (state["GlobalReadVectorWidthB"] * state["ProblemType"]["DataTypeB"].numBytes()) > 16:
-        reject(state, "GRVWB * DataTypeB.numBytes() > 16")
+        reject(state, printRejectionReason, "GRVWB * DataTypeB.numBytes() > 16")
 
       ########################################
       # Search DepthU
@@ -3089,10 +1993,10 @@ class Solution(collections.abc.Mapping):
           totalElementsM = totalElementsCoalescedM * totalElementsPerpM
 
         tva = totalElementsA // state["GlobalReadVectorWidthA"]
-        if not Solution.setGlobalReadVectorWidth(state, "A", tva, state["GlobalReadVectorWidthA"]):
+        if not Solution.setGlobalReadVectorWidth(state, "A", tva, state["GlobalReadVectorWidthA"], printRejectionReason):
           validDepthU = False
         tvb = totalElementsB // state["GlobalReadVectorWidthB"]
-        if not Solution.setGlobalReadVectorWidth(state, "B", tvb, state["GlobalReadVectorWidthB"]):
+        if not Solution.setGlobalReadVectorWidth(state, "B", tvb, state["GlobalReadVectorWidthB"], printRejectionReason):
           validDepthU = False
 
         if state["EnableMatrixInstruction"] and state["GlobalReadVectorWidthA"]:
@@ -3111,7 +2015,7 @@ class Solution(collections.abc.Mapping):
             # reduce GLVA if GLVA larger than MIOVW
             if state["GlobalReadVectorWidthA"] > glvwAlimit:
               tva = totalElementsA // glvwAlimit
-              if not Solution.setGlobalReadVectorWidth(state, "A", tva, glvwAlimit):
+              if not Solution.setGlobalReadVectorWidth(state, "A", tva, glvwAlimit, printRejectionReason):
                 validDepthU = False
 
         if state["EnableMatrixInstruction"] and state["GlobalReadVectorWidthB"]:
@@ -3129,14 +2033,14 @@ class Solution(collections.abc.Mapping):
             # reduce GLVB if GLVB larger than MIOVW
             if state["GlobalReadVectorWidthB"] > glvwBlimit:
               tvb = totalElementsB // glvwBlimit
-              if not Solution.setGlobalReadVectorWidth(state, "B", tvb, glvwBlimit):
+              if not Solution.setGlobalReadVectorWidth(state, "B", tvb, glvwBlimit, printRejectionReason):
                 validDepthU = False
 
         if validDepthU and state["KernelLanguage"] == "Assembly":
-          if globalParameters["ArchCaps"][globalParameters["CurrentISA"]]["HasEccHalf"]:
+          if isaInfoMap[state["ISA"]].archCaps["HasEccHalf"]:
             if state["ProblemType"]["DataType"].numRegisters() == 0.5 and (not state["ProblemType"]["HighPrecisionAccumulate"]):
                 if state["GlobalReadVectorWidthA"] == 1 or state["GlobalReadVectorWidthB"] == 1:
-                  reject(state, "HalfEcc requires HPA if glvw = 1")
+                  reject(state, printRejectionReason, "HalfEcc requires HPA if glvw = 1")
                   break
 
         if state["ProblemType"]["Sparse"] and not state["DirectToVgprSparseMetadata"]:
@@ -3146,19 +2050,19 @@ class Solution(collections.abc.Mapping):
             grvw = state["GlobalReadVectorWidthB"] // 4
             vw = state["VectorWidthB"] // 4
             if state["GlobalReadVectorWidthB"] % 4 != 0:
-              reject(state, "Sparse B requires GRVWB %% 4 == 0, current GRVWB is %u"%state["GlobalReadVectorWidthB"])
+              reject(state, printRejectionReason, "Sparse B requires GRVWB %% 4 == 0, current GRVWB is %u"%state["GlobalReadVectorWidthB"])
               break
           else:
             grvw = state["GlobalReadVectorWidthA"] // 4
             vw = state["VectorWidthA"] // 4
             if state["GlobalReadVectorWidthA"] % 4 != 0:
-              reject(state, "Sparse A requires GRVWA %% 4 == 0, current GRVWA is %u"%state["GlobalReadVectorWidthA"])
+              reject(state, printRejectionReason, "Sparse A requires GRVWA %% 4 == 0, current GRVWA is %u"%state["GlobalReadVectorWidthA"])
               break
 
 
           tvm = totalElementsM // grvw
 
-          if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, grvw):
+          if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, grvw, printRejectionReason):
             validDepthU = False
 
           if state["EnableMatrixInstruction"] and state["GlobalReadVectorWidthMetadata"]:
@@ -3181,12 +2085,12 @@ class Solution(collections.abc.Mapping):
               # reduce GLVMetadata if GLVMetadata larger than MIOVW
               if state["GlobalReadVectorWidthMetadata"] > glvwMlimit:
                 tvm = totalElementsM // glvwMlimit
-                if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, glvwMlimit):
+                if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, glvwMlimit, printRejectionReason):
                   validDepthU = False
 
         if state["ProblemType"]["Sparse"] and state["DirectToVgprSparseMetadata"]:
           if state["VectorWidthA"] > 1 or state["VectorWidthB"] > 1 :
-            reject(state, "Not implement DTVSM with VW>1")
+            reject(state, printRejectionReason, "Not implement DTVSM with VW>1")
             break
 
         # Now convert elements to vectors based on GlobalReadVectorWidth
@@ -3215,7 +2119,7 @@ class Solution(collections.abc.Mapping):
 
         # this depthU not valid
         else:
-          reject(state, "No valid DepthU found")
+          reject(state, printRejectionReason, "No valid DepthU found")
           state["ValidDepthU"] = False
           break
       ########################################
@@ -3264,11 +2168,11 @@ class Solution(collections.abc.Mapping):
     if state["EnableMatrixInstruction"]:
       if state["SourceSwap"]:
         if ((state["VectorWidthA"] % state["StoreVectorWidth"]) != 0):
-          reject(state, "MFMA SourceSwap mode doesn't support vwA(%u) with svw(%u)" % (state["VectorWidthA"], state["StoreVectorWidth"]))
+          reject(state, printRejectionReason, "MFMA SourceSwap mode doesn't support vwA(%u) with svw(%u)" % (state["VectorWidthA"], state["StoreVectorWidth"]))
           return
       else:
         if (((state["VectorWidthA"] * state["MIOutputVectorWidth"]) % state["StoreVectorWidth"]) != 0):
-          reject(state, "MFMA non-SourceSwap mode doesn't support miovw(%u) with svw(%u)" % (state["VectorWidthA"]*state["MIOutputVectorWidth"], state["StoreVectorWidth"]))
+          reject(state, printRejectionReason, "MFMA non-SourceSwap mode doesn't support miovw(%u) with svw(%u)" % (state["VectorWidthA"]*state["MIOutputVectorWidth"], state["StoreVectorWidth"]))
           return
 
     # LocalSplitU too large?
@@ -3276,14 +2180,14 @@ class Solution(collections.abc.Mapping):
     numElementsPerWorkGroup = state["MacroTile0"]*state["MacroTile1"]*state["NumWaveSplitK"]
 
     if numElementsPerWorkGroup < state["NumThreads"]:
-      reject(state, "NumElementsPerWorkGroup %u < NumThreads %u; reduce LocalSplitU" \
+      reject(state, printRejectionReason, "NumElementsPerWorkGroup %u < NumThreads %u; reduce LocalSplitU" \
           % (numElementsPerWorkGroup, state["NumThreads"]))
       return
 
     state["NumElementsPerThread"] = numElementsPerWorkGroup // state["NumThreads"]
     state["GlobalWriteVectorWidth"] = min(state["VectorWidthA"], state["NumElementsPerThread"] )
     if state["NumElementsPerThread"] % state["GlobalWriteVectorWidth"] != 0:
-      reject(state, "LSU NumElementsPerThread %u not divisible into GWVW %u" \
+      reject(state, printRejectionReason, "LSU NumElementsPerThread %u not divisible into GWVW %u" \
           % (state["NumElementsPerThread"], state["GlobalWriteVectorWidth"]))
       return
     state["NumGlobalWriteVectorsPerThread"] = state["NumElementsPerThread"] \
@@ -3293,21 +2197,21 @@ class Solution(collections.abc.Mapping):
     # LocalSplitU but can't NumThreads%MacroTile doesn't support sideways store
     if state["LocalSplitU"] > 1:
       if not state["SourceSwap"] and state["StoreVectorWidth"] > state["VectorWidthA"]:
-        reject(state, "LSU and non-SourceSwap doesn't support StoreVectorWidth(%u)>VWA(%u)." \
+        reject(state, printRejectionReason, "LSU and non-SourceSwap doesn't support StoreVectorWidth(%u)>VWA(%u)." \
             % (state["StoreVectorWidth"], state["VectorWidthA"]))
         return
       if not (state["ProblemType"]["ComputeDataType"].isSingle() or state["ProblemType"]["ComputeDataType"].isInt32()):
-        reject(state, "TODO: LSU doesn't support ComputeDataType!=(single or Int32).")
+        reject(state, printRejectionReason, "TODO: LSU doesn't support ComputeDataType!=(single or Int32).")
         return
       if state["StoreRemapVectorWidth"] > 0:
-        reject(state, "TODO: LSU doesn't support StoreRemapVectorWidth>0.")
+        reject(state, printRejectionReason, "TODO: LSU doesn't support StoreRemapVectorWidth>0.")
         return
       if state["NumThreads"] % state["MacroTile0"] != 0:
-        reject(state, "LocalSplitU but NumThreads=%u not divisible by MT0=%u for sideways store" \
+        reject(state, printRejectionReason, "LocalSplitU but NumThreads=%u not divisible by MT0=%u for sideways store" \
             % (state["NumThreads"], state["MacroTile0"]))
         return
       if state["MacroTile0"]*state["MacroTile1"] % state["NumThreads"] != 0:
-        reject(state, "LocalSplitU but MT0*MT1=%u elements doesn't divide into NumThreads=%u" \
+        reject(state, printRejectionReason, "LocalSplitU but MT0*MT1=%u elements doesn't divide into NumThreads=%u" \
             % (state["MacroTile0"]*state["MacroTile1"], state["NumThreads"]))
         return
 
@@ -3323,16 +2227,16 @@ class Solution(collections.abc.Mapping):
             (state["_GlobalAccumulation"])
         )
       if not supported:
-        reject(state, "GlobalSplitU only compatible with single or asm and (half or mixed) precision")
+        reject(state, printRejectionReason, "GlobalSplitU only compatible with single or asm and (half or mixed) precision")
         return
 
     if state["ProblemType"]["DataType"].isHalf() and state["KernelLanguage"] == "Assembly":
       if state["GlobalSplitU"] > 1 and (not state["_GlobalAccumulation"]):
         if state["AssertFree0ElementMultiple"] < 2:
-          reject(state, "Assembly GSU half requires AF0EM>=2 (for atomics on edge tiles)")
+          reject(state, printRejectionReason, "Assembly GSU half requires AF0EM>=2 (for atomics on edge tiles)")
 
-        if state["EnableMatrixInstruction"] and globalParameters["AsmCaps"][isa]['HasWMMA']:
-          reject(state, "Half WMMA doesn't support single buffer GSU")
+        if state["EnableMatrixInstruction"] and isaInfoMap[isa].asmCaps['HasWMMA']:
+          reject(state, printRejectionReason, "Half WMMA doesn't support single buffer GSU")
           return
     # dot2 limitation
     if state["UseDotInstruction"]:
@@ -3365,10 +2269,10 @@ class Solution(collections.abc.Mapping):
       state["NumLoadsCoalescedMetadata"] = 1
 
     if not Solution.setGlobalLoadTileDimClassic(state, "A", state["NumLoadsA"], \
-        totalVectorsCoalescedA, totalElementsPerpA, depthUA):
+        totalVectorsCoalescedA, totalElementsPerpA, depthUA, printRejectionReason):
       return
     if not Solution.setGlobalLoadTileDimClassic(state, "B", state["NumLoadsB"], \
-        totalVectorsCoalescedB, totalElementsPerpB, depthUB):
+        totalVectorsCoalescedB, totalElementsPerpB, depthUB, printRejectionReason):
       return
 
     if state["ProblemType"]["Sparse"] and not state["DirectToVgprSparseMetadata"]:
@@ -3387,10 +2291,10 @@ class Solution(collections.abc.Mapping):
       if state["ProblemType"]["Sparse"] == 2:
         GlobalReadVectorWidth = min(state["GlobalReadVectorWidthMetadata"] * state["NumLoadsPerpendicularB"], depthUM) #sum all need read
         tvm = totalElementsM // GlobalReadVectorWidth
-        if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, GlobalReadVectorWidth):
+        if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, GlobalReadVectorWidth, printRejectionReason):
           #fallback
           tvm = totalElementsM // bGlobalReadVectorWidthMetadata
-          Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, bGlobalReadVectorWidthMetadata)
+          Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, bGlobalReadVectorWidthMetadata, printRejectionReason)
 
         GlobalReadVectorWidthMetadata = state["GlobalReadVectorWidthMetadata"]
         if GlobalReadVectorWidthMetadata == 0:
@@ -3400,10 +2304,10 @@ class Solution(collections.abc.Mapping):
       else:
         GlobalReadVectorWidth = min(state["GlobalReadVectorWidthMetadata"] * state["NumLoadsPerpendicularA"], depthUM) #sum all need read
         tvm = totalElementsM // GlobalReadVectorWidth
-        if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, GlobalReadVectorWidth):
+        if not Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, GlobalReadVectorWidth, printRejectionReason):
           #fallback
           tvm = totalElementsM // bGlobalReadVectorWidthMetadata
-          Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, bGlobalReadVectorWidthMetadata)
+          Solution.setGlobalReadVectorWidth(state, "Metadata", tvm, bGlobalReadVectorWidthMetadata, printRejectionReason)
 
         GlobalReadVectorWidthMetadata = state["GlobalReadVectorWidthMetadata"]
         if GlobalReadVectorWidthMetadata == 0:
@@ -3412,21 +2316,21 @@ class Solution(collections.abc.Mapping):
         totalVectorsM = totalElementsM // GlobalReadVectorWidthMetadata
 
       if not Solution.setGlobalLoadTileDimClassic(state, "Metadata", state["NumLoadsMetadata"], \
-          totalVectorsCoalescedM, totalElementsPerpM, depthUM):
+          totalVectorsCoalescedM, totalElementsPerpM, depthUM, printRejectionReason):
         return
 
     # TODO
     if (0 and state["LSCA"] % state["GlobalReadVectorWidthA"] != 0):
-      reject(state, "lsca % grvw != 0")
+      reject(state, printRejectionReason, "lsca % grvw != 0")
       return
     if (0 and state["LSPA"] % state["GlobalReadVectorWidthA"] != 0):
-      reject(state, "lspa % grvw != 0")
+      reject(state, printRejectionReason, "lspa % grvw != 0")
       return
     if (0 and state["LSCB"] % state["GlobalReadVectorWidthB"] != 0):
-      reject(state, "lscb % grvw != 0")
+      reject(state, printRejectionReason, "lscb % grvw != 0")
       return
     if (0 and state["LSPB"] % state["GlobalReadVectorWidthB"] != 0):
-      reject(state, "lspb % grvw != 0")
+      reject(state, printRejectionReason, "lspb % grvw != 0")
       return
 
     state["LVCA"] = roundupRatio(state["LSCA"] , state["GlobalReadVectorWidthA"])
@@ -3452,7 +2356,7 @@ class Solution(collections.abc.Mapping):
     # lds buffer size for A, B
     if state["KernelLanguage"] == "Source" and \
        state["LdsPadA"] != state["LdsPadB"]:
-      reject(state, "Source KernelLanguage only supports LdsPadA == LdsPadB")
+      reject(state, printRejectionReason, "Source KernelLanguage only supports LdsPadA == LdsPadB")
       return
 
     # NoTailLoop parameter initialization.
@@ -3465,10 +2369,10 @@ class Solution(collections.abc.Mapping):
     # Determine if we can load directly-to-Vgpr
     # need to check after state["LocalReadVectorWidth"] = -1 is resolved
     if state["DirectToVgprA"]:
-      if not Solution.isDirectToVgprDoable(state, 'A'):
+      if not Solution.isDirectToVgprDoable(state, 'A', printRejectionReason, isaInfoMap):
         return  # rejected
     if state["DirectToVgprB"]:
-      if not Solution.isDirectToVgprDoable(state, 'B'):
+      if not Solution.isDirectToVgprDoable(state, 'B', printRejectionReason, isaInfoMap):
         return  # rejected
 
     ########################################
@@ -3497,23 +2401,23 @@ class Solution(collections.abc.Mapping):
       if state["LdsBlockSizePerPadA"]:
         if state["UnrollMajorLDSA"]:
           if state["LdsBlockSizePerPadA"] % (state["_DepthUA"] * state["ProblemType"]["DataTypeA"].numBytes()) != 0:
-            reject(state, "reject: LdsBlockSizePerPadA %u %% depthU %u x bpeA != 0" % (state["LdsBlockSizePerPadA"],state["_DepthUA"]))
+            reject(state, printRejectionReason, "reject: LdsBlockSizePerPadA %u %% depthU %u x bpeA != 0" % (state["LdsBlockSizePerPadA"],state["_DepthUA"]))
           if (state["LdsBlockSizePerPadA"] // (state["_DepthUA"] * state["ProblemType"]["DataType"].numBytes())) % state["LSPA"] != 0 and \
               state["LSPA"] % (state["LdsBlockSizePerPadA"] // (state["_DepthUA"] * state["ProblemType"]["DataType"].numBytes())) != 0:
-            reject(state, "can't pad by addrVgpr or instOffset")
+            reject(state, printRejectionReason, "can't pad by addrVgpr or instOffset")
 
       if state["LdsBlockSizePerPadB"]:
         if state["UnrollMajorLDSB"]:
           if state["LdsBlockSizePerPadB"] % state["_DepthUB"] * state["ProblemType"]["DataTypeB"].numBytes() != 0:
-            reject(state, "reject: LdsBlockSizePerPadB %u %% depthU %u x bpeB != 0" % (state["LdsBlockSizePerPadB"],state["_DepthUB"]))
+            reject(state, printRejectionReason, "reject: LdsBlockSizePerPadB %u %% depthU %u x bpeB != 0" % (state["LdsBlockSizePerPadB"],state["_DepthUB"]))
           if (state["LdsBlockSizePerPadB"] // (state["_DepthUB"] * state["ProblemType"]["DataType"].numBytes())) % state["LSPB"] != 0 and \
               state["LSPB"] % (state["LdsBlockSizePerPadB"] // (state["_DepthUB"] * state["ProblemType"]["DataType"].numBytes())) != 0:
-            reject(state, "can't pad by addrVgpr or instOffset")
+            reject(state, printRejectionReason, "can't pad by addrVgpr or instOffset")
     else:
       if not state["UseDotInstruction"] and (state["UnrollMajorLDSA"] or state["UnrollMajorLDSB"]):
-        reject(state, "didn't support UnrollMajorLDS in VALU mode yet (except for dot2 kernel)")
+        reject(state, printRejectionReason, "didn't support UnrollMajorLDS in VALU mode yet (except for dot2 kernel)")
       if state["LdsBlockSizePerPadA"] != 0 or state["LdsBlockSizePerPadB"] != 0:
-        reject(state, "didn't support LdsBlockSizePerPad in VALU mode yet")
+        reject(state, printRejectionReason, "didn't support LdsBlockSizePerPad in VALU mode yet")
 
     def checkLdsBlockSizePerPad(tc):
       """
@@ -3601,7 +2505,7 @@ class Solution(collections.abc.Mapping):
             blockWidth = bw
             break
         if blockWidth == 0:
-          reject(state, "invalid local write block width")
+          reject(state, printRejectionReason, "invalid local write block width")
 
         return blockWidth
 
@@ -3663,7 +2567,7 @@ class Solution(collections.abc.Mapping):
             printWarning("Padded address is inconisstent, set LdsBlockSizePerPad%s=0."%tc)
             state["LdsBlockSizePerPad%s"%tc] = 0
           else:
-            reject(state, "%s's padded address is inconisstent"%tc)
+            reject(state, printRejectionReason, "%s's padded address is inconisstent"%tc)
 
     if(not (state["CustomKernelName"] and state["CustomKernelName"] != "")): #don't check the custom kernel.
       checkLdsBlockSizePerPad("A")
@@ -3681,14 +2585,14 @@ class Solution(collections.abc.Mapping):
     # LDS (load size coalesced) * LSPA must load some multiple of 256 bytes.
     # No longer support loadX2/loadx4 .
     if state["DirectToLds"]:
-      if (not state["DirectToVgprA"]) and Solution.isDirectToLdsDoable(state, 'A'):
+      if (not state["DirectToVgprA"]) and Solution.isDirectToLdsDoable(state, 'A', isaInfoMap, printRejectionReason):
         state["DirectToLdsA"] = True
         state["LocalWriteUseSgprA"] = True
         state["LdsPadA"] = 0
         printWarning("DirectToLdsA enabled, set LdsPadA=0.")
         #print("DirectToLdsA", state["DirectToLdsA"])
 
-      if (not state["DirectToVgprB"]) and Solution.isDirectToLdsDoable(state, 'B'):
+      if (not state["DirectToVgprB"]) and Solution.isDirectToLdsDoable(state, 'B', isaInfoMap, printRejectionReason):
         state["DirectToLdsB"] = True
         state["LocalWriteUseSgprB"] = True
         state["LdsPadB"] = 0
@@ -3704,10 +2608,10 @@ class Solution(collections.abc.Mapping):
       # Re-check DTV + WaveGroup after DTL is confirmed
       if state["DirectToLds"]:
         if state["DirectToVgprA"] and state['MIWaveGroup'][1] > 1:
-          reject(state, "DirectToLds + (DirectToVgprA + WaveGroups along N-Dim) is not supported yet")
+          reject(state, printRejectionReason, "DirectToLds + (DirectToVgprA + WaveGroups along N-Dim) is not supported yet")
           return False
         if state["DirectToVgprB"] and state['MIWaveGroup'][0] > 1:
-          reject(state, "DirectToLds + (DirectToVgprB + WaveGroups along M-Dim) is not supported yet")
+          reject(state, printRejectionReason, "DirectToLds + (DirectToVgprB + WaveGroups along M-Dim) is not supported yet")
           return False
 
     # set NoLdsWriteCode if (DirectToVgpr or DirectToLds)A+B is enabled
@@ -3716,7 +2620,7 @@ class Solution(collections.abc.Mapping):
       state["NoLdsWriteCode"] = True
 
     # calculate ldsPad
-    state["LdsPadA"], state["LdsPadB"], state["LdsPadMetadata"] = calcLdsPad(state["LocalReadVectorWidth"])
+    state["LdsPadA"], state["LdsPadB"], state["LdsPadMetadata"] = calcLdsPad(state["LocalReadVectorWidth"], isaInfoMap)
 
     if state["GlobalReadVectorWidthA"] * state["ProblemType"]["DataType"].numBytes() == 32 and state["LdsPadA"] == 16 // state["ProblemType"]["DataType"].numBytes():
       if auto_LdsBlockSizePerPadA_for_mix:
@@ -3729,7 +2633,7 @@ class Solution(collections.abc.Mapping):
     assert(state["LdsPadB"] >= 0)
 
     if (state["UnrollMajorLDSA"] or state["UnrollMajorLDSB"]) and (not state["EnableMatrixInstruction"]) and (not state["UseDotInstruction"]):
-        reject(state, "UnrollMajorLDS Supports only in EnableMatrixInstruction=1 or dot2 kernel")
+        reject(state, printRejectionReason, "UnrollMajorLDS Supports only in EnableMatrixInstruction=1 or dot2 kernel")
 
     ldsNumBytesA, ldsNumBytesAlignedA, ldsNumBytesB, ldsNumBytesAlignedB, ldsNumBytesMetadata, ldsNumBytesAlignedMetadata = calcLdsNumBytes(state["LdsPadA"], state["LdsBlockSizePerPadA"], state["LdsPadB"], state["LdsBlockSizePerPadB"])
     state["LdsOffsetA_Blk"]=0
@@ -3760,13 +2664,13 @@ class Solution(collections.abc.Mapping):
     # if User want to control the LDS usage, we may open this para in the future
     ldsNumBytesReduction = state["LocalSplitU"] * state["MacroTile0"] * state["MacroTile1"] * state["ProblemType"]["ComputeDataType"].numBytes() if state["LocalSplitU"] > 1 else 0
     state["LocalSplitUReuseLDS"] = 1
-    if ldsNumBytesReduction > globalParameters["MaxLDS"]:
-      state["LocalSplitUReuseLDS"] = math.ceil(ldsNumBytesReduction / globalParameters["MaxLDS"])
+    if ldsNumBytesReduction > depthUConfig.maxLDS:
+      state["LocalSplitUReuseLDS"] = math.ceil(ldsNumBytesReduction / depthUConfig.maxLDS)
       # reserve all the LDS to LSU.
-      ldsNumBytesReduction = globalParameters["MaxLDS"]
+      ldsNumBytesReduction = depthUConfig.maxLDS
 
     # lds max occupancy
-    ldsSizeOccupancy = globalParameters["DeviceLDS"] // state["MaxOccupancy"]
+    ldsSizeOccupancy = depthUConfig.deviceLDS // state["MaxOccupancy"]
     ldsNumBytesOccupancy = ldsSizeOccupancy
 
     #print("LdsOffsetB", state["LdsOffsetB"])
@@ -3778,22 +2682,22 @@ class Solution(collections.abc.Mapping):
 
     if state["EnableMatrixInstruction"]:
       if state["DirectToLds"] and state["1LDSBuffer"]:
-        reject(state, "1LDSBuffer must be 0 for directToLds")
+        reject(state, printRejectionReason, "1LDSBuffer must be 0 for directToLds")
 
     if state["1LDSBuffer"] == -1:
       if ldsNumBytesAB  <= max(ldsSizeOccupancy,32768) or \
           (state["ProblemType"]["ComputeDataType"].numBytes() * state["MacroTile0"] * state["MacroTile1"] > 32768*4 and \
-            not (ldsNumBytesAB > globalParameters["DeviceLDS"])):
+            not (ldsNumBytesAB > depthUConfig.deviceLDS)):
         state["1LDSBuffer"] = 0
       else:
         state["1LDSBuffer"] = 1
 
     if state["1LDSBuffer"]:
       if not state["PrefetchGlobalRead"]:
-        reject(state, "PGR=0 already use 1 LDS buffer only")
+        reject(state, printRejectionReason, "PGR=0 already use 1 LDS buffer only")
       # Should be able to support as long as NO scheduleLocalWrite
       if (not state["ScheduleIterAlg"] == 2) and (not state["ScheduleIterAlg"] == 3) and (state["ScheduleLocalWrite"]):
-        reject(state, "1LDSBuffer only support SIA2 or SIA3, or SIA1 without SLW")
+        reject(state, printRejectionReason, "1LDSBuffer only support SIA2 or SIA3, or SIA1 without SLW")
       state["LdsOffsetB"] = ldsNumBytesAlignedA
       state["LdsOffsetMetadata"] = state["LdsOffsetB"] + ldsNumBytesAlignedB
       ldsNumBytesAB = ldsNumBytesAlignedA + ldsNumBytesAlignedB + ldsNumBytesMetadata
@@ -3823,7 +2727,7 @@ class Solution(collections.abc.Mapping):
         ldsNumElementsRemapC = max(ldsNumElementsRemapC, ldsNumElementsRemapC * (computeBytes / state["ProblemType"]["DestDataType"].numBytes()))
         ldsSize = ldsNumElementsRemapC * state["ProblemType"]["DestDataType"].numBytes()
         if not math.log(state["MacroTile0"],2).is_integer() or \
-            ldsSize > globalParameters["MaxLDS"] or \
+            ldsSize > depthUConfig.maxLDS or \
             state["SourceSwap"] or \
             (state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer') or \
             state["MatrixInstBN"] > 1 and state["MatrixInstN"] == 4 :
@@ -3835,9 +2739,9 @@ class Solution(collections.abc.Mapping):
 
       if not state["SourceSwap"]:
         if not state["StoreRemapVectorWidth"]:
-          reject(state, "reject to reduce number of kernels")
+          reject(state, printRejectionReason, "reject to reduce number of kernels")
         elif state["VectorWidthA"] > 1:
-          reject(state, "reject to reduce number of kernels")
+          reject(state, printRejectionReason, "reject to reduce number of kernels")
 
     # GuaranteeNoPartial
     if state["ProblemType"]["TLUA"]:
@@ -3855,73 +2759,73 @@ class Solution(collections.abc.Mapping):
     # SourceSwap
     if state["StoreRemapVectorWidth"]:
       if state["SourceSwap"]:
-        reject(state, "SourceSwap not compatible with StoreRemap")
+        reject(state, printRejectionReason, "SourceSwap not compatible with StoreRemap")
         return
       if state["VectorWidthA"] > 1 or state["VectorWidthB"] > 1:
-        reject(state, "VW>1 not compatible with StoreRemap")
+        reject(state, printRejectionReason, "VW>1 not compatible with StoreRemap")
         return
 
     # Sparse problem
     if state["ProblemType"]["Sparse"]:
       if state["PrefetchGlobalRead"] and not state["ExpandPointerSwap"]:
-        reject(state, "Sparse A kernel only support PGR with EPS=1.")
+        reject(state, printRejectionReason, "Sparse A kernel only support PGR with EPS=1.")
         return
       if state["EnableMatrixInstruction"] and state["MIArchVgpr"]:
-        reject(state, "Sparse A kernel does not support MIArchVgpr yet.")
+        reject(state, printRejectionReason, "Sparse A kernel does not support MIArchVgpr yet.")
         return
       # Not Support Feature
       if state["ProblemType"]["Sparse"] == 1 and state["SourceSwap"] :
-        reject(state, "Sparse A kernel cannot support SourceSwap.")
+        reject(state, printRejectionReason, "Sparse A kernel cannot support SourceSwap.")
         return
       else:
         if state["ProblemType"]["Sparse"] == 2 and not state["SourceSwap"]:
-          reject(state, "Sparse B kernel must enable SourceSwap.")
+          reject(state, printRejectionReason, "Sparse B kernel must enable SourceSwap.")
           return
       state["AssertSummationElementMultiple"] = 8
 
     # check if need to use lds init Acc vgprs
     state["LdsInitCVgprs"] = False
-    if globalParameters["ArchCaps"][isa]["HasAccCD"] and \
+    if isaInfoMap[isa].archCaps["HasAccCD"] and \
          state["EnableMatrixInstruction"] and state["StorePriorityOpt"] and \
          state["ProblemType"]["DataType"].isDouble():
       state["LdsInitCVgprs"] = True
 
     # force MIArchVgpr when using WMMA
-    if state["EnableMatrixInstruction"] and globalParameters["AsmCaps"][isa]["HasWMMA"]:
+    if state["EnableMatrixInstruction"] and isaInfoMap[isa].asmCaps["HasWMMA"]:
       state["MIArchVgpr"] = True
 
     if state["MIArchVgpr"]:
       if not state["EnableMatrixInstruction"]:
-        reject(state, "MIArchVgpr only support for MatrixInstruction")
+        reject(state, printRejectionReason, "MIArchVgpr only support for MatrixInstruction")
         return
 
-      if globalParameters["AsmCaps"][isa]["HasMFMA"]:
+      if isaInfoMap[isa].asmCaps["HasMFMA"]:
         if not (state["ProblemType"]["ComputeDataType"].isDouble() or \
                 state["ProblemType"]["ComputeDataType"].isSingle() or \
                 (state["ProblemType"]["ComputeDataType"].isHalf() and state["ProblemType"]["HighPrecisionAccumulate"]) or \
                 state["ProblemType"]["ComputeDataType"].isInt32() or \
                 state["ProblemType"]["ComputeDataType"].isComplex()):
-          reject(state, "MIArchVgpr now only support fp64, fp64c, fp32, fp32c, fp16, int8 MatrixInstruction.")
+          reject(state, printRejectionReason, "MIArchVgpr now only support fp64, fp64c, fp32, fp32c, fp16, int8 MatrixInstruction.")
           return
 
     #check not support cases and calculate lds resources
     ldsNumBytesRemapC = 0
     if state["StoreRemapVectorWidth"]:
       if not state["EnableMatrixInstruction"]:
-        reject(state, "storeRemap only support MatrixInstruction kernel")
+        reject(state, printRejectionReason, "storeRemap only support MatrixInstruction kernel")
         return
       if ((state["GlobalSplitU"] > 1) and (state["_GlobalAccumulation"] != 'MultipleBuffer' or state["_GlobalAccumulation"] == 'MultipleBufferSingleKernel')) or \
         (state["GlobalSplitU"] == 1 and state["_GlobalAccumulation"] == 'SingleBuffer'):
-        reject(state, "storeRemap doesn't support GlobalSplitU yet, except GSU algorithm 2")
+        reject(state, printRejectionReason, "storeRemap doesn't support GlobalSplitU yet, except GSU algorithm 2")
         return
       if packedC0 or packedC1:
-        reject(state, "storeRemap doesn't support packedC0 and packedC1 yet")
+        reject(state, printRejectionReason, "storeRemap doesn't support packedC0 and packedC1 yet")
         return
       if state["MatrixInstBN"] > 1 and state["MatrixInstN"] == 4:
-        reject(state, "storeRemap doesn't support MI4x4 multi blocks in N direction yet")
+        reject(state, printRejectionReason, "storeRemap doesn't support MI4x4 multi blocks in N direction yet")
         return
       if not math.log(state["MacroTile0"],2).is_integer():
-        reject(state, "storeRemap only supports power-of-2 MT0")
+        reject(state, printRejectionReason, "storeRemap only supports power-of-2 MT0")
         # TODO - this return should be here, but this is a hotfix,
         # Somehow we have a "Validation Failed" kernel in rocBLAS now (SRVW=4 and MT0=96) and this will stop the whole building process
         # Actions: 1. Hotfix, comment out this "return" temporarily for that invalidated kernel
@@ -3940,15 +2844,15 @@ class Solution(collections.abc.Mapping):
       while srMaxVw < state["StoreRemapVectorWidth"]:
         state["StoreRemapVectorWidth"] = state["StoreRemapVectorWidth"] // 2
       if srMinVw > state["StoreRemapVectorWidth"] or srMaxVw < state["StoreRemapVectorWidth"]:
-        reject(state, "StoreRemapVectorWidth %u is not allowed for this data type" % state["StoreRemapVectorWidth"])
+        reject(state, printRejectionReason, "StoreRemapVectorWidth %u is not allowed for this data type" % state["StoreRemapVectorWidth"])
         return
 
       if state["StoreRemapVectorWidth"] * state["WavefrontSize"] < state["MacroTile0"]:
-        reject(state, "storeRemap: Per wave single global write instruction doesn't enough to write one M column." + \
+        reject(state, printRejectionReason, "storeRemap: Per wave single global write instruction doesn't enough to write one M column." + \
                " Please use larger StoreRemapVectorWidth.")
         return
       if (state["MacroTile0"]*state["MatrixInstN"])//state["MIWaveGroup"][0] < state["StoreRemapVectorWidth"]*state["WavefrontSize"]:
-        reject(state, "storeRemap: number elements of lds less than per wave per local read elements." + \
+        reject(state, printRejectionReason, "storeRemap: number elements of lds less than per wave per local read elements." + \
                " Please use smaller StoreRemapVectorWidth.")
         return
       ldsRemapPad = max(state["StoreRemapVectorWidth"],state["MIOutputVectorWidth"])
@@ -3977,7 +2881,7 @@ class Solution(collections.abc.Mapping):
         # TODO- Remove this DataType test condition,
         # Currently we do this test is just because we don't want to affect existing logic in rocBLAS
         if state["ProblemType"]["DataType"].isInt8():
-          reject(state, "LDS usage is bound be StoreRemap, thus 1LDSBuffer wouldn't have any help. Skip.")
+          reject(state, printRejectionReason, "LDS usage is bound be StoreRemap, thus 1LDSBuffer wouldn't have any help. Skip.")
           return
 
       ldsNumBytes = max(ldsNumBytes, ldsNumBytesRemapC)
@@ -4017,7 +2921,7 @@ class Solution(collections.abc.Mapping):
       maxTurn = calcEpilogueTurns([0, 1])
     vecDT.bias(0).turn = maxTurn
     vecDT.bias(1).turn = maxTurn
-  
+
     # Calc LDS for SAV
     maxTurn = 0
     if savDim == 1:
@@ -4073,8 +2977,8 @@ class Solution(collections.abc.Mapping):
 
     state["LdsNumBytes"] = ldsNumBytes
     ldsSize = ldsNumBytes
-    if ldsSize > globalParameters["MaxLDS"]:
-      reject(state, "Kernel Uses %u > %u bytes of LDS" % ( ldsSize, globalParameters["MaxLDS"]))
+    if ldsSize > depthUConfig.maxLDS:
+      reject(state, printRejectionReason, "Kernel Uses %u > %u bytes of LDS" % ( ldsSize, depthUConfig.maxLDS))
       state["ValidDepthU"] = False
       return
 
@@ -4084,7 +2988,7 @@ class Solution(collections.abc.Mapping):
     if state["LoopUnroll"] * state["LocalSplitU"] != state["DepthU"]:
       state["Valid"] = False
     if state["KernelLanguage"] != "Assembly" and state["InnerUnroll"] != 1:
-      reject(state, "InnerUnroll only supported on assembly")
+      reject(state, printRejectionReason, "InnerUnroll only supported on assembly")
     state["LoopUnroll"] //= state["InnerUnroll"]
 
     if 0:
@@ -4104,7 +3008,7 @@ class Solution(collections.abc.Mapping):
       state["LoopIters"] //= (state["NumDotElements"] * state["NumWaveSplitK"])
 
     if state["LoopIters"] < 1:
-      reject(state, "LoopIters need to greater than 0")
+      reject(state, printRejectionReason, "LoopIters need to greater than 0")
       return
 
     # Since we use PLR >= LoopIters for allocating numberOfIters vgprBuffer for a while
@@ -4113,7 +3017,7 @@ class Solution(collections.abc.Mapping):
       # 1 or 2 Byte input + DTVA or DTVB case, does not work with PLR=0. Reject it here.
       if state["ProblemType"]["DataType"].numBytes() < 4 and \
          (state["ProblemType"]["TLUA"] and state["DirectToVgprA"] or state["ProblemType"]["TLUB"] and state["DirectToVgprB"]):
-        reject(state, "DirectToVgpr does not work with 1 or 2 Byte input + TLU + PrefetchLocalRead(%u) >= LoopIters(%u)"%(state["PrefetchLocalRead"], state["LoopIters"]))
+        reject(state, printRejectionReason, "DirectToVgpr does not work with 1 or 2 Byte input + TLU + PrefetchLocalRead(%u) >= LoopIters(%u)"%(state["PrefetchLocalRead"], state["LoopIters"]))
         return
       state["ClusterLocalRead"] = 0
       state["PrefetchLocalRead"] = 0
@@ -4130,33 +3034,33 @@ class Solution(collections.abc.Mapping):
       # Multiple = WLR-size / input-size = how many iters could be covered by one WLR ?
       wlrMultiple = state["LocalReadVectorWidth"]//state["MIInputPerThread"]
       # NOTE: wlrmultiple can be 0 for new MFMA
-      if not state["ProblemType"]["Sparse"] and (not globalParameters["AsmCaps"][isa]["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
+      if not state["ProblemType"]["Sparse"] and (not isaInfoMap[isa].asmCaps["HasMFMA_f8f6f4"] or state["MatrixInstK"] <= 32):
         if wlrMultiple == 0:
-          reject(state, "LocalReadVectorWidth %u is less than MIInput" % (state["LocalReadVectorWidth"]))
+          reject(state, printRejectionReason, "LocalReadVectorWidth %u is less than MIInput" % (state["LocalReadVectorWidth"]))
           return
       # for example, if the original ds_read is b32...
       #   1. if LoopIters = 5 (b32 x 5 times), WLR-Multiple = 2 (b64), then we can fit the WLR
       #   2. if LoopIters = 2 (b32 x 2 times), WLR-Multiple = 4 (b128), this is not allowed
       #   3. if LoopIters = 2 (b32 x 2 times), WLR-Multiple = 2 (b64), this is allowed
       if wlrMultiple and state["LoopIters"] % wlrMultiple != 0:
-        reject(state, "LocalReadVectorWidth %u cannot be distributed evenly, LoopIters %u should be divisible by WLR-Multiple %u" \
+        reject(state, printRejectionReason, "LocalReadVectorWidth %u cannot be distributed evenly, LoopIters %u should be divisible by WLR-Multiple %u" \
           % (state["LocalReadVectorWidth"], state["LoopIters"], wlrMultiple))
 
       if state["LoopIters"] - (state["PrefetchLocalRead"] * wlrMultiple) < 0 :
-        reject(state, "with PrefetchLocalRead %u LoopIters %u LocalReadVectorWidth %u, not enough LoopIters to prefetch %ux%u iterations, " \
+        reject(state, printRejectionReason, "with PrefetchLocalRead %u LoopIters %u LocalReadVectorWidth %u, not enough LoopIters to prefetch %ux%u iterations, " \
           % (state["PrefetchLocalRead"],state["LoopIters"],state["LocalReadVectorWidth"], state["PrefetchLocalRead"] , wlrMultiple) )
 
     # # reject conditions with lower performance
     # if state["ScheduleIterAlg"] == 2 and \
     # (state["ExpandPointerSwap"] != 1 or state["LoopIters"] != 1 or state["ScheduleGlobalRead"] != 1):
-    #   reject(state, "ScheduleIterAlg 2 only work with EPS1_SGR1, LoopIter=1")
+    #   reject(state, printRejectionReason, "ScheduleIterAlg 2 only work with EPS1_SGR1, LoopIter=1")
 
     if state["TransposeLDS"] == 1:
       if not state["EnableMatrixInstruction"]:
-        reject(state, "TransposeLds Supports only in MatrixInstruction=1")
+        reject(state, printRejectionReason, "TransposeLds Supports only in MatrixInstruction=1")
       if state["ProblemType"]["TLUA"] and state["ProblemType"]["TLUB"]:
           # TODO: Now in rocBLAS, lot of logic yamls are Type=NT and TLDS=1? Why aren't they rejected and how to get rid of them?
-          reject(state, "TransposeLds requires TLUA=0 or TLUB=0")
+          reject(state, printRejectionReason, "TransposeLds requires TLUA=0 or TLUB=0")
     if state["EnableMatrixInstruction"]:
       # enable widerLocalRead
       if state["LocalReadVectorWidth"] > state["MIInputPerThread"]:
@@ -4166,10 +3070,10 @@ class Solution(collections.abc.Mapping):
         if not (state["PrefetchLocalRead"] >= state["LoopIters"] and state["InnerUnroll"] == 1) and \
             not state["ClusterLocalRead"] and \
             not state["InnerUnroll"] >= state["LocalReadVectorWidth"] // state["MIInputPerThread"]:
-          reject(state, "wider localRead only support ClusterLocalRead or (InnerUnroll > WiderLocalReadxN)")
+          reject(state, printRejectionReason, "wider localRead only support ClusterLocalRead or (InnerUnroll > WiderLocalReadxN)")
 
     if state["GlobalReadPerMfma"] > 1 and state["PrefetchGlobalRead"] == 2:
-      reject(state, "GlobalReadPerMfma need to be 1 if PGR2")
+      reject(state, printRejectionReason, "GlobalReadPerMfma need to be 1 if PGR2")
 
     if state["UseInstOffsetForGRO"] == -1:
       state["UseInstOffsetForGRO"] = 1 if state["DirectToLds"] else 0
@@ -4183,7 +3087,7 @@ class Solution(collections.abc.Mapping):
       numVgprG2LB = roundUp((state["NumLoadsCoalescedB"] * state["NumLoadsPerpendicularB"] * \
         state["GlobalReadVectorWidthB"] * bpeAB) / (float)(bpr))
       if numVgprG2LA % 2 == 1 or numVgprG2LB % 2 == 1:
-        reject(state, "G2LA/B vgpr has bubble inside. Cannot use UnrollLoopSwapGlobalReadOrder=1.")
+        reject(state, printRejectionReason, "G2LA/B vgpr has bubble inside. Cannot use UnrollLoopSwapGlobalReadOrder=1.")
       if state["GlobalReadVectorWidthA"] != state["GlobalReadVectorWidthB"]:
         # TODO: Add a configuration to schedule better.
         state["ULSGRODoubleG2L"] = 1
@@ -4192,11 +3096,11 @@ class Solution(collections.abc.Mapping):
         # G2LA/B vgpr index will jump.
         state["ULSGRODoubleG2L"] = 1
       if state["ExpandPointerSwap"] == 1:
-        reject(state, "ExpandPointerSwap need to be 0 if UnrollLoopSwapGlobalReadOrder")
+        reject(state, printRejectionReason, "ExpandPointerSwap need to be 0 if UnrollLoopSwapGlobalReadOrder")
       if state["PrefetchGlobalRead"] != 2:
-        reject(state, "PrefetchGlobalRead need to be 2 if UnrollLoopSwapGlobalReadOrder")
+        reject(state, printRejectionReason, "PrefetchGlobalRead need to be 2 if UnrollLoopSwapGlobalReadOrder")
       if state["ProblemType"]["DataTypeA"].numBytes() != state["ProblemType"]["DataTypeB"].numBytes():
-        reject(state, "UnrollLoopSwapGlobalReadOrder doesn't support mixed precision.")
+        reject(state, printRejectionReason, "UnrollLoopSwapGlobalReadOrder doesn't support mixed precision.")
 
     # guard against out of bounds reads
     # None: don't guard against ou
@@ -4225,7 +3129,7 @@ class Solution(collections.abc.Mapping):
     if bufferLoad and state["_UseSgprForGRO"] and state["EdgeType"]=="ShiftPtr":
       if not state["GuaranteeNoPartialA"] or not state["GuaranteeNoPartialB"] or not state["GuaranteeNoPartialMetadata"]:
         state["_UseSgprForGRO"] = False
-        #reject(state, "PBC with wide load has insufficient overlap guarantees- try GRVW=1 or adding appropriate Assert*ElementMultiple")
+        #reject(state, printRejectionReason, "PBC with wide load has insufficient overlap guarantees- try GRVW=1 or adding appropriate Assert*ElementMultiple")
 
 
 
@@ -4234,7 +3138,7 @@ class Solution(collections.abc.Mapping):
       cont1 = not state["GuaranteeNoPartialB"]
       cont2 = ((state["MatrixInstN"] % state["GlobalReadVectorWidthB"]) != 0)
       if cont1 and cont2:
-        reject(state, "MatrixInstN %u %% GlobalReadVectorWidthB %u must be 0" % \
+        reject(state, printRejectionReason, "MatrixInstN %u %% GlobalReadVectorWidthB %u must be 0" % \
           (state["MatrixInstN"], state["GlobalReadVectorWidthB"]))
 
     # Use SGPR to store an offset from GlobalReadOffsetA+0.
@@ -4243,7 +3147,7 @@ class Solution(collections.abc.Mapping):
     # individual vector registers doing bounds compares.
 
     if state["_UseSgprForGRO"] == 1 and (state["ProblemType"]["SwizzleTensorA"] or state["ProblemType"]["SwizzleTensorB"]):
-      reject(state, "UseSgprForGRO for Swizzle is not supported")
+      reject(state, printRejectionReason, "UseSgprForGRO for Swizzle is not supported")
 
     if state["_UseSgprForGRO"] == -1:
       # Don't use SGPR if it looks like we might not have enough - better to leave PBC enabled even if we have to use VGPR
@@ -4260,60 +3164,45 @@ class Solution(collections.abc.Mapping):
         state["_UseSgprForGRO"] = 1
 
     if packedC0 and not state["GuaranteeNoPartialA"]:
-      reject(state, "packedC0 requires GuaranteeNoPartialA")
+      reject(state, printRejectionReason, "packedC0 requires GuaranteeNoPartialA")
     if packedC1 and not state["GuaranteeNoPartialB"]:
-      reject(state, "packedC1 requires GuaranteeNoPartialB")
+      reject(state, printRejectionReason, "packedC1 requires GuaranteeNoPartialB")
 
     if packedC0 or packedC1:
       state["_UseSgprForGRO"] = 0
 
       if state["EdgeType"] != "ShiftPtr":
-        reject(state, "Packed dims requires EdgeType==ShiftPtr")
+        reject(state, printRejectionReason, "Packed dims requires EdgeType==ShiftPtr")
       if state["KernelLanguage"] == "Assembly":
         if not bufferLoad:
-          reject(state, "Packed dims for Assembly requires BufferLoad")
+          reject(state, printRejectionReason, "Packed dims for Assembly requires BufferLoad")
 
     if packedC0: # VectorWidth must not span tensor dim
       if state["KernelLanguage"] == "Source":
         if state["AssertFree0ElementMultiple"]<state["VectorWidthA"]:
-          reject(state, "packedC0 Source requires AF0EM>=VectorWidth (for loads and stores)")
+          reject(state, printRejectionReason, "packedC0 Source requires AF0EM>=VectorWidth (for loads and stores)")
       else:
         if state["AssertFree0ElementMultiple"]<state["VectorWidthA"]\
           or state["AssertFree0ElementMultiple"] == 1:
             if state["VectorStore"] <= 0:
               state["_VectorStore"] = 0
             else:
-              reject(state, "packedC0 Assembly requires AF0EM>=VectorWidth or not VectorStore (for stores)")
+              reject(state, printRejectionReason, "packedC0 Assembly requires AF0EM>=VectorWidth or not VectorStore (for stores)")
 
     state["AssignedDerivedParameters"] = True
-
-    # UnrollLoopEfficiencyEnable does not work with f16/bf16/int8x4
-    if globalParameters["UnrollLoopEfficiencyEnable"] and (state["ProblemType"]["DataType"].isHalf() or \
-       state["ProblemType"]["DataType"].isBFloat16() or state["ProblemType"]["DataType"].isInt8x4()):
-      reject(state, "UnrollLoopEfficiencyEnable does not support f16/bf16/int8x4")
-
-    # UnrollLoopEfficiencyEnable supports only ThreadTile0,1=[6,4] or [4,6] or [4,4] or [6.6] or [8,4] or [4,8]
-    if globalParameters["UnrollLoopEfficiencyEnable"] and \
-      not ((state["ThreadTile0"] == 6 and state["ThreadTile1"] == 4) or \
-           (state["ThreadTile0"] == 4 and state["ThreadTile1"] == 6) or \
-           (state["ThreadTile0"] == 4 and state["ThreadTile1"] == 4) or \
-           (state["ThreadTile0"] == 6 and state["ThreadTile1"] == 6) or \
-           (state["ThreadTile0"] == 8 and state["ThreadTile1"] == 4) or \
-           (state["ThreadTile0"] == 4 and state["ThreadTile1"] == 8)):
-      reject(state, "UnrollLoopEfficiencyEnable does not support ThreadTile0,1 = [%u,%u]"%(state["ThreadTile0"], state["ThreadTile1"]))
 
     # Set E
     if state["ProblemType"]["UseE"]:
       if (state["_GlobalAccumulation"] == 'SingleBuffer') and state["GlobalSplitU"] > 1:
-        reject(state, "GlobalSplitU > 1 only compatible with MultipleBuffer")
+        reject(state, printRejectionReason, "GlobalSplitU > 1 only compatible with MultipleBuffer")
       if len(state["PackedC1IndicesX"]) > 1:
-        reject(state, "Use E does not support len(PackedC1IndicesX) > 1.")
+        reject(state, printRejectionReason, "Use E does not support len(PackedC1IndicesX) > 1.")
       if not state["BufferStore"]:
-        reject(state, "Use E only supports BufferStore due to no suppress no store.")
+        reject(state, printRejectionReason, "Use E only supports BufferStore due to no suppress no store.")
       if state["StoreRemapVectorWidth"] and (state["GlobalSplitU"] == 1):
-        reject(state, "Use E does not support StoreRemapVectorWidth if GSU == 1.")
+        reject(state, printRejectionReason, "Use E does not support StoreRemapVectorWidth if GSU == 1.")
       if state["GroupLoadStore"]:
-        reject(state, "Use E does not support GroupLoadStore.")
+        reject(state, printRejectionReason, "Use E does not support GroupLoadStore.")
 
     # Activation
     # Function call is set to false if GSU != 1 or Activation is not fused or ActivationType is not All.
@@ -4322,24 +3211,24 @@ class Solution(collections.abc.Mapping):
       state["ActivationFuncCall"] = False
 
     if state["ActivationAlt"]:
-      reject(state, "Currently does not accept ActivationAlt.")
+      reject(state, printRejectionReason, "Currently does not accept ActivationAlt.")
 
     # Bias reduction
     if state["ProblemType"]["UseBias"] and state["ProblemType"]["Gradient"]:
       if (state["_GlobalAccumulation"] == 'SingleBuffer') and state["GlobalSplitU"] > 1:
-        reject(state, "GlobalSplitU > 1 only compatible with MultipleBuffer for bias reduction")
+        reject(state, printRejectionReason, "GlobalSplitU > 1 only compatible with MultipleBuffer for bias reduction")
       if len(state["PackedC1IndicesX"]) > 1:
-        reject(state, "Bias reduction does not support len(PackedC1IndicesX) > 1.")
+        reject(state, printRejectionReason, "Bias reduction does not support len(PackedC1IndicesX) > 1.")
       if not state["BufferStore"]:
-        reject(state, "Bias reduction only supports BufferStore due to no suppress no store.")
+        reject(state, printRejectionReason, "Bias reduction only supports BufferStore due to no suppress no store.")
       if state["StoreRemapVectorWidth"] and (state["GlobalSplitU"] == 1):
-        reject(state, "Bias reduction does not support StoreRemapVectorWidth if GSU == 1.")
+        reject(state, printRejectionReason, "Bias reduction does not support StoreRemapVectorWidth if GSU == 1.")
       if state["GroupLoadStore"]:
-        reject(state, "Bias reduction does not support GroupLoadStore.")
+        reject(state, printRejectionReason, "Bias reduction does not support GroupLoadStore.")
 
     # Bias and ScaleAlphaVec
     if state["ProblemType"]["UseBias"] != 0 and state["ProblemType"]["UseScaleAlphaVec"] != 0 and state["ProblemType"]["UseBias"] != state["ProblemType"]["UseScaleAlphaVec"]:
-      reject(state, "When both UseBias and UseScaleAlphaVec are enabled then UseBias and UseScaleAlphaVec must have same settings.")
+      reject(state, printRejectionReason, "When both UseBias and UseScaleAlphaVec are enabled then UseBias and UseScaleAlphaVec must have same settings.")
 
     # ScaleAB or ScaleABVec
     if state["ProblemType"]["DataTypeA"] != state["ProblemType"]["DataTypeB"] and \
@@ -4355,242 +3244,28 @@ class Solution(collections.abc.Mapping):
 
     # if state["GlobalSplitU"] > 1:
     #   if state["ProblemType"]["SupportUserArgs"] and state["_GlobalAccumulation"] != 'MultipleBufferSingleKernel':
-    #     reject(state, "Currently SupportUserArgs does not support GSU > 1.")
+    #     reject(state, printRejectionReason, "Currently SupportUserArgs does not support GSU > 1.")
 
     if state["_GlobalAccumulation"] == 'MultipleBufferSingleKernel':
-      if (state["NumElementsPerBatchStore"] == 1):
-        reject(state, "too many store at MultipleBufferSingleKernel direct reject")
+      if state["NumElementsPerBatchStore"] == 1:
+        reject(state, printRejectionReason, "too many store at MultipleBufferSingleKernel direct reject")
       if state["ProblemType"]["UseScaleCD"]:
-        reject(state, "MultipleBufferSingleKernel not support UseScaleCD yet")
+        reject(state, printRejectionReason, "MultipleBufferSingleKernel not support UseScaleCD yet")
       if state["ProblemType"]["UseE"]:
-        reject(state, "MultipleBufferSingleKernel not support UseE yet")
+        reject(state, printRejectionReason, "MultipleBufferSingleKernel not support UseE yet")
       if state["ProblemType"]["BiasSrc"] != "D":
-        reject(state, "MultipleBufferSingleKernel not support BiasSrc not D yet")
+        reject(state, printRejectionReason, "MultipleBufferSingleKernel not support BiasSrc not D yet")
       if state["ProblemType"]["DataType"].isDouble():
-        reject(state, "MultipleBufferSingleKernel not support " + str(state["ProblemType"]["DataType"])  + " yet")
+        reject(state, printRejectionReason, "MultipleBufferSingleKernel not support " + str(state["ProblemType"]["DataType"])  + " yet")
       if state["ProblemType"]["Sparse"] != 0:
-        reject(state, "MultipleBufferSingleKernel not support sparse yet")
+        reject(state, printRejectionReason, "MultipleBufferSingleKernel not support sparse yet")
 
     #Need to force disabling PreloadKernArgs if compiler does not support
     #Can not just reject the solution since the user library may find any solutions
     if state["PreloadKernArgs"]:
-      hipccver = globalParameters['HipClangVersion'].split(".")
-      hipccMaj = int(hipccver[0])
-      hipccPatch = int(hipccver[2].split("-")[0])
-      if not (hipccMaj >= 6 and hipccPatch >= 32650 and (isa == (9, 0, 10) or isa[:2] == (9, 4))):
+      if not (rocmVersion.major >= 6 and rocmVersion.patch >= 32650 and (isa == (9, 0, 10) or isa[:2] == (9, 4))):
         #print("Force to Disable PreloadKernArgs since this hipcc version doesn't support",)
         state["PreloadKernArgs"] = 0
-
-  ########################################
-  # create a dictionary with booleans on whether to include parameter in name
-  @staticmethod
-  def getMinNaming(objs):
-    nonCKObjs = [obj for obj in objs if not isCustomKernelConfig(obj)]
-
-    # early return
-    if len(nonCKObjs) == 0:
-      return {}
-
-    # determine keys
-    requiredParameters = {}
-    if isinstance(nonCKObjs[0], Solution):
-      keys = list(nonCKObjs[0]._state.keys())
-    else:
-      keys = list(nonCKObjs[0].keys())
-    # only 1, rather than name being nothing, it'll be everything
-    if len(nonCKObjs) == 1:
-      for key in keys:
-        if key in list(validParameters.keys()):
-          requiredParameters[key] = False
-    else:
-      for key in keys:
-        required = False
-        if key in list(validParameters.keys()):
-          for i in range(1, len(nonCKObjs)):
-            if nonCKObjs[0][key] != nonCKObjs[i][key]:
-              required = True
-              break
-        if required:
-          requiredParameters[key] = True
-        else:
-          requiredParameters[key] = False
-
-    requiredParameters["GlobalSplitU"] = True
-    requiredParameters["WorkGroupMapping"] = True
-
-    if "MatrixInstM" in nonCKObjs[0]._state:
-      # Use MIWaveGroup and MIWaveTile instead of WG and MT
-      requiredParameters["MIWaveTile"]  = True
-      requiredParameters["ThreadTile"]  = False
-
-    requiredParameters["ProblemType"]       = False # always prepended
-    requiredParameters["MacroTile0"]        = False # always prepended
-    requiredParameters["MacroTile1"]        = False # always prepended
-    requiredParameters["DepthU"]            = False # always prepended
-    requiredParameters["MatrixInstruction"] = False # always prepended
-    requiredParameters["MatrixInstM"]       = False # always prepended
-    requiredParameters["MatrixInstN"]       = False # always prepended
-    requiredParameters["MatrixInstK"]       = False # always prepended
-    requiredParameters["MatrixInstB"]       = False # always prepended
-    requiredParameters["MatrixInstBM"]      = False # always prepended
-    requiredParameters["MatrixInstBN"]      = False # always prepended
-    requiredParameters["CustomKernelName"]  = False # Will not affect naming
-
-    requiredParameters["Kernel"]            = True  # distinguish kernels from solutions
-                                                    # for single-source compilation
-    return requiredParameters
-
-  ########################################
-  @ staticmethod
-  def getKeyNoInternalArgs(state):
-    state_copy = deepcopy(state)
-
-    state_copy["ProblemType"]["GroupedGemm"] = False
-
-    if globalParameters["SplitGSU"]:
-      state_copy["GlobalSplitU"] = "M" if (state_copy["GlobalSplitU"] > 1) else state_copy["GlobalSplitU"]
-    elif state["GlobalSplitU"] > 0:
-      state_copy["GlobalSplitU"] = "M"
-    state_copy["WorkGroupMapping"] = "M"
-    state_copy["WorkGroupMappingXCC"] = "M"
-    state_copy["WorkGroupMappingXCCGroup"] = "M"
-    state_copy["StaggerU"] = "M"
-    state_copy["StaggerUStride"] = "M"
-    state_copy["StaggerUMapping"] = "M"
-    state_copy["GlobalSplitUCoalesced"] = "M"
-    state_copy["GlobalSplitUWorkGroupMappingRoundRobin"] = "M"
-
-    return state_copy
-
-  @ staticmethod
-  def getNameFull(state):
-    requiredParameters = {}
-    for key in state:
-      if key in list(validParameters.keys()):
-        requiredParameters[key] = True
-    if "MatrixInstM" in state:
-      # Use MIWaveGroup and MIWaveTile instead of WG and MT
-      requiredParameters["MIWaveTile"]  = True
-      requiredParameters["ThreadTile"]  = False
-    return Solution.getNameMin(state, requiredParameters)
-
-  ########################################
-  # Get Name Min
-  @ staticmethod
-  def getNameMin(state, requiredParameters, ignoreInternalArgs = False):
-    if isCustomKernelConfig(state):
-      return state["CustomKernelName"]
-
-    components = []
-
-    backup = state["ProblemType"]["GroupedGemm"]
-    if ignoreInternalArgs:
-      state["ProblemType"]["GroupedGemm"] = False
-
-    if "ProblemType" in state:
-      components.append(f'{str(state["ProblemType"])}')
-      # name += str(state["ProblemType"]) + "_"
-
-    if ignoreInternalArgs:
-      state["ProblemType"]["GroupedGemm"] = backup
-
-    if "MacroTile0" in state \
-        and "MacroTile1" in state \
-        and "DepthU" in state:
-      components.append(f'{Solution.getParameterNameAbbreviation("MacroTile")}{state["MacroTile0"]}x{state["MacroTile1"]}x{state["DepthU"]}')
-
-    if "MatrixInstM" in state:
-      components.append(f'{Solution.getParameterNameAbbreviation("MatrixInstruction")}{state["MatrixInstM"]}x{state["MatrixInstN"]}x{state["MatrixInstB"]}')
-
-    backup = state["GlobalSplitU"]
-
-    if ignoreInternalArgs:
-      if globalParameters["SplitGSU"]:
-        state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
-      elif state["GlobalSplitU"] > 0:
-        requiredParameters["GlobalSplitU"] = False
-      requiredParameters["WorkGroupMapping"] = False
-      requiredParameters["WorkGroupMappingXCC"] = False
-      requiredParameters["WorkGroupMappingXCCGroup"] = False
-      requiredParameters["StaggerU"] = False
-      requiredParameters["StaggerUStride"] = False
-      requiredParameters["StaggerUMapping"] = False
-      requiredParameters["GlobalSplitUCoalesced"] = False
-      requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
-
-    useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
-
-    if 'MatrixInstM' in state:
-      requiredParameters["MIWaveTile"] = True
-      requiredParameters["ThreadTile"] = False
-    else:
-      requiredParameters["MIWaveTile"] = False
-      requiredParameters["ThreadTile"] = True
-
-    components.append('SN')
-    for key in sorted(state.keys()):
-      if key in requiredParameters and key[0] != '_':
-        if requiredParameters[key] and key != "CustomKernelName":
-          components.append(f'{Solution.getParameterNameAbbreviation(key)}{Solution.getParameterValueAbbreviation(key, state[key])}')
-
-    state["GlobalSplitU"] = backup
-    requiredParameters["GlobalSplitU"] = True
-    requiredParameters["WorkGroupMapping"] = True
-    requiredParameters["WorkGroupMappingXCC"] = True
-    requiredParameters["WorkGroupMappingXCCGroup"] = True
-    requiredParameters["StaggerU"] = True
-    requiredParameters["StaggerUStride"] = True
-    requiredParameters["StaggerUMapping"] = True
-    requiredParameters["GlobalSplitUCoalesced"] = True
-    requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
-    requiredParameters["MIWaveTile"] = useWaveTile
-    requiredParameters["ThreadTile"] = useThreadTile
-
-    return '_'.join(components)
-
-  ########################################
-  # create a dictionary of lists of parameter values
-  @staticmethod
-  def getSerialNaming(objs):
-    data = {}
-    for obj in objs:
-      for paramName in sorted(obj.keys()):
-        if paramName in validParameters.keys():
-          paramValue = obj[paramName]
-          if paramName in data:
-            if paramValue not in data[paramName]:
-              data[paramName].append(paramValue)
-          else:
-            data[paramName] = [ paramValue ]
-    maxObjs = 1
-    for paramName in data:
-      if not isinstance(data[paramName][0], dict):
-        data[paramName] = sorted(data[paramName])
-      maxObjs *= len(data[paramName])
-    numDigits = len(str(maxObjs))
-    return [ data, numDigits ]
-
-  ########################################
-  # Get Name Serial
-  @ staticmethod
-  def getNameSerial(state, serialNaming):
-    data = serialNaming[0]
-    numDigits = serialNaming[1]
-
-    serial = 0
-    multiplier = 1
-    for paramName in sorted(state.keys()):
-      if paramName in list(validParameters.keys()):
-        paramValue = state[paramName]
-        paramData = data[paramName]
-        paramNameMultiplier = len(paramData)
-        if paramValue in paramData:
-          paramValueIdx = paramData.index(paramValue)
-        serial += paramValueIdx * multiplier
-        multiplier *= paramNameMultiplier
-    name = "%s%0*u" % ("S" if isinstance(state, Solution) else "K", \
-        numDigits, serial)
-    return name
 
 
   ########################################
@@ -4602,60 +3277,10 @@ class Solution(collections.abc.Mapping):
       s += "%s%s: %s\n" % (indent, str(key), str(state[key]))
     return s
 
-  ########################################
-  @ staticmethod
-  @ lru_cache(maxsize=None)
-  def getParameterNameAbbreviation( name: str ):
-    return ''.join(c for c in name if c.isupper())
-
-  ########################################
 
   class NonprimitiveParameterValueException(Exception):
     pass
 
-  @ staticmethod
-  @ lru_cache(maxsize=None)
-  def getPrimitiveParameterValueAbbreviation(key, value):
-    if isinstance(value, str):
-      return Solution.getParameterNameAbbreviation(value)
-    elif isinstance(value, bool):
-      return "1" if value else "0"
-    elif isinstance(value, int):
-      if value >= 0:
-        return "%u" % value
-      else: # -1 -> n1
-        return "n%01u" % abs(value)
-    elif isinstance(value, ProblemType):
-      return str(value)
-    elif isinstance(value, float):
-      val1 = int(value)
-      val2 = int(round(value*100)) - int(value)*100
-      if val2 > 0:
-        s =  "%dp%s" % (val1,str(val2).zfill(2))
-      else:
-        s = "%d" % (val1)
-      return s
-
-  ########################################
-
-  @ staticmethod
-  def getParameterValueAbbreviation( key, value ):
-    if key == "ISA":
-      return f"{value[0]}{value[1]}{value[2]:x}"
-
-    compositieTypes = (dict, list, tuple,)
-
-    if not isinstance(value, compositieTypes):
-      return Solution.getPrimitiveParameterValueAbbreviation(key, value)
-    elif isinstance(value, tuple):
-      return ''.join(str(v) for v in value)
-    elif isinstance(value, list):
-      return '_'.join(Solution.getParameterValueAbbreviation(key, v) for v in value)
-    elif isinstance(value, dict):
-      return "_".join(f"{pos:d}{k:d}" for pos,k in value.items())
-    else:
-      printExit('Parameter {key}={value} is new object type ({t})'.format(key=key, value=value, t=type(value)))
-      return str(value)
 
   ##########################
   # make class look like dict
@@ -4677,7 +3302,7 @@ class Solution(collections.abc.Mapping):
 
   def __str__(self):
     if self._name is None:
-      self._name = Solution.getNameFull(self._state)
+      self._name = getNameFull(self._state, self.splitGSU)
     return self._name
 
   def __repr__(self):

--- a/tensilelite/Tensile/SolutionStructs/Utilities.py
+++ b/tensilelite/Tensile/SolutionStructs/Utilities.py
@@ -1,0 +1,68 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+import sys
+import math
+
+def reject(state: dict, printSolutionRejectionReason: bool = True, *args) -> bool:
+  """
+  Reject a solution based on its internal state.
+
+  Args:
+      state: The state of the solution.
+      printSolutionRejectionReason: If True, print the rejection reason.
+      *args: Additional arguments to print if rejection occurs.
+
+  Returns:
+      True if the solution is rejected, False otherwise.
+  """
+  if state and "NoReject" in state and state["NoReject"]:
+    return False
+  if printSolutionRejectionReason:
+    sys.stdout.write("\nreject: ")
+    for a in args:
+      print(a)
+    #traceback.print_stack(None, 2)
+    solutionIndex = state["SolutionIndex"] if (state != None and "SolutionIndex" in state) else -1
+    if solutionIndex != -1:
+      # If we have valid solutionIndex, this means we are during TensileCreateLibrary stage
+      # In this stage, all solutions in the logic should be valid
+      # So if any rejection happens, print the warning for further check
+      # This will be done only when --global-parameters=PrintSolutionRejectionReason=True
+      solutionNameMin = state["SolutionNameMin"] if ("SolutionNameMin" in state) else None
+      # if we don't have SolutionNameMin, we simply use the problemTypeName
+      solutionNameMin = str(state["ProblemType"]) if (solutionNameMin == None) else solutionNameMin
+      raise Exception("!! Warning: Any rejection of a LibraryLogic is not expected, please check. \
+        SolutionIndex: %d (or SolutionName/ProblemType: %s)"%(solutionIndex, solutionNameMin))
+  if state != None:
+    state["Valid"] = False
+    return True
+
+# print a labled variable
+def pvar(state, field):
+  return field + "=" + str(state[field])
+
+def roundupRatio(dividend, divisor):
+  return int(math.ceil(float(dividend) / float(divisor)))
+

--- a/tensilelite/Tensile/SolutionStructs/Validators/MatrixInstruction.py
+++ b/tensilelite/Tensile/SolutionStructs/Validators/MatrixInstruction.py
@@ -1,0 +1,295 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+import pprint
+from typing import Dict, Optional
+
+from Tensile.Common import IsaVersion, IsaInfo, print1, print2, elineno
+from Tensile.Common.Architectures import SUPPORTED_ISA
+from Tensile.Common.ValidParameters import makeValidMatrixInstructions, makeValidMFMA, makeValidSMFMA, makeValidWMMA
+from Tensile.TensileInstructions.DataType import DataType
+
+from ..Utilities import reject
+
+MI_KEY: str = "MatrixInstruction"
+MI_ENABLED_KEY: str = "EnableMatrixInstruction"
+
+def matrixInstructionToMIParameters(
+      mi: list,
+      isa: IsaVersion,
+      wavefrontSize: int,
+      problemType: dict,
+      workGroup: Optional[list],
+      isaInfoMap: Dict[IsaVersion, IsaInfo]
+    ):
+    """
+    Converts a 9-item matrix instruction into the associated 4-item representation and
+    populates supporting MI parameters.
+
+    Args:
+        mi: The matrix instruction to convert. Must have length 9.
+        isa: The ISA tuple.
+        wavefrontSize: The wavefront size. Typically "WavefrontSize" in a solution.
+        problemType: The problem type dictionary. Typically "ProblemType" in a solution.
+    """
+    print2(f">> Converting MatrixInstruction {mi} to MI parameters")
+
+    if len(mi) != 9:
+      raise ValueError(f"MatrixInstruction must be 9 items long to convert into MI"
+                       f" Parameters, found {mi} with length {len(mi)}")
+
+    result = {}
+    result["ISA"] = isa
+
+    # Enable F32 XDL math operation only when the input type is f32.
+    enableF32xdl = (
+      "F32XdlMathOp" in problemType
+      and not problemType["F32XdlMathOp"].isSingle()
+      and problemType["DataType"].isSingle()
+    )
+    result["EnableF32XdlMathOp"] = enableF32xdl
+
+    mi4  = [mi[0], mi[1], mi[2], mi[3]]
+    result["MatrixInstruction"] = mi4
+    result["EnableMatrixInstruction"] = True
+    result["MatrixInstM"] = mi[0]
+    result["MatrixInstN"] = mi[1]
+    result["MatrixInstK"] = mi[2]
+    result["MatrixInstB"] = mi[3]
+
+    waves = mi[7]* mi[8]
+    wg0 = mi[4] * mi[0] * mi[7]
+
+    result["WavefrontSize"] = wavefrontSize
+    if workGroup:
+      # NOTE: Typically, the WorkGroup is set to the default [16, 16, 1] for a 
+      # length-9 matrix instruction. However, some custom kernel solutions used
+      # during benchmarking don't have WorkGroup set at all.
+      result["WorkGroup"] = [wg0, waves*wavefrontSize//wg0, workGroup[2]]
+    result["ThreadTile"] = [1, 1]  # dummy
+
+    isSparse = problemType.get("Sparse", 0)
+    miDataType = DataType(
+        problemType["DataType"]
+        if not enableF32xdl
+        else problemType["F32XdlMathOp"]
+    )
+
+    validMFMA = makeValidMFMA()
+    result["MFMA_BF16_1K"] = (
+        not isSparse
+        and isaInfoMap[isa].asmCaps["HasMFMA"]
+        and not (miDataType.toChar() in validMFMA and mi4 in validMFMA[miDataType.toChar()])
+        and miDataType.isBFloat16()
+        and mi4 in validMFMA["B1k"]
+    )
+
+    # set MIBlock
+    MIBlockBM = wg0 // mi[0]
+    MIBlockBM = min(MIBlockBM, mi[3])
+    MIBlockBN = mi[3] // MIBlockBM
+    result["MatrixInstBM"] = MIBlockBM
+    result["MatrixInstBN"] = MIBlockBN
+    result["MIBlock"]    = [mi[0], mi[1], mi[2], mi[3], MIBlockBM, MIBlockBN]
+
+    # set MIWaveGroup
+    miwg0 = min((wg0 // mi[0]) // MIBlockBM, waves)
+    result['MIWaveGroup'] = [miwg0, waves // miwg0]
+
+    # set MIWaveTile
+    result['MIWaveTile'] = [mi[5], mi[6]]
+
+    # set MIInputPerThread
+    hasMFMA = isaInfoMap[isa].asmCaps["HasMFMA"]
+    hasWMMA = isaInfoMap[isa].asmCaps["HasWMMA"]
+
+    result['MIInputPerThread'] = mi[0] * mi[2] * mi[3] // wavefrontSize
+    if (not hasMFMA) and hasWMMA and (isa[0] == 10 or isa[0] == 11):
+      result['MIInputPerThread'] = mi[2]
+
+    sparseA = False if not isSparse else False if isSparse == 2 else True
+    sparseB = False if not isSparse else True if isSparse == 2 else False
+    result['MIInputPerThreadA'] = result['MIInputPerThread'] if not sparseA else result['MIInputPerThread'] // 2
+    result['MIInputPerThreadB'] = result['MIInputPerThread'] if not sparseB else result['MIInputPerThread'] // 2
+    result['MIInputPerThreadMetadata'] = result['MIInputPerThread'] if not isSparse else result['MIInputPerThread'] // 8
+    result['Sparse'] = isSparse
+
+    print2(f">> MI Parameters: {pprint.pformat(result)}")
+    return result
+
+
+def validateMIParameters(
+    solution: dict, isaInfoMap: Dict[IsaVersion, IsaInfo], printSolutionRejectionReason: bool = True
+):
+    """
+    Validates matrix instruction (MI) related parameters in the given solution.
+
+    This function performs the following checks:
+    - Ensures that "MatrixInstruction" is of length 4.
+    - Ensures that the solution contains the required keys for matrix instruction support.
+    - Ensures that the matrix instruction is not empty when it is enabled.
+    - Validates that the matrix instruction is in the list of valid matrix instructions.
+    - Validates the work group dimensions.
+    - Checks if the matrix instruction is supported by the assembler capabilities (MFMA or WMMA).
+    - Validates the input per thread for sparse and non-sparse configurations.
+    - Validates the matrix instruction block, wave group, and wave tile dimensions.
+    - If the matrix instruction has 4 elements, it ensures that matrix instructions are enabled.
+    - If the matrix instruction is empty, it ensures that matrix instructions are disabled.
+
+    Args:
+        solution: The solution to validate.
+        isaInfoMap: The map of ISA versions to assembler and architecture capabilities.
+        filepath: The path to the file containing the solution.
+
+    Raises:
+        AssertionError: If any of the validation checks fail.
+    """
+    validMatrixInstructions = makeValidMatrixInstructions()
+    validMFMA = makeValidMFMA()
+    validSMFMA = makeValidSMFMA()
+    validWMMA = makeValidWMMA()
+
+    assert MI_KEY in solution, elineno() + ": missing MatrixInstruction"
+    assert MI_ENABLED_KEY in solution, elineno() + ": missing EnableMatrixInstruction"
+    assert not (solution[MI_KEY] == [] and solution[MI_ENABLED_KEY] == True), (
+        elineno() + ": MI empty but enabled"
+    )
+
+    isa = IsaVersion(*solution["ISA"])
+    assert isa in SUPPORTED_ISA, elineno() + ": Unsupported ISA: " + str(isa)
+    # TODO: Temporary until all 940/941 ISAs are removed
+    if (9, 4, 0) <= isa <= (9, 4, 1):
+        isa = (9, 4, 2)
+
+    ptype = solution["ProblemType"]
+    isSparse = ptype.get("Sparse", 0)
+    miDataType = DataType(
+        ptype["DataType"]
+        if not solution.get("EnableF32XdlMathOp", False)
+        else ptype["F32XdlMathOp"]
+    )
+
+    mi4 = solution[MI_KEY]
+    miEnabled = solution[MI_ENABLED_KEY]
+    assert len(mi4) == 4 or len(mi4) == 0, elineno() + ": MI length not 4 or 0"
+    if len(mi4) == 0:
+        assert miEnabled == False, elineno()
+        return True
+
+    assert solution["MatrixInstM"] == mi4[0]
+    assert solution["MatrixInstN"] == mi4[1]
+    assert solution["MatrixInstK"] == mi4[2]
+    assert solution["MatrixInstB"] == mi4[3]
+
+    assert mi4 in validMatrixInstructions, f"{elineno()} : invalid MI4: {str(mi4)} for type {miDataType.toChar()}"
+
+    mi9 = [mi4[0], mi4[1], mi4[2], mi4[3]]
+    assert "MatrixInstBM" in solution, elineno() + ": missing MatrixInstBM"
+    mi9.append(solution["MatrixInstBM"])
+    assert "MIWaveTile" in solution, elineno() + ": missing MIWaveTile"
+    mi9.extend(solution["MIWaveTile"])
+    assert "MIWaveGroup" in solution, elineno() + ": missing MIWaveGroup"
+    mi9.extend(solution["MIWaveGroup"])
+
+    assert len(mi4) == 4 and len(mi9) == 9, elineno() + " MI4: " + str(mi4) + " MI9: " + str(mi9)
+
+    if not miEnabled:
+        return False
+
+
+    wfsize = solution["WavefrontSize"]
+    waves = solution["MIWaveGroup"][0] * solution["MIWaveGroup"][1]
+    wg0 = mi9[4] * mi9[0] * mi9[7]  # Work group 0
+
+    hasMFMA = isaInfoMap[isa].asmCaps["HasMFMA"]
+    hasWMMA = isaInfoMap[isa].asmCaps["HasWMMA"]
+
+    miBlock = solution["MIBlock"]
+    miWaveGroup = solution["MIWaveGroup"]
+    miWaveTile = solution["MIWaveTile"]
+
+    if not isSparse:
+        if hasMFMA:
+            if not (miDataType.toChar() in validMFMA and mi4 in validMFMA[miDataType.toChar()]):
+                if miDataType.isBFloat16() and mi4 in validMFMA["B1k"]:  # but is valid bf16 MFMA
+                    assert solution["MFMA_BF16_1K"], elineno()
+                else:
+                    return not reject(
+                        solution,
+                        printSolutionRejectionReason,
+                        f"Invalid MFMA configuration: {solution}",
+                    )
+        elif hasWMMA and (not mi4 in validWMMA):
+            return not reject(
+                solution, printSolutionRejectionReason, f"Invalid WMMA configuration: {solution}"
+            )
+    else:
+        if not (miDataType.toChar() in validSMFMA and mi4 in validSMFMA[miDataType.toChar()]):
+            return not reject(
+                solution, printSolutionRejectionReason, f"Invalid SMFMA configuration: {solution}"
+            )
+
+    # Check MIBlock
+    assert miBlock[0] == mi4[0], elineno()
+    assert miBlock[1] == mi4[1], elineno()
+    assert miBlock[2] == mi4[2], elineno()
+    assert miBlock[3] == mi4[3], elineno()
+    assert miBlock[4] == min(wg0 // mi4[0], mi4[3]), elineno()
+    assert miBlock[5] == mi4[3] // miBlock[4], elineno()
+
+    # Check MIWaveGroup
+    assert miWaveGroup[0] == min((wg0 // mi4[0]) // miBlock[4], waves), elineno()
+    assert miWaveGroup[1] == waves // miWaveGroup[0], elineno()
+
+    # Check MIWaveTile
+    assert miWaveTile[0] == mi9[5], elineno()
+    assert miWaveTile[1] == mi9[6], elineno()
+
+    # Check MIInputPerThread
+    miInputPerThread = solution["MIInputPerThread"]
+
+    if (not hasMFMA) and hasWMMA:
+        if isa[0] == 10 or isa[0] == 11:
+            assert miInputPerThread == mi4[2], elineno()
+
+    # If Navi architecture, the input per thread is different
+    if IsaVersion(10, 0, 0) <= isa <= IsaVersion(11, 0, 2):
+        assert miInputPerThread == mi4[2], elineno()
+    else:
+        assert miInputPerThread == mi4[0] * mi4[2] * mi4[3] // wfsize, f"{elineno()} MIInputPerThread: {miInputPerThread} != {mi4[0]} * {mi4[2]} * {mi4[3]} / {wfsize} = {mi4[0] * mi4[2] * mi4[3] // wfsize}"
+
+    if "MIInputPerThreadA" in solution:
+        miInputPerThreadA = solution["MIInputPerThreadA"]
+        sparseA = False if not isSparse else False if isSparse == 2 else True
+        assert miInputPerThreadA == miInputPerThread if not sparseA else miInputPerThread // 2, elineno()
+
+    if "MIInputPerThreadB" in solution:
+        miInputPerThreadB = solution["MIInputPerThreadB"]
+        sparseB = False if not isSparse else True if isSparse == 2 else False
+        assert miInputPerThreadB == miInputPerThread if not sparseB else miInputPerThread // 2, elineno()
+    
+    if "MIInputPerThreadMetadata" in solution:
+        miInutPerThreadMeta = solution["MIInputPerThreadMetadata"]
+        assert miInutPerThreadMeta == miInputPerThread if not isSparse else miInputPerThread // 8, elineno()
+    return True

--- a/tensilelite/Tensile/SolutionStructs/Validators/WorkGroup.py
+++ b/tensilelite/Tensile/SolutionStructs/Validators/WorkGroup.py
@@ -1,0 +1,32 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+from Tensile.Common.Utilities import elineno
+from Tensile.Common.ValidParameters import makeValidWorkGroups
+
+def validateWorkGroup(solution: dict):
+    assert "WorkGroup" in solution, elineno()
+    validWorkGroups = makeValidWorkGroups()
+    assert solution["WorkGroup"] in validWorkGroups, elineno()
+    return True

--- a/tensilelite/Tensile/SolutionStructs/__init__.py
+++ b/tensilelite/Tensile/SolutionStructs/__init__.py
@@ -1,0 +1,3 @@
+from .Naming import *
+from .Solution import *
+from .Problem import *

--- a/tensilelite/Tensile/TensileClientConfig.py
+++ b/tensilelite/Tensile/TensileClientConfig.py
@@ -25,7 +25,7 @@
 from . import ClientWriter
 from . import LibraryIO
 from .Contractions import ProblemType as ContractionsProblemType
-from .SolutionStructs import ProblemSizes, ProblemType
+from Tensile.SolutionStructs.Problem import ProblemType, ProblemSizes
 from .Common import globalParameters, print1, printExit, printWarning, assignGlobalParameters, \
         restoreDefaultGlobalParameters, HR, __version__
 from .Tensile import addCommonArguments, argUpdatedGlobalParameters

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -26,7 +26,8 @@ import os
 from argparse import ArgumentParser
 from typing import Any, Dict, List, Optional
 
-from Tensile.Common import architectureMap, coVersionMap
+from Tensile.Common import coVersionMap
+from Tensile.Common.Architectures import architectureMap
 from Tensile.Toolchain.Validators import ToolchainDefaults
 
 
@@ -201,11 +202,8 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     if args.CmakeCxxCompiler:
         os.environ["CMAKE_CXX_COMPILER"] = args.CmakeCxxCompiler
     arguments["ShortNames"] = args.ShortNames
-    arguments["CodeFromFiles"] = False
     arguments["LogicFormat"] = args.LogicFormat
     arguments["LibraryFormat"] = args.LibraryFormat
-    if args.no_enumerate:
-        arguments["AMDGPUArchPath"] = False
     arguments["CpuThreads"] = args.CpuThreads
     arguments["PrintLevel"] = args.PrintLevel
     arguments["AsmDebug"] = args.AsmDebug

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -29,26 +29,32 @@ import os
 import shutil
 from pathlib import Path
 from timeit import default_timer as timer
-from typing import List, NamedTuple, Optional, Sequence, Union
+from typing import List, NamedTuple, Optional, Union
 
 from Tensile import SOURCE_PATH, LibraryIO
 from Tensile.Common import (
-    HR,
     CHeader,
+    DebugConfig,
+    DepthUConfig,
+    ensurePath,
+    HR,
     IsaVersion,
     ParallelMap2,
-    SemanticVersion,
-    architectureMap,
-    assignGlobalParameters,
-    ensurePath,
-    globalParameters,
-    isaToGfx,
     print1,
     print2,
+    printWarning,
     printExit,
+    printWarning,
     state,
     tqdm,
+    setVerbosity,
+    getVerbosity
 )
+from Tensile.Common.Architectures import gfxToIsa, isaToGfx, SUPPORTED_GFX
+from Tensile.Common.Capabilities import makeIsaInfoMap
+from Tensile.Common.GlobalParameters import assignGlobalParameters, globalParameters
+from Tensile.SolutionStructs.Naming import getKernelFileBase, getKeyNoInternalArgs, getMinNaming, getSerialNaming
+
 from Tensile.CustomYamlLoader import load_logic_gfx_arch
 from Tensile.KernelWriterAssembly import KernelWriterAssembly
 from Tensile.KernelWriterBase import (
@@ -58,13 +64,13 @@ from Tensile.KernelWriterBase import (
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
 from Tensile.TensileInstructions import TensileInstructions
-from Tensile.Toolchain.Assembly import AssemblyToolchain, buildAssemblyCodeObjectFiles
-from Tensile.Toolchain.Source import SourceToolchain, buildSourceCodeObjectFiles
+from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
+from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles
 from Tensile.Toolchain.Validators import (
     ToolchainDefaults,
-    getVersion,
     validateToolchain,
 )
+from Tensile.Toolchain.Component import Assembler
 from Tensile.Utilities.Decorators.Profile import profile
 from Tensile.Utilities.Decorators.Timing import timing
 
@@ -81,15 +87,15 @@ class KernelCodeGenResult(NamedTuple):
     wavefrontSize: int
 
 
-def processKernelSource(kernelWriterAssembly, ti, kernel) -> KernelCodeGenResult:
+def processKernelSource(kernelWriterAssembly, ti, useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, kernel) -> KernelCodeGenResult:
     """
     Generate source for a single kernel.
     Returns (error, source, header, kernelName).
     """
     kernelWriter = kernelWriterAssembly
     kernelWriter.setTensileInstructions(ti)
-    asmFilename = kernelWriter.getKernelFileBase(kernel)
-    err, src = kernelWriter.getSourceFileString(kernel)
+    asmFilename = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, kernel)
+    err, src = kernelWriter.getSourceFileString(kernel, useShortNames)
     header = kernelWriter.getHeaderFileString(kernel)
     objFilename = kernel._state.get("codeObjectFile", None)
 
@@ -98,14 +104,14 @@ def processKernelSource(kernelWriterAssembly, ti, kernel) -> KernelCodeGenResult
     )
 
 
-def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant, globalParameters):
+def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant, printLevel: bool, splitGSU: bool):
     removeKernels = []
     removeKernelNames = []
     removeSolutions = []
     removeResults = []
 
     for kernIdx, r in (
-        tqdm(enumerate(results)) if globalParameters["PrintLevel"] > 1 else enumerate(results)
+        tqdm(enumerate(results)) if printLevel > 1 else enumerate(results)
     ):
         if r.err != 0:
             if not errorTolerant:
@@ -116,7 +122,7 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
                 )
                 print(kernels[kernIdx]["SolutionNameMin"])
             removeKernels.append(kernels[kernIdx])
-            kName = Solution.getKeyNoInternalArgs(kernels[kernIdx])
+            kName = getKeyNoInternalArgs(kernels[kernIdx], splitGSU)
             if kName not in removeKernelNames:
                 removeKernelNames.append(kName)
             removeResults.append(results[kernIdx])
@@ -129,12 +135,12 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
 
     for solution in (
         tqdm(solutions, "Finding invalid solutions")
-        if globalParameters["PrintLevel"] > 1
+        if printLevel > 1
         else solutions
     ):
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
-            kName = Solution.getKeyNoInternalArgs(kernel)
+            kName = getKeyNoInternalArgs(kernel, splitGSU)
             if kName in removeKernelNames:
                 removeSolutions.append(solution)
                 break
@@ -174,9 +180,8 @@ def writeHelpers(
         kernelHeaderFile.write(CHeader)
         kernelSourceFile.write('#include "Kernels.h"\n')
         kernelHeaderFile.write("#pragma once\n")
-        if globalParameters["RuntimeLanguage"] == "HIP":
-            kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-            kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
         kernelHeaderFile.write('#include "KernelHeader.h"\n\n')
         HeaderText = ""
         for ko in kernelHelperObjs:
@@ -197,10 +202,14 @@ def writeSolutionsAndKernels(
     kernels,
     kernelHelperObjs,
     kernelWriterAssembly,
+    splitGSU: bool,
+    cmdlineArchs: List[str],
+    kernelSerialNaming,
+    kernelMinNaming,
     errorTolerant=False,
     generateSourcesAndExit=False,
     compress=True,
-    fromTensile=False,
+    useShortNames=False,
 ):
     codeObjectFiles = []
 
@@ -221,8 +230,10 @@ def writeSolutionsAndKernels(
     visited = set()
     duplicates = 0
     for k in asmKernels:
-        base = kernelWriterAssembly.getKernelFileBase(k)
+        base = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, k)
         k.duplicate = True if base in visited else False
+        if not k.duplicate:
+            k["BaseName"] = base
         duplicates += k.duplicate
         print2(f"Duplicate: {base}")
         visited.add(base)
@@ -232,16 +243,22 @@ def writeSolutionsAndKernels(
     numKernels = len(asmKernels)
     assert numKernels == numAsmKernels, "Only assembly kernels are supported in TensileLite"
     asmIter = zip(
-        itertools.repeat(kernelWriterAssembly), itertools.repeat(TensileInstructions()), asmKernels
+        itertools.repeat(kernelWriterAssembly),
+        itertools.repeat(TensileInstructions()),
+        itertools.repeat(useShortNames),
+        itertools.repeat(splitGSU),
+        itertools.repeat(kernelMinNaming),
+        itertools.repeat(kernelSerialNaming),
+        asmKernels
     )
-    asmResults = ParallelMap2(processKernelSource, asmIter, "Generating assembly kernels")
+    asmResults = ParallelMap2(processKernelSource, asmIter, "Generating assembly kernels", return_as="list")
     removeInvalidSolutionsAndKernels(
-        asmResults, asmKernels, solutions, errorTolerant, globalParameters
+        asmResults, asmKernels, solutions, errorTolerant, getVerbosity(), splitGSU
     )
 
     def assemble(ret):
         p, isa, wavefrontsize = ret
-        asmToolchain.assemble(str(p), str(p.with_suffix(".o")), isaToGfx(isa), wavefrontsize)
+        asmToolchain.assembler(isaToGfx(isa), wavefrontsize, str(p), str(p.with_suffix(".o")))
 
     unaryWriteAssembly = functools.partial(writeAssembly, assemblyTmpPath)
     compose = lambda *F: functools.reduce(lambda f, g: lambda x: f(g(x)), F)
@@ -258,10 +275,22 @@ def writeSolutionsAndKernels(
 
     if not generateSourcesAndExit:
         codeObjectFiles += buildAssemblyCodeObjectFiles(
-            asmToolchain, asmKernels, kernelWriterAssembly, destLibPath, assemblyTmpPath, compress
+            asmToolchain.linker,
+            asmToolchain.bundler,
+            globalParameters["ROCmLdPath"],
+            asmKernels,
+            destLibPath,
+            assemblyTmpPath,
+            compress,
         )
         buildSourceCodeObjectFiles(
-            srcToolchain, destLibPath, objectTmpPath, outputPath, srcKernelFile, fromTensile
+            srcToolchain.compiler,
+            srcToolchain.bundler,
+            destLibPath,
+            objectTmpPath,
+            outputPath,
+            srcKernelFile,
+            cmdlineArchs,
         )
 
     return codeObjectFiles, numKernels
@@ -274,10 +303,12 @@ def writeSolutionsAndKernelsTCL(
     kernels,
     kernelHelperObjs,
     kernelWriterAssembly,
+    cmdlineArchs: List[str],
+    kernelSerialNaming,
+    kernelMinNaming,
     compress=True,
-    fromTensile=False,
+    useShortNames=False,
 ):
-
     outputPath = Path(outputPath)
     destLibPath = ensurePath(
         outputPath / "library"
@@ -294,8 +325,10 @@ def writeSolutionsAndKernelsTCL(
 
     visited = set()
     duplicates = 0
+    splitGSU = False
     for k in asmKernels:
-        base = kernelWriterAssembly.getKernelFileBase(k)
+        base = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, k)
+        k["BaseName"] = base
         k.duplicate = True if base in visited else False
         duplicates += k.duplicate
         print2(f"Duplicate: {base}")
@@ -306,11 +339,18 @@ def writeSolutionsAndKernelsTCL(
 
     def assemble(ret):
         p, isa, wavefrontsize = ret
-        asmToolchain.assemble(str(p), str(p.with_suffix(".o")), isaToGfx(isa), wavefrontsize)
+        asmToolchain.assembler(isaToGfx(isa), wavefrontsize, str(p), str(p.with_suffix(".o")))
 
     unaryProcessKernelSource = functools.partial(
-        processKernelSource, kernelWriterAssembly, TensileInstructions()
+        processKernelSource,
+        kernelWriterAssembly,
+        TensileInstructions(),
+        useShortNames,
+        splitGSU,
+        kernelMinNaming,
+        kernelSerialNaming
     )
+
     unaryWriteAssembly = functools.partial(writeAssembly, assemblyTmpPath)
     compose = lambda *F: functools.reduce(lambda f, g: lambda x: f(g(x)), F)
     ret = ParallelMap2(
@@ -318,32 +358,31 @@ def writeSolutionsAndKernelsTCL(
         uniqueAsmKernels,
         "Generating assembly kernels",
         multiArg=False,
+        return_as="list"
     )
     buildAssemblyCodeObjectFiles(
-        asmToolchain, asmKernels, kernelWriterAssembly, destLibPath, assemblyTmpPath, compress
+        asmToolchain.linker,
+        asmToolchain.bundler,
+        globalParameters["ROCmLdPath"],
+        asmKernels,
+        destLibPath,
+        assemblyTmpPath,
+        compress,
     )
 
     writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
     srcKernelFile = Path(outputPath) / "Kernels.cpp"
     buildSourceCodeObjectFiles(
-        srcToolchain, destLibPath, objectTmpPath, outputPath, srcKernelFile, fromTensile
+        srcToolchain.compiler,
+        srcToolchain.bundler,
+        destLibPath,
+        objectTmpPath,
+        outputPath,
+        srcKernelFile,
+        cmdlineArchs,
     )
 
     return len(uniqueAsmKernels)
-
-
-@timing
-def getSolutionAndKernelWriters(
-    solutions, kernels, assembler: str, assemblerVersion: SemanticVersion
-):
-    kernelSerialNaming = Solution.getSerialNaming(kernels)
-    solutionMinNaming = Solution.getMinNaming(solutions)
-    kernelMinNaming = Solution.getMinNaming(kernels)
-    kernelWriterAssembly = KernelWriterAssembly(
-        kernelMinNaming, kernelSerialNaming, assembler, assemblerVersion
-    )
-
-    return (kernelWriterAssembly, kernelMinNaming, solutionMinNaming)
 
 
 @timing
@@ -370,11 +409,11 @@ def generateKernelObjectsFromSolutions(solutions):
     kernelHelperObjs = []
     kernelNames = set()
     kernelHelperNames = set()
-
+    splitGSU = False
     for solution in solutions:
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
-            kName = Solution.getKeyNoInternalArgs(kernel)
+            kName = getKeyNoInternalArgs(kernel, splitGSU)
             if kName not in kernelNames:
                 kernels.append(kernel)
                 kernelNames.add(kName)
@@ -394,7 +433,7 @@ def generateKernelObjectsFromSolutions(solutions):
 
 
 @timing
-def generateLogicDataAndSolutions(logicFiles, args, cxxCompiler):
+def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInfoMap):
 
     if ";" in args["Architecture"]:
         archs = args["Architecture"].split(";")  # user arg list format
@@ -404,8 +443,20 @@ def generateLogicDataAndSolutions(logicFiles, args, cxxCompiler):
     solutions = []
     masterLibraries = {}
     nextSolIndex = 0
+    splitGSU = False
+    printSolutionRejectionReason = False
+    printIndexAssignmentInfo = False
 
-    fIter = zip(logicFiles, itertools.repeat(cxxCompiler), itertools.repeat(archs))
+    fIter = zip(
+        logicFiles,
+        itertools.repeat(assembler),
+        itertools.repeat(splitGSU),
+        itertools.repeat(printSolutionRejectionReason),
+        itertools.repeat(printIndexAssignmentInfo),
+        itertools.repeat(DepthUConfig()),
+        itertools.repeat(isaInfoMap),
+        itertools.repeat(args["LazyLibraryLoading"]),
+    )
 
     def libraryIter(lib: MasterSolutionLibrary):
         if len(lib.solutions):
@@ -493,49 +544,45 @@ def run():
     print2("")
 
     arguments = parseArguments()
+    setVerbosity(arguments["PrintLevel"])
     outputPath = Path(ensurePath(os.path.abspath(arguments["OutputPath"])))
-    cxxCompiler, cCompiler, offloadBundler, assembler, hipconfig = validateToolchain(
+    cxxCompiler, _, offloadBundler, _, _ = validateToolchain(
         arguments["CxxCompiler"],
         arguments["CCompiler"],
         arguments["OffloadBundler"],
         arguments["Assembler"],
         ToolchainDefaults.HIP_CONFIG,
     )
-    print1(f"# HIP Version:         {getVersion(hipconfig, regex=r'(.+)')}")
-    print1(f"# Cxx Compiler:        {cxxCompiler} (version {getVersion(cxxCompiler)})")
-    print1(f"# C Compiler:          {cCompiler} (version {getVersion(cCompiler)})")
-    print1(f"# Assembler:           {assembler} (version {getVersion(assembler)})")
-    print1(f"# Offload Bundler:     {offloadBundler} (version {getVersion(offloadBundler)})")
-    print1(f"# Code Object Version: {arguments['CodeObjectVersion']}")
-    print1(f"# Architecture(s):     {arguments['Architecture']}")
-    print1(f"# Library Format:      {arguments['LibraryFormat']}")
-
-    assignGlobalParameters(arguments, cxxCompiler)
-
-    asmToolchain = AssemblyToolchain(
-        assembler, offloadBundler, globalParameters["BuildIdKind"], arguments["CodeObjectVersion"]
-    )
-    srcToolchain = SourceToolchain(
-        cxxCompiler,
-        offloadBundler,
-        globalParameters["BuildIdKind"],
-        globalParameters["AsanBuild"],
-        globalParameters["SaveTemps"],
-    )
-
-    if not os.path.exists(arguments["LogicPath"]):
-        printExit(f"LogicPath {arguments['LogicPath']} doesn't exist")
 
     if ";" in arguments["Architecture"]:
         archs = arguments["Architecture"].split(";")
     else:
         archs = arguments["Architecture"].split("_")
-    logicArchs = set()
-    for arch in archs:
-        if arch in architectureMap:
-            logicArchs.add(architectureMap[arch])
-        else:
-            printExit("Architecture %s not supported" % arch)
+    archs = SUPPORTED_GFX if archs == "all" else archs
+
+    targetIsas = [gfxToIsa(a) for a in archs]
+    isaInfoMap = makeIsaInfoMap(targetIsas, cxxCompiler)
+    assignGlobalParameters(arguments, isaInfoMap)
+
+    asmToolchain = makeAssemblyToolchain(
+        cxxCompiler,
+        offloadBundler,
+        arguments["CodeObjectVersion"],
+        arguments["BuildIdKind"]
+    )
+    srcToolchain = makeSourceToolchain(
+        cxxCompiler,
+        offloadBundler,
+        arguments["AsanBuild"],
+        arguments["BuildIdKind"],
+        save_temps=False
+    )
+
+    print1(asmToolchain.assembler)
+    print1(asmToolchain.bundler)
+
+    if not os.path.exists(arguments["LogicPath"]):
+        printExit(f"LogicPath {arguments['LogicPath']} doesn't exist")
 
     logicExtFormat = ".yaml"
     if arguments["LogicFormat"] == "yaml":
@@ -570,13 +617,22 @@ def run():
         ]
 
     print2(f"# LibraryLogicFiles: {len(logicFiles)}")
+
     for logicFile in logicFiles:
         print2("#   %s" % logicFile)
 
-    solutions, masterLibraries = generateLogicDataAndSolutions(logicFiles, arguments, cxxCompiler)
+    solutions, masterLibraries = generateLogicDataAndSolutions(
+        logicFiles, arguments, asmToolchain.assembler, isaInfoMap
+    )
+
     kernels, kernelHelperObjs, _ = generateKernelObjectsFromSolutions(solutions)
-    kernelWriterAssembly, kernelMinNaming, _ = getSolutionAndKernelWriters(
-        solutions, kernels, asmToolchain.assembler, asmToolchain.assemblerVersion
+    kernelSerialNaming = getSerialNaming(kernels)
+    kernelMinNaming = getMinNaming(kernels)
+    kernelWriterAssembly = KernelWriterAssembly(
+        kernelMinNaming,
+        kernelSerialNaming,
+        asmToolchain.assembler,
+        DebugConfig(),
     )
 
     copyStaticFiles(outputPath)
@@ -588,30 +644,34 @@ def run():
         kernels,
         kernelHelperObjs,
         kernelWriterAssembly,
+        archs,
+        kernelSerialNaming,
+        kernelMinNaming,
+        useShortNames=arguments["ShortNames"],
         compress=arguments["UseCompression"],
     )
 
-    archs = [
+    archs = [ # is this really different than the other archs above?
         isaToGfx(arch)
-        for arch in globalParameters["SupportedISA"]
-        if globalParameters["AsmCaps"][arch]["SupportedISA"]
+        for arch in targetIsas
+        if isaInfoMap[arch].asmCaps["SupportedISA"]
     ]
     newLibraryDir = ensurePath(os.path.join(outputPath, "library"))
-
+    splitGSU = False
     for archName, newMasterLibrary in masterLibraries.items():
         if archName in archs:
-            if globalParameters["LazyLibraryLoading"]:
+            if arguments["LazyLibraryLoading"]:
                 masterFile = os.path.join(newLibraryDir, "TensileLibrary_lazy_" + archName)
             else:
                 masterFile = os.path.join(newLibraryDir, "TensileLibrary_" + archName)
-            newMasterLibrary.applyNaming(kernelMinNaming)
+            newMasterLibrary.applyNaming(splitGSU, kernelMinNaming)
             LibraryIO.write(masterFile, state(newMasterLibrary), arguments["LibraryFormat"])
             for name, lib in newMasterLibrary.lazyLibraries.items():
                 filename = os.path.join(newLibraryDir, name)
-                lib.applyNaming(kernelMinNaming)
+                lib.applyNaming(splitGSU, kernelMinNaming)
                 LibraryIO.write(filename, state(lib), arguments["LibraryFormat"])
 
-    if not globalParameters["KeepBuildTmp"]:
+    if not arguments["KeepBuildTmp"]:
         buildTmp = Path(arguments["OutputPath"]).parent / "library" / "build_tmp"
         if buildTmp.exists() and buildTmp.is_dir():
             shutil.rmtree(buildTmp)

--- a/tensilelite/Tensile/TensileInstructions/Base.py
+++ b/tensilelite/Tensile/TensileInstructions/Base.py
@@ -27,9 +27,11 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Tuple
 
-from ..Common import initAsmCaps, initArchCaps, initRegisterCaps, initAsmBugs
+from Tensile.Common import IsaInfo, IsaVersion
+from Tensile.Common.Capabilities import initAsmCaps, initArchCaps, initRegisterCaps, initAsmBugs
 from .Formatting import __TI_DEBUG_LEVEL__, printExit
 
+from timeit import default_timer as timer 
 
 def fastdeepcopy(x):
     # Note: Some object can't be pickled
@@ -61,26 +63,27 @@ class TensileInstructions:
 
     @dataclass
     class kernelInfo:
-        isa: Tuple[int, int, int]
+        isa: IsaVersion
         wavefrontSize: int = 64
 
-    def init(self, isaVersion: Tuple[int, int, int], assemblerPath: str, debug: bool=False) -> None:
+    def init(self, isaVersion: IsaVersion, assemblerPath: str, debug: bool=False) -> None:
         with self._lock:
             if len(self._kernelInfo) > 1000:
                 self._kernelInfo = _removeIdent(self._kernelInfo)
             self._kernelInfo[threading.get_ident()] = TensileInstructions.kernelInfo(isa=isaVersion)
             if isaVersion not in self._isaInfo: # type: ignore
+                start = timer()
                 asmCaps  = initAsmCaps(isaVersion, assemblerPath, debug)
                 archCaps = initArchCaps(isaVersion)
                 regCaps  = initRegisterCaps(isaVersion, archCaps)
                 asmBugs  = initAsmBugs(asmCaps)
-                self._isaInfo[isaVersion] = TensileInstructions.IsaInfo(assemblerPath, # type: ignore
-                    asmCaps, archCaps, regCaps, asmBugs)
+                self._isaInfo[isaVersion] = IsaInfo(asmCaps, archCaps, regCaps, asmBugs)
+
 
     def setDebugLevel(self, level: int) -> None:
         __TI_DEBUG_LEVEL__ = level
 
-    def setKernelInfo(self, isaVersion: Tuple[int, int, int], wavefrontSize: int) -> None:
+    def setKernelInfo(self, isaVersion: IsaVersion, wavefrontSize: int) -> None:
         if isaVersion not in self._isaInfo: # type: ignore
             import traceback
             printExit(f"Current isa {str(isaVersion)} not initialized. Initialized isas are {str(self._isaInfo.keys())}, traceback: {traceback.format_stack()}")

--- a/tensilelite/Tensile/TensileInstructions/Code.py
+++ b/tensilelite/Tensile/TensileInstructions/Code.py
@@ -20,7 +20,7 @@
 # CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ################################################################################
 
-from ..Common import isaToGfx
+from Tensile.Common.Architectures import isaToGfx
 from .Base import Item
 from .Enums import SignatureValueKind
 from .Formatting import slash, slash50, block, block3Line, blockNewLine, \

--- a/tensilelite/Tensile/TensileLogic/HandleCustomKernel.py
+++ b/tensilelite/Tensile/TensileLogic/HandleCustomKernel.py
@@ -1,0 +1,123 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+
+from pprint import pformat
+from pathlib import Path
+from typing import Dict, Tuple
+
+from Tensile.Common import print1, IsaVersion, IsaInfo
+from Tensile.SolutionStructs.Validators.MatrixInstruction import matrixInstructionToMIParameters
+
+from Tensile.CustomKernels import isCustomKernelConfig, getCustomKernelConfig
+from Tensile import CUSTOM_KERNEL_PATH
+
+
+def handleCustomKernel(sol: dict, isaInfoMap: Dict[IsaVersion, IsaInfo]) -> Tuple[dict, bool]:
+    """
+    Process custom kernel configuration for a given solution.
+
+    Args:
+        sol: Dictionary containing the solution.
+        isaInfoMap: Dictionary mapping IsaVersion to IsaInfo.
+
+    Returns:
+        A tuple containing the updated solution dictionary and a boolean indicating
+        whether the solution uses a custom kernel.
+    """
+    if not isCustomKernelConfig(sol):
+        return sol, False
+
+    name = sol["CustomKernelName"]
+    dir = CUSTOM_KERNEL_PATH
+    config = getCustomKernelConfig(name, {}, dir)
+    sol.update(config)
+
+    mi = sol["MatrixInstruction"]
+    print1(f">>   Found custom kernel: {name} with MI {mi}")
+
+    if not (len(mi) == 4 or len(mi) == 0):
+        print1(
+            f">>     Error: Custom kernels in logic files should have 'MatrixInstruction' of length 4 or 0, not length {len(mi)}"
+        )
+        mi = sol["MatrixInstruction"]
+        isa = next(iter(isaInfoMap.keys()))
+        wavefrontSize = sol["WavefrontSize"]
+        ptype = sol["ProblemType"]
+        workgroup = sol.get("WorkGroup", None)
+        miParams = matrixInstructionToMIParameters(
+            mi, isa, wavefrontSize, ptype, workgroup, isaInfoMap
+        )
+        print1(
+            f">>     Hint: Replace 'MatrixInstruction' in {name}.s with following diff:\n"
+            f"{prepareCustomKernelConfig(miParams, mi)}"
+        )
+    return sol, True
+
+
+def hasCustomKernel(file: Path) -> bool:
+    """
+    Check if the given logic file contains at least one custom kernel.
+
+    Args:
+        file: Path to a logic file.
+
+    Returns:
+        True if the logic file contains at least one custom kernel.
+    """
+    with open(file, "r") as f:
+        for line in f:
+            l = line.strip()
+            if l.startswith("CustomKernelName:") and not l.endswith("''"):
+                return True
+    return False
+
+
+def prepareCustomKernelConfig(miParams: dict, prevMi: list) -> str:
+    """
+    Formats fields on custom kernel configuration to be used by developers to update
+    prototype custom kernel configuration for production serialized logic files.
+
+    Args:
+        miParams: Dictionary of matrix instruction parameters.
+
+    Returns:
+        A string containing formatted fields for the custom kernel configuration.
+    """
+    pformatStr = pformat(miParams)
+    # Remove the dictionary braces and split into lines
+    lines = pformatStr.strip("{}").split("\n")
+    formattedLines = []
+    for line in lines:
+        line = line.strip()
+        # Remove the 'ISA' line as it is not needed in the output
+        if line.startswith("'ISA'"):
+            continue
+        line = line.replace("'", "")
+        line = "+   " + line
+        formattedLines.append(line[:-1] if line.endswith(",") else line)
+    result = "\n".join(formattedLines)
+
+    result = f"-   MatrixInstruction: {prevMi}\n" + result
+    return result

--- a/tensilelite/Tensile/TensileLogic/ParseArguments.py
+++ b/tensilelite/Tensile/TensileLogic/ParseArguments.py
@@ -23,28 +23,30 @@
 ################################################################################
 
 from argparse import ArgumentParser
-from typing import Any, Dict
 
 from Tensile.Toolchain.Validators import ToolchainDefaults
 
 
-def parseArguments() -> Dict[str, Any]:
+def parseArguments():
     """
     Returns:
         A dictionary containing the keys representing options and their values.
     """
 
     argParser = ArgumentParser(
-        description="TensileValidateLogic runs critical checks to ensure the "
+        description="TensileLogic runs critical checks to ensure the "
         "integrity of the supplied logic files.",
     )
+    argParser.add_argument("LogicPath", help="path to library logic (yaml) files")
 
-    argParser.add_argument("LogicPath", help="Path to LibraryLogic.yaml files.")
     argParser.add_argument(
-        "--check-matrix-instruction",
-        dest="CheckMatrixInstruction",
-        action="store_true",
-        help="Checks that matrix instructions are valid for all target ISAs.",
+        "-v",
+        "--verbose",
+        dest="Verbose",
+        type=int,
+        default=1,
+        choices=[0, 1, 2, 3],
+        help="set print level with `-v 2`",
     )
     argParser.add_argument(
         "--jobs",
@@ -52,14 +54,25 @@ def parseArguments() -> Dict[str, Any]:
         dest="Jobs",
         action="store",
         default=48,
-        help="Number of worker processes to use during validation checks.",
+        help="number of worker processes to use during validation checks",
     )
     argParser.add_argument(
         "--cxx-compiler",
         dest="CxxCompiler",
         action="store",
         default=ToolchainDefaults.CXX_COMPILER,
-        help=f"Default: {ToolchainDefaults.CXX_COMPILER}",
+        help=f"default: {ToolchainDefaults.CXX_COMPILER}",
+    )
+
+    group = argParser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--check-all", dest="CheckAll", action="store_true", help="run all logic file checks"
+    )
+    group.add_argument(
+        "--check-only-custom-kernels",
+        dest="CheckOnlyCustomKernels",
+        action="store_true",
+        help="run logic file checks only on custom kernels",
     )
     args = argParser.parse_args()
 

--- a/tensilelite/Tensile/TensileLogic/Run.py
+++ b/tensilelite/Tensile/TensileLogic/Run.py
@@ -1,62 +1,143 @@
-import yaml
-import functools
-from pathlib import Path
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
 
-from Tensile.Common import globalParameters, assignGlobalParameters, ParallelMap2
+
+import functools
+
+from pathlib import Path
+from typing import List, Dict, NamedTuple
+
+from Tensile.Common import ParallelMap2, print1, IsaVersion, IsaInfo, setVerbosity
+from Tensile.Common.Architectures import SUPPORTED_ISA
+from Tensile.Common.Capabilities import makeIsaInfoMap
+from Tensile.Common.GlobalParameters import assignGlobalParameters
 from Tensile.LibraryIO import readYAML
 from Tensile.Toolchain.Validators import validateToolchain
 
 from .ParseArguments import parseArguments
-from .ValidMatrixInstruction import validateMatrixInstruction
+from .ValidMatrixInstruction import _validateMatrixInstruction
+from .ValidWorkGroup import _validateWorkGroup
+from .HandleCustomKernel import handleCustomKernel, hasCustomKernel
 
 
-def getParams(cxxCompiler):
-    gp = globalParameters
-
-    gpcache = Path.cwd() / "gpcache.yaml"
-    if gpcache.exists():
-        with open(gpcache, "r") as f:
-            gp = yaml.load(f, yaml.CSafeLoader)
-    else:
-        assignGlobalParameters({}, cxxCompiler)
-        with open(gpcache, "w") as f:
-            yaml.dump(gp, f, yaml.CSafeDumper)
-
-    return gp
+class Check(NamedTuple):
+    OnlyCustomKernels: bool
+    All: bool
 
 
-def runChecks(logicPath, gp, file):
-    if "Experimental" in file.parts:
-        return 0, 0
+def _runChecks(
+    logicPath: Path, isaInfoMap: Dict[IsaVersion, IsaInfo], check: Check, files: List[Path]
+):
+    """
+    Run checks on the given logic files.
 
+    Args:
+        logicPath: Path to a directory containing logic files or to an individual logic file.
+        isaInfoMap: Map of IsaVersion to IsaInfo.
+        check: Object containing flags for checking.
+        files: List of logic files to check.
+
+    Returns:
+        Tuple of (keep, total) where keep is the number of unrejected solutions and
+        total is the total number of solutions parsed.
+    """
     keep, total = 0, 0
-    solutions = readYAML(file)[5]  # Solutions are the 5th index
-    for s in solutions:
-        total += 1
-        keep += validateMatrixInstruction(s, file.relative_to(logicPath), gp)
-    print(f">> {file.relative_to(logicPath)}")
+    for file in files:
+        if "Experimental" in file.parts:
+            return keep, total
+
+        solutions = []
+        if check.OnlyCustomKernels and hasCustomKernel(file):
+            print1(f">> {file.relative_to(logicPath)}")
+            solutions = readYAML(file)[5]  # Solutions are the 5th index
+        elif check.All:
+            print1(f">> {file.relative_to(logicPath)}")
+            solutions = readYAML(file)[5]  # Solutions are the 5th index
+
+        for s in solutions:
+            s, isCustom = handleCustomKernel(s, isaInfoMap)
+            if check.OnlyCustomKernels and not isCustom:
+                continue
+
+            if all(
+                [
+                    _validateMatrixInstruction(s, isaInfoMap, file.relative_to(logicPath)),
+                    _validateWorkGroup(s, file.relative_to(logicPath)),
+                ]
+            ):
+                keep += 1
+            total += 1
+
     return keep, total
 
 
-def main():
+def _setup():
     args = parseArguments()
+
+    setVerbosity(args.Verbose)
+    jobs = int(args.Jobs)
     cxxCompiler = validateToolchain(args.CxxCompiler)
-    gp = getParams(cxxCompiler)
-
     logicPath = Path(args.LogicPath)
-    pattern = "**/*.yaml"
-    files = logicPath.glob(pattern)
-    print(f"Checking logic files with glob {args.LogicPath}{pattern}")
 
-    if not any([args.CheckMatrixInstruction]):
-        print("No checks specified. Exiting.")
+    if not any([args.CheckAll, args.CheckOnlyCustomKernels]):
+        print1("No checks specified. Exiting.")
         exit(0)
+    check = Check(
+        OnlyCustomKernels=args.CheckOnlyCustomKernels,
+        All=args.CheckAll,
+    )
 
-    fn = functools.partial(runChecks, logicPath, gp)
-    results = ParallelMap2(fn, files, multiArg=False, procs=args.Jobs)
+    if logicPath.is_file() and logicPath.suffix == ".yaml":
+        files = [logicPath]
+    else:
+        pattern = "**/*.yaml"
+        files = list(logicPath.glob(pattern))
+    if len(files) == 0:
+        print1(f"No files found in {logicPath}")
+        exit(1)
+    print1(f"Found {len(files)} files")
 
-    keep = sum([x[0] for x in results])
-    total = sum([x[1] for x in results])
+    isaInfoMap = makeIsaInfoMap(SUPPORTED_ISA, str(cxxCompiler))
+    assignGlobalParameters({"PrintSolutionRejectionReason": True}, isaInfoMap)
+
+    return jobs, isaInfoMap, logicPath, files, check
+
+
+def main():
+    jobs, isaInfoMap, logicPath, files, check = _setup()
+
+    batchSize = len(files) // min(len(files), jobs)
+    batches = (files[i : i + batchSize] for i in range(0, len(files), batchSize))
+
+    fn = functools.partial(_runChecks, logicPath, isaInfoMap, check)
+    keep, total = 0, 0
+
+    results = ParallelMap2(fn, batches, multiArg=False, procs=jobs, return_as="list")
+
+    for _keep, _total in results:
+        keep += _keep
+        total += _total
 
     rejects = total - keep
     print(f"Total  {total} solutions")

--- a/tensilelite/Tensile/TensileLogic/ValidMatrixInstruction.py
+++ b/tensilelite/Tensile/TensileLogic/ValidMatrixInstruction.py
@@ -1,235 +1,72 @@
-import math
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+"""
+ValidMatrixInstruction
+---
+Format: (M x N x K x B)
+    XDLOPS tile definition, only valid for gfx908, gfx90a
+    MxNxKxB specifies matrix instruction variants
+    MxNxB determines the shape of the C tile each instruction worked on
+        K determines the unroll depth
+
+Alternative format: (M x N x K x B x MIBlockM x WaveTileM x WaveTileN x WaveM x WaveN)
+    (Note: MxN means M-by-N in the following comments)
+    MIBlockM determines how many blocks along M dimension for multi-block MI variants. Concrete examples:
+    - MI 16x16x1x4 (4-block variant) with MIBlockM=4 -> (16x16)*(4x1)=64x16 tile per instruction executed
+    - MI 32x32x1x2 (2-block variant) with MIBlockM=1 -> (32x32)*(1x2)=32x64 tile per instruction executed
+    WaveTileM/N are dimensions of the C tile each wave works on, and is close to the concept of ThreadTile in classic VALU kernels
+    - WT 4x1 -> each wave executes 4x1 matrix instructions on the C tile of total area (4*MITileM)x(1*MITileN)
+    WaveM/N are dimensions of waves spawned for one workgroup where each wave consists of 64 threads
+    - Wave2x2 -> a total of 4 waves in one workgroup of shape 2x2
+    Putting it all together:
+    - [32, 32, 1, 2, 1,  4, 1,  2, 2]
+       ^^^^^^^^^^^^  ^   ^^^^   ^^^^
+        MatrixInst  BlkM  WT    Wave
+    - means (32x64) per MI * (4x1) per wave * (2x2) per workgroup = (32*4*2)x(64*1*2) = 256x128 macro tile
+    Tensile will ignore the parameters ThreadTile and WorkGroup when the alternative format is used
+
+Notes:
+    - If empty, do not use these instructions
+"""
+
+from typing import Dict
 from pathlib import Path
-from inspect import currentframe, getframeinfo
 
-MI_KEY: str = "MatrixInstruction"
-MI_ENABLED_KEY: str = "EnableMatrixInstruction"
-
-
-validMFMA = {}
-validMFMA["H"] = [[32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
-               + [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["S"] = [[32, 32, 1, 2], [32, 32, 2, 1], [16, 16, 1, 4], [16, 16, 4, 1], [4, 4, 1, 16]]
-validMFMA["B"] = [[32, 32, 2, 2], [32, 32, 4, 1], [16, 16, 2, 4], [16, 16, 8, 1], [4, 4, 2, 16]]
-               + [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["4xi8"] = [
-    [32, 32, 4, 2],
-    [32, 32, 8, 1],
-    [16, 16, 4, 4],
-    [16, 16, 16, 1],
-    [4, 4, 4, 16],
-    [32, 32, 16, 1],
-    [16, 16, 32, 1],
-]
-validMFMA["D"] = [[16, 16, 4, 1], [4, 4, 4, 4]]
-validMFMA["B1k"] = [[32, 32, 4, 2], [32, 32, 8, 1], [16, 16, 4, 4], [16, 16, 16, 1], [4, 4, 4, 16]]
-validMFMA["C"] = validMFMA["S"]
-validMFMA["Z"] = validMFMA["D"]
-validMFMA["I8"] = [
-    [32, 32, 4, 2],
-    [32, 32, 8, 1],
-    [16, 16, 4, 4],
-    [16, 16, 16, 1],
-    [4, 4, 4, 16],
-] + [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["X"] = [[32, 32, 4, 1], [16, 16, 8, 1]]
-validMFMA["F8"] = [[32, 32, 16, 1], [16, 16, 32, 1]] + [[32, 32, 64, 1], [16, 16, 128, 1]]
-validMFMA["B8"] = validMFMA["F8"]
-validMFMA["F8B8"] = validMFMA["F8"]
-validMFMA["B8F8"] = validMFMA["F8"]
-validMFMA["F8N"] = [[32, 32, 16, 1], [16, 16, 32, 1]]
-validMFMA["B8N"] = validMFMA["F8N"]
-validMFMA["F8B8N"] = validMFMA["F8N"]
-validMFMA["B8F8N"] = validMFMA["F8N"]
-validWMMA = [
-    [16, 16, 16, 1],
-]
-validTT = 32
-validMFMA["_format9"] = []
-
-for MFMA in [
-    validMFMA["H"],
-    validMFMA["S"],
-    validMFMA["B"],
-    validMFMA["D"],
-    validMFMA["X"],
-    validMFMA["F8N"],
-    validWMMA,
-]:
-    for MI in MFMA:
-        for bm in range(int(math.log(MI[3], 2)) + 1):
-            for tt0 in range(1, validTT + 1):
-                for tt1 in range(1, validTT + 1):
-                    for wave_m in range(3):
-                        for wave_n in range(3):
-                            validMFMA["_format9"].append(
-                                [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
-                            )
-validMatrixInstructions = (
-    [[], [-1]]
-    + validMFMA["H"]
-    + validMFMA["S"]
-    + validMFMA["B"]
-    + validMFMA["D"]
-    + validMFMA["B1k"]
-    + validMFMA["X"]
-)
-validMatrixInstructions = validMatrixInstructions + validMFMA["_format9"]
-
-validSMFMA = {}
-validSMFMA["H"] = [[32, 32, 16, 1], [16, 16, 32, 1]] + [[32, 32, 32, 1], [16, 16, 64, 1]]
-validSMFMA["B"] = [[32, 32, 16, 1], [16, 16, 32, 1]] + [[32, 32, 32, 1], [16, 16, 64, 1]]
-validSMFMA["4xi8"] = [[32, 32, 32, 1], [16, 16, 64, 1]] + [[32, 32, 64, 1], [16, 16, 128, 1]]
-validSMFMA["I8"] = validSMFMA["4xi8"]
-validSMFMA["F8"] = [[32, 32, 32, 1], [16, 16, 64, 1]] + [[32, 32, 64, 1], [16, 16, 128, 1]]
-validSMFMA["B8"] = validSMFMA["F8"]
-validSMFMA["F8B8"] = validSMFMA["F8"]
-validSMFMA["B8F8"] = validSMFMA["F8"]
-validSMFMA["F8N"] = [[32, 32, 32, 1], [16, 16, 64, 1]]
-validSMFMA["B8N"] = validSMFMA["F8N"]
-validSMFMA["F8B8N"] = validSMFMA["F8N"]
-validSMFMA["B8F8N"] = validSMFMA["F8N"]
-validSMFMA["_format9"] = []
-for SMFMA in [validSMFMA["H"], validSMFMA["B"], validSMFMA["4xi8"], validSMFMA["F8N"]]:
-    for MI in SMFMA:
-        for bm in range(int(math.log(MI[3], 2)) + 1):
-            for tt0 in range(1, validTT + 1):
-                for tt1 in range(1, validTT + 1):
-                    for wave_m in range(3):
-                        for wave_n in range(3):
-                            validSMFMA["_format9"].append(
-                                [MI[0], MI[1], MI[2], MI[3], 2**bm, tt0, tt1, 2**wave_m, 2**wave_n]
-                            )
-validSparseMatrixInstructions = validSMFMA["H"] + validSMFMA["B"] + validSMFMA["4xi8"]
-validMatrixInstructions = (
-    validMatrixInstructions + validSparseMatrixInstructions + validSMFMA["_format9"]
-)
+from Tensile.Common import IsaVersion, IsaInfo, elineno
+from Tensile.SolutionStructs.Validators.MatrixInstruction import validateMIParameters
 
 
-def elineno():
-    """
-    Return the file name and line number of the caller.
-    """
-    frame = getframeinfo(currentframe().f_back)
-    return f"{Path(frame.filename).name}:{frame.lineno}"
-
-
-def validateMatrixInstruction(solution: dict, filepath: Path, params: dict):
-    """
-    Validates the matrix instruction configured in the given solution.
-
-    The function performs the following checks:
-    - Ensures that the solution contains the required keys for matrix instruction support.
-    - Ensures that the matrix instruction is not empty when it is enabled.
-    - Validates that the matrix instruction is in the list of valid matrix instructions.
-    - If the matrix instruction has 9 elements, it performs detailed validation checks:
-        - Validates the work group dimensions.
-        - Checks if the matrix instruction is supported by the assembler capabilities (MFMA or WMMA).
-        - Validates the input per thread for sparse and non-sparse configurations.
-        - Validates the matrix instruction block, wave group, and wave tile dimensions.
-    - If the matrix instruction has 4 elements, it ensures that matrix instructions are enabled.
-    - If the matrix instruction is empty, it ensures that matrix instructions are disabled.
-
-    Args:
-        solution: The solution to validate.
-        filepath: The path to the file containing the solution.
-        params: The global parameters for the solution.
-
-    Raises:
-        AssertionError: If any of the validation checks fail.
-    """
+def _validateMatrixInstruction(
+    solution: dict, isaInfoMap: Dict[IsaVersion, IsaInfo], filepath: Path
+) -> bool:
     try:
-        _validateMatrixInstruction(solution, params)
+        validateMIParameters(solution, isaInfoMap)
+        assert solution["Valid"], f"Solution was rejected: {elineno()}"
         return True
     except AssertionError as e:
-        print(f"Validation failed: {filepath} (index {solution['SolutionIndex']})")
-        print(f"Error: file: {e}")
-        return False
-
-
-def _validateMatrixInstruction(solution: dict, params: dict):
-    """
-    Function to validate the matrix instruction for the provided solution.
-    See exported function for more details.
-    """
-    assert MI_KEY in solution, elineno()
-    assert MI_ENABLED_KEY in solution, elineno()
-    assert not (solution[MI_KEY] == [] and solution[MI_ENABLED_KEY] == True), elineno()
-
-    isa = tuple(solution["ISA"])
-    miFull = solution[MI_KEY]
-    miEnabled = solution[MI_ENABLED_KEY]
-
-    assert miFull in validMatrixInstructions, elineno()
-
-    if len(solution[MI_KEY]) == 9:
-        wfsize = solution["WavefrontSize"]
-        mi = [miFull[0], miFull[1], miFull[2], miFull[3]]
-        waves = miFull[7] * miFull[8]
-        miwg0 = miFull[4] * miFull[0] * miFull[7]  # Matrix instruction work group 0
-        miwg1 = waves * wfsize // miwg0
-
-        isSparse = solution["ProblemType"]["Sparse"]
-        miDataType = (
-            solution["ProblemType"]["DataType"]
-            if (not solution["EnableF32XdlMathOp"])
-            else solution["ProblemType"]["F32XdlMathOp"]
+        print(
+            f"Error: Validation failed: {e} (file: {filepath}, index: {solution['SolutionIndex']})"
         )
-        miBlock = solution["MIBlock"]
-        miWaveGroup = solution["MIWaveGroup"]
-        miWaveTile = solution["MIWaveTile"]
-        miInputPerThread = solution["MIInputPerThread"]
-        miInputPerThreadA = solution["MIInputPerThreadA"]
-        miInputPerThreadB = solution["MIInputPerThreadB"]
-        miInutPerThreadMeta = solution["MIInputPerThreadMetadata"]
-
-        # Check work group
-        assert solution["WorkGroup"] == [miwg0, miwg1], elineno()
-
-        # Check datatype
-        if not isSparse:
-            if params["AsmCaps"][isa]["HasMFMA"]:
-                if not (miDataType.toChar() in validMFMA and mi in validMFMA[miDataType.toChar()]):
-                    assert miDataType.isBFloat16() and mi in validMFMA["B1k"], elineno()
-            elif params["AsmCaps"][isa]["HasWMMA"]:
-                assert mi in validWMMA, elineno()
-        else:
-            assert miDataType.toChar() in validSMFMA and mi in validSMFMA[miDataType.toChar()], elineno()
-
-        if (not params["AsmCaps"][isa]["HasMFMA"]) and params["AsmCaps"][isa]["HasWMMA"]:
-            if isa[0] == 10 or isa[0] == 11:
-                assert miInputPerThread == mi[2], elineno()
-
-        assert solution["MFMA_BF16_1K"] == False, elineno()
-
-        # Check MIBlock
-        assert miBlock[0] == mi[0], elineno()
-        assert miBlock[1] == mi[1], elineno()
-        assert miBlock[2] == mi[2], elineno()
-        assert miBlock[3] == mi[3], elineno()
-        assert miBlock[4] == min(miwg0 // mi[0], mi[3]), elineno()
-        assert miBlock[5] == mi[3] // miBlock[4], elineno()
-
-        # Check MIWaveGroup
-        assert miWaveGroup[0] == min((miwg0 // mi[0]) // miBlock[4], waves), elineno()
-        assert miWaveGroup[1] == waves // miWaveGroup[0], elineno()
-
-        # Check MIWaveTile
-        assert miWaveTile[0] == mi[5], elineno()
-        assert miWaveTile[1] == mi[6], elineno()
-
-        # Check MIInputPerThread
-        assert miInputPerThread == mi[0] * mi[2] * mi[3] // wfsize, elineno()
-
-        # TODO: sparsity in hipBLASLt appears to be unused or always zero
-        sparseA = not isSparse if isSparse != 2 else False
-        sparseB = isSparse == 2 if isSparse else False
-        assert miInputPerThreadA == miInputPerThread if not sparseA else miInputPerThread // 2, elineno()
-        assert miInputPerThreadB == miInputPerThread if not sparseB else miInputPerThread // 2, elineno()
-        assert miInutPerThreadMeta == miInputPerThread if not isSparse else miInputPerThread // 8, elineno()
-
-        assert miEnabled == True, elineno()
-    elif miFull != [] and len(miFull) == 4:
-        assert miEnabled == True, elineno()
-    else:
-        assert miEnabled == False, elineno()
+        return False

--- a/tensilelite/Tensile/TensileLogic/ValidWorkGroup.py
+++ b/tensilelite/Tensile/TensileLogic/ValidWorkGroup.py
@@ -1,0 +1,47 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+################################################################################
+
+"""
+ValidWorkGroup
+---
+Dimensions of the workgroup which will operate on a tile and share lds
+Example: ( wg0 x wg1 x LocalSplitU )
+"""
+
+from pathlib import Path
+
+from Tensile.Common import elineno
+from Tensile.SolutionStructs.Validators.WorkGroup import validateWorkGroup
+
+
+def _validateWorkGroup(solution: dict, filepath: Path):
+    try:
+        validateWorkGroup(solution)
+        assert solution["Valid"], f"Solution was rejected: {elineno()}"
+        return True
+    except AssertionError as e:
+        print(
+            f"Error: Validation failed: {e} (file: {filepath}, index: {solution['SolutionIndex']})"
+        )
+        return False

--- a/tensilelite/Tensile/Tests/conftest.py
+++ b/tensilelite/Tensile/Tests/conftest.py
@@ -116,8 +116,10 @@ def pytest_collection_modifyitems(items):
     Adds a mark for the root directory name to each test.
     """
     for item in items:
+        
         relpath = item.fspath.relto(testdir)
         components = relpath.split(os.path.sep)
+        # print(f"Items: {item}, Testdir: {testdir}, Components: {components}")
         if len(components) > 0 and len(components[0]) > 0:
             item.add_marker(getattr(pytest.mark, components[0]))
 
@@ -139,8 +141,8 @@ def useGlobalParameters(tensile_args):
             Common.restoreDefaultGlobalParameters()
             if args.CxxCompiler:
                 Common.globalParameters["CxxCompiler"] = args.CxxCompiler
-
-            Common.assignGlobalParameters({})
+            isa = Common.detectGlobalCurrentISA(args.device)
+            Common.assignGlobalParameters({}, isa)
 
             overrideParameters = Tensile.argUpdatedGlobalParameters(args)
             for key, value in overrideParameters.items():

--- a/tensilelite/Tensile/Tests/unit/test_MatrixInstructionConversion.py
+++ b/tensilelite/Tensile/Tests/unit/test_MatrixInstructionConversion.py
@@ -1,0 +1,192 @@
+import pytest
+import yaml
+from pprint import pformat
+
+from Tensile.Common.Architectures import SUPPORTED_ISA
+from Tensile.Common.Capabilities import makeIsaInfoMap
+from Tensile.Common.Types import IsaVersion
+from Tensile.Common.GlobalParameters import defaultSolution
+from Tensile.Toolchain.Validators import validateToolchain
+from Tensile.SolutionStructs.Validators.MatrixInstruction import matrixInstructionToMIParameters, validateMIParameters
+from Tensile.SolutionStructs.Validators.WorkGroup import validateWorkGroup
+
+cxxCompiler = validateToolchain("amdclang++")
+isaInfoMap = makeIsaInfoMap(SUPPORTED_ISA, cxxCompiler)
+
+def test_convert_9_item_custom_kernel_config():
+    input_conf = yaml.load(
+"""
+ProblemType:
+    OperationType: GEMM
+    DataTypeA: f8n
+    DataTypeB: h
+    UseScaleAB: "Scalar"
+    DataType: h
+    DestDataType: s
+    ComputeDataType: s
+    HighPrecisionAccumulate: True
+    TransposeA: False
+    TransposeB: False
+    UseBias: 1
+    Activation: True
+    UseScaleAlphaVec: 1
+    UseBeta: True
+    Batched: True
+    GroupedGemm:   True
+    SupportUserArgs: True
+MatrixInstruction: [32, 32, 8, 1, 1, 31, 16, 4, 2]
+WavefrontSize: 48
+WorkGroup: [16, 16, 1]
+""", yaml.SafeLoader)
+
+    # NOTE: This is not a valid MatrixInstruction, but since we are testing the conversion
+    # functionality, it is useful to have unique values for each item in the list.
+    mi = input_conf["MatrixInstruction"]
+    wavefrontSize = input_conf["WavefrontSize"]
+    workgroup = input_conf["WorkGroup"]
+    ptype = input_conf["ProblemType"]
+    isa = IsaVersion(9, 0, 10)
+
+    outputConf = matrixInstructionToMIParameters(
+        mi,
+        isa,
+        wavefrontSize,
+        ptype,
+        workgroup,
+        isaInfoMap,
+    )
+
+    input = {
+        "MatrixInstruction": input_conf["MatrixInstruction"],
+    }
+
+    print("inputConf: ", pformat(input))
+    print("outputConf: ", pformat(outputConf))
+
+    assert outputConf["MatrixInstruction"] == [32, 32, 8, 1]
+    assert outputConf["EnableMatrixInstruction"] == True
+    assert outputConf["MIBlock"] == [32, 32, 8, 1, 1, 1]
+    assert outputConf["MIWaveGroup"] == [4, 2]
+    assert outputConf["MIWaveTile"] == [31, 16]
+    assert outputConf["MatrixInstBM"] == 1
+    assert outputConf["MatrixInstBN"] == 1
+    assert outputConf["MIInputPerThread"] == 5
+    assert outputConf["MIInputPerThreadA"] == 5
+    assert outputConf["MIInputPerThreadB"] == 5
+    assert outputConf["MIInputPerThreadMetadata"] == 5
+    assert outputConf["ThreadTile"] == [1, 1]
+    assert outputConf["Sparse"] == 0
+    assert outputConf["WorkGroup"] == [128, 3, 1]
+    assert outputConf["WavefrontSize"] == 48
+    assert outputConf["ISA"] == isa
+    assert outputConf["EnableF32XdlMathOp"] == False
+    assert outputConf["MFMA_BF16_1K"] == False
+
+    solution = defaultSolution
+    solution.update(input_conf)
+    solution.update(outputConf)
+
+    assert validateMIParameters(solution, isaInfoMap, True)
+    assert validateWorkGroup(solution)
+
+    mi4 = solution["MatrixInstruction"]
+    bm = solution["MatrixInstBM"]
+    tt0 = solution["MIWaveTile"][0]
+    tt1 = solution["MIWaveTile"][1]
+    wg0 = solution["MIWaveGroup"][0]
+    wg1 = solution["MIWaveGroup"][1]
+    format9 = [mi4[0], mi4[1], mi4[2], mi4[3], bm, tt0, tt1, wg0, wg1]
+
+    assert format9 == mi
+    
+
+def testConvert9ItemCustomKernelConfig():
+
+    inputConf = yaml.load(
+"""
+custom.config:
+   ProblemType:
+      OperationType: GEMM
+      DataTypeA: f8n
+      DataTypeB: h
+      UseScaleAB: "Scalar"
+      DataType: h
+      DestDataType: s
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBias: 1
+      Activation: True
+      UseScaleAlphaVec: 1
+      UseBeta: True
+      Batched: True
+      GroupedGemm:   True
+      SupportUserArgs: True
+   MatrixInstruction: [32, 32, 8, 1, 5, 6, 7, 8, 9]
+   1LDSBuffer: 1
+   ScheduleIterAlg: 3
+   DepthU: 32
+   StaggerU: 0
+   WorkGroupMapping: 8
+   WaveSeparateGlobalReadA: 1
+   WaveSeparateGlobalReadB: 1
+   GlobalReadVectorWidthA: 4
+   GlobalReadVectorWidthB: 2
+   AssertFree0ElementMultiple: 4
+   AssertSummationElementMultiple: 1
+   NoReject: 1
+   InternalSupportParams:
+      KernArgsVersion: 0
+      SupportUserGSU: False
+      SupportCustomWGM: False
+      SupportCustomStaggerU: False
+      UseUniversalArgs: False
+""", yaml.SafeLoader)
+
+    inputConf = inputConf["custom.config"]
+
+    isa = IsaVersion(9, 4, 2)
+    wavefrontSize = 48
+    workGroup = [4, 5, 6]
+
+    outputConf = matrixInstructionToMIParameters(
+        inputConf["MatrixInstruction"],
+        isa,
+        wavefrontSize,
+        inputConf["ProblemType"],
+        workGroup,
+        isaInfoMap,
+    )
+
+    input = {
+        "MatrixInstruction": inputConf["MatrixInstruction"],
+    }
+
+    print("inputConf: ", pformat(input))
+    print("outputConf: ", pformat(outputConf))
+
+    assert outputConf["MatrixInstruction"] == [32, 32, 8, 1]
+    assert outputConf["EnableMatrixInstruction"] == True
+    assert outputConf["MIBlock"] == [32, 32, 8, 1, 1, 1]
+    assert outputConf["MIWaveGroup"] == [40, 1]
+    assert outputConf["MIWaveTile"] == [6, 7]
+    assert outputConf["MatrixInstBM"] == 1
+    assert outputConf["MatrixInstBN"] == 1
+    assert outputConf["MIInputPerThread"] == 5
+    assert outputConf["MIInputPerThreadA"] == 5
+    assert outputConf["MIInputPerThreadB"] == 5
+    assert outputConf["MIInputPerThreadMetadata"] == 5
+    assert outputConf["ThreadTile"] == [1, 1]
+    assert outputConf["Sparse"] == 0
+    assert outputConf["WorkGroup"] == [1280, 2, 6]  # Why do we change the workgroup here?
+    assert outputConf["WavefrontSize"] == 48
+    assert outputConf["ISA"] == isa
+    assert outputConf["EnableF32XdlMathOp"] == False
+    assert outputConf["MFMA_BF16_1K"] == False
+
+    solution = defaultSolution
+    solution.update(inputConf)
+    solution.update(outputConf)
+
+    assert validateMIParameters(solution, isaInfoMap, True) == True

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -1,0 +1,377 @@
+
+from os import name as os_name
+from os import environ
+from pathlib import Path
+from re import search, IGNORECASE
+from shlex import split
+from subprocess import check_output, STDOUT, CalledProcessError, PIPE, run
+from typing import List
+
+from Tensile.Common import SemanticVersion, print1
+from .Validators import ToolchainDefaults
+
+def _invoke(args: List[str], desc: str=""):
+  """Invokes a command with the provided arguments in a subprocess.
+  Args:
+      args: A list of arguments to pass to the subprocess.
+      desc: A description of the subprocess invocation.
+  Raises:
+      RuntimeError: If the subprocess invocation fails.
+  Return:
+      subprocess output
+  """
+  #print1(f"{desc}: {' '.join(args)}")
+  try:
+      out = check_output(args, stderr=STDOUT)
+  except CalledProcessError as err:
+      raise RuntimeError(
+          f"Error with {desc}: {err.output}\n"
+          f"Failed command: {' '.join(args)}"
+      )
+  #print2(f"Output: {out}")
+  return out
+
+
+def _getVersion(executable: str, versionFlag: str, regex: str) -> str:
+    """Compute the version string of a toolchain component.
+
+    Args:
+        executable: The toolchain component to check the version of.
+        versionFlag: The flag to pass to the executable to get the version.
+        regex: pattern used to extract version string.
+    Raises:
+        RuntimeError: If querying executable for version fails.
+    Return:
+        Executable version
+    """
+    args = f'"{executable}" "{versionFlag}"'
+    try:
+        output = run(args, stdout=PIPE, shell=True).stdout.decode().strip()
+        match = search(regex, output, IGNORECASE)
+        result = match.group(1) if match else "<unknown>"
+        return SemanticVersion(*[int(c.split("-")[0]) for c in result.split(".")[:3]])
+    except Exception as e:
+        raise RuntimeError(f"Failed to get version when calling {args}: {e}")
+
+
+def get_rocm_version() -> str:
+    """Compute the ROCm version string using hipconfig.
+
+    Raises:
+        RuntimeError: If hipconfig fails to execute.
+    Return:
+        ROCm version string
+    """
+    return _getVersion(ToolchainDefaults.HIP_CONFIG, "--version", r'(.+)')
+
+
+class Component:
+    """A class used to represent a ROCm toolchain component such as clang++"""
+
+    _rocm_version = get_rocm_version()
+
+    def __init__(self, component_path: Path, version_flag: str="--version", version_regex: str=r"version\s+([\d.]+)"):
+        self._version = _getVersion(str(component_path), version_flag, version_regex)
+        self._component_path = component_path
+
+    def __str__(self):
+        result = f"ROCm {Component._rocm_version.major}.{Component._rocm_version.minor}.{Component._rocm_version.patch} "
+        result += f"Component path: {self._component_path} version: {self._version.major}.{self._version.minor}.{self._version.patch}"
+        return result
+
+    @property
+    def path(self):
+        return self._component_path
+
+    @property
+    def version(self):
+        return self._version
+
+    @property
+    def rocm_version(self):
+        return Component._rocm_version
+
+
+class Assembler(Component):
+    """
+    ROCm assembler class used to build objects from assembly source files.
+
+    ...
+
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    path : str
+        path to assembler
+
+    Methods
+    -------
+    __call__(self, targetGfx: str, wavefrontSize: int, debug: bool, srcPath: str, destPath: str)
+        Invokes the assembler on the provided arguments
+    """
+
+    def __init__(self, component_path: Path, co_version: str, debug: bool=False):
+        """Constructs instance of assmebler.
+
+        Args:
+            assembler_path: The path to the assember.
+            co_version: The code object version to use.
+        """
+
+        super(Assembler, self).__init__(component_path)
+        self._code_object_version = co_version
+        
+        self._default_args = [
+            *split(environ.get('Tensile_ASM_COMPILER_LAUNCHER', '')),
+            str(component_path),
+            "-x", "assembler",
+            "--target=amdgcn-amd-amdhsa",
+            "-g" if debug else "",
+            f"-mcode-object-version={co_version}",
+            "-c",
+        ]
+
+    def __call__(self, targetGfx: str, wavefrontSize: int, srcPath: str, destPath: str):
+        """Assemble an assembly source file into an object file.
+        Args:
+            targetGfx: The target GPU gfx architecture.
+            wavefrontSize: The wavefront size to use.
+            debug: add debug flags if True.
+            srcPath: The path to the assembly source file.
+            destPath: The destination path for the generated object file.
+        """
+        args = self._default_args
+        args = [
+            *args,
+            f"-mcpu={targetGfx}",
+            "-mwavefrontsize64" if wavefrontSize == 64 else "-mno-wavefrontsize64",
+            srcPath,
+            "-o",
+            destPath
+        ]
+        return _invoke(args, "Assembling assembly source code into object file (.s -> .o)")
+
+    @property
+    def code_object_version(self):
+        return self._code_object_version
+
+class Compiler(Component):
+    """
+    ROCm compiler class used to build objects from C++ source files.
+
+    ...
+
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    path : str
+        path to compiler
+
+    Methods
+    -------
+    __call__(self, include_path: str, target_list: List[str], srcPath: str, destPath: str):
+        Invokes the compiler on the provided arguments
+    """
+
+    def __init__(self, compiler_path: Path, build_id_kind: str, asan_build: bool=False, save_temps: bool=False):
+        """Constructs and instance of a Compiler."""
+        super(Compiler, self).__init__(compiler_path)
+
+        self.default_args = [
+            *split(environ.get("Tensile_CXX_COMPILER_LAUNCHER", "")),
+             compiler_path,
+            "-D__HIP_HCC_COMPAT_MODE__=1",
+            "--offload-device-only",
+            "-x", "hip", "-O3",
+            "-Xoffload-linker", f"--build-id={build_id_kind}",
+            "-std=c++17",
+        ]
+
+        if asan_build:
+            self.default_args.extend(["-fsanitize=address", "-shared-libasan", "-fuse-ld=lld"])
+        if save_temps:
+            self.default_args.append("--save-temps")
+        if os_name == "nt":                                                    # should we use fPIIC on all arches?
+            self.default_args.extend(["-fms-extensions", "-fms-compatibility", "-fPIC", "-Wno-deprecated-declarations"])
+
+
+    def __call__(self, include_path: str, target_list: List[str], srcPath: str, destPath: str):
+        """Compiles a source file into an object file.
+
+        Args:
+            include_path: Path appened to "-I" to directory with required include files.
+            target_list: List of offload architectures of the form gfxXYZ e.g. gfx942.
+            sercPath: The path to the source file.
+            destPath: Path to the object file output during compilation.
+        Raises:
+            RuntimeError: If the compilation command fails.
+        """
+        archFlags = [f"--offload-arch={gfx}" for gfx in target_list]
+        args = [
+            *(self.default_args), "-I", include_path, *archFlags, srcPath, "-c", "-o", destPath
+        ]
+        return _invoke(args, f"Compiling HIP source kernels into objects (.cpp -> .o)")
+
+
+class Bundler(Component):
+    """
+    ROCm bundler class used to unbundle objects into code object files.
+
+    ...
+
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    Methods
+    -------
+    __call__(self, targetGfx: str, wavefrontSize: int, debug: bool, srcPath: str, destPath: str)
+        Invokes the assembler on the provided arguments
+    def targets(self, objFile: str):
+      returns a list of target triple strings of the form amdgcn-amd--gfx942
+    def compress(self, srcPath: str, destPath: str, target: str):
+        Compresses a code object file using the provided bundler.
+    """
+
+    def __init__(self, bundler_path: Path):
+        """Constructs and instance of a Bunder."""
+        super(Bundler, self).__init__(bundler_path)
+
+    def targets(self, objFile: str):
+        """returns a list of target triple strings of the form amdgcn-amd--gfx942"""
+        args = [self._component_path, "--type=o", f"--input={objFile}", "-list"]
+        return _invoke(args, f"Listing target triples in object file").decode().split("\n")
+
+    def compress(self, srcPath: str, destPath: str, target: str):
+        """Compresses a code object file using the provided bundler.
+
+        Args:
+            srcPath: The source path of the code object file to be compressed.
+            destPath: The destination path for the compressed code object file.
+            gfx: The target GPU architecture.
+
+        Raises:
+            RuntimeError: If compressing the code object file fails.
+        """
+        args = [
+            self._component_path,
+            "--compress",
+            "--type=o",
+            "--bundle-align=4096",
+            f"--targets=host-x86_64-unknown-linux-gnu,hipv4-amdgcn-amd-amdhsa-unknown-{target}",
+            "--input=/dev/null",
+            f"--input={srcPath}",
+            f"--output={destPath}",
+        ]
+
+        return _invoke(args, "Bundling/compressing code object file (.co -> .co)")
+
+    def __call__(self, target: str, srcPath: str, destPath: str):
+        """Unbundles source code object files using the Clang Offload Bundler.
+        Args:
+            target: The target triple, see https://llvm.org/docs/AMDGPUUsage.html#target-triples.
+            srcPath: The path to the input object file.
+            destPath: The path to the unbundled code object.
+        Raises:
+            RuntimeError: If unbundling the source code object file fails.
+        """
+        args = [
+            self._component_path,
+            "--type=o",
+            f"--targets={target}",
+            f"--input={srcPath}",
+            f"--output={destPath}",
+            "--unbundle",
+        ]
+        return _invoke(args, f"Unbundling source code object file")
+
+
+class Linker(Component):
+    """
+    ROCm Linker class used to link objects into code object files.
+
+    ...
+
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    Methods
+    -------
+    __call__(self, srcPaths: List[str], destPath: str):
+        Invokes the linker on the provided arguments
+    """
+
+    def __init__(self, linker_path: Path, build_id_kind: str):
+        """Constructs and instance of a Linker."""
+        super(Linker, self).__init__(linker_path)
+        self.default_args = [
+                self._component_path,
+                "--target=amdgcn-amd-amdhsa",
+                "-Xlinker", f"--build-id={build_id_kind}",
+        ]
+
+
+    def __call__(self, srcPaths: List[str], destPath: str):
+        """Links object files into a code object file.
+
+        Args:
+            srcPaths: A list of paths to object files.
+            destPath: A destination path for the generated code object file.
+        Raises:
+            RuntimeError: If linker invocation fails.
+        """
+        if os_name == "nt":
+            # Use args file on Windows b/c the command may exceed the limit of 8191 characters
+            with open(Path.cwd() / "clang_args.txt", "wt") as file:
+                file.write(" ".join(srcPaths))
+                file.flush()
+            args = [*(self.default_args), "-o", destPath, "@clang_args.txt"]
+        else:
+            args = [*(self.default_args), *srcPaths, "-o", destPath]
+        return _invoke(args, "Linking assembly object files into code object (*.o -> .co)")
+
+
+# class DeviceEnumerator(Component):
+#     """
+#     ROCm amdgpu-arch or rocm_agent_enumerator class used to inspect system for current architecture.
+
+#     ...
+
+#     Attributes
+#     ----------
+#     version : str
+#         the version of the component
+#     rocm_version : str
+#         the ROCm version
+#     path : str
+#         path to component
+
+#     Methods
+#     -------
+#     __call__(self)
+#         Invokes component.
+#     """
+#     def __init__(self, component_path: Path):
+#         """Constructs instance of SystemInterogator.
+
+#         Args:
+#             component_path: The path to amdgpu-arch or rocm_agent_enumeraor.
+#         """
+#         super(Assembler, self).__init__(component_path)
+#         self._default_args = [str(component_path)]
+
+#     def __call__(self):
+#         """Run component without args to detect system settings."""
+
+#         return _invoke(self._default_args, "running system inspection")

--- a/tensilelite/Tensile/Toolchain/Validators.py
+++ b/tensilelite/Tensile/Toolchain/Validators.py
@@ -104,10 +104,17 @@ def _posixSearchPaths() -> List[Path]:
     return searchPaths
 
 
+def isRhel8():
+    import platform
+    osRelease = platform.freedesktop_os_release()
+    return ("8.8" == osRelease["VERSION_ID"] and "rhel" == osRelease["ID"])
+
+
 class ToolchainDefaults(NamedTuple):
-    CXX_COMPILER= osSelect(linux="amdclang++", windows="clang++.exe")
-    C_COMPILER= osSelect(linux="amdclang", windows="clang.exe")
-    OFFLOAD_BUNDLER= osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
+    CXX_COMPILER = osSelect(linux="amdclang++", windows="clang++.exe")
+    C_COMPILER = osSelect(linux="amdclang", windows="clang.exe")
+    OFFLOAD_BUNDLER = osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
+    DEVICE_ENUMERATOR = osSelect(linux="rocm_agent_enumerator" if isRhel8() else "amdgpu-arch", windows="hipinfo")
     ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
     HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig")
 
@@ -245,20 +252,5 @@ def validateToolchain(*args: str):
     searchPaths = _windowsSearchPaths() if os.name == "nt" else _posixSearchPaths()
 
     out = (_validateExecutable(x, searchPaths) for x in args)
+    
     return next(out) if len(args) == 1 else tuple(out)
-
-
-def getVersion(executable: str, versionFlag: str="--version", regex: str=r"version\s+([\d.]+)") -> str:
-    """Print the version of a toolchain component.
-
-    Args:
-        executable: The toolchain component to check the version of.
-        versionFlag: The flag to pass to the executable to get the version.
-    """
-    args = f'"{executable}" "{versionFlag}"'
-    try:
-        output = run(args, stdout=PIPE, shell=True).stdout.decode().strip()
-        match = re.search(regex, output, re.IGNORECASE)
-        return match.group(1) if match else "<unknown>"
-    except Exception as e:
-        raise RuntimeError(f"Failed to get version when calling {args}: {e}")

--- a/tensilelite/pytest.ini
+++ b/tensilelite/pytest.ini
@@ -5,6 +5,7 @@ junit_log_passing_tests = False
 xfail_strict = True
 markers =
  common: Common tests
+ unit: Unit tests
 
  amaxd: Common tests for amaxd.
  client: Common tests for client.


### PR DESCRIPTION
**Summary**

The assembler and architecture capabilities were previously bound to the global parameters "AsmCaps" and "ArchCaps", respectively. Since these entries are replicated for each KernelWriter, they contribute to the memory bloat of the build system. This PR is the first step towards using a single instance of the assembler and architecture capabilities across all uses in the build system, thereby reducing the memory within each spawned process.