### PR TITLE
Fix support for building all target ISAs

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -557,7 +557,7 @@ def run():
         archs = arguments["Architecture"].split(";")
     else:
         archs = arguments["Architecture"].split("_")
-    archs = SUPPORTED_GFX if archs == "all" else archs
+    archs = SUPPORTED_GFX if "all" in archs else archs
 
     targetIsas = [gfxToIsa(a) for a in archs]
     isaInfoMap = makeIsaInfoMap(targetIsas, cxxCompiler)


### PR DESCRIPTION
PR #1677 broke the `--architecture=all` option when invoking TensileCreateLibrary. This simple fix resolves this breakage.