### PR TITLE
perf: Supported multi-samples for PTS to calc significance value (p-value)

### DIFF
--- a/clients/scripts/performance/bench_sample.py
+++ b/clients/scripts/performance/bench_sample.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import statistics
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+@dataclass
+class MeasurementKey:
+    name: str = None
+    samples: int = 0
+    mean: float = 0
+    median: float = 0
+    values: List[float] = field(init=False)
+
+    def __init__(self, name):
+        self.name = name
+        self.values = []
+
+    def getMeanName(self):
+        assert(self.name != None)
+        return 'mean_' + self.name
+
+    def getMedianName(self):
+        assert(self.name != None)
+        return 'median_' + self.name
+
+    def addSample(self, value):
+        self.samples += 1
+        self.values.append(float(value))
+
+    def calcMean(self):
+        assert(len(self.values) == self.samples)
+        assert(self.name != None)
+        self.mean = statistics.mean(self.values)
+        return self.mean
+
+    def calcMedian(self):
+        assert(len(self.values) == self.samples)
+        assert(self.name != None)
+        self.median = statistics.median(self.values)
+        return self.median
+
+    def getValuesStr(self):
+        assert(len(self.values) == self.samples)
+        assert(self.name != None)
+        return ','.join([str(v) for v in self.values])
+
+@dataclass
+class BenchSample:
+    probKey: str = None
+    measurements: Dict[str, MeasurementKey] = field(default_factory=dict)
+
+    def addSampleOfKey(self, key, value):
+        if key not in self.measurements:
+            self.measurements[key] = MeasurementKey(name=key)
+        self.measurements[key].addSample(value)
+
+    def getMeasurementMeanMedianPair(self, key):
+        mean = self.measurements[key].calcMean()
+        median = self.measurements[key].calcMedian()
+        return str(mean) + ',' + str(median)
+
+    def getMeasurementValues(self, key):
+        return self.measurements[key].getValuesStr()
+
+    def finalize(self, num_samples, keysOrder):
+        assert(self.probKey != None)
+        content = self.probKey + ',' + str(num_samples)
+
+        for key in keysOrder:
+            assert(self.measurements[key].samples == num_samples)
+            content += ',' + self.getMeasurementMeanMedianPair(key)
+
+        for key in keysOrder:
+            content += ',' + self.getMeasurementValues(key)
+
+        return content

--- a/clients/scripts/performance/hipblaslt-perf
+++ b/clients/scripts/performance/hipblaslt-perf
@@ -26,14 +26,17 @@ import os
 import argparse
 import logging
 import bench
+from dataclasses import dataclass, field
+from bench_sample import BenchSample, MeasurementKey
 from generator import SuiteProblemGenerator
 from pathlib import Path
 from git_info import create_github_file
 from specs import get_machine_specs
+from typing import Dict, List
 
 console = logging.StreamHandler()
 
-# Parameters for output csv file, we track fields according to each function.
+# Output from bench exe msg:
 matmul_paramList = ['function','transA','transB','grouped_gemm','batch_count','m','n','k','alpha','lda','stride_a','beta','ldb','stride_b',
                     'ldc','stride_c','ldd','stride_d','a_type','b_type','c_type','d_type','compute_type','scaleA','scaleB','scaleC',
                     'scaleD','amaxD','activation_type','bias_vector','bias_type','rotating_buffer','gflops','GB/s','us']
@@ -42,21 +45,52 @@ amax_paramList = ['function','m','n','type','dtype','us']
 
 api_overhead_paramList = ['function','api_name','us/iter','best_us']
 
