### PR TITLE
Default valid StaggerUStride generation.

### DIFF
--- a/tensilelite/Tensile/SolutionStructs.py
+++ b/tensilelite/Tensile/SolutionStructs.py
@@ -2667,19 +2667,11 @@ class Solution(collections.abc.Mapping):
         state["StaggerUMapping"] = 0
         state["StaggerUStride"] = 0
 
-      if state["StaggerUStride"] == -1:
+      if state["StaggerUStride"] == -1 or state["StaggerUStride"] < (state["DepthU"] * bpeAB):
+        # (StaggerUStride) shoud be greater than or equal to (DepthU * bpeAB)
         state["StaggerUStride"] = state["DepthU"] * bpeAB
 
-      try:
-          staggerStrideShift = (int)(math.ceil(math.log(state["StaggerUStride"] / \
-                  (state["DepthU"] * bpeAB), 2)))
-      except ValueError: # i.e., StaggerUStride == 0
-          staggerStrideShift = 0
-      if staggerStrideShift < 0:
-        reject(state, "StaggerUStride=%u is less than size of DepthU=%u * BytesPerElement=%u" \
-          % (state["StaggerUStride"], state["DepthU"], bpeAB))
-      #print "staggerStrideShift=", staggerStrideShift, "depthu=", state["DepthU"]
-      state["_staggerStrideShift"] = staggerStrideShift
+      state["_staggerStrideShift"] = (int)(math.ceil(math.log(state["StaggerUStride"] / (state["DepthU"] * bpeAB), 2)))
 
       def calcLdsPad(lrvw: int) -> int:
         ldsPadA = state["LdsPadA"]


### PR DESCRIPTION
# [Fixed] Default Valid StaggerUStride Generation
---
The value of [StaggerUStride] must be greater than or equal to [DepthU * bpeAB].

In the original implementation:
1. We blocked solutions where [StaggerUStride] was less than [DepthU * bpeAB].
   a. If the expression $$\text{int} \left( \lceil \log_2 \left( \frac{\text{state}["StaggerUStride"]}{\text{state}["DepthU"] \times \text{bpeAB}} \right) \rceil \right)$$ is negative, we reject the solution.
   b. If [StaggerUStride] is zero, it triggers a ValueError, we set staggerStrideShift to zero and let it passed.
   
2. However, the default [StaggerUStride] is set to 256 for each channel, which is 256 bytes wide. This setting may inadvertently block solutions with larger depths, specifically for [DepthU * bpeAB].

To address this, we are adding a default generation mechanism that will automatically generate a valid [StaggerUStride] for larger values of [DepthU]. This improvement will enhance the search for better solutions.