### PR TITLE
Only override internal keys if not already written

### DIFF
--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -1049,6 +1049,7 @@ class Solution(collections.abc.Mapping):
     state["AssignedDerivedParameters"] = False
 
     for s in Solution.InternalKeys:
+      if '_'+s not in state:
         state['_'+s] = state[s]
         #del state[s]
 


### PR DESCRIPTION
- InternalKeys includes ["UseSgprForGRO","VectorStore"]
- When creating the Logic file, if UseSgprForGRO == -1, _UseSgprForGRO gets set to some value, say 0. These are both written the the logic file. From here, TensileCreateLibrary then _also_ updates _UseSgprForGRO to -1 instead of using the value set in the Logic file. I believe here, we are getting a mixture of interpreting _UseSgprForGRO as -1 (passing boolean comparisons where the code thinks it should be in the set [0, 1]