### PR TITLE
[OPT] Reschedule DTV TN cases which nrc is multiple of 2

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -1169,7 +1169,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
               flagInsert = True
           if flagInsert:
             iterCode.add(SSetPrior(prior=3, comment="store optimization"))
-
         if (mfmaIndex >= self.states.lwStartMfmaIndex):
           for j in range(self.states.numLocalWriteModPerMfma):
             # in case there are localWrite and globalread in same iteration
@@ -2651,6 +2650,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
         tailLoopOpt1st, tailLoopOpt2nd = tailLoopOpt2nd, tailLoopOpt1st
         tc1, tc2 = tc2, tc1
 
+      # globalReadMode = 2 -> optimized by using more vgpr to reorder GR, waitcnt, v_or_b32 instructions.
+      # globalReadMode = 3 -> optimized by using wider global read instructions.
       globalReadMode1st = 2 if (((tensorParameters1st["glvw"] * tensorParameters1st["bpeGR"]) < 4) or \
                                tailLoopOpt1st == False) else 3
       globalReadMode2nd = 2 if (((tensorParameters2nd["glvw"] * tensorParameters2nd["bpeGR"]) < 4) or \

--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -1396,6 +1396,18 @@ class Solution(collections.abc.Mapping):
     if (state["DirectToVgprB"]):
       state["tailLoopOptB"] = False
 
+    # reorder globalread instructions if dtv and TN cases. (along coalesced dim)
+    if state["ScheduleIterAlg"] == 3:
+      state["reorderGRInstForDTVA"] = True if state["ProblemType"]["TransposeA"] and \
+                                              state["DirectToVgprA"] and \
+                                              not state["ProblemType"]["SwizzleTensorA"] else False
+      state["reorderGRInstForDTVB"] = True if not state["ProblemType"]["TransposeB"] and \
+                                              state["DirectToVgprB"] and \
+                                              not state["ProblemType"]["SwizzleTensorB"] else False
+    else:
+      state["reorderGRInstForDTVA"] = False
+      state["reorderGRInstForDTVB"] = False
+
     # done
     state["AssignedProblemIndependentDerivedParameters"] = True
 


### PR DESCRIPTION
Detail:
    Original scheduling way of globalread instructions is to read along
    perp. dim first and then read in coal. dim.
    This commit is to reorder instructions to read in coal. dim first.
    And insert 2 continuous global read instructions if TN and nrc = 2.

    Note: Disabled if isSwizzled. Enabled if coalesced along K dim.

Ex: MT256x256x64 TN
Reorder global read instructions:
<img width="342" alt="{AB54D757-CB08-46E2-9170-3DB9F5557D41}" src="https://github.com/user-attachments/assets/200155d1-4790-4034-ba84-016b83ca0e4b" />
<img width="593" alt="{958CF36B-BC3F-4269-A6C4-9535911FA2CD}" src="https://github.com/user-attachments/assets/6268f14e-b5f6-4bb0-88bc-851576a4a01a" />

In loop, insert 2 continuous global read instructions:
<img width="755" alt="{B3A35F7F-70BE-487E-B384-A98A82C80349}" src="https://github.com/user-attachments/assets/fd783fcf-18e2-4dcb-88c9-7239f399c233" />




