### PR TITLE
Add missing f8 macro guards

### DIFF
--- a/clients/gtest/hipblaslt_gtest_ext_op.cpp
+++ b/clients/gtest/hipblaslt_gtest_ext_op.cpp
@@ -465,12 +465,14 @@ TEST_P(ExtOpAMaxWithScaleTest, amaxSuccess)
                                                            testdata.n,
                                                            "94\\d");
     }
+#ifdef ROCM_USE_FLOAT8
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_32F
        && testdata.scaleType == HIP_R_8F_E4M3)
     {
         AMaxTestWithScale<float, float, hipblaslt_f8>(
             testdata.type, testdata.dtype, testdata.scaleType, testdata.initMethod, testdata.m, testdata.n, "95?");
     }
+#endif
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_32F
             && testdata.scaleType == HIP_R_8F_E5M2_FNUZ)
     {
@@ -482,12 +484,14 @@ TEST_P(ExtOpAMaxWithScaleTest, amaxSuccess)
                                                             testdata.n,
                                                             "94//d");
     }
+#ifdef ROCM_USE_FLOAT8
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_32F
             && testdata.scaleType == HIP_R_8F_E5M2)
     {
         AMaxTestWithScale<float, float, hipblaslt_bf8>(
             testdata.type, testdata.dtype, testdata.scaleType, testdata.initMethod, testdata.m, testdata.n, "95?");
     }
+#endif
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_16F
             && testdata.scaleType == HIP_R_8F_E4M3_FNUZ)
     {
@@ -499,12 +503,14 @@ TEST_P(ExtOpAMaxWithScaleTest, amaxSuccess)
                                                                    testdata.n,
                                                                    "94//d");
     }
+#ifdef ROCM_USE_FLOAT8
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_16F
             && testdata.scaleType == HIP_R_8F_E4M3)
     {
         AMaxTestWithScale<float, hipblasLtHalf, hipblaslt_f8>(
             testdata.type, testdata.dtype, testdata.scaleType, testdata.initMethod, testdata.m, testdata.n, "95?");
     }
+#endif
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_16F
             && testdata.scaleType == HIP_R_8F_E5M2_FNUZ)
     {
@@ -516,12 +522,14 @@ TEST_P(ExtOpAMaxWithScaleTest, amaxSuccess)
                                                                     testdata.n,
                                                                     "94//d");
     }
+#ifdef ROCM_USE_FLOAT8
     else if(testdata.type == HIP_R_32F && testdata.dtype == HIP_R_16F
             && testdata.scaleType == HIP_R_8F_E5M2)
     {
         AMaxTestWithScale<float, hipblasLtHalf, hipblaslt_bf8>(
             testdata.type, testdata.dtype, testdata.scaleType, testdata.initMethod, testdata.m, testdata.n, "95?");
     }
+#endif
 }
 
 TEST_P(ExtOpSoftmaxUnsupportedDatatypeTest, softmaxFailureUnsupportedDatatype)

--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -481,8 +481,11 @@ hipblasStatus_t hipblasltAMaxWithScaleRun(const hipDataType datatype,
                                           hipStream_t       stream)
 {
     if(datatype != HIP_R_32F
-       || scaleDatatype != HIP_R_8F_E4M3_FNUZ && scaleDatatype != HIP_R_8F_E5M2_FNUZ 
-          && scaleDatatype != HIP_R_8F_E4M3 && scaleDatatype != HIP_R_8F_E5M2)
+       || scaleDatatype != HIP_R_8F_E4M3_FNUZ && scaleDatatype != HIP_R_8F_E5M2_FNUZ
+#ifdef ROCM_USE_FLOAT8
+          && scaleDatatype != HIP_R_8F_E4M3 && scaleDatatype != HIP_R_8F_E5M2
+#endif
+      )
     {
         return HIPBLAS_STATUS_NOT_SUPPORTED;
     }


### PR DESCRIPTION
Add f8 macro guards for older rocm builds without ocp f8 support.