### PR TITLE
Support new library logic format

### DIFF
--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -259,11 +259,14 @@ def parseLibraryLogicData(data, srcFile, cxxCompiler, archs=None):
             data["Library"]["indexOrder"] = None
             data["Library"]["table"] = [0, len(data["Solutions"])]
             data["Library"]["distance"] = None
-        elif libraryType == "Matching":
+        else:
+            data["LibraryType"] = "Matching"
             data["Library"] = {}
             data["Library"]["indexOrder"] = data["IndexOrder"]
             data["Library"]["table"] = data["ExactLogic"]
             data["Library"]["distance"] = libraryType
+    else:
+        printExit(f"Library Logic format not recognized")
 
     is_arch_valid = lambda cArch, tArch : (cArch == tArch or cArch == "all")
     if not (archs is None) and "ArchitectureName" in data:
@@ -387,6 +390,7 @@ def parseLibraryLogicList(data, srcFile="?"):
     else:
         printExit("Library logic file {} is missing required field matching property." \
                 .format(srcFile))
+
     if libraryType == "FreeSize":
         rv["LibraryType"] = "FreeSize"
         rv["Library"] = {}
@@ -441,6 +445,8 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
         tileSelection = True
 
     data = {}
+    # LibraryLogicVersion
+    data["LibraryLogicVersion"] = "0.0.0"
     # Tensile version
     data["MinimumRequiredVersion"] = __version__
     # schedule name
@@ -449,7 +455,7 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     # schedule device names
     data["DeviceNames"] = deviceNames
     # default solution (default values for tuning parameters)
-    data["DefaultSolution"] = Common.defaultSolution
+    data["DefaultSolution"] = defaultSolution
     # problem type
     problemTypeState = problemType.state
     problemTypeState["DataType"] = \
@@ -484,8 +490,8 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     # so they are copied to the yaml files
     def removeDefaultVals(params):
         for k in list(params.keys()):
-            if k in Common.defaultSolution.keys():
-                if params[k] == Common.defaultSolution[k]:
+            if k in defaultSolution.keys():
+                if params[k] == defaultSolution[k]:
                     del params[k]
     # solutions
     solutionList = []
@@ -514,9 +520,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     if exactLogic:
         for key in exactLogic:
             exactLogicList.append([list(key), exactLogic[key]])
-        data.append(exactLogicList)
+        data["ExactLogic"] = exactLogicList
     else:
-        data.append(None)
+        data["ExactLogic"] = None
 
     # rangeLogic
     data["RangeLogic"] = rangeLogic
@@ -525,9 +531,9 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
         tileSelectionLogic = {}
         tileSelectionIndices = logicTuple[6]
         tileSelectionLogic["TileSelectionIndices"] = tileSelectionIndices
-        data.append(tileSelectionLogic)
+        data["TileSelection"] = tileSelectionLogic
     else:
-        data.append(None)
+        data["TileSelection"] = None
 
     data["PerfMetric"] = logicTuple[7]
     data["LibraryType"] = libraryType

--- a/tensilelite/Tensile/LibraryIO.py
+++ b/tensilelite/Tensile/LibraryIO.py
@@ -26,7 +26,7 @@ from .CustomKernels import getCustomKernelConfig
 from .SolutionStructs import Solution, ProblemSizes, ProblemType
 from . import SolutionLibrary
 from .CustomYamlLoader import load_yaml_stream
-from .Common import gfxToIsa, printExit, printWarning, print2, versionIsCompatible, __version__
+from .Common import defaultSolution, gfxToIsa, printExit, printWarning, print2, versionIsCompatible, __version__
 
 from typing import NamedTuple, List
 import os
@@ -90,6 +90,8 @@ def writeYAML(filename, data, **kwargs):
         kwargs["explicit_end"] = True
     if "default_flow_style" not in kwargs:
         kwargs["default_flow_style"] = None
+    if "sort_keys" not in kwargs:
+        kwargs["sort_keys"] = False
 
     with open(filename, "w") as f:
         yaml.dump(data, f, **kwargs)
@@ -248,7 +250,20 @@ def parseLibraryLogicFile(filename, cxxCompiler, archs=None):
 def parseLibraryLogicData(data, srcFile, cxxCompiler, archs=None):
     """Parses the data of a library logic file."""
     if isinstance(data, List):
+        # TODO: this can be removed when all logic files have dict format
         data = parseLibraryLogicList(data, srcFile)
