### PR TITLE
Cache swizzled tensor for tuning

### DIFF
--- a/tensilelite/Tensile/Source/client/main.cpp
+++ b/tensilelite/Tensile/Source/client/main.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -57,6 +57,7 @@
 
 #include <chrono>
 #include <cstddef>
+#include <memory>
 
 namespace po = boost::program_options;
 
@@ -646,8 +647,7 @@ int main(int argc, const char* argv[])
         iter--;
     }
 
-    auto* ptr      = new DataInitialization(args, problemFactory);
-    auto  dataInit = std::shared_ptr<DataInitialization>(ptr);
+    auto dataInit = std::make_shared<DataInitialization>(args, problemFactory);
 
     auto solutionIterator = SolutionIterator::Default(library, hardware, args);
 

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -94,6 +94,10 @@ namespace TensileLite
                 return track.first;
             }
 
+            const K &back() const {
+                return entries.back();
+            }
+
         private:
             EntryMap entryMap;
             Entries  entries;
@@ -1945,6 +1949,12 @@ namespace TensileLite
         {
             for(size_t i = 0; i < m_vdata.size(); i++)
             {
+                bool needSwizzle
+                    = (problem.swizzleTensorA() && i == ContractionProblemGemm::TENSOR::A)
+                      || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B);
+                //Copy swizzle tensor would be in copySwizzledToGPUBuffer
+                if(needSwizzle)
+                    continue;
                 void* ptr  = nullptr;
                 auto& desc = problem.tensors()[i];
                 auto  it   = m_vdata[i].pristine.find(desc.dataType());
@@ -1999,11 +2009,18 @@ namespace TensileLite
                     if(g_swizzleCache.count(swizzleKey))
                     {
                         Tensor& permuted = g_swizzleCache.at(swizzleKey);
-                        ptr              = copyInputBuffers(desc,
-                                               p.gpuInput.valid.get(),
-                                               permuted.as<void>(),
-                                               permuted.getDesc().flattenSize(),
-                                               hipMemcpyHostToDevice);
+
+                        if (swizzleKey != g_swizzleCache.back()) {
+                            ptr = copyInputBuffers(desc,
+                                    p.gpuInput.valid.get(),
+                                    permuted.as<void>(),
+                                    permuted.getDesc().flattenSize(),
+                                    hipMemcpyHostToDevice);
+                        }
+                        else
+                        {
+                            ptr = p.gpuInput.valid.get();
+                        }
                     }
                     else
                     {

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -2008,9 +2008,8 @@ namespace TensileLite
 
                     if(g_swizzleCache.count(swizzleKey))
                     {
-                        Tensor& permuted = g_swizzleCache.at(swizzleKey);
-
                         if (swizzleKey != g_swizzleCache.back()) {
+                            Tensor& permuted = g_swizzleCache.at(swizzleKey);
                             ptr = copyInputBuffers(desc,
                                     p.gpuInput.valid.get(),
                                     permuted.as<void>(),

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -40,11 +40,11 @@ namespace TensileLite
 {
     namespace Client
     {
-        using BitWidth = uint8_t;
-        using Size = uint64_t;
+        using BitWidth        = uint8_t;
+        using Size            = uint64_t;
         using SwizzleCacheKey = std::tuple<BitWidth, Size, Size>;
         using SwizzleCacheVal = ::Tensor::Manipulation::Tensor;
-        using SwizzleCache = std::map<SwizzleCacheKey, SwizzleCacheVal>;
+        using SwizzleCache    = std::map<SwizzleCacheKey, SwizzleCacheVal>;
         static thread_local SwizzleCache g_swizzleCache;
 
         BitWidth toBitWidth(DataType datatype)
@@ -1507,10 +1507,11 @@ namespace TensileLite
                                                          tDim);
                                         break;
                                     case DataType::BFloat8_fnuz:
-                                        pruneSparseArray((BFloat8_fnuz*)p.second.cpuInput.valid.get()
-                                                             + gemmInitOffset,
-                                                         t,
-                                                         tDim);
+                                        pruneSparseArray(
+                                            (BFloat8_fnuz*)p.second.cpuInput.valid.get()
+                                                + gemmInitOffset,
+                                            t,
+                                            tDim);
                                         break;
                                     default:
                                         throw std::runtime_error("SparseMatrix doesn't support");
@@ -1920,51 +1921,53 @@ namespace TensileLite
                       || (problem.swizzleTensorB() && i == ContractionProblemGemm::TENSOR::B);
 
                 void* ptr{};
-                //FIXME: Not good, need to use format to specify the way for swizzling.
-                //TODO: Support more swizzling type, such as 32x32x8, currently we have 16x16x8 only.
-                if(needSwizzle)
+
+                //if no validation, skip the swizzle
+                if(needSwizzle && m_elementsToValidate != 0)
                 {
                     using Tensor = Tensor::Manipulation::Tensor;
                     // currently, if A then it means MiM = 16, if B then it means MiN = 16
                     size_t MiM_N = 16, MiK = 0, MiKv = 0, PackK = 0;
                     calculateKforSwizzling(desc.dataType(), MiK, MiKv, PackK);
-                    auto unrolledSize = desc.sizes()[0];
-                    auto tiledSize    = desc.sizes()[1];
+                    auto                          unrolledSize = desc.sizes()[0];
+                    auto                          tiledSize    = desc.sizes()[1];
                     ::Tensor::Manipulation::Shape paddedShape{
                         ((tiledSize / MiM_N) + !!(tiledSize % MiM_N)) * MiM_N,
                         (unrolledSize / (MiK * PackK) + !!(unrolledSize % (MiK * PackK))) * MiK
                             * PackK};
-                    auto swizzleKey = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize);
+                    auto swizzleKey
+                        = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize);
 
                     if(g_swizzleCache.count(swizzleKey))
                     {
-                        Tensor &permuted = g_swizzleCache.at(swizzleKey);
+                        Tensor& permuted = g_swizzleCache.at(swizzleKey);
                         ptr              = copyInputBuffers(desc,
-                                                            p.gpuInput.valid.get(),
-                                                            permuted.as<void>(),
-                                                            permuted.getDesc().flattenSize(),
-                                                            hipMemcpyHostToDevice);
+                                               p.gpuInput.valid.get(),
+                                               permuted.as<void>(),
+                                               permuted.getDesc().flattenSize(),
+                                               hipMemcpyHostToDevice);
                     }
-                    else 
+                    else
                     {
-                        auto tmpTensor    = Tensor({tiledSize, unrolledSize}, desc.elementBytes());
+                        auto tmpTensor = Tensor({tiledSize, unrolledSize}, desc.elementBytes());
 
-                        memcpy(tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
+                        memcpy(
+                            tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
                         //Temporary hack
                         uint64_t padVal{};
                         auto     paddedTensor = ::Tensor::Manipulation::pad(
                             tmpTensor, paddedShape, &padVal, tmpTensor.getElementSize());
                         paddedTensor.reshape({paddedShape[0] / MiM_N,
-                                            MiM_N,
-                                            paddedShape[1] / (MiK * PackK),
-                                            MiK / MiKv,
-                                            MiKv * PackK});
+                                              MiM_N,
+                                              paddedShape[1] / (MiK * PackK),
+                                              MiK / MiKv,
+                                              MiKv * PackK});
                         Tensor permuted = permute(paddedTensor, {0, 2, 3, 1, 4});
                         ptr             = copyInputBuffers(desc,
-                                            p.gpuInput.valid.get(),
-                                            permuted.as<void>(),
-                                            permuted.getDesc().flattenSize(),
-                                            hipMemcpyHostToDevice);
+                                               p.gpuInput.valid.get(),
+                                               permuted.as<void>(),
+                                               permuted.getDesc().flattenSize(),
+                                               hipMemcpyHostToDevice);
                         g_swizzleCache.emplace(swizzleKey, std::move(permuted));
                     }
                 }

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -34,11 +34,46 @@
 #include <hip/hip_runtime.h>
 
 #include <algorithm>
+#include <tuple>
 
 namespace TensileLite
 {
     namespace Client
     {
+        using BitWidth = uint8_t;
+        using Size = uint64_t;
+        using SwizzleCacheKey = std::tuple<BitWidth, Size, Size>;
+        using SwizzleCacheVal = ::Tensor::Manipulation::Tensor;
+        using SwizzleCache = std::map<SwizzleCacheKey, SwizzleCacheVal>;
+        static thread_local SwizzleCache g_swizzleCache;
+
+        BitWidth toBitWidth(DataType datatype)
+        {
+            switch(datatype)
+            {
+            case DataType::Double:
+                return 64;
+            case DataType::XFloat32:
+            case DataType::Float:
+                return 32;
+            case DataType::Half:
+            case DataType::BFloat16:
+                return 16;
+            case DataType::Int8:
+            case DataType::Float8_fnuz:
+            case DataType::BFloat8_fnuz:
+            case DataType::Float8BFloat8_fnuz:
+            case DataType::BFloat8Float8_fnuz:
+            case DataType::Float8:
+            case DataType::BFloat8:
+            case DataType::Float8BFloat8:
+            case DataType::BFloat8Float8:
+                return 8;
+            default:
+                throw std::runtime_error("unsupported datatype");
+            }
+        }
+
         std::string ToString(InitMode mode)
         {
             switch(mode)
@@ -1895,28 +1930,43 @@ namespace TensileLite
                     calculateKforSwizzling(desc.dataType(), MiK, MiKv, PackK);
                     auto unrolledSize = desc.sizes()[0];
                     auto tiledSize    = desc.sizes()[1];
-                    auto tmpTensor    = Tensor({tiledSize, unrolledSize}, desc.elementBytes());
-
-                    memcpy(tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
                     ::Tensor::Manipulation::Shape paddedShape{
                         ((tiledSize / MiM_N) + !!(tiledSize % MiM_N)) * MiM_N,
                         (unrolledSize / (MiK * PackK) + !!(unrolledSize % (MiK * PackK))) * MiK
                             * PackK};
-                    //Temporary hack
-                    uint64_t padVal{};
-                    auto     paddedTensor = ::Tensor::Manipulation::pad(
-                        tmpTensor, paddedShape, &padVal, tmpTensor.getElementSize());
-                    paddedTensor.reshape({paddedShape[0] / MiM_N,
-                                          MiM_N,
-                                          paddedShape[1] / (MiK * PackK),
-                                          MiK / MiKv,
-                                          MiKv * PackK});
-                    Tensor permuted = permute(paddedTensor, {0, 2, 3, 1, 4});
-                    ptr             = copyInputBuffers(desc,
-                                           p.gpuInput.valid.get(),
-                                           permuted.as<void>(),
-                                           permuted.getDesc().flattenSize(),
-                                           hipMemcpyHostToDevice);
+                    auto swizzleKey = std::make_tuple(toBitWidth(desc.dataType()), unrolledSize, tiledSize);
+
+                    if(g_swizzleCache.count(swizzleKey))
+                    {
+                        Tensor &permuted = g_swizzleCache.at(swizzleKey);
+                        ptr              = copyInputBuffers(desc,
+                                                            p.gpuInput.valid.get(),
+                                                            permuted.as<void>(),
+                                                            permuted.getDesc().flattenSize(),
+                                                            hipMemcpyHostToDevice);
+                    }
+                    else 
+                    {
+                        auto tmpTensor    = Tensor({tiledSize, unrolledSize}, desc.elementBytes());
+
+                        memcpy(tmpTensor.as<void>(), p.cpuInput.valid.get(), tmpTensor.getNumBytes());
+                        //Temporary hack
+                        uint64_t padVal{};
+                        auto     paddedTensor = ::Tensor::Manipulation::pad(
+                            tmpTensor, paddedShape, &padVal, tmpTensor.getElementSize());
+                        paddedTensor.reshape({paddedShape[0] / MiM_N,
+                                            MiM_N,
+                                            paddedShape[1] / (MiK * PackK),
+                                            MiK / MiKv,
+                                            MiKv * PackK});
+                        Tensor permuted = permute(paddedTensor, {0, 2, 3, 1, 4});
+                        ptr             = copyInputBuffers(desc,
+                                            p.gpuInput.valid.get(),
+                                            permuted.as<void>(),
+                                            permuted.getDesc().flattenSize(),
+                                            hipMemcpyHostToDevice);
+                        g_swizzleCache.emplace(swizzleKey, std::move(permuted));
+                    }
                 }
                 else
                 {

--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -34,17 +34,76 @@
 #include <hip/hip_runtime.h>
 
 #include <algorithm>
+#include <list>
+#include <map>
 #include <tuple>
 
 namespace TensileLite
 {
     namespace Client
     {
+        template <typename K, typename T, std::size_t MaxNumEntries = 128>
+        class LRUCache
+        {
+            using Entries    = std::list<K>;
+            using EntryTrack = std::pair<T, typename Entries::iterator>;
+            using EntryMap   = std::map<K, EntryTrack>;
+
+        public:
+            template <typename... Args>
+            std::pair<typename EntryMap::iterator, bool> emplace(const K& key, Args&&... args)
+            {
+                if(!entryMap.count(key))
+                {
+                    entries.push_back(key);
+                    auto&& ret = entryMap.emplace(
+                        key, std::make_pair(T(std::forward<Args>(args)...), --entries.end()));
+                    while(entries.size() > MaxNumEntries)
+                    {
+                        auto& front = entries.front();
+                        entryMap.erase(front);
+                        entries.pop_front();
+                    }
+                    return ret;
+                }
+                else
+                {
+                    auto& track = entryMap.at(key);
+                    track.first = T(std::forward<Args>(args)...);
+                    entries.splice(entries.end(), entries, track.second);
+                }
+                return {entryMap.find(key), true};
+            }
+
+            size_t count(const K& key) const
+            {
+                return entryMap.count(key);
+            }
+
+            const T& at(const K& key) const
+            {
+                auto& track = entryMap.at(key);
+                entries.splice(entries.end(), entries, track.second);
+                return track.first;
+            }
+
+            T& at(const K& key)
+            {
+                auto& track = entryMap.at(key);
+                entries.splice(entries.end(), entries, track.second);
+                return track.first;
+            }
+
+        private:
+            EntryMap entryMap;
+            Entries  entries;
+        };
+
         using BitWidth        = uint8_t;
         using Size            = uint64_t;
         using SwizzleCacheKey = std::tuple<BitWidth, Size, Size>;
         using SwizzleCacheVal = ::Tensor::Manipulation::Tensor;
-        using SwizzleCache    = std::map<SwizzleCacheKey, SwizzleCacheVal>;
+        using SwizzleCache    = LRUCache<SwizzleCacheKey, SwizzleCacheVal>;
         static thread_local SwizzleCache g_swizzleCache;
 
         BitWidth toBitWidth(DataType datatype)
@@ -1922,8 +1981,7 @@ namespace TensileLite
 
                 void* ptr{};
 
-                //if no validation, skip the swizzle
-                if(needSwizzle && m_elementsToValidate != 0)
+                if(needSwizzle)
                 {
                     using Tensor = Tensor::Manipulation::Tensor;
                     // currently, if A then it means MiM = 16, if B then it means MiN = 16


### PR DESCRIPTION
 - Cache swizzled tensor according to its datatype and size, to avoid repeating host side swizzles.
 - An LRUCache was introduced for balancing memory usage and performance.
 - ~~Re-layout will be skipped if validation disabled.~~