### PR TITLE
Add Gaussian input initialization and raise the accuracy bar

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -444,7 +444,7 @@ try
         ("initialization",
          value<std::string>(&initialization)->default_value("hpl"),
          "Initialize matrix data."
-         "Options: rand_int, trig_float, hpl(floating), special, zero")
+         "Options: rand_int, trig_float, hpl(floating), special, zero, norm_dist")
 
         ("transA",
          value<char>(&arg.transA)->default_value('N'),

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -30,8 +30,6 @@
 #include "hipblaslt_random.hpp"
 #include "hipblaslt_test.hpp"
 #include <hipblaslt/hipblaslt.h>
-#include <rocrand/rocrand.h>
-#include <rocrand/rocrand_kernel.h>
 
 template <typename T, typename F>
 __global__ void fill_kernel(T* A, size_t size, size_t offset, F f)
@@ -200,11 +198,11 @@ void hipblaslt_init_device(ABC                      abc,
         case hipblaslt_initialization::norm_dist:
             {
                 std::random_device rd;
-                unsigned long base_seed = rd(); // Get a random seed for each run
+                auto base_seed = rd(); // Get a random seed for each run
                 fill_batch(A, M, N, lda, stride, batch_count, [base_seed] __device__ (size_t idx) -> T {
-                    rocrand_state_philox4x32_10 state;
-                    rocrand_init(base_seed + idx, 0, 0, &state);
-                    return T(rocrand_normal(&state));
+                    hipblaslt_norm_dist::XorwowState state;
+                    hipblaslt_norm_dist::init_xorwow(&state, base_seed + idx); // Unique seed per thread
+                    return T(hipblaslt_norm_dist::box_muller_normal(&state));
                 });
                 break;
             }

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -30,6 +30,8 @@
 #include "hipblaslt_random.hpp"
 #include "hipblaslt_test.hpp"
 #include <hipblaslt/hipblaslt.h>
+#include <rocrand/rocrand.h>
+#include <rocrand/rocrand_kernel.h>
 
 template <typename T, typename F>
 __global__ void fill_kernel(T* A, size_t size, size_t offset, F f)
@@ -195,6 +197,17 @@ void hipblaslt_init_device(ABC                      abc,
         case hipblaslt_initialization::zero:
             fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T { return T(0); });
             break;
+        case hipblaslt_initialization::norm_dist:
+            {
+                std::random_device rd;
+                unsigned long base_seed = rd(); // Get a random seed for each run
+                fill_batch(A, M, N, lda, stride, batch_count, [base_seed] __device__ (size_t idx) -> T {
+                    rocrand_state_philox4x32_10 state;
+                    rocrand_init(base_seed + idx, 0, 0, &state);
+                    return T(rocrand_normal(&state));
+                });
+                break;
+            }
         default:
             hipblaslt_cerr << "Error type in hipblaslt_init_device" << std::endl;
             break;

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -30,8 +30,6 @@
 #include "hipblaslt_random.hpp"
 #include "hipblaslt_test.hpp"
 #include <hipblaslt/hipblaslt.h>
-#include <rocrand/rocrand.h>
-#include <rocrand/rocrand_kernel.h>
 
 template <typename T, typename F>
 __global__ void fill_kernel(T* A, size_t size, size_t offset, F f)

--- a/clients/include/allclose.hpp
+++ b/clients/include/allclose.hpp
@@ -103,8 +103,8 @@ bool allclose_check_general(char    allclose_type,
         }
     }
 
-    std::vector<double> atols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
-    std::vector<double> rtols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> atols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> rtols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
     for(auto& atol : atols)
     {
         for(auto& rtol : rtols)
@@ -159,8 +159,8 @@ bool allclose_check_general(char    allclose_type,
         }
     }
 
-    std::vector<double> atols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
-    std::vector<double> rtols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> atols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> rtols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
     for(auto& atol : atols)
     {
         for(auto& rtol : rtols)
@@ -215,8 +215,8 @@ bool allclose_check_general(char    allclose_type,
         }
     }
 
-    std::vector<double> atols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
-    std::vector<double> rtols{1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> atols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
+    std::vector<double> rtols{1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1};
     for(auto& atol : atols)
     {
         for(auto& rtol : rtols)

--- a/clients/include/hipblaslt_datatype2string.hpp
+++ b/clients/include/hipblaslt_datatype2string.hpp
@@ -38,6 +38,7 @@ enum class hipblaslt_initialization
     hpl        = 333,
     special    = 444,
     zero       = 555,
+    norm_dist  = 666,
 };
 
 typedef enum class _hipblaslt_activation_type
@@ -114,6 +115,8 @@ constexpr auto hipblaslt_initialization2string(hipblaslt_initialization init)
         return "special";
     case hipblaslt_initialization::zero:
         return "zero";
+    case hipblaslt_initialization::norm_dist:
+        return "norm_dist";
     }
     return "invalid";
 }