+    elif isinstance(data, dict) and "LibraryLogicVersion" in data:
+        libraryType = data["LibraryType"]
+        if libraryType == "FreeSize":
+            data["Library"] = {}
+            data["Library"]["indexOrder"] = None
+            data["Library"]["table"] = [0, len(data["Solutions"])]
+            data["Library"]["distance"] = None
+        elif libraryType == "Matching":
+            data["Library"] = {}
+            data["Library"]["indexOrder"] = data["IndexOrder"]
+            data["Library"]["table"] = data["ExactLogic"]
+            data["Library"]["distance"] = libraryType
 
     is_arch_valid = lambda cArch, tArch : (cArch == tArch or cArch == "all")
     if not (archs is None) and "ArchitectureName" in data:
@@ -270,8 +285,25 @@ def parseLibraryLogicData(data, srcFile, cxxCompiler, archs=None):
     # unpack problemType
     problemType = ProblemType(data["ProblemType"])
 
+    defaultSolutionLibLogic = data.get("DefaultSolution", defaultSolution)
+
     # unpack solution
     def solutionStateToSolution(solutionState, cxxCompiler) -> Solution:
+
+        # If parameter not in yaml, fill with default values
+        if "KernelLanguage" not in solutionState.keys():
+            solutionState["KernelLanguage"] = defaultSolution["KernelLanguage"]
+        if "CustomKernelName" not in solutionState.keys():
+            solutionState["CustomKernelName"] = defaultSolution["CustomKernelName"]
+
+        solutionState["ProblemType"] = data["ProblemType"];
+
+        # Default parameter values in the library logic take priority over ones in Common.py
+        for param, defVal in defaultSolutionLibLogic.items():
+            if param == "SolutionIndex": continue
+            if defaultSolution[param] != defVal:
+                solutionState[param] = defVal
+
         if solutionState["KernelLanguage"] == "Assembly":
             solutionState["ISA"] = gfxToIsa(data["ArchitectureName"])
         else:
@@ -317,11 +349,9 @@ def parseLibraryLogicList(data, srcFile="?"):
                 .format(srcFile, len(data)))
 
     rv = {}
+    rv["LibraryLogicVersion"] = "0.0.0"
     rv["MinimumRequiredVersion"] = data[0]["MinimumRequiredVersion"]
     rv["ScheduleName"] = data[1]
-    rv["DeviceNames"] = data[3]
-    rv["ProblemType"] = data[4]
-    rv["Solutions"] = data[5]
 
     if type(data[2]) is dict:
         rv["ArchitectureName"] = data[2]["Architecture"]
@@ -330,7 +360,19 @@ def parseLibraryLogicList(data, srcFile="?"):
         rv["ArchitectureName"] = data[2]
         rv["CUCount"] = None
 
+    rv["DeviceNames"] = data[3]
+
+    # DefaultSolution Field
+    if len(data) > 12 and data[12]:
+        rv["DefaultSolution"] = data[12]
+    else:
+        rv["DefaultSolution"] = dict(sorted(defaultSolution.items()))
+
+    rv["ProblemType"] = data[4]
+    rv["Solutions"] = data[5]
+
     # TODOBEN: figure out what to do with these...
+    rv["IndexOrder"] = data[6]
     rv["ExactLogic"] = data[7]
     rv["RangeLogic"] = data[8]
 
@@ -398,14 +440,16 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     if len(logicTuple) > 5 and logicTuple[5]:
         tileSelection = True
 
-    data = []
+    data = {}
     # Tensile version
-    data.append({"MinimumRequiredVersion": __version__})
+    data["MinimumRequiredVersion"] = __version__
     # schedule name
-    data.append(schedulePrefix)  # change from Tensile to vega10
-    data.append(architectureName)
+    data["ScheduleName"] = schedulePrefix  # change from Tensile to vega10
+    data["ArchitectureName"] = architectureName
     # schedule device names
-    data.append(deviceNames)
+    data["DeviceNames"] = deviceNames
+    # default solution (default values for tuning parameters)
+    data["DefaultSolution"] = Common.defaultSolution
     # problem type
     problemTypeState = problemType.state
     problemTypeState["DataType"] = \
@@ -433,74 +477,37 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     if "DataTypeMetadata" in problemTypeState:
         problemTypeState["DataTypeMetadata"] = \
                 problemTypeState["DataTypeMetadata"].value
-    data.append(problemTypeState)
+
+    data["ProblemType"] = problemTypeState
+
+    # remove parameters with are set to the default values
+    # so they are copied to the yaml files
+    def removeDefaultVals(params):
+        for k in list(params.keys()):
+            if k in Common.defaultSolution.keys():
+                if params[k] == Common.defaultSolution[k]:
+                    del params[k]
     # solutions
     solutionList = []
     for solution in solutions:
         solutionState = solution.getAttributes()
