### PR TITLE
Use proper logging for lib path printing

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -1932,8 +1932,12 @@ namespace
             const char* env = getenv("HIPBLASLT_TENSILE_LIBPATH");
             if(env)
             {
-                std::cout << "rocblaslt info: Using HIPBLASLT_TENSILE_LIBPATH=" << env
-                          << std::endl;
+                if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+                {
+                    std::ostringstream msg;
+                    msg << "Using HIPBLASLT_TENSILE_LIBPATH=" << env << std::endl;
+                    log_info(__func__, msg.str());
+                }
                 path = env;
             }
             else
@@ -1961,8 +1965,12 @@ namespace
                 if(TestPath(path + "/" + processor))
                     path += "/" + processor;
 
-                std::cout << "rocblaslt info: HIPBLASLT_TENSILE_LIBPATH not set: Using " << path 
-                          << std::endl;
+                if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+                {
+                    std::ostringstream msg;
+                    msg << "HIPBLASLT_TENSILE_LIBPATH not set: Using " << path << std::endl;
+                    log_info(__func__, msg.str());
+                }
             }
 
             // only load modules for the current architecture


### PR DESCRIPTION
Replace unconditional printing with proper logging utilities.

Example:
```bash
$ ./build/release/clients/staging/sample_hipblaslt_gemm
[no output]
```
Output can be displayed with HIPBLASLT_LOG_LEVEL=4.
```bash
$ HIPBLASLT_LOG_LEVEL=4 ./build/release/clients/staging/sample_hipblaslt_gemm
[2025-04-03 20:46:16][HIPBLASLT][66208][Info][initialize] HIPBLASLT_TENSILE_LIBPATH not set: Using /mnt/host/hipBLASLt/build/release/library/../Tensile/library
```

See: https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/logging-heuristics.html