### PR TITLE
Update README.md and set Python_ROOT to /usr if not set

### DIFF
--- a/tensilelite/CMakeLists.txt
+++ b/tensilelite/CMakeLists.txt
@@ -78,6 +78,12 @@ else()
     message(FATAL_ERROR "TENSILE_BIN is not defined. Please set it to one of the valid options: ${VALID_BINS}")
 endif()
 
+if("$ENV{Python_ROOT}" STREQUAL "" AND NOT Python_ROOT)
+    message(STATUS "Python_ROOT is unset. Setting Python_ROOT to /usr.")
+    message(STATUS "Configure Python_ROOT variable if a different installation is preferred.")
+    set(Python_ROOT /usr)
+endif()
+
 # Add rocisa
 add_subdirectory(rocisa)
 
@@ -91,7 +97,7 @@ set(PYTHONPATH "${PROJECT_BINARY_DIR}/lib")
 if(DEFINED DEVELOP_MODE)
     include(ProcessorCount)
     ProcessorCount(NPROC)
-    set(CMAKE_BUILD_COMMAND "cmake --build . -j ${NPROC}")
+    set(CMAKE_BUILD_COMMAND "cmake --build ${PROJECT_BINARY_DIR} -j ${NPROC}")
     if(WIN32)
         set(SCRIPT_NAME ${TENSILE_BIN}.bat)
         file(WRITE "${PROJECT_BINARY_DIR}/${SCRIPT_NAME}"

--- a/tensilelite/README.md
+++ b/tensilelite/README.md
@@ -14,9 +14,9 @@ Assumptions:
 
 Example:
 
-```cmake -DTENSILE_BIN=Tensile -DDEVELOP_MODE=ON -S hipBLASLt/tensilelite -B <tensile-out>```
+```cmake -DTENSILE_BIN=Tensile -DDEVELOP_MODE=ON -S <path-to-tensilelite-root> -B <tensile-out>```
 
-The script will be created in the build folder and will be named in Tensile.bat or Tensile.sh depending on the platform. Then you can then run the script as usual:
+The script will be created in the build folder and will be named in Tensile.bat or Tensile.sh depending on the platform. Then you can then run the script under the ``tensile-out`` folder as usual:
 
 ```
 Tensile.sh <abs-path>/Tensile/Tests/gemm/fp16_use_e.yaml tensile-out
@@ -27,6 +27,8 @@ or
 ```
 Tensile.bat <abs-path>/Tensile/Tests/gemm/fp16_use_e.yaml tensile-out
 ```
+
+**You don't need to rerun CMake unless you delete the ``tensile-out`` folder.**
 
 To build asm only:
 


### PR DESCRIPTION
The CMakeLists.txt is a tool inside TensileLite and is currently not used anywhere except local development.