### PR TITLE
Enable MX datatype support on SLES Linuz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,12 +259,6 @@ else()
     endif()
 endif()
 
-find_package(Boost REQUIRED)
-if(Boost_VERSION VERSION_LESS "1.74.0")
-    message(WARNING "Boost version ${Boost_VERSION} too old, not building RocRoller")
-    set(USE_ROCROLLER OFF)
-endif()
-
 if( LEGACY_HIPBLAS_DIRECT )
   find_package( hipblas REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm)
 else()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -114,10 +114,13 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       ../common/hipblaslt_init_device.cpp
       ${BLIS_CPP}
     )
-    
+
   # RocRoller integration
   include(FetchContent)
+  include(../cmake/Utilities.cmake)
   if(USE_ROCROLLER)
+      _save_var(INSTALL_GTEST)
+      set(INSTALL_GTEST OFF)
       add_definitions(-DUSE_ROCROLLER)
 
       FetchContent_Declare(
@@ -134,6 +137,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       list(APPEND hipblaslt_test_bench_common
        ../common/mxDataGen.cpp
        )
+      _restore_var(INSTALL_GTEST)
   endif()
 
   if( BUILD_CLIENTS_BENCHMARKS )

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -119,14 +119,14 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
   include(FetchContent)
   include(../cmake/Utilities.cmake)
   if(USE_ROCROLLER)
-      _save_var(INSTALL_GTEST)
-      set(INSTALL_GTEST OFF)
+      _save_var(BUILD_TESTING)
+      set(BUILD_TESTING OFF)
       add_definitions(-DUSE_ROCROLLER)
 
       FetchContent_Declare(
         mxDataGenerator
         GIT_REPOSITORY https://github.com/ROCm/mxDataGenerator.git
-        GIT_TAG 7a9778977f19111d3b9fc4497758df4aaa8165c5
+        GIT_TAG 12c016dc694139317feb2e23c59028fde70beaf4
       )
       FetchContent_MakeAvailable(mxDataGenerator)
 
@@ -137,7 +137,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       list(APPEND hipblaslt_test_bench_common
        ../common/mxDataGen.cpp
        )
-      _restore_var(INSTALL_GTEST)
+      _restore_var(BUILD_TESTING)
   endif()
 
   if( BUILD_CLIENTS_BENCHMARKS )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -181,7 +181,7 @@ if(USE_ROCROLLER)
   FetchContent_Declare(
     rocRoller
     GIT_REPOSITORY https://github.com/ROCm/rocRoller.git
-    GIT_TAG 00606264bc2d32b7da7ec4ebc7e6b2733ac2a556
+    GIT_TAG 34307b30956cac16e459db6cfdd3ba1f07c7e9b8
   )
   FetchContent_MakeAvailable(rocRoller)
   target_link_libraries(hipblaslt PRIVATE rocroller_interface)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -181,7 +181,7 @@ if(USE_ROCROLLER)
   FetchContent_Declare(
     rocRoller
     GIT_REPOSITORY https://github.com/ROCm/rocRoller.git
-    GIT_TAG 33fb58b76df640f98726b90a45fc5b9aa3e8af3b
+    GIT_TAG 00606264bc2d32b7da7ec4ebc7e6b2733ac2a556
   )
   FetchContent_MakeAvailable(rocRoller)
   target_link_libraries(hipblaslt PRIVATE rocroller_interface)

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -174,8 +174,8 @@ endif()
 include(FetchContent)
 if(USE_ROCROLLER)
   _save_var(BUILD_TESTING)
-  set(BUILD_CLIENTS OFF)
   _save_var(BUILD_CLIENTS)
+  set(BUILD_CLIENTS OFF)
   set(BUILD_TESTING OFF)
 
   FetchContent_Declare(

--- a/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -3,6 +3,7 @@
 #include "utility.hpp"
 
 #include <rocRoller/CommandSolution.hpp>
+#include <rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp>
 #include <rocRoller/Operations/Command.hpp>
 #include <rocRoller/TensorDescriptor.hpp>
 


### PR DESCRIPTION
Update rocRoller commit to a version that does not need boost to be in the user API headers. This will allow for hipBLASLt to be built on systems with older versions of boost installed.