### PR TITLE
Fix bug in streamk + ScaleAlphaVec + UseBias + Activation + persistent loop for f16 and bf16

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -487,10 +487,16 @@ class KernelWriterAssembly(KernelWriter):
          or kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat():
         module.add(self.defineSgpr("PackKForV0", 1))
         module.add(self.defineSgpr("PackKForV1", 1))
+        if kernel["StreamK"] != 0:
+          self.states.nonPostLoopSgpr.append("PackKForV0")
+          self.states.nonPostLoopSgpr.append("PackKForV1")
         if (self.states.lrvwTileA > 2 or self.states.lrvwTileB > 2 or self.states.lrvwTileMetadata > 2) and \
             (kernel["ProblemType"]["DataType"].isInt8() or kernel["ProblemType"]["DataType"].is8bitFloat()):
           module.add(self.defineSgpr("PackKForV2", 1))
           module.add(self.defineSgpr("PackKForV3", 1))
+          if kernel["StreamK"] != 0:
+            self.states.nonPostLoopSgpr.append("PackKForV2")
+            self.states.nonPostLoopSgpr.append("PackKForV3")
 
     if kernel["ProblemType"]["StochasticRounding"]:
       module.add(self.defineSgpr("RNDSeed", 1))

--- a/tensilelite/Tensile/Tests/common/gemm/dot2_gfx942.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dot2_gfx942.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx90a, skip-gfx940, skip-gfx941, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1

