### PR TITLE
Added missing support for bpl==64

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11052,42 +11052,31 @@ class KernelWriterAssembly(KernelWriter):
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
           return rv
-        elif bpl==64:
+        elif bpl==64 and not lds:
           rv = Module("emulated _buffer_load_b512")
           # +0.25
-          dst = None if lds else vgpr(destVgpr, rpv//4)
+          dst = vgpr(destVgpr, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf, comment=comment))
+          
           mubuf2 = MUBUFModifiers(offen=True, offset12=offset+bpl/4, glc=glc, slc=slc, nt=nt, lds=lds)
-          
-          if isinstance(destVgpr, str):
-            dst2 = destVgpr + "+" + str(int(rpv//4))
-          else:       
-            dst2 = int(destVgpr + int(rpv//4))
-          
-          dst = None if lds else vgpr(dst2, rpv//4)          
+          dst2 = destVgpr + "+" + str(int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//4))
+
+          dst = vgpr(dst2, rpv//4)          
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
           #+0.5          
-          mubuf3 = MUBUFModifiers(offen=True, offset12=offset+bpl / 2, glc=glc, slc=slc, nt=nt, lds=lds)          
+          mubuf3 = MUBUFModifiers(offen=True, offset12=offset+bpl / 2, glc=glc, slc=slc, nt=nt, lds=lds)
+          dst3 = destVgpr + "+" + str(int(rpv//2)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//2))
           
-          if isinstance(destVgpr, str):
-            dst3 = destVgpr + "+" + str(int(rpv//2))
-          else:
-            dst3 = int(destVgpr + int(rpv//2))            
-          
-          dst = None if lds else vgpr(dst3, rpv//4)          
+          dst = vgpr(dst3, rpv//4)          
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf3, comment=comment))
           #+0.75
-          mubuf4 = MUBUFModifiers(offen=True, offset12=offset + 3 * (bpl / 4), glc=glc, slc=slc, nt=nt, lds=lds)
+          mubuf4 = MUBUFModifiers(offen=True, offset12=offset + 3 * (bpl / 4), glc=glc, slc=slc, nt=nt, lds=lds)          
+          dst4 = destVgpr + "+" + str(3*int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + 3*int(rpv//4))         
           
-          if isinstance(destVgpr, str):
-            dst4 = destVgpr + "+" + str(3*int(rpv//4))
-          else:
-            dst4 = int(destVgpr + 3*int(rpv//4))
-          
-          dst = None if lds else vgpr(dst4, rpv//4)
+          dst = vgpr(dst4, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf4, comment=comment))        
         else:

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11062,23 +11062,23 @@ class KernelWriterAssembly(KernelWriter):
           mubuf2 = MUBUFModifiers(offen=True, offset12=int(offset + bpl/4), glc=glc, slc=slc, nt=nt, lds=lds)
           dst2 = destVgpr + "+" + str(int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//4))
 
-          dst = vgpr(dst2, rpv//4)          
+          dst = vgpr(dst2, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
-          #+0.5          
+          #+0.5
           mubuf3 = MUBUFModifiers(offen=True, offset12=int(offset + bpl/2), glc=glc, slc=slc, nt=nt, lds=lds)
           dst3 = destVgpr + "+" + str(int(rpv//2)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//2))
           
-          dst = vgpr(dst3, rpv//4)          
+          dst = vgpr(dst3, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf3, comment=comment))
           #+0.75
-          mubuf4 = MUBUFModifiers(offen=True, offset12= int(offset + 3*(bpl/4)), glc=glc, slc=slc, nt=nt, lds=lds)          
-          dst4 = destVgpr + "+" + str(3*int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + 3*int(rpv//4))         
+          mubuf4 = MUBUFModifiers(offen=True, offset12= int(offset + 3*bpl/4), glc=glc, slc=slc, nt=nt, lds=lds)
+          dst4 = destVgpr + "+" + str(3*int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + 3*int(rpv//4))
           
           dst = vgpr(dst4, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
-                                soffset=soffset, mubuf=mubuf4, comment=comment))        
+                                soffset=soffset, mubuf=mubuf4, comment=comment))
         else:
           assert 0, "%s\nchooseGlobalRead: bad bpl %u"%(self.states.kernelName,bpl)
 

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11052,6 +11052,44 @@ class KernelWriterAssembly(KernelWriter):
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
           return rv
+        elif bpl==64:
+          rv = Module("emulated _buffer_load_b256")
+          # +0.25
+          dst = None if lds else vgpr(destVgpr, rpv//4)
+          rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
+                                soffset=soffset, mubuf=mubuf, comment=comment))
+          mubuf2 = MUBUFModifiers(offen=True, offset12=offset+bpl/4, glc=glc, slc=slc, nt=nt, lds=lds)
+          
+          if isinstance(destVgpr, str):
+            dst2 = destVgpr + "+" + str(int(rpv//4))
+          else:       
+            dst2 = int(destVgpr + int(rpv//4))
+          
+          dst = None if lds else vgpr(dst2, rpv//4)          
+          rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
+                                soffset=soffset, mubuf=mubuf2, comment=comment))
+          #+0.5          
+          mubuf3 = MUBUFModifiers(offen=True, offset12=offset+bpl / 2, glc=glc, slc=slc, nt=nt, lds=lds)          
+          
+          if isinstance(destVgpr, str):
+            dst3 = destVgpr + "+" + str(int(rpv//2))
+          else:
+            dst3 = int(destVgpr + int(rpv//2))            
+          
+          dst = None if lds else vgpr(dst3, rpv//4)          
+          rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
+                                soffset=soffset, mubuf=mubuf3, comment=comment))
+          #+0.75
+          mubuf4 = MUBUFModifiers(offen=True, offset12=offset + 3 * (bpl / 4), glc=glc, slc=slc, nt=nt, lds=lds)
+          
+          if isinstance(destVgpr, str):
+            dst4 = destVgpr + "+" + str(3*int(rpv//4))
+          else:
+            dst4 = int(destVgpr + 3*int(rpv//4))
+          
+          dst = None if lds else vgpr(dst4, rpv//4)
+          rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
+                                soffset=soffset, mubuf=mubuf4, comment=comment))        
         else:
           assert 0, "%s\nchooseGlobalRead: bad bpl %u"%(self.states.kernelName,bpl)
 

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11043,7 +11043,7 @@ class KernelWriterAssembly(KernelWriter):
           dst = None if lds else vgpr(destVgpr, rpv//2)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf, comment=comment))
-          mubuf2 = MUBUFModifiers(offen=True, offset12=offset+bpl/2, glc=glc, slc=slc, nt=nt, lds=lds)
+          mubuf2 = MUBUFModifiers(offen=True, offset12=int(offset + bpl/2), glc=glc, slc=slc, nt=nt, lds=lds)
           if isinstance(destVgpr, str):
             dst2 = destVgpr + "+" + str(int(rpv//2))
           elif isinstance(destVgpr, int):
@@ -11059,21 +11059,21 @@ class KernelWriterAssembly(KernelWriter):
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf, comment=comment))
           
-          mubuf2 = MUBUFModifiers(offen=True, offset12=offset+bpl/4, glc=glc, slc=slc, nt=nt, lds=lds)
+          mubuf2 = MUBUFModifiers(offen=True, offset12=int(offset + bpl/4), glc=glc, slc=slc, nt=nt, lds=lds)
           dst2 = destVgpr + "+" + str(int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//4))
 
           dst = vgpr(dst2, rpv//4)          
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
           #+0.5          
-          mubuf3 = MUBUFModifiers(offen=True, offset12=offset+bpl / 2, glc=glc, slc=slc, nt=nt, lds=lds)
+          mubuf3 = MUBUFModifiers(offen=True, offset12=int(offset + bpl/2), glc=glc, slc=slc, nt=nt, lds=lds)
           dst3 = destVgpr + "+" + str(int(rpv//2)) if isinstance(destVgpr, str) else int(destVgpr + int(rpv//2))
           
           dst = vgpr(dst3, rpv//4)          
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \
                                 soffset=soffset, mubuf=mubuf3, comment=comment))
           #+0.75
-          mubuf4 = MUBUFModifiers(offen=True, offset12=offset + 3 * (bpl / 4), glc=glc, slc=slc, nt=nt, lds=lds)          
+          mubuf4 = MUBUFModifiers(offen=True, offset12= int(offset + 3*(bpl/4)), glc=glc, slc=slc, nt=nt, lds=lds)          
           dst4 = destVgpr + "+" + str(3*int(rpv//4)) if isinstance(destVgpr, str) else int(destVgpr + 3*int(rpv//4))         
           
           dst = vgpr(dst4, rpv//4)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -11053,7 +11053,7 @@ class KernelWriterAssembly(KernelWriter):
                                 soffset=soffset, mubuf=mubuf2, comment=comment))
           return rv
         elif bpl==64:
-          rv = Module("emulated _buffer_load_b256")
+          rv = Module("emulated _buffer_load_b512")
           # +0.25
           dst = None if lds else vgpr(destVgpr, rpv//4)
           rv.add(BufferLoadB128(dst=dst, vaddr=addr0, saddr=addr1, \


### PR DESCRIPTION
**Symptom:** Error message of this kind:
AssertionError: Cijk_Ailk_Bljk.....
chooseGlobalRead: bad bpl 64
**Reason:** There is no condition handler for the case of 
bpl==64 (bytes) in the fille **KernelWriterAssembly.py**
**Occurrence:** The use of such is not very common and has been encountered for grid generating routine for I8II data type in several "cat" scripts
**How to reproduce:**
sudo bash run_I8II_NN_cat34.sh
for attached files (extensions changed to "txt")
I8II_NN_cat34.yaml
run_I8II_NN_cat34.sh
Validation:
The successful validation for the proposed solution has been logged in "I8II_NN_cat34-tensileliteVALIDM1.log", attached to this pull request. Can be reproduced for the very same scenario with 
**NumElementsToValidate: -1**

[I8II_NN_cat34-tensileliteVALIDM1.log](https://github.com/user-attachments/files/19070428/I8II_NN_cat34-tensileliteVALIDM1.log)
[I8II_NN_cat34.txt](https://github.com/user-attachments/files/19070435/I8II_NN_cat34.txt)

[run_I8II_NN_cat34.txt](https://github.com/user-attachments/files/19070444/run_I8II_NN_cat34.txt)
