### PR TITLE
Restore default and other co versions

### DIFF
--- a/tensilelite/Tensile/Common/Constants.py
+++ b/tensilelite/Tensile/Common/Constants.py
@@ -1,3 +1,13 @@
+# Map for converting between Tensile-accepted co version strings
+# and code object versions accepted by the compiler.
+coVersionMap = {
+    "4": "4",
+    "V4": "4",
+    "5": "5",
+    "V5": "5",
+    "default": "4",
+}
+
 # Subdirectories for Tensile build artifacts
 CLIENT_BUILD_DIR: str = "0_Build"
 BENCHMARK_PROBLEMS_DIR: str = "1_BenchmarkProblems"

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -31,7 +31,8 @@ import os
 import sys
 import argparse
 from .Common import globalParameters, print1, printExit, printWarning, ensurePath, \
-    assignGlobalParameters, restoreDefaultGlobalParameters, HR, __version__, LIBRARY_LOGIC_DIR
+    assignGlobalParameters, restoreDefaultGlobalParameters, HR, __version__, LIBRARY_LOGIC_DIR, \
+    coVersionMap
 from .Toolchain.Assembly import AssemblyToolchain
 from .Toolchain.Source import SourceToolchain
 from .Toolchain.Validators import validateToolchain, ToolchainDefaults
@@ -141,7 +142,7 @@ def addCommonArguments(argParser):
     argParser.add_argument("--runtime-language", dest="RuntimeLanguage", \
         choices=["HIP", "OCL"], help="override which runtime language to use")
     argParser.add_argument("--code-object-version", dest="CodeObjectVersion", \
-        choices=["4", "5"], action="store", default="4", help="HSA code-object version")
+        choices=["4", "5", "V4", "V5", "default"], action="store", default="4", help="HSA code-object version")
     argParser.add_argument("-v", "--verbose", action="store_true", \
         help="set PrintLevel=2")
     argParser.add_argument("--debug", dest="debug", action="store_true", \
@@ -363,6 +364,8 @@ def Tensile(userArgs):
         globalParameters['LogicFormat'] = args.LogicFormat
     if args.LibraryFormat:
         globalParameters['LibraryFormat'] = args.LibraryFormat
+    globalParameters['CodeObjectVersion'] = coVersionMap[args.CodeObjectVersion]
+    print1(f"# Code Object Version: {globalParameters['CodeObjectVersion']}")
 
     # default config format
     if not altFormat:

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -26,7 +26,7 @@ import os
 from argparse import ArgumentParser
 from typing import Any, Dict, List, Optional
 
-from Tensile.Common import architectureMap
+from Tensile.Common import architectureMap, coVersionMap
 from Tensile.Toolchain.Validators import ToolchainDefaults
 
 
@@ -74,7 +74,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     argParser.add_argument(
         "--code-object-version",
         dest="CodeObjectVersion",
-        choices=["4", "5"],
+        choices=["4", "5", "V4", "V5", "default"],
         default="4",
         action="store",
     )
@@ -194,7 +194,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
 
     arguments = {}
     arguments["RuntimeLanguage"] = args.RuntimeLanguage
-    arguments["CodeObjectVersion"] = args.CodeObjectVersion
+    arguments["CodeObjectVersion"] = coVersionMap[args.CodeObjectVersion]
     arguments["Architecture"] = args.Architecture
     arguments["LazyLibraryLoading"] = args.LazyLibraryLoading
     arguments["EnableMarker"] = args.EnableMarker


### PR DESCRIPTION
Restoring "default", "V4", and "V5" options for `--code-object-version` until ROCm 7.0.

Testing was conducting with gfx1101 target
Test 1: `./install.sh -dc -a gfx1101`
- Passes `--code-object-version=4` to TensileCreateLibrary and shows `# Code Object Version: 4`
- Build succeeds

Test 2: `cmake ... -DAMDGPU_TARGETS="gfx1101" -DTensile_CODE_OBJECT_VERSION="default" ...`
- Passes `--code-object-version=default` to TensileCreateLibrary and shows `# Code Object Version: 4`
- Build succeeds