### PR TITLE
Print git hash in hipblaslt-test output

### DIFF
--- a/clients/benchmarks/client.cpp
+++ b/clients/benchmarks/client.cpp
@@ -43,10 +43,6 @@
 
 #include "testing_matmul.hpp"
 
-#include "utility.hpp"
-#include <algorithm>
-#undef I
-
 using namespace roc; // For emulated program_options
 using namespace std::literals; // For std::string literals of form "str"s
 
@@ -269,17 +265,6 @@ bool tuning_path_compare_git_version(const char* tuningEnv)
     hipblaslt_cout << "The hipBLASLt git version and the tuning file git version are not the same."
                    << std::endl;
     return false;
-}
-
-void hipblaslt_print_version(void)
-{
-    int                    version;
-    char                   git_version[128];
-    hipblaslt_local_handle handle;
-    hipblasLtGetVersion(handle, &version);
-    hipblasLtGetGitRevision(handle, &git_version[0]);
-    hipblaslt_cout << "hipBLASLt version: " << version << std::endl;
-    hipblaslt_cout << "hipBLASLt git version: " << git_version << std::endl;
 }
 
 int main(int argc, char* argv[])

--- a/clients/common/utility.cpp
+++ b/clients/common/utility.cpp
@@ -258,6 +258,7 @@ std::vector<void*> benchmark_allocation()
     }
     return ptrs;
 }
+
 int32_t hipblaslt_get_arch_major()
 {
     int             deviceId;
@@ -276,4 +277,15 @@ int32_t hipblaslt_get_arch_major()
     static_cast<void>(hipGetDeviceProperties(&deviceProperties, deviceId));
     auto gpu_arch_no_prefix = removePrefix(deviceProperties.gcnArchName);
     return stoi(gpu_arch_no_prefix) / 100;
+}
+
+void hipblaslt_print_version()
+{
+    int                    version;
+    char                   git_version[128];
+    hipblaslt_local_handle handle;
+    hipblasLtGetVersion(handle, &version);
+    hipblasLtGetGitRevision(handle, &git_version[0]);
+    hipblaslt_cout << "hipBLASLt version: " << version << std::endl;
+    hipblaslt_cout << "hipBLASLt git version: " << git_version << std::endl;
 }

--- a/clients/gtest/hipblaslt_gtest_main.cpp
+++ b/clients/gtest/hipblaslt_gtest_main.cpp
@@ -181,14 +181,6 @@ static int hipblaslt_version()
     return version;
 }
 
-// Print Version
-static void hipblaslt_print_version()
-{
-    static int version = hipblaslt_version();
-
-    hipblaslt_cout << "hipBLASLt version: " << version << "\n" << std::endl;
-}
-
 static void hipblaslt_print_usage_warning()
 {
     std::string warning(

--- a/clients/include/utility.hpp
+++ b/clients/include/utility.hpp
@@ -525,3 +525,4 @@ typename std::enable_if<!std::is_same<int8_t, T>::value, T>::type saturate_cast(
 
 std::vector<void*> benchmark_allocation();
 int32_t            hipblaslt_get_arch_major();
+void hipblaslt_print_version();


### PR DESCRIPTION
hipblaslt-bench output should be unaffected, hipblaslt-test version output now matches hipblaslt-bench by printing the git hash as well.