### PR TITLE
Added assert support for Int32

### DIFF
--- a/tensilelite/Tensile/Components/GlobalWriteBatch.py
+++ b/tensilelite/Tensile/Components/GlobalWriteBatch.py
@@ -1243,7 +1243,8 @@ class GlobalWriteBatchWriter:
         for vi in range(0, self.gwvw):
           inputVgpr = dataBias + + (0 if self.factorDim else vi)
           sumIdxV   = self.ss.elementSumIdx[elementIdx] + vi
-          if self.kernel["ProblemType"]["ComputeDataType"].isSingle():
+          if self.kernel["ProblemType"]["ComputeDataType"].isSingle() or self.kernel["ProblemType"]["ComputeDataType"].isInt32():
+  
             vgprIdx = sumIdxV - self.parentWriter.states.c.startVgprValu
             vgprDst = (self.activationSetPCStruct.vgprActCopy + vi) if mergeActFuncCall else "ValuC+%d"%vgprIdx
             # Generate single f32 code if edge is detected.

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -10058,7 +10058,8 @@ class KernelWriterAssembly(KernelWriter):
         isSingleKernel and \
         ((kernel["ProblemType"]["DataTypeA"].numRegisters() <= kernel["ProblemType"]["DataType"].numRegisters()) or \
         (kernel["ProblemType"]["DataTypeB"].numRegisters() <= kernel["ProblemType"]["DataType"].numRegisters())):
-        assert(kernel["ProblemType"]["ComputeDataType"].isSingle())
+        assert(kernel["ProblemType"]["ComputeDataType"].isSingle() or kernel["ProblemType"]["ComputeDataType"].isInt32())
+
         sgprScaleA = self.sgprPool.checkOut(1, preventOverflow=False)
         sgprScaleB = self.sgprPool.checkOut(1, preventOverflow=False)
         for i,name in enumerate(['A','B']):
@@ -10315,7 +10316,8 @@ class KernelWriterAssembly(KernelWriter):
       if kernel["ProblemType"]["UseScaleAB"] == "Scalar" and ((kernel["GlobalSplitU"] == 1 or kernel["StreamK"] > 0) or kernel["_GlobalAccumulation"] == 'MultipleBufferSingleKernel') and \
         ((kernel["ProblemType"]["DataTypeA"].numRegisters() <= kernel["ProblemType"]["DataType"].numRegisters()) or \
         (kernel["ProblemType"]["DataTypeB"].numRegisters() <= kernel["ProblemType"]["DataType"].numRegisters())):
-        assert(kernel["ProblemType"]["ComputeDataType"].isSingle())
+        assert(kernel["ProblemType"]["ComputeDataType"].isSingle() or kernel["ProblemType"]["ComputeDataType"].isInt32())
+
         newAlphaVgpr = self.vgprPool.checkOut(1)
         module.add(VMovB32(dst=vgpr(newAlphaVgpr), src=sgpr("Alpha")))
         module.add(SWaitCnt(lgkmcnt=0, kmcnt=0, comment="wait for scaleAB load"))


### PR DESCRIPTION
**Errors:**
1.
Failed assertions of those kinds
" assert(kernel["ProblemType"]["ComputeDataType"].isSingle())
AssertionError"
2. Throws messages of those kinds
Unsupported bias compute data type
**Details:**
not needed
**Symptom:**
The code in

1. First error (c.f. Errors) is triggered  by lines 10056,10314  

in

C:\Users\mgeorgie\Downloads\ticket\KernelWriterAssembly_mod.py
2. Second error (c.f. Errors) is triggered by line 1263 in
hipBLASLt/tensilelite/Tensile/Components/GlobalWriteBatch.py

**How to reproduce:**
It has been first encountered, when TuningDriver has been used to generate solution grid for I8II data type (not added yet) by following instructions in https://github.amd.com/MLSE-Math-Lib/TuningDriver/blob/develop/docs/GridTuning.md 

It can be reproduced by running for a command 
sudo ~/Tensile/bin/TensileCreateLibrary --code-object-version=4 --library-format=msgpack ~/merged ~/tensile HIP
for the attached files (the files have been zipped into ticket_yaml_files.zip due to the big size)
aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_Bias_HAS_SAV_UserArgs.yaml
aquavanjaram_Cijk_Ailk_Bljk_I8II_BH_UserArgs.yaml

[ticket_yaml_files.zip](https://github.com/user-attachments/files/19070923/ticket_yaml_files.zip)

