### PR TITLE
Fix pickle copying singleton

### DIFF
--- a/tensilelite/Tensile/TensileInstructions/Base.py
+++ b/tensilelite/Tensile/TensileInstructions/Base.py
@@ -48,6 +48,9 @@ class TensileInstructions:
                 cls._instance._kernelInfo = {}
         return cls._instance
 
+    def __reduce__(self):
+        return (TensileInstructions, ())
+
     @dataclass
     class IsaInfo:
         assemblerPath: str


### PR DESCRIPTION
Prevents any modules or functions which use pickle as backend copy a new instance.