@@ -133,6 +136,7 @@ inline hipblaslt_initialization string2hipblaslt_initialization(const std::strin
         value == "hpl"        ? hipblaslt_initialization::hpl        :
         value == "special"    ? hipblaslt_initialization::special    :
         value == "zero"       ? hipblaslt_initialization::zero       :
+        value == "norm_dist"  ? hipblaslt_initialization::norm_dist  :
         static_cast<hipblaslt_initialization>(0);
 }
 // clang-format on

--- a/clients/include/hipblaslt_random.hpp
+++ b/clients/include/hipblaslt_random.hpp
@@ -384,3 +384,51 @@ inline std::string random_string(size_t n)
     }
     return str;
 }
+
+namespace hipblaslt_norm_dist {
+    // XORWOW state structure
+    struct XorwowState {
+        unsigned int x[5];
+        unsigned int counter;
+    };
+
+    // Device function to initialize XORWOW state
+    __device__ void init_xorwow(XorwowState* state, unsigned int seed) {
+        unsigned int s = seed;
+        for (int i = 0; i < 5; ++i) {
+            s = s * 69069 + (i + 1); // Scramble seed
+            state->x[i] = s;
+        }
+        state->counter = seed ^ 362437;
+    }
+
+    // Device function for XORWOW RNG
+    __device__ unsigned int xorwow_rand(XorwowState* state) {
+        unsigned int t = state->x[4];
+        unsigned int s = state->x[0];
+        state->x[4] = state->x[3];
+        state->x[3] = state->x[2];
+        state->x[2] = state->x[1];
+        state->x[1] = s;
+        t ^= t >> 2;
+        t ^= t << 1;
+        state->x[0] = t ^ s ^ (s << 4);
+        state->counter += 362437;
+        return state->x[0] + state->counter;
+    }
+
+    // Device function for uniform distribution
+    __device__ float xorwow_uniform(XorwowState* state) {
+        return xorwow_rand(state) / 4294967296.0f;
+    }
+
+    // Device function for Box-Muller normal distribution
+    __device__ float box_muller_normal(XorwowState* state) {
+        float u1 = xorwow_uniform(state);
+        float u2 = xorwow_uniform(state);
+        if (u1 < 1e-10f) u1 = 1e-10f;
+        float r = sqrtf(-2.0f * logf(u1));
+        float theta = 2.0f * 3.1415926535f * u2;
+        return r * cosf(theta);
+    }
+}

--- a/clients/include/hipblaslt_random.hpp
+++ b/clients/include/hipblaslt_random.hpp
@@ -385,6 +385,8 @@ inline std::string random_string(size_t n)
     return str;
 }
 
+/* ============================================================================================ */
+/*! \brief  Random number generator which generates random values in normal distribution N(0,1) */
 namespace hipblaslt_norm_dist {
     // XORWOW state structure
     struct XorwowState {


### PR DESCRIPTION
Features
- Add gaussian distribution N(0,1) to input initialization
- Add 1e-6 to the accuracy bar list

Test:
- Local build is fine
- hipblaslt-test passed
  -  [  PASSED  ] 53599 tests.
     hipBLASLt version: 1300
- hipblaslt-bench test
  - script: ```./clients/staging/hipblaslt-bench --precision f32_r -v --initialization norm_dist```
  - Result: `[0]:Is supported 1 / Total solutions: 1
[0]:transA,transB,grouped_gemm,batch_count,m,n,k,alpha,lda,stride_a,beta,ldb,stride_b,ldc,stride_c,ldd,stride_d,a_type,b_type,c_type,d_type,compute_type,scaleA,scaleB,scaleC,scaleD,amaxD,activation_type,bias_vector,bias_type,hipblaslt-Gflops,hipblaslt-GB/s,us,CPU-Gflops,CPU-us,norm_error,atol,rtol
    N,N,0,1,128,128,128,1,128,16384,0,128,16384,128,16384,128,16384,f32_r,f32_r,f32_r,f32_r,f32_r,0,0,0,0,0,none,0,f32_r,411.206,17.9515,10.2,0.0717453,58461,2.31791e-07,1e-06,0.01`
- self test the gaussian data quality (10+ times)
  - The mean is nearly 0, and the stdev is nearly 1
  - Histogram is as below, which is actually a normal distribution.
  
![Figure_2](https://github.com/user-attachments/assets/f0785b19-1cd0-423a-b40f-d5b55e559588)
