### PR TITLE
Amended auto ds write splitting mechanism

### DIFF
--- a/tensilelite/Tensile/Components/SIA.py
+++ b/tensilelite/Tensile/Components/SIA.py
@@ -30,12 +30,11 @@ from rocisa.instruction import SWaitCnt, DSStoreB128, DSStoreB64, DSStoreB32
 
 from ..TensileInstructions import replaceHolder
 
-from ..Common import roundUp
+from ..Common import roundUp, print2
 from ..Component import SIA
 
-import copy
 from copy import deepcopy
-from math import ceil
+from typing import Tuple
 
 PRECISION = 100
 class SIA3(SIA):
@@ -57,7 +56,7 @@ class SIA3(SIA):
         else:
             numLocalWriteModPerMfma = roundUp(kernel["LocalWritePerMfma"]*PRECISION)
 
-        AssignGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma)
+        writer.states.numGlobalReadInsPerMfma, writer.states.numLocalWriteModPerMfma = calculateGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma)
         localWriteEndIter = fixLocalWriteEndMfmaIndex(writer, kernel, tensorParametersA, tensorParametersB, \
             globalReadIncACode, globalReadIncBCode, numMfmaBetweenLWandBarrier, lastLoop)
         numGlobalReadInsPerIter, numLocalWriteModPerIter, numEmptyGlobalReadIncCode = getScheduleParamMfma(writer)
@@ -417,7 +416,7 @@ def getNumLocalWritePerMfma(writer, kernel, lwStartMfmaIndex):
         newValue = roundUp((writesToSched+1 + (oldValue - (writesToSched+1) % oldValue) + oldValue%PRECISION) / numMfmaCanSched)
     return newValue
 
-def AssignGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma):
+def calculateGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma) -> Tuple[int, int]:
     #####
     # Assign GRPM and LWPM
     #####
@@ -427,8 +426,7 @@ def AssignGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma):
     #   Ex. GRPM = 0.5
     #        GR ---------99--------- GR --------99---------- GR
     #   mfma --49-- mfma --49-- mfma --49-- mfma --49-- mfma --49--
-    writer.states.numGlobalReadInsPerMfma = roundUp(kernel["GlobalReadPerMfma"]*PRECISION)
-
+    numGlobalReadInsPerMfma = roundUp(kernel["GlobalReadPerMfma"]*PRECISION)
     # HOW THIS WORK
     # padding each globalReadInstruction to 100 with empty instruction,
     # each mfma will schedule intructions GRPM*100 times from padded globalReadInstruction.
@@ -441,11 +439,11 @@ def AssignGRPMandLWPM(writer, kernel, numLocalWriteModPerMfma):
         #   However, larger LWPM may cause mfma bubbles
         #   we set LWPM to 1 unless it requires larger LWPM to enable 1LDSB
         if kernel["1LDSBuffer"]:
-            writer.states.numLocalWriteModPerMfma = max(numLocalWriteModPerMfma,PRECISION)
+            numLocalWriteModPerMfma = max(numLocalWriteModPerMfma, PRECISION)
         else:
-            writer.states.numLocalWriteModPerMfma = PRECISION
-    else:
-        writer.states.numLocalWriteModPerMfma = numLocalWriteModPerMfma
+            numLocalWriteModPerMfma = PRECISION
+
+    return numGlobalReadInsPerMfma, numLocalWriteModPerMfma
 
 def getScheduleParamMfma(writer):
     numMfmaPerIter = writer.states.numMfmaPerIter
