### PR TITLE
Corrected incomplete&wrong condition in Pass.py for empty list range

### DIFF
--- a/tensilelite/Tensile/TensileInstructions/Pass.py
+++ b/tensilelite/Tensile/TensileInstructions/Pass.py
@@ -117,8 +117,8 @@ def _addRegToGraph(item, assignmentDict, params: list, graph, noOpt):
             if p.regType == "acc":
                 continue
             for i in range(p.regIdx, p.regIdx + p.regNum):                 
-                # Checks out of range
-                if i >= len(graph[p.regType]):
+                # Checks out of range               
+                if i not in graph[p.regType]:                                       
                     continue
                 # Does it exists?            
                 if not graph[p.regType][i]:

--- a/tensilelite/Tensile/TensileInstructions/Pass.py
+++ b/tensilelite/Tensile/TensileInstructions/Pass.py
@@ -116,9 +116,16 @@ def _addRegToGraph(item, assignmentDict, params: list, graph, noOpt):
             _setName2RegNum(p, assignmentDict)
             if p.regType == "acc":
                 continue
-            for i in range(p.regIdx, p.regIdx + p.regNum):
-                if graph[p.regType][i] and graph[p.regType][i][-1] == item:
+            for i in range(p.regIdx, p.regIdx + p.regNum):                 
+                # Checks out of range
+                if i >= len(graph[p.regType]):
                     continue
+                # Does it exists?            
+                if not graph[p.regType][i]:
+                    continue
+                # Whether to append?
+                if graph[p.regType][i][-1] == item:
+                    continue                
                 # print("[%s] Index %d %d" %(p.regType, i, len(graph[p.regType])))
                 if noOpt:
                     graph[p.regType][i].append(NoOptItem(item))


### PR DESCRIPTION
**Error:**

Index Error: List index out of range in
tensilelite/Tensile/TensileInstrictions/Pass.py
(c.f. screenshot below)
**Symptom:**
Wrong and incomplete condition in 
line : 134
if graph[p.regType][i] and graph[p.regType][i][-1] == item:

**Detail:**
It happens in a workaround code placed earlier to avoid appending to non-existing reg range or already appended item
**How to reproduce:**
It has been first encountered, when TuningDriver has been used to generate solution grid for I8II data type (not added yet) by following instructions in https://github.amd.com/MLSE-Math-Lib/TuningDriver/blob/develop/docs/GridTuning.md 

It can be reproduced by running for a command for the attached files
sudo bash run_I8II_NN_cat293.sh
for the attached files (the file extensions have been modified to "txt")
run_I8II_NN_cat293.sh
I8II_NN_cat293.yaml
[run_I8II_NN_cat293.txt](https://github.com/user-attachments/files/19070668/run_I8II_NN_cat293.txt)

**Solution:**
The proposed solution passed for the very same scenario given above with modified parameter in the yaml
NumElementsToValidate: -1

![image](https://github.com/user-attachments/assets/9cbd29b1-f113-491d-ab11-047704bc614a)
[I8II_NN_cat293.txt](https://github.com/user-attachments/files/19070673/I8II_NN_cat293.txt)
