### PR TITLE
Accept more code object versions

### DIFF
--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -112,7 +112,7 @@ def addCommonArguments(argParser):
     argParser.add_argument("--runtime-language", dest="RuntimeLanguage", \
         choices=["HIP", "OCL"], help="override which runtime language to use")
     argParser.add_argument("--code-object-version", dest="CodeObjectVersion", \
-        choices=["default", "V4", "V5"], help="HSA code-object version")
+        choices=["default", "V4", "V5", "4", "5"], help="HSA code-object version")
     argParser.add_argument("-v", "--verbose", action="store_true", \
         help="set PrintLevel=2")
     argParser.add_argument("--debug", dest="debug", action="store_true", \

--- a/tensilelite/Tensile/TensileCreateLibrary.py
+++ b/tensilelite/Tensile/TensileCreateLibrary.py
@@ -520,7 +520,7 @@ def TensileCreateLibrary():
   argParser.add_argument("--cmake-cxx-compiler",     dest="CmakeCxxCompiler",  action="store")
   argParser.add_argument("--offload-bundler",        dest="OffloadBundler",    action="store", default=ToolchainDefaults.OFFLOAD_BUNDLER)
   argParser.add_argument("--assembler",              dest="Assembler",         action="store", default=ToolchainDefaults.ASSEMBLER)
-  argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5"], action="store")
+  argParser.add_argument("--code-object-version",    dest="CodeObjectVersion", choices=["default", "V4", "V5", "4", "5"], action="store")
   argParser.add_argument("--architecture",           dest="Architecture",      type=str, action="store", default="all", help="Supported archs: " + " ".join(architectureMap.keys()))
   argParser.add_argument("--merge-files",            dest="MergeFiles",        action="store_true")
   argParser.add_argument("--no-merge-files",         dest="MergeFiles",        action="store_false")

--- a/tensilelite/Tensile/TensileInstructions/Base.py
+++ b/tensilelite/Tensile/TensileInstructions/Base.py
@@ -191,9 +191,9 @@ def getSlcBitName(hasGLCModifier):
   return "sc1"
 
 def getCOVFromParam(versionString):
-  if versionString == "default" or versionString == "V4":
+  if versionString == "default" or versionString == "V4" or versionString == "4":
     return 4
-  elif versionString == "V5":
+  elif versionString == "V5" or versionString == "5":
     return 5
   printExit("Unknown CodeObjectVersion %s" % (versionString))
 


### PR DESCRIPTION
Update 6.4 release to include "4" and "5" for `--code-object-version`

Testing was conducting with gfx1101 target
Test 1: `./install.sh -dc -a gfx1101`
- Passes `--code-object-version=default` to TensileCreateLibrary and shows `# Code Object Version: default`
- Build succeeds

Test 2: `cmake ... -DAMDGPU_TARGETS="gfx1101" -DTensile_CODE_OBJECT_VERSION=4 ...`
- Passes `--code-object-version=4` to TensileCreateLibrary and shows `# Code Object Version: 4`
- Build succeeds