-        solutionState["ProblemType"] = solutionState["ProblemType"].state
-        solutionState["ProblemType"]["DataType"] = \
-                solutionState["ProblemType"]["DataType"].value
-        solutionState["ProblemType"]["DataTypeA"] = \
-                solutionState["ProblemType"]["DataTypeA"].value
-        solutionState["ProblemType"]["DataTypeB"] = \
-                solutionState["ProblemType"]["DataTypeB"].value
-        solutionState["ProblemType"]["DataTypeE"] = \
-                solutionState["ProblemType"]["DataTypeE"].value
-        solutionState["ProblemType"]["DataTypeAmaxD"] = \
-                solutionState["ProblemType"]["DataTypeAmaxD"].value
-        solutionState["ProblemType"]["DestDataType"] = \
-                solutionState["ProblemType"]["DestDataType"].value
-        solutionState["ProblemType"]["ComputeDataType"] = \
-                solutionState["ProblemType"]["ComputeDataType"].value
-        solutionState["ProblemType"]["BiasDataTypeList"] = \
-                [btype.value for btype in solutionState["ProblemType"]["BiasDataTypeList"]]
-        solutionState["ProblemType"]["ActivationComputeDataType"] = \
-                solutionState["ProblemType"]["ActivationComputeDataType"].value
-        solutionState["ProblemType"]["ActivationType"] = \
-                solutionState["ProblemType"]["ActivationType"].value
-        solutionState["ProblemType"]["F32XdlMathOp"] = \
-                solutionState["ProblemType"]["F32XdlMathOp"].value
-        if "DataTypeMetadata" in solutionState["ProblemType"]:
-            solutionState["ProblemType"]["DataTypeMetadata"] = \
-                    solutionState["ProblemType"]["DataTypeMetadata"].value
+        removeDefaultVals(solutionState)
+        if "ProblemType" in solutionState.keys():
+            del solutionState["ProblemType"]
         solutionList.append(solutionState)
 
     if tileSelection:
         tileSolutions = logicTuple[5]
         for solution in tileSolutions:
             solutionState = solution.getAttributes()
-            solutionState["ProblemType"] = solutionState["ProblemType"].state
-            solutionState["ProblemType"]["DataType"] = \
-                    solutionState["ProblemType"]["DataType"].value
-            solutionState["ProblemType"]["DataTypeA"] = \
-                    solutionState["ProblemType"]["DataTypeA"].value
-            solutionState["ProblemType"]["DataTypeB"] = \
-                    solutionState["ProblemType"]["DataTypeB"].value
-            solutionState["ProblemType"]["DataTypeE"] = \
-                    solutionState["ProblemType"]["DataTypeE"].value
-            solutionState["ProblemType"]["DataTypeAmaxD"] = \
-                    solutionState["ProblemType"]["DataTypeAmaxD"].value
-            solutionState["ProblemType"]["DestDataType"] = \
-                    solutionState["ProblemType"]["DestDataType"].value
-            solutionState["ProblemType"]["ComputeDataType"] = \
-                    solutionState["ProblemType"]["ComputeDataType"].value
-            solutionState["ProblemType"]["BiasDataTypeList"] = \
-                    [btype.value for btype in solutionState["ProblemType"]["BiasDataTypeList"]]
-            solutionState["ProblemType"]["ActivationComputeDataType"] = \
-                    solutionState["ProblemType"]["ActivationComputeDataType"].value
-            solutionState["ProblemType"]["ActivationType"] = \
-                    solutionState["ProblemType"]["ActivationType"].value
-            solutionState["ProblemType"]["F32XdlMathOp"] = \
-                solutionState["ProblemType"]["F32XdlMathOp"].value
-            if "DataTypeMetadata" in solutionState["ProblemType"]:
-                solutionState["ProblemType"]["DataTypeMetadata"] = \
-                    solutionState["ProblemType"]["DataTypeMetadata"].value
+            removeDefaultVals(solutionState)
+            if "ProblemType" in solutionState.keys():
+                del solutionState["ProblemType"]
             solutionList.append(solutionState)
 
-    data.append(solutionList)
+    data["Solutions"] = solutionList
     # index order
-    data.append(indexOrder)
+    data["IndexOrder"] = indexOrder
 
     # exactLogic
     exactLogicList = []
@@ -512,7 +519,7 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
         data.append(None)
 
     # rangeLogic
-    data.append(rangeLogic)
+    data["RangeLogic"] = rangeLogic
 
     if tileSelection:
         tileSelectionLogic = {}
