### PR TITLE
solution proposed with small polish in client.cpp

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -419,15 +419,15 @@ try
 
         ("c_type",
          value<std::string>(&c_type), "Precision of matrix C. "
-         "Options: f32_r,f16_r,bf16_r,i8_r")
+         "Options: f32_r, f16_r, bf16_r, i8_r, i32_r")
 
         ("d_type",
          value<std::string>(&d_type), "Precision of matrix D. "
-        "Options: f32_r,f16_r,bf16_r,i8_r")
+        "Options: f32_r, f16_r, bf16_r, i8_r, i32_r")
 
         ("compute_type",
          value<std::string>(&compute_type)->default_value("f32_r"), "Precision of computation. "
-         "Options: s,f32_r,x,xf32_r,f64_r,i32_r")
+         "Options: s, f32_r, x, xf32_r, f64_r, i32_r")
 
         ("compute_input_typeA",
          value<std::string>(&compute_input_typeA), "Precision of computation input A. "
@@ -504,7 +504,7 @@ try
 
         ("bias_type",
          value<std::string>(&bias_type), "Precision of bias vector."
-        "Options: f16_r,bf16_r,f32_r,default(same with D type)")
+        "Options: f16_r, bf16_r, f32_r, i32_r, default(same with D type - d_type)")
 
         ("bias_source",
          value<std::string>(&bias_source)->default_value("d"),

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -1056,8 +1056,10 @@ hipDataType derive_unset_bias_type(const Arguments& arg)
         {
             real_bias_type = arg.d_type;
         }
-    }
-
+    }     
+    else if(arg.compute_type == HIPBLAS_COMPUTE_32I && arg.bias_type == HIP_R_32F) //if bias_type equals to default (HIP_R_32_F)    
+         real_bias_type = HIP_R_32I; // default should be arg.d_type
+    
     if(supported_bias_types.count(real_bias_type) == 0)
         throw std::invalid_argument("Invalid bias type "
                                     + std::string(hip_datatype_to_string(real_bias_type)));


### PR DESCRIPTION
**Details:** There is a nested confusion for the default bias type (bias_type)  when I8II data format scheme is used

**Symptom:**

hipblaslt-bench client confuses the default bias type (bias_type) for I8II data format scheme
for 32-bit float (f32_r) instead of (i32_r) (c.f screenshot below, highlighted text)
![image](https://github.com/user-attachments/assets/e5bd85c7-18bc-41ff-93c4-ad68097e202c)

**HOW TO REPRODUCE**

Run hipblaslt-bench for I8II kernel scheme
e.g. 
hipblaslt-bench --yaml ./bias_tests.yaml 
where 
bias_tests.yaml is a file with an exemplary test line as follows

- {function: matmul, transA: N, transB: N, a_type: i8_r, b_type: i8_r, c_type: i32_r, d_type: i32_r, scale_type: i32_r, compute_type: c_i32_r, bias_type: i32_r, M: 7, N: 16, K: 2048, ldc: 7, ldd: 7, lda: 7, ldb: 2048, initialization: rand_int, alpha: 1, beta: 1, iters: 406009, cold_iters: 406009}

**SOLUTION**
a solution is given for mixed default type in testing_matmul.hpp
a mild polishing is added in the helper, where additional optional data type added for i32_r
**VALIDATION**

![image](https://github.com/user-attachments/assets/fdca7a06-c4d1-4416-9345-161308fe4825)

 