@@ -792,7 +790,7 @@ def schedLocalWrite(writer, kernel, numLocalWriteModPerIter, numLocalWritesPerSc
         for idx in newAdditionalIndexList:
             additionalIndexList[idx - itemPerIter] = newAdditionalIndexList[idx]
 
-        if u==(localWriteEndIter):
+        if u == localWriteEndIter:
             itemPerIter = len(itemsLWToSched) # schedule all remaining activity
         else:
             itemPerIter = numLocalWriteModPerIter
@@ -812,8 +810,18 @@ def schedLocalWrite(writer, kernel, numLocalWriteModPerIter, numLocalWritesPerSc
                 if kernel["ProblemType"]["Sparse"] and not writesPerItem:
                     writesPerItem = item.name.startswith("MetadataWrite") and countVMovB32(item)
                 if writesPerItem:
+                    writesPerItem = countLocalWrite(item)
+                    if kernel["ProblemType"]["Sparse"] and not writesPerItem:
+                        writesPerItem = item.name.startswith("MetadataWrite") and countVMovB32(item)
                     # Split into several dsStore32
-                    itemNew, numItemNew, globalReadInstOffset = splitDSInstructionIntoSmaller(writer, kernel, item, numLocalWritesPerSched, len(itemsLWToSched), itemsLWToSchedIndex)
+                    syncEndExpandedNumIndex = len(itemsLWToSched)
+
+                    if u == (writer.states.lwEndMfmaIndex // writer.states.numMfmaPerIter):
+                        syncEndExpandedNumIndex = numLocalWriteModPerIter
+                        syncEndExpandedNumIndex *= ((writer.states.syncPlrMfmaIndex % writer.states.numMfmaPerIter) / writer.states.numMfmaPerIter)
+                        syncEndExpandedNumIndex = roundUp(syncEndExpandedNumIndex)
+
+                    itemNew, numItemNew, globalReadInstOffset = splitDSInstructionIntoSmaller(writer, kernel, item, numLocalWritesPerSched, syncEndExpandedNumIndex, itemsLWToSchedIndex) if writer.do["AutoSplitDsWrite"] else (None, 0, 0)
                     if itemsLWToSchedIndex + globalReadInstOffset <= len(itemsLWToSched):
                         additionalIndexList = {}
                         for i in range(numItemNew): 
@@ -931,16 +939,8 @@ def splitDSInstructionIntoSmaller(writer, kernel, item, numLocalWritesPerSched, 
         # only support one b128
         return None, 0, 0
 
-    instruction = None
     itemList = item.flatitems()
-    for inst in itemList:
-        if isinstance(inst, DSStoreB128):
-            instruction = inst
-            break
-    if instruction == None:
-        assert 0, "no instructions to be splitted"
-
-    lwLatency = DSStoreB128.issueLatency()
+    instruction = next(filter(lambda inst: isinstance(inst, DSStoreB128), itemList))
     miLatency = writer.states.miLatency
     div       = 1
     dsOffset  = 0
@@ -997,6 +997,8 @@ def splitDSInstructionIntoSmaller(writer, kernel, item, numLocalWritesPerSched, 
         r1.regNum //= div
         r1.regName.addOffset(4 // div * d)
         writeInst.append(LocalWriteX(dstAddr=addr, src=r1, ds=ds1, comment=instruction.comment + " splitted"))
+
+    print2(f"Split ds_write_b128 to 4xds_write_b32 for {str(instruction)}")
     
     return writeInst, len(writeInst), numLocalWritesPerSched * (div - 1)
 

--- a/tensilelite/Tensile/Components/SIA.py
+++ b/tensilelite/Tensile/Components/SIA.py
@@ -816,7 +816,7 @@ def schedLocalWrite(writer, kernel, numLocalWriteModPerIter, numLocalWritesPerSc
                     # Split into several dsStore32
                     syncEndExpandedNumIndex = len(itemsLWToSched)
 
-                    if u == (writer.states.lwEndMfmaIndex // writer.states.numMfmaPerIter):
+                    if writer.states.numMfmaPerIter and u == (writer.states.lwEndMfmaIndex // writer.states.numMfmaPerIter):
                         syncEndExpandedNumIndex = numLocalWriteModPerIter
                         syncEndExpandedNumIndex *= ((writer.states.syncPlrMfmaIndex % writer.states.numMfmaPerIter) / writer.states.numMfmaPerIter)
                         syncEndExpandedNumIndex = roundUp(syncEndExpandedNumIndex)

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -400,6 +400,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.do["EdgeWrite"]   = True
     self.do["KeepDirectToLdsAlloc"] = False  # If true, keep regs used for LDS alloc even if not used
     self.do["OptimizeNumItersPLR0"] = True
+    self.do["AutoSplitDsWrite"] = True
 
     self.do["executeToInitEnd"] = 0
     self.do["executeToPrefetchEnd"] = 0


### PR DESCRIPTION
## Implementation
 - Shrink ds write range if `lwEndMfmaIndex` in scheduling unrolled iteration
 - An internal option to disable/enable this mechanism
 - Minor refactor

## Result ##
For kernel `Cijk_Alik_Bljk_HHS_STA_BH_UserArgs_MT256x256x64_MI16x16x1_SN_K1_MIWT8_8`, here's the scheduled results
### Before 
```c
v_mfma_f32_16x16x16_f16 acc[100:103], v[vgprG2LA+36+2:vgprG2LA+36+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[100:103] // left value = acc[100+0:103+0]
/*  mfmaIndex:218  */
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+0] offset:0 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[104:107], v[vgprG2LA+40+2:vgprG2LA+40+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[104:107] // left value = acc[104+0:107+0]
/*  mfmaIndex:219  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+1] offset:4 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[108:111], v[vgprG2LA+44+2:vgprG2LA+44+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[108:111] // left value = acc[108+0:111+0]
/*  mfmaIndex:220  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+2] offset:8 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[112:115], v[vgprG2LA+48+2:vgprG2LA+48+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[112:115] // left value = acc[112+0:115+0]
/*  mfmaIndex:221  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+3] offset:12 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[116:119], v[vgprG2LA+52+2:vgprG2LA+52+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[116:119] // left value = acc[116+0:119+0]
/*  mfmaIndex:222  */
buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_0_0
v_mfma_f32_16x16x16_f16 acc[120:123], v[vgprG2LA+56+2:vgprG2LA+56+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[120:123] // left value = acc[120+0:123+0]
/*  mfmaIndex:223  */
v_mfma_f32_16x16x16_f16 acc[124:127], v[vgprG2LA+60+2:vgprG2LA+60+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[124:127] // left value = acc[124+0:127+0]
/*  mfmaIndex:224  */
v_mfma_f32_16x16x16_f16 acc[128:131], v[vgprG2LA+32+2:vgprG2LA+32+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[128:131] // left value = acc[128+0:131+0]
/*  mfmaIndex:225  */
v_mfma_f32_16x16x16_f16 acc[132:135], v[vgprG2LA+36+2:vgprG2LA+36+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[132:135] // left value = acc[132+0:135+0]
/*  mfmaIndex:226  */
v_mfma_f32_16x16x16_f16 acc[136:139], v[vgprG2LA+40+2:vgprG2LA+40+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[136:139] // left value = acc[136+0:139+0]
/*  mfmaIndex:227  */
v_mfma_f32_16x16x16_f16 acc[140:143], v[vgprG2LA+44+2:vgprG2LA+44+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[140:143] // left value = acc[140+0:143+0]
/*  mfmaIndex:228  */
v_mfma_f32_16x16x16_f16 acc[144:147], v[vgprG2LA+48+2:vgprG2LA+48+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[144:147] // left value = acc[144+0:147+0]
/*  mfmaIndex:229  */
v_mfma_f32_16x16x16_f16 acc[148:151], v[vgprG2LA+52+2:vgprG2LA+52+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[148:151] // left value = acc[148+0:151+0]
/*  mfmaIndex:230  */
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+4+0] offset:4224 // lwoB_0_0_1_0 = (0*LSCB)*(MT1J+PAD) + (1*LSPB) = 4224 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+4+1] offset:4228 // lwoB_0_0_1_0 = (0*LSCB)*(MT1J+PAD) + (1*LSPB) = 4224 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+4+2] offset:4232 // lwoB_0_0_1_0 = (0*LSCB)*(MT1J+PAD) + (1*LSPB) = 4224 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+4+3] offset:4236 // lwoB_0_0_1_0 = (0*LSCB)*(MT1J+PAD) + (1*LSPB) = 4224 splitted
buffer_load_dwordx4 v[vgprG2LB+4:vgprG2LB+4+3], v[vgprGlobalReadOffsetB+1], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_1_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+8+0] offset:8448 // lwoB_0_0_2_0 = (0*LSCB)*(MT1J+PAD) + (2*LSPB) = 8448 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+8+1] offset:8452 // lwoB_0_0_2_0 = (0*LSCB)*(MT1J+PAD) + (2*LSPB) = 8448 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+8+2] offset:8456 // lwoB_0_0_2_0 = (0*LSCB)*(MT1J+PAD) + (2*LSPB) = 8448 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+8+3] offset:8460 // lwoB_0_0_2_0 = (0*LSCB)*(MT1J+PAD) + (2*LSPB) = 8448 splitted
buffer_load_dwordx4 v[vgprG2LB+8:vgprG2LB+8+3], v[vgprGlobalReadOffsetB+2], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_2_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+12+0] offset:12672 // lwoB_0_0_3_0 = (0*LSCB)*(MT1J+PAD) + (3*LSPB) = 12672 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+12+1] offset:12676 // lwoB_0_0_3_0 = (0*LSCB)*(MT1J+PAD) + (3*LSPB) = 12672 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+12+2] offset:12680 // lwoB_0_0_3_0 = (0*LSCB)*(MT1J+PAD) + (3*LSPB) = 12672 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+12+3] offset:12684 // lwoB_0_0_3_0 = (0*LSCB)*(MT1J+PAD) + (3*LSPB) = 12672 splitted
buffer_load_dwordx4 v[vgprG2LB+12:vgprG2LB+12+3], v[vgprGlobalReadOffsetB+3], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_3_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+16+0] offset:16896 // lwoB_0_0_4_0 = (0*LSCB)*(MT1J+PAD) + (4*LSPB) = 16896 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+16+1] offset:16900 // lwoB_0_0_4_0 = (0*LSCB)*(MT1J+PAD) + (4*LSPB) = 16896 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+16+2] offset:16904 // lwoB_0_0_4_0 = (0*LSCB)*(MT1J+PAD) + (4*LSPB) = 16896 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+16+3] offset:16908 // lwoB_0_0_4_0 = (0*LSCB)*(MT1J+PAD) + (4*LSPB) = 16896 splitted
buffer_load_dwordx4 v[vgprG2LB+16:vgprG2LB+16+3], v[vgprGlobalReadOffsetB+4], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_4_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+20+0] offset:21120 // lwoB_0_0_5_0 = (0*LSCB)*(MT1J+PAD) + (5*LSPB) = 21120 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+20+1] offset:21124 // lwoB_0_0_5_0 = (0*LSCB)*(MT1J+PAD) + (5*LSPB) = 21120 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+20+2] offset:21128 // lwoB_0_0_5_0 = (0*LSCB)*(MT1J+PAD) + (5*LSPB) = 21120 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+20+3] offset:21132 // lwoB_0_0_5_0 = (0*LSCB)*(MT1J+PAD) + (5*LSPB) = 21120 splitted
buffer_load_dwordx4 v[vgprG2LB+20:vgprG2LB+20+3], v[vgprGlobalReadOffsetB+5], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_5_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+24+0] offset:25344 // lwoB_0_0_6_0 = (0*LSCB)*(MT1J+PAD) + (6*LSPB) = 25344 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+24+1] offset:25348 // lwoB_0_0_6_0 = (0*LSCB)*(MT1J+PAD) + (6*LSPB) = 25344 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+24+2] offset:25352 // lwoB_0_0_6_0 = (0*LSCB)*(MT1J+PAD) + (6*LSPB) = 25344 splitted
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+24+3] offset:25356 // lwoB_0_0_6_0 = (0*LSCB)*(MT1J+PAD) + (6*LSPB) = 25344 splitted
buffer_load_dwordx4 v[vgprG2LB+24:vgprG2LB+24+3], v[vgprGlobalReadOffsetB+6], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_6_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+28:vgprG2LB+28+3] offset:29568 // lwoB_0_0_7_0 = (0*LSCB)*(MT1J+PAD) + (7*LSPB) = 29568
buffer_load_dwordx4 v[vgprG2LB+28:vgprG2LB+28+3], v[vgprGlobalReadOffsetB+7], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_7_0

/* local write swap offsets a */

/* local write swap offsets b */
v_mfma_f32_16x16x16_f16 acc[152:155], v[vgprG2LA+56+2:vgprG2LA+56+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[152:155] // left value = acc[152+0:155+0]
/*  mfmaIndex:231  */
v_mfma_f32_16x16x16_f16 acc[156:159], v[vgprG2LA+60+2:vgprG2LA+60+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[156:159] // left value = acc[156+0:159+0]
/*  mfmaIndex:232  */
s_waitcnt lgkmcnt(0)
// Skip force waitcnt0
s_barrier
v_mfma_f32_16x16x16_f16 acc[160:163], v[vgprG2LA+32+2:vgprG2LA+32+2+1], v[vgprValuB_X2_I0+20+2+0:vgprValuB_X2_I0+20+2+0+1], acc[160:163] // left value = acc[160+0:163+0]
/*  mfmaIndex:233  */
ds_read_b128 v[vgprValuB_X0_I0+0:vgprValuB_X0_I0+0+3], v[vgprLocalReadAddrB] offset:0 // L -> Reg lro=0 swapByteOffset=0 ti=256 vIdx=0 eIdx=0 rIdx=0 oIdx=0 buffer=0 iui=0
```

### After
```c
v_mfma_f32_16x16x16_f16 acc[100:103], v[vgprG2LA+36+2:vgprG2LA+36+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[100:103] // left value = acc[100+0:103+0]
/*  mfmaIndex:218  */
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+0] offset:0 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[104:107], v[vgprG2LA+40+2:vgprG2LA+40+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[104:107] // left value = acc[104+0:107+0]
/*  mfmaIndex:219  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+1] offset:4 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[108:111], v[vgprG2LA+44+2:vgprG2LA+44+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[108:111] // left value = acc[108+0:111+0]
/*  mfmaIndex:220  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+2] offset:8 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[112:115], v[vgprG2LA+48+2:vgprG2LA+48+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[112:115] // left value = acc[112+0:115+0]
/*  mfmaIndex:221  */
ds_write_b32 v[vgprLocalWriteAddrB], v[vgprG2LB+0+3] offset:12 // lwoB_0_0_0_0 = (0*LSCB)*(MT1J+PAD) + (0*LSPB) = 0 splitted
v_mfma_f32_16x16x16_f16 acc[116:119], v[vgprG2LA+52+2:vgprG2LA+52+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[116:119] // left value = acc[116+0:119+0]
/*  mfmaIndex:222  */
buffer_load_dwordx4 v[vgprG2LB+0:vgprG2LB+0+3], v[vgprGlobalReadOffsetB+0], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_0_0
v_mfma_f32_16x16x16_f16 acc[120:123], v[vgprG2LA+56+2:vgprG2LA+56+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[120:123] // left value = acc[120+0:123+0]
/*  mfmaIndex:223  */
v_mfma_f32_16x16x16_f16 acc[124:127], v[vgprG2LA+60+2:vgprG2LA+60+2+1], v[vgprValuB_X2_I0+12+2+0:vgprValuB_X2_I0+12+2+0+1], acc[124:127] // left value = acc[124+0:127+0]
/*  mfmaIndex:224  */
v_mfma_f32_16x16x16_f16 acc[128:131], v[vgprG2LA+32+2:vgprG2LA+32+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[128:131] // left value = acc[128+0:131+0]
/*  mfmaIndex:225  */
v_mfma_f32_16x16x16_f16 acc[132:135], v[vgprG2LA+36+2:vgprG2LA+36+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[132:135] // left value = acc[132+0:135+0]
/*  mfmaIndex:226  */
v_mfma_f32_16x16x16_f16 acc[136:139], v[vgprG2LA+40+2:vgprG2LA+40+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[136:139] // left value = acc[136+0:139+0]
/*  mfmaIndex:227  */
v_mfma_f32_16x16x16_f16 acc[140:143], v[vgprG2LA+44+2:vgprG2LA+44+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[140:143] // left value = acc[140+0:143+0]
/*  mfmaIndex:228  */
v_mfma_f32_16x16x16_f16 acc[144:147], v[vgprG2LA+48+2:vgprG2LA+48+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[144:147] // left value = acc[144+0:147+0]
/*  mfmaIndex:229  */
v_mfma_f32_16x16x16_f16 acc[148:151], v[vgprG2LA+52+2:vgprG2LA+52+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[148:151] // left value = acc[148+0:151+0]
/*  mfmaIndex:230  */
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+4:vgprG2LB+4+3] offset:4224 // lwoB_0_0_1_0 = (0*LSCB)*(MT1J+PAD) + (1*LSPB) = 4224
buffer_load_dwordx4 v[vgprG2LB+4:vgprG2LB+4+3], v[vgprGlobalReadOffsetB+1], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_1_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+8:vgprG2LB+8+3] offset:8448 // lwoB_0_0_2_0 = (0*LSCB)*(MT1J+PAD) + (2*LSPB) = 8448
buffer_load_dwordx4 v[vgprG2LB+8:vgprG2LB+8+3], v[vgprGlobalReadOffsetB+2], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_2_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+12:vgprG2LB+12+3] offset:12672 // lwoB_0_0_3_0 = (0*LSCB)*(MT1J+PAD) + (3*LSPB) = 12672
buffer_load_dwordx4 v[vgprG2LB+12:vgprG2LB+12+3], v[vgprGlobalReadOffsetB+3], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_3_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+16:vgprG2LB+16+3] offset:16896 // lwoB_0_0_4_0 = (0*LSCB)*(MT1J+PAD) + (4*LSPB) = 16896
buffer_load_dwordx4 v[vgprG2LB+16:vgprG2LB+16+3], v[vgprGlobalReadOffsetB+4], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_4_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+20:vgprG2LB+20+3] offset:21120 // lwoB_0_0_5_0 = (0*LSCB)*(MT1J+PAD) + (5*LSPB) = 21120
buffer_load_dwordx4 v[vgprG2LB+20:vgprG2LB+20+3], v[vgprGlobalReadOffsetB+5], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_5_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+24:vgprG2LB+24+3] offset:25344 // lwoB_0_0_6_0 = (0*LSCB)*(MT1J+PAD) + (6*LSPB) = 25344
buffer_load_dwordx4 v[vgprG2LB+24:vgprG2LB+24+3], v[vgprGlobalReadOffsetB+6], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_6_0
/* sched write - iter 3 writesPerItem=1 */
s_waitcnt vmcnt(23)                                // wait for global read before writing to local
ds_write_b128 v[vgprLocalWriteAddrB], v[vgprG2LB+28:vgprG2LB+28+3] offset:29568 // lwoB_0_0_7_0 = (0*LSCB)*(MT1J+PAD) + (7*LSPB) = 29568
buffer_load_dwordx4 v[vgprG2LB+28:vgprG2LB+28+3], v[vgprGlobalReadOffsetB+7], s[sgprSrdB:sgprSrdB+3], 0 offen offset:0 // G -> Reg 0_0_7_0

/* local write swap offsets a */

/* local write swap offsets b */
v_mfma_f32_16x16x16_f16 acc[152:155], v[vgprG2LA+56+2:vgprG2LA+56+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[152:155] // left value = acc[152+0:155+0]
/*  mfmaIndex:231  */
v_mfma_f32_16x16x16_f16 acc[156:159], v[vgprG2LA+60+2:vgprG2LA+60+2+1], v[vgprValuB_X2_I0+16+2+0:vgprValuB_X2_I0+16+2+0+1], acc[156:159] // left value = acc[156+0:159+0]
/*  mfmaIndex:232  */
s_waitcnt lgkmcnt(0)
// Skip force waitcnt0
s_barrier
v_mfma_f32_16x16x16_f16 acc[160:163], v[vgprG2LA+32+2:vgprG2LA+32+2+1], v[vgprValuB_X2_I0+20+2+0:vgprValuB_X2_I0+20+2+0+1], acc[160:163] // left value = acc[160+0:163+0]
/*  mfmaIndex:233  */
```

### Performance

|Before|After|No splitting|
|------|-----|------------|
|534.157|512.784|515.159|