--- a/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_epilogues.yaml
+++ b/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_epilogues.yaml
@@ -1,0 +1,131 @@
+TestParameters:
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+
+GlobalParameters:
+  NumElementsToValidate: -1
+  BoundsCheck: False
+  KernelTime: False
+  DataInitTypeAlpha: 2
+  DataInitTypeBeta: 2
+  DataInitTypeA: 12
+  DataInitTypeB: 13
+  DataInitTypeC: 12
+  MaxWorkspaceSize: 134217728
+  NumWarmups: 10
+  EnqueuesPerSync: 30
+  # ValidationPrintValids: True
+  # PrintSolutionRejectionReason: True
+  # ForceGenerateKernel: True
+  # GenerateSourcesAndExit: True
+  KeepBuildTmp: True
+  # DeviceLDS: 163840
+  # MaxLDS: 163840
+  RotatingBufferSize: 514
+
+BenchmarkProblems:
+  - # HGEMM HHS NN
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: False
+      TransposeB: False
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      BiasDataTypeList: [s,h]
+      Activation: True
+      ActivationType: all
+      UseScaleAlphaVec: 1
+
+    - # Grid
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ['Assembly']
+      ForkParameters:
+        - MatrixInstruction:
+          # - [16,16,32,1, 1, 8,8, 2,2]
+          # - [16,16,32,1, 1, 4,8, 2,2]
+          # - [16,16,32,1, 1, 8,4, 2,2]
+          # - [16,16,32,1, 1, 2,8, 2,2]
+          # - [16,16,32,1, 1, 8,2, 2,2]
+          # - [16,16,32,1, 1, 1,8, 2,2]
+          # - [16,16,32,1, 1, 8,1, 2,2]
+          # - [16,16,32,1, 1, 4,4, 2,2]
+          - [16,16,16,1, 1, 2,4, 2,2]
+          # - [16,16,32,1, 1, 4,2, 2,2]
+          # - [16,16,32,1, 1, 1,4, 2,2]
+          # - [16,16,32,1, 1, 4,1, 2,2]
+          # - [16,16,32,1, 1, 2,2, 2,2]
+          # - [16,16,32,1, 1, 1,2, 2,2]
+          # - [16,16,32,1, 1, 2,1, 2,2]
+          # - [16,16,32,1, 1, 1,1, 2,2]
+
+          # - [16,16,32,1, 1, 4,9, 4,1]
+          # - [16,16,32,1, 1, 9,4, 1,4]
+          # - [16,16,32,1, 1, 2,8, 4,1]
+          # - [16,16,32,1, 1, 8,2, 1,4]
+          # - [16,16,32,1, 1, 1,8, 4,1]
+          # - [16,16,32,1, 1, 1,9, 4,1]
+          # - [16,16,32,1, 1, 2,9, 4,1]
+          # - [16,16,32,1, 1, 8,1, 1,4]
+          # - [16,16,32,1, 1, 9,1, 1,4]
+          # - [16,16,32,1, 1, 9,2, 1,4]
+
+          # - [32,32,16,1, 1, 7,2, 1,4]
+
+          # - [32,32,16,1, 1, 4,4, 2,2]
+          # - [32,32,16,1, 1, 2,4, 2,2]
+          # - [32,32,16,1, 1, 4,2, 2,2]
+          # # - [32,32,16,1, 1, 1,4, 2,2]
+          # # - [32,32,16,1, 1, 4,1, 2,2]
+          # - [32,32,16,1, 1, 2,2, 2,2]
+          # - [32,32,16,1, 1, 1,2, 2,2]
+          # - [32,32,16,1, 1, 2,1, 2,2]
+          # - [32,32,16,1, 1, 1,1, 2,2]
+        - 1LDSBuffer: [-1]
+        - ClusterLocalRead: [True]
+        - DepthU: [32]
+        - ExpandPointerSwap: [0]
+        - GlobalReadVectorWidthA: [2]
+        - GlobalReadVectorWidthB: [8]
+        - LdsBlockSizePerPadA: [512]
+        - LdsBlockSizePerPadB: [512]
+        - LdsPadA: [32]
+        - LdsPadB: [8]
+        - LocalReadVectorWidth: [4, 8]
+        # - NonTemporalC: [0, 3, 4, 7]
+        # - NonTemporalD: [0, 3, 4, 7]
+        # - NumElementsPerBatchStore: [0, 16]
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - ScheduleIterAlg: [3]
+        - SourceSwap: [True]
+        - StaggerU: [0]
+        # - StaggerU: [0, 32]
+        # - StaggerUStride: [-1]
+        # - StaggerUMapping: [0, 1, 3]
+        # - StorePriorityOpt: [False, True]
+        # - StoreRemapVectorWidth: [0, 1, 2, 4, 8]
+        - StoreVectorWidth: [-1]
+        - StreamK: [3]
+        - StreamKXCCMapping: [8]
+        - TransposeLDS: [-1]
+        # - UnrollLoopSwapGlobalReadOrder: [0, 1]
+        - UseSgprForGRO: [0]
+        # - VectorWidthA: [1, 2, 4, 8]
+        # - VectorWidthB: [1, 2, 4, 8]
+        # - WaveSeparateGlobalReadA: [0, 1]
+        # - WaveSeparateGlobalReadB: [0, 1]
+        - WorkGroupMapping: [1]
+        # - WorkGroupMappingXCC: [1, 8, 16]
+        # - WorkGroupMappingXCCGroup: [304]
+        - ActivationFuncCall: [1]
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [24000, 256, 1, 256]
+        - BiasTypeArgs: ['s', 'h']
+        - ActivationArgs:
+          - [Enum: gelu]

--- a/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_epilogues.yaml
+++ b/tensilelite/Tensile/Tests/common/streamk/sk_hgemm_epilogues.yaml
@@ -1,5 +1,5 @@
 TestParameters:
-  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
+  marks: [skip-gfx900, skip-gfx906, skip-gfx908, skip-gfx950, skip-gfx1010, skip-gfx1011, skip-gfx1012, skip-gfx1030, skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported by arch
 
 GlobalParameters:
   NumElementsToValidate: -1


### PR DESCRIPTION
PackKForV* sgprs need to be saved or restored when running a persistent loop. Pack sgprs were being released at the end of the main loop, and there was a bug when using multiple epilogue parameters that the sgprs could be used as temps for other operations.

Added a new testcase to demonstrate the problem.