-# maps of paramList
-benchTrackedParams = {'matmul' : matmul_paramList,
+# maps of outputParamList
+benchMsgOutParams = {'matmul' : matmul_paramList,
                       'amax' : amax_paramList,
                       'api_overhead' : api_overhead_paramList}
+
+#
+# The real key in csv file, we need to add sample-num, and corresponding mean_, median_ fields
+#
+matmul_probKey = ['function','transA','transB','grouped_gemm','batch_count','m','n','k','alpha','lda','stride_a','beta','ldb','stride_b',
+                    'ldc','stride_c','ldd','stride_d','a_type','b_type','c_type','d_type','compute_type','scaleA','scaleB','scaleC',
+                    'scaleD','amaxD','activation_type','bias_vector','bias_type','rotating_buffer']
+
+amax_probKey = ['function','m','n','type','dtype']
+
+api_overhead_probKey = ['function','api_name']
+
+# perf-measure key fields of each function
+benchProbDescKeys = {'matmul' : matmul_probKey,
+                      'amax' : amax_probKey,
+                      'api_overhead' : api_overhead_probKey}
+
+# perf-measure key fields of each function
+benchMeasuredKeys = {'matmul' : ['GB/s','gflops','us'],
+                    'amax' : ['us'],
+                    'api_overhead' : ['us/iter','best_us']}
+
+sample_filed_name = 'sample_num'
+
+#
+# full csv-file key = benchProbDescKeys + 'sample_num' + <mean,median>-of-each-(benchMeasuredKeys) + benchMeasuredKeys
+#
 
 # maps of benchmark executable
 benchExecs = {'matmul' : 'hipblaslt-bench',
               'amax' : 'hipblaslt-bench-extop-amax',
               'api_overhead' : 'hipblaslt-api-overhead'}
 
-#d is default dict or contains a superset of trackedParams
+#d is default dict or contains a superset of msgOutputParams
 def extractTrackedParams(d, trackedParam):
     return [d[p] for p in trackedParam]
 
-def runBenchmark(benchType, prob_args, executable_folder, probYamlFolder, out_csv_File, write_csv_header):
+#d is default dict or contains a superset of ProbTokenKeys, returned string is a token of this problem
+def extractProblemDescStr(d, probTokenKeys):
+    return ','.join([str(d[t]) for t in probTokenKeys])
+
+def runBenchmark(benchType, probBenchResults:Dict[str, BenchSample], prob_args, executable_folder, probYamlFolder, out_csv_File, write_csv_header, total_samples, finalize = False):
 
     # get the actual exec-path of this bench type
     benchExec = benchExecs[benchType]
@@ -64,23 +98,46 @@ def runBenchmark(benchType, prob_args, executable_folder, probYamlFolder, out_cs
 
     csvKeys, benchResults, success = bench.run_bench(benchCmd, probYamlFolder, benchType, prob_args, True)
     # get the actual params we want to track and show in csv of this bench type
-    trackedParams = benchTrackedParams[benchType]
-    # TODO- check csvKeys == trackedParams
-    header = ''
-    header += ','.join([str(key) for key in trackedParams])+'\n'
+    # TODO- check csvKeys == msgOutputParams
+    msgOutputParams = benchMsgOutParams[benchType]
+    problemDescKeys = benchProbDescKeys[benchType]
+    measurementKeys = benchMeasuredKeys[benchType]
 
     content = ''
+    # 1. Extract problem token
+    # 2. Extract perf measurement data and add single sample
+    # 3. Finalize- output mean, median and all data for each problem
     for eachResult in benchResults:
-        extracted = extractTrackedParams(eachResult, trackedParams)
-        content += ','.join([str(e) for e in extracted])+'\n'
+        # data in problem description
+        probDesc = extractProblemDescStr(eachResult, problemDescKeys)
+        if probDesc not in probBenchResults:
+            probBenchResults[probDesc] = BenchSample(probKey=probDesc)
+        benchSample = probBenchResults[probDesc]
+        for measuredKey in measurementKeys:
+            benchSample.addSampleOfKey(measuredKey, eachResult[measuredKey])
+        if finalize:
+            content += benchSample.finalize(total_samples, measurementKeys) + '\n'
+
+    header = ''
+    if write_csv_header is True:
+        measurements = []
+        for Mkey in measurementKeys:
+            measurements.append(MeasurementKey(Mkey))
+        header += ','.join([str(key) for key in problemDescKeys]) + ',' + sample_filed_name + ','
+        for measure in measurements:
+            header += measure.getMeanName() + ',' + measure.getMedianName() + ','
+        header += ','.join([m.name for m in measurements])+'\n'
 
     if out_csv_File is not None:
         if write_csv_header is True:
             out_csv_File.write(header)
-        out_csv_File.write(content)
+        if finalize:
+            out_csv_File.write(content)
     else:
-        print(header)
-        print(content)
+        if write_csv_header is True:
+            print(header)
+        if finalize:
+            print(content)
 
 def command_perf(arguments, probYaml_foler):
     """Run bench"""
@@ -105,6 +162,7 @@ def command_perf(arguments, probYaml_foler):
 
     out_folder = arguments.workspace
     exec_folder = arguments.execFolder
+    num_samples = arguments.samples
 
     needExportCSV = (arguments.csv == True) or (arguments.pts == True)
 
@@ -124,9 +182,13 @@ def command_perf(arguments, probYaml_foler):
 
         # only the first time we need to write header
         writeCSVHeader = True
-        for p in problemSet.generate_problems():
-            runBenchmark(pTypeName, p.args, exec_folder, probYaml_foler, csv_file, writeCSVHeader)
-            writeCSVHeader = False
+        curProbSet:Dict[str, BenchSample] = {}
+        for iter in range(num_samples):
+            print(f"\nSampling Iteration: {iter}")
+            finalize = (iter == num_samples - 1)
+            for p in problemSet.generate_problems():
+                runBenchmark(pTypeName, curProbSet, p.args, exec_folder, probYaml_foler, csv_file, writeCSVHeader, num_samples, finalize)
+                writeCSVHeader = False
 
         if csv_file is not None:
             print("\nResults written to {}".format(csv_file.name))
@@ -175,6 +237,11 @@ def main():
                         type=str,
                         help='subfolder under workspace, (optional, useful for comparing two commits)',
                         default='')
+
+    parser.add_argument('--samples',
+                        type=int,
+                        help='number of runs of all benchmarks, used to calculate the significance value, default is 5',
+                        default=5)
 
     parser.add_argument('--csv',
                         help='dump result to csv files, default is True',


### PR DESCRIPTION
- [x] Able to set multiple samples: run the whole benchmark for multi-times. `e.g. ./hipblaslt-perf --suite all --samples 10 (default 5)`
- [x] Modified the csv data format, added sample_num, mean, median, samples values

The new csv looks like this:
[amax] - new: sample_num, mean_us, median_us, us result *5 
![image](https://github.com/user-attachments/assets/6ccedc29-8eb1-4307-abe1-2d1ad0b90d92)

[matmul] - new: sample_num, mean_GB/s, median_GB/s, mean_gflops, median_gflops, mean_us, median_us
and then 5 GB/s results, 5 gflops results, 5 us result. 
![image](https://github.com/user-attachments/assets/b0a2423a-4e49-4648-bd97-8c1ed40680aa)

Note that sample_num =5 doesn't mean that each problem is bench with 5 iterations.
**Each problem still follows the "cold_iter" & "hot_iter" setting. The sample_num is another outer loop, which repeats 5 times.**