@@ -522,6 +529,6 @@ def createLibraryLogic(schedulePrefix, architectureName, deviceNames, libraryTyp
     else:
         data.append(None)
 
-    data.append(logicTuple[7]) # PerfMetric
-    data.append(libraryType) # LibraryType
+    data["PerfMetric"] = logicTuple[7]
+    data["LibraryType"] = libraryType
     return data

--- a/tensilelite/Tensile/TensileUpdateLibrary.py
+++ b/tensilelite/Tensile/TensileUpdateLibrary.py
@@ -61,33 +61,6 @@ def UpdateLogic(filename, logicPath, outputPath):
     solutionList = []
     for solution in solutions:
         solutionState = solution.getAttributes()
-        solutionState["ProblemType"] = solutionState["ProblemType"].state
-        solutionState["ProblemType"]["DataType"] = \
-                solutionState["ProblemType"]["DataType"].value
-        solutionState["ProblemType"]["DataTypeA"] = \
-                solutionState["ProblemType"]["DataTypeA"].value
-        solutionState["ProblemType"]["DataTypeB"] = \
-                solutionState["ProblemType"]["DataTypeB"].value
-        solutionState["ProblemType"]["DataTypeE"] = \
-                solutionState["ProblemType"]["DataTypeE"].value
-        solutionState["ProblemType"]["DataTypeAmaxD"] = \
-                solutionState["ProblemType"]["DataTypeAmaxD"].value
-        solutionState["ProblemType"]["DestDataType"] = \
-                solutionState["ProblemType"]["DestDataType"].value
-        solutionState["ProblemType"]["ComputeDataType"] = \
-                solutionState["ProblemType"]["ComputeDataType"].value
-        solutionState["ProblemType"]["BiasDataTypeList"] = \
-                [btype.value for btype in solutionState["ProblemType"]["BiasDataTypeList"]]
-        solutionState["ProblemType"]["ActivationComputeDataType"] = \
-                solutionState["ProblemType"]["ActivationComputeDataType"].value
-        solutionState["ProblemType"]["ActivationType"] = \
-                solutionState["ProblemType"]["ActivationType"].value
-        solutionState["ProblemType"]["F32XdlMathOp"] = \
-            solutionState["ProblemType"]["F32XdlMathOp"].value
-        if "DataTypeMetadata" in solutionState["ProblemType"]:
-            solutionState["ProblemType"]["DataTypeMetadata"] = \
-                solutionState["ProblemType"]["DataTypeMetadata"].value
-
         solutionState["ISA"] = list(solutionState["ISA"])
         solutionList.append(solutionState)
 

--- a/tensilelite/Tensile/Utilities/merge.py
+++ b/tensilelite/Tensile/Utilities/merge.py
@@ -30,6 +30,10 @@ import argparse
 from copy import deepcopy
 from enum import IntEnum
 
+sys.path.insert(0, '../')
+
+from Tensile import LibraryIO, Common
+
 verbosity = 1
 
 def ensurePath(path):
@@ -49,8 +53,8 @@ def allFiles(startDir):
     return files
 
 def reindexSolutions(data):
-    for i, _ in enumerate(data[5]):
-        data[5][i]["SolutionIndex"] = i
+    for i, _ in enumerate(data["Solutions"]):
+        data["Solutions"][i]["SolutionIndex"] = i
     return data
 
 def fixSizeInconsistencies(sizes, fileType):
@@ -93,39 +97,39 @@ def addKernel(solutionPool, solution):
 # update dependant parameters if StaggerU == 0
 def sanitizeSolutions(solList):
     for sol in solList:
-        if sol.get("StaggerU") == 0:
+        if sol.get("StaggerU", Common.defaultSolution["StaggerU"]) == 0:
             sol["StaggerUMapping"] = 0
             sol["StaggerUStride"] = 0
             sol["_staggerStrideShift"] = 0
 
 def removeUnusedKernels(oriData, prefix=""):
-    origNumSolutions = len(oriData[5])
+    origNumSolutions = len(oriData["Solutions"])
 
     kernelsInUse = [ index for _, [index, _] in oriData[7] ]
-    for i, solution in enumerate(oriData[5]):
+    for i, solution in enumerate(oriData["Solutions"]):
         solutionIndex = solution["SolutionIndex"]
-        oriData[5][i]["__InUse__"] = True if solutionIndex in kernelsInUse else False
+        oriData["Solutions"][i]["__InUse__"] = True if solutionIndex in kernelsInUse else False
 
     # debug prints
-    for o in [o for o in oriData[5] if o["__InUse__"]==False]:
+    for o in [o for o in oriData["Solutions"] if o["__InUse__"]==False]:
         debug("{}Solution ({}) {} is unused".format(
             prefix,
             o["SolutionIndex"],
             o["SolutionNameMin"] if "SolutionNameMin" in o else "(SolutionName N/A)"))
 
     # filter out dangling kernels
-    oriData[5] = [ {k: v for k, v in o.items() if k != "__InUse__"}
-                    for o in oriData[5] if o["__InUse__"]==True ]
+    oriData["Solutions"] = [ {k: v for k, v in o.items() if k != "__InUse__"}
+                    for o in oriData["Solutions"] if o["__InUse__"]==True ]
 
     # reindex solutions
     idMap = {} # new = idMap[old]
-    for i, solution in enumerate(oriData[5]):
+    for i, solution in enumerate(oriData["Solutions"]):
         idMap[solution["SolutionIndex"]] = i
-        oriData[5][i]["SolutionIndex"] = i
+        oriData["Solutions"][i]["SolutionIndex"] = i
     for i, [size, [oldSolIndex, eff]] in enumerate(oriData[7]):
         oriData[7][i] = [size, [idMap[oldSolIndex], eff]]
 
-    numInvalidRemoved = origNumSolutions - len(oriData[5])
+    numInvalidRemoved = origNumSolutions - len(oriData["Solutions"])
     return oriData, numInvalidRemoved
 
 def loadData(filename):
@@ -136,6 +140,27 @@ def loadData(filename):
         sys.stdout.flush()
         sys.exit(-1)
     data = yaml.load(stream, yaml.SafeLoader)
+
+    # If logic file in list format, convert to dictionary format during load
+    # and write back.
+    if type(data) == list:
+        rv = LibraryIO.parseLibraryLogicList(data, filename)
+        if "Library" in rv.keys():
+            del rv["Library"]
+
+        numKernels=len(rv["Solutions"])
+        for kernel in rv["Solutions"]:
+            for k in list(kernel.keys()):
+                v = kernel[k]
+                if k == 'ProblemType':
+                    del kernel['ProblemType']
+                if k in Common.defaultSolution.keys():
+                    if v == Common.defaultSolution[k]:
+                        del kernel[k]
+
+        LibraryIO.writeYAML(filename, rv, explicit_start=False, explicit_end=False)
+        data = rv
+
     return data
 
 def compareDestFolderToYaml(originalDir, incFile, incData):
@@ -152,8 +177,8 @@ def compareDestFolderToYaml(originalDir, incFile, incData):
 
 def compareProblemType(oriData, incData):
     # ProblemType defined in originalFiles and incrementalFiles
-    oriProblemType = oriData[4] # header
-    incProblemType = incData[4] # header
+    oriProblemType = oriData["ProblemType"] # header
+    incProblemType = incData["ProblemType"] # header
     # Delete waived ProblemType items in originalFiles
     waivedItems = [item for item in oriProblemType if item not in incProblemType]
     if waivedItems:
@@ -161,22 +186,24 @@ def compareProblemType(oriData, incData):
         for item in waivedItems:
             oriProblemType.pop(item)
         # Kernel ProblemType
-        for i, _ in enumerate(oriData[5]):
+        for i, _ in enumerate(oriData["Solutions"]):
             # TODO: delete this for loop if kernel ProblemType is removed in the future
-            oriKernelProblemType = oriData[5][i]["ProblemType"]
+            oriKernelProblemType = oriData["Solutions"][i]["ProblemType"]
             for item in waivedItems:
                 try:
                     oriKernelProblemType.pop(item)
                 except KeyError:
-                    oriSolutionIndex = oriData[5][i]["SolutionIndex"]
+                    oriSolutionIndex = oriData["Solutions"][i]["SolutionIndex"]
                     print(f"[Warning] Popping '{item}' failed in oriData(idx={oriSolutionIndex})")
 
     results = ""
     solIdx = 0
     # Compare existing ProblemType items of originalFiles with incrementalFiles
-    for i, _ in enumerate(incData[5]):
+    for i, _ in enumerate(incData["Solutions"]):
+        # Skip if kernel does not have problem type
+        if "ProblemType" not in incData["Solutions"][i]: continue
         # TODO: check header ProblemType if kernel ProblemType is removed in the future
-        incKernelProblemType = incData[5][i]["ProblemType"]
+        incKernelProblemType = incData["Solutions"][i]["ProblemType"]
         if oriProblemType !=  incKernelProblemType:
             for item in oriProblemType:
                 if oriProblemType[item] != incKernelProblemType[item]:
@@ -185,6 +212,40 @@ def compareProblemType(oriData, incData):
             break
     if (results):
         sys.exit(f"[Error] ProblemType in library logic doesn't match solution(idx={solIdx}): \n{results}")
+
+def syncDefaultParams(origData, incData, origDefaultValues, incDefaultValues):
+
+    # if orig and inc default values are the same, nothing to do
+    if origDefaultValues == incDefaultValues: return
+
+    # Parameters in solutions that need to be updated.
+    # These either had their default values changed, were newly added
+    # or are set to the default values (and can be removed)
+    # Assume incDefaultValues is more up-to-date
+    paramsToUpdate = []
+
+    for p,v in incDefaultValues.items():
+        if p not in origDefaultValues.keys() or origDefaultValues[p] != v:
+            paramsToUpdate.append(p)
+
+    for soln in origData["Solutions"]:
+        for p in paramsToUpdate:
+            # Was originally set to default but not anymore
+            if p in origDefaultValues.keys() and p not in soln.keys():
+                soln[p] = origDefaultValues[p]
+            # Remove any keys which are now considered default-init
+            elif p in soln.keys() and soln[p] == incDefaultValues[p]:
+                del soln[p]
+
+# Check each solution and remove any parameters are set to default value
+def removeDefaultInitParams(data):
+    defaultSolution = data["DefaultSolution"]
+
+    for soln in data["Solutions"]:
+        solnParams = list(soln.keys())
+        for param in solnParams:
+            if param in defaultSolution.keys() and soln[param] == defaultSolution[param]:
+                del soln[param]
 
 # this is for complying the behavior of legacy merge script, where incremental logic
 # file always replaces the base logic file even it's slower in performance -
@@ -318,27 +379,27 @@ def findFastestCompatibleSolution(origDict, sizeMapping):
 
 # returns merged logic data as list
 def mergeLogic(oriData, incData, forceMerge, trimSize=True, addSolutionTags=False, noEff=False):
-    origNumSizes = len(oriData[7])
-    origNumSolutions = len(oriData[5])
+    incData["ExactLogic"] = incData["ExactLogic"] or []
+    origNumSizes = len(oriData["ExactLogic"])
+    origNumSolutions = len(oriData["Solutions"])
 
-    incData[7] = incData[7] or []
-    incNumSizes = len(incData[7])
-    incNumSolutions = len(incData[5])
+    incNumSizes = len(incData["ExactLogic"])
+    incNumSolutions = len(incData["Solutions"])
 
     verbose(origNumSizes, "sizes and", origNumSolutions, "kernels in base logic file")
     verbose(incNumSizes, "sizes and", incNumSolutions, "kernels in incremental logic file")
 
     # Add SolutionTag to distinguish solutions with different requirements
-    origTaggedSizes = addSolutionTagToKeys(oriData[7], oriData[5])
-    incTaggedSizes  = addSolutionTagToKeys(incData[7],  incData[5])
+    origTaggedSizes = addSolutionTagToKeys(oriData["ExactLogic"], oriData["Solutions"])
+    incTaggedSizes  = addSolutionTagToKeys(incData["ExactLogic"],  incData["Solutions"])
     if addSolutionTags:
-        oriData[7] = origTaggedSizes
-        incData[7] = incTaggedSizes
+        oriData["ExactLogic"] = origTaggedSizes
+        incData["ExactLogic"] = incTaggedSizes
     # Print warning if addSolutionTags=False results in removed sizes
     else:
-        origSet       = {tuple(size) for size, [_, _] in oriData[7]}
+        origSet       = {tuple(size) for size, [_, _] in oriData["ExactLogic"]}
         origTaggedSet = {tuple(size) for size, [_, _] in origTaggedSizes}
-        incSet        = {tuple(size) for size, [_, _] in incData[7]}
+        incSet        = {tuple(size) for size, [_, _] in incData["ExactLogic"]}
         incTaggedSet  = {tuple(size) for size, [_, _] in incTaggedSizes}
 
         if len(origSet) != len(origTaggedSet):
@@ -353,20 +414,23 @@ def mergeLogic(oriData, incData, forceMerge, trimSize=True, addSolutionTags=Fals
     if trimSize:
         # trim 8-tuple gemm size format to 4-tuple [m, n, b, k]
         # TODO future gemm size could include dictionary format so need robust preprocessing
-        [oriData[7], origNumSizes] = fixSizeInconsistencies(oriData[7], "base")
-        [incData[7], incNumSizes] = fixSizeInconsistencies(incData[7], "incremental")
+        [oriData["ExactLogic"], origNumSizes] = fixSizeInconsistencies(oriData["ExactLogic"], "base")
+        [incData["ExactLogic"], incNumSizes] = fixSizeInconsistencies(incData["ExactLogic"], "incremental")
 
-    sanitizeSolutions(oriData[5])
-    sanitizeSolutions(incData[5])
+    sanitizeSolutions(oriData["Solutions"])
+    sanitizeSolutions(incData["Solutions"])
     oriData, numOrigRemoved = removeUnusedKernels(oriData, "Base logic file: ")
     incData, numIncRemoved = removeUnusedKernels(incData, "Inc logic file: ")
 
-    solutionPool = deepcopy(oriData[5])
-    solutionMap = deepcopy(oriData[7])
+    solutionPool = deepcopy(oriData["Solutions"])
+    solutionMap = deepcopy(oriData["ExactLogic"])
 
-    origDict = {tuple(origSize): [i, origEff] for i, [origSize, [origIndex, origEff]] in enumerate(oriData[7])}
-    for incSize, [incIndex, incEff] in incData[7]:
-        incSolution = findSolutionWithIndex(incData[5], incIndex)
+    origDict = {tuple(origSize): [i, origEff] for i, [origSize, [origIndex, origEff]] in enumerate(oriData["ExactLogic"])}
+    for incSize, [incIndex, incEff] in incData["ExactLogic"]:
+        incSolution = findSolutionWithIndex(incData["Solutions"], incIndex)
+
+        if "ProblemType" in incSolution.keys():
+            del incSolution["ProblemType"]
 
         storeEff = incEff if noEff == False else 0.0
         try:
@@ -398,12 +462,12 @@ def mergeLogic(oriData, incData, forceMerge, trimSize=True, addSolutionTags=Fals
         solutionMap = removeSolutionTagFromKeys(solutionMap)
 
     mergedData = deepcopy(oriData)
-    mergedData[5] = solutionPool
-    mergedData[7] = solutionMap
+    mergedData["Solutions"] = solutionPool
+    mergedData["ExactLogic"] = solutionMap
     mergedData, numReplaced = removeUnusedKernels(mergedData, "Merged data: ")
 
-    numSizesAdded = len(solutionMap)-len(oriData[7])
-    numSolutionsAdded = len(solutionPool)-len(oriData[5])
+    numSizesAdded = len(solutionMap)-len(oriData["ExactLogic"])
+    numSolutionsAdded = len(solutionPool)-len(oriData["Solutions"])
     numSolutionsRemoved = numReplaced+numOrigRemoved # incremental file not counted
 
     return [mergedData, numSizesAdded, numSolutionsAdded, numSolutionsRemoved]
@@ -439,6 +503,12 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         # For example, merge Gridbased yaml to Equality folder or Equality yaml to GridBased folder
         compareDestFolderToYaml(originalDir, incFile, incData)
 
+        # Original library logic may not have default solution included yet (for now)
+        origDefaultValues = deepcopy(oriData["DefaultSolution"])
+        incDefaultValues = deepcopy(incData["DefaultSolution"])
+
+        syncDefaultParams(oriData, incData, origDefaultValues, incDefaultValues)
+
         # Terminate when ProblemType of originalFiles and incrementalFiles mismatch
         compareProblemType(oriData, incData)
 
@@ -448,10 +518,15 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         incData = reindexSolutions(incData)
 
         mergedData, *stats = mergeLogic(oriData, incData, forceMerge, trimSize, addSolutionTags, noEff)
+        # Replace base default solution with newer version
+        mergedData["DefaultSolution"] = incData["DefaultSolution"]
+
         msg(stats[0], "size(s) and", stats[1], "kernel(s) added,", stats[2], "kernel(s) removed")
 
-        with open(os.path.join(outputPath, basename), "w") as outFile:
-            yaml.safe_dump(mergedData,outFile,default_flow_style=None)
+        # final check of default init parameters, before writing to yaml
+        removeDefaultInitParams(mergedData)
+
+        LibraryIO.writeYAML(os.path.join(outputPath, basename), mergedData, explicit_start=False, explicit_end=False)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 
@@ -480,13 +555,23 @@ def mergePartialLogics(partialLogicFilePaths, outputDir, forceMerge, trimSize=Tr
         msg("Incremental file:", f, "| Merge policy: %s"%("Forced" if forceMerge else "Winner"), "| Trim size:", trimSize)
         incLogicData = loadData(f)
 
+        baseDefaultValues = deepcopy(baseLogicData["DefaultSolution"])
+        incDefaultValues = deepcopy(incLogicData["DefaultSolution"])
+
+        syncDefaultParams(baseLogicData, incLogicData, baseDefaultValues, incDefaultValues)
+
         # So far "SolutionIndex" in logic yamls has zero impact on actual 1-1 size mapping (but the order of the Solution does)
         # since mergeLogic() takes that value very seriously so we reindex them here so it doesn't choke on duplicated SolutionIndex
         baseLogicData = reindexSolutions(baseLogicData)
         incLogicData = reindexSolutions(incLogicData)
 
         mergedData, *stats = mergeLogic(baseLogicData, incLogicData, forceMerge, trimSize, addSolutionTags)
+        # Replace base default solution with newer version
+        mergedData["DefaultSolution"] = incData["DefaultSolution"]
         msg(stats[0], "size(s) and", stats[1], "kernel(s) added,", stats[2], "kernel(s) removed")
+
+        # final check of default init parameters, before writing to yaml
+        removeDefaultInitParams(mergedData)
 
         # Use the merged data as the base data for the next partial logic file
         baseLogicData = deepcopy(mergedData)
@@ -494,8 +579,7 @@ def mergePartialLogics(partialLogicFilePaths, outputDir, forceMerge, trimSize=Tr
 
     baseFileName = os.path.basename(baseLogicFile)
     outputFilePath = os.path.join(outputDir, baseFileName)
-    with open(outputFilePath, "w") as outFile:
-        yaml.safe_dump(baseLogicData, outFile, default_flow_style=None)
+    LibraryIO.writeYAML(outputFilePath, baseLogicData, explicit_start=False, explicit_end=False)
     msg("File written to", outputFilePath)
     msg("------------------------------")
 

--- a/tensilelite/Tensile/Utilities/merge.py
+++ b/tensilelite/Tensile/Utilities/merge.py
@@ -30,9 +30,16 @@ import argparse
 from copy import deepcopy
 from enum import IntEnum
 
-sys.path.insert(0, '../')
+try:
+    from Tensile import Tensile
+except ImportError:
+    import os.path
+    import sys
+    parentdir = os.path.normpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "..", ".."))
+    sys.path.append(parentdir)
 
-from Tensile import LibraryIO, Common
+from Tensile.LibraryIO import writeYAML, parseLibraryLogicList
+from Tensile.Common import defaultSolution
 
 verbosity = 1
 
@@ -144,7 +151,7 @@ def loadData(filename):
     # If logic file in list format, convert to dictionary format during load
     # and write back.
     if type(data) == list:
-        rv = LibraryIO.parseLibraryLogicList(data, filename)
+        rv = parseLibraryLogicList(data, filename)
         if "Library" in rv.keys():
             del rv["Library"]
 
@@ -154,11 +161,11 @@ def loadData(filename):
                 v = kernel[k]
                 if k == 'ProblemType':
                     del kernel['ProblemType']
-                if k in Common.defaultSolution.keys():
-                    if v == Common.defaultSolution[k]:
+                if k in defaultSolution.keys():
+                    if v == defaultSolution[k]:
                         del kernel[k]
 
-        LibraryIO.writeYAML(filename, rv, explicit_start=False, explicit_end=False)
+        writeYAML(filename, rv, explicit_start=False, explicit_end=False)
         data = rv
 
     return data
@@ -167,7 +174,7 @@ def compareDestFolderToYaml(originalDir, incFile, incData):
     checkFolders = ["Equality", "GridBased"]
     # Parsing destination folder and yaml attribute
     destFolder = originalDir.rstrip('/').split('/')[-1]
-    incAttribute = incData[11] # the last item in yaml file
+    incAttribute = incData["LibraryType"] # the last item in yaml file
     if not incAttribute:
         sys.exit(f"[Error] Empty YAML attribute. Need to set Equality or GridBased in {incFile}.")
     # Check Equality and GradBased folders only
@@ -499,6 +506,9 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         oriData = loadData(origFile)
         incData = loadData(incFile)
 
+        if oriData == incData:
+          continue
+
         # Terminate when the destination folder doesn't match Incremental logic yaml
         # For example, merge Gridbased yaml to Equality folder or Equality yaml to GridBased folder
         compareDestFolderToYaml(originalDir, incFile, incData)
@@ -526,7 +536,7 @@ def avoidRegressions(originalDir, incrementalDir, outputPath, forceMerge, trimSi
         # final check of default init parameters, before writing to yaml
         removeDefaultInitParams(mergedData)
 
-        LibraryIO.writeYAML(os.path.join(outputPath, basename), mergedData, explicit_start=False, explicit_end=False)
+        writeYAML(os.path.join(outputPath, basename), mergedData, explicit_start=False, explicit_end=False)
         msg("File written to", os.path.join(outputPath, basename))
         msg("------------------------------")
 
@@ -579,7 +589,7 @@ def mergePartialLogics(partialLogicFilePaths, outputDir, forceMerge, trimSize=Tr
 
     baseFileName = os.path.basename(baseLogicFile)
     outputFilePath = os.path.join(outputDir, baseFileName)
-    LibraryIO.writeYAML(outputFilePath, baseLogicData, explicit_start=False, explicit_end=False)
+    writeYAML(outputFilePath, baseLogicData, explicit_start=False, explicit_end=False)
     msg("File written to", outputFilePath)
     msg("------------------------------")
 


### PR DESCRIPTION
Opening a new PR for https://github.com/ROCm/hipBLASLt/pull/1365 since there have been quite a bit of refactoring work done recently.

This PR makes a few changes to the library logic format and related for simplification purposes:

1. Fields in the library logic are now structured as key-value pairs (previously a list)
2. Removed `ProblemType` field in each solution - the global one is used instead
3. Add a `DefaultSolution` field in each logic file.
4. For each solution, parameters that are set to default their values are omitted in the logic file.
    * During library load, we reference `DefaultSolution` in each logic file to fill in the missing parameter values
5. Add a new field `LibraryLogicVersion` to track any logic file format changes in the future.
6. `merge.py` will automatically convert an older format library logic to the newer format.
7. The current implementation supports library logic in both a list or dictionary format. 
   - I can update all the library logic to the dictionary format in this PR or do it in a separate PR.
