### PR TITLE
Additional test case to ensure all f8 instruction varieties are tested on gfx950

### DIFF
--- a/tensilelite/Tensile/Tests/common/streamk/sk_f8gemm_quick.yaml
+++ b/tensilelite/Tensile/Tests/common/streamk/sk_f8gemm_quick.yaml
@@ -62,6 +62,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -140,6 +141,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -219,6 +221,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -299,6 +302,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -378,6 +382,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -458,6 +463,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -538,6 +544,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]
@@ -617,6 +624,7 @@ BenchmarkProblems:
         - MatrixInstruction:
           - [16,16,32, 1, 1, 2,2, 2,2]
           - [16,16,128, 1, 1, 2,2, 2,2]
+          - [32,32,16,1, 1, 2,1, 2,2]
           - [32,32,64,1, 1, 1,1, 2,2]
         - LdsBlockSizePerPadA: [0]
         - LdsBlockSizePerPadB: [0]


### PR DESCRIPTION
Based on comment on previous PR to include gfx950 F8 testing, this adds test cases for the remaining instruction type.