### PR TITLE
Remove leftover globals in ParallelMap

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -207,7 +207,8 @@ def writeBenchmarkFiles(
         depthUConfig: DepthUConfig,
         deviceId: int,
         gfxName: str,
-        isaInfoMap: Dict[IsaVersion, IsaInfo]
+        isaInfoMap: Dict[IsaVersion, IsaInfo],
+        procs: int
     ):
     """Write all the files needed for a given benchmarking step"""
 
@@ -260,6 +261,7 @@ def writeBenchmarkFiles(
                             cmdLineArchs,
                             kernelSerialNaming,
                             kernelMinNaming,
+                            procs,
                             errorTolerant=True,
                             generateSourcesAndExit=globalParameters["GenerateSourcesAndExit"], # put in debug config
                             compress=False,
@@ -324,7 +326,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                          asmToolchain: AssemblyToolchain, srcToolchain: SourceToolchain, cCompiler: str,
                          buildTmpPath: Path, benchmarkProblemsPath: Path, useShortNames: bool,
                          debugConfig: DebugConfig, depthUConfig: DepthUConfig, deviceId: int,
-                         gfxName: str, isaInfoMap: Dict[str, IsaInfo]
+                         gfxName: str, isaInfoMap: Dict[IsaVersion, IsaInfo], procs: int
     ):
     """Run the benchmarking for a single entry in the BenchmarkProblems of a Tensile config"""
     benchmarkTestFails = 0
@@ -439,7 +441,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                     benchmarkStep.problemSizes, benchmarkStep.biasTypeArgs, \
                     benchmarkStep.factorDimArgs, benchmarkStep.activationArgs, \
                     benchmarkStep.icacheFlushArgs, shortName, [], asmToolchain, srcToolchain, \
-                    sourcePath, useShortNames, debugConfig, depthUConfig, deviceId, gfxName, isaInfoMap)
+                    sourcePath, useShortNames, debugConfig, depthUConfig, deviceId, gfxName, isaInfoMap, procs)
             # ^ this mutates solutions
 
             # write cache data
@@ -517,7 +519,8 @@ def main(
     depthUConfig: DepthUConfig,
     deviceId: int,
     gfxName: str,
-    isaInfoMap: Dict[str, IsaInfo]
+    isaInfoMap: Dict[str, IsaInfo],
+    procs: int
 ):
     """Entry point for the "BenchmarkProblems" section of a Tensile config yaml"""
     ClientExecutable.getClientExecutable(str(srcToolchain.compiler.path), cCompiler, outputPath)
@@ -572,7 +575,8 @@ def main(
                             depthUConfig,
                             deviceId,
                             gfxName,
-                            isaInfoMap
+                            isaInfoMap,
+                            procs
                         )
                 totalTestFails += benchmarkErrors
 

--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -49,7 +49,7 @@ from .CustomKernels import getCustomKernelConfig
 from .Toolchain.Assembly import AssemblyToolchain
 from .Toolchain.Source import SourceToolchain
 from Tensile.Common import HR, print1, print2, IsaInfo, IsaVersion, \
-        printExit, printWarning, ensurePath, tqdm, state, \
+        printExit, printWarning, ensurePath, showProgress, state, \
         BENCHMARK_PROBLEMS_DIR, BENCHMARK_DATA_DIR, DepthUConfig
 from Tensile.Common.Architectures import isaToGfx, gfxToVariants
 from Tensile.Common.GlobalParameters import globalParameters, startTime
@@ -221,7 +221,7 @@ def writeBenchmarkFiles(
     kernelHelperNames = set()
 
     # get unique kernels and kernel helpers
-    for solution in tqdm(solutions, "Finding unique solutions"):
+    for solution in showProgress(solutions, desc="Finding unique solutions"):
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
             kName = getKeyNoInternalArgs(kernel, debugConfig.splitGSU)

--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -117,9 +117,6 @@ globalParameters["GenerateSourcesAndExit"] = False  # Exit after kernel source g
 globalParameters["ExitOnFails"] = (
     1  # 1: Exit after benchmark run if failures detected.  2: Exit during benchmark run.
 )
-# globalParameters["CpuThreads"] = (
-#     -1
-# )  # How many CPU threads to use for kernel generation.  0=no threading, -1 == nproc, N=min(nproc,N).  TODO - 0 sometimes fails with a kernel name error?  0 does not check error codes correctly
 globalParameters["NumWarmups"] = 0
 
 ########################################

--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -110,10 +110,6 @@ globalParameters["ForceRedoLibraryLogic"] = (
 globalParameters["ForceRedoLibraryClient"] = (
     True  # if False and library client already built, then building library client will be skipped when tensile is re-run
 )
-
-globalParameters["ShowProgressBar"] = (
-    True  # if False and library client already built, then building library client will be skipped when tensile is re-run
-)
 globalParameters["SolutionSelectionAlg"] = (
     1  # algorithm to determine which solutions to keep. 0=removeLeastImportantSolutions, 1=keepWinnerSolutions (faster)
 )
@@ -609,6 +605,8 @@ def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
         "OutputPath",
         "Experimental",
         "GenSolTable",
+        "CpuThreads",
+        "ShowProgressBar",
     ]
     for key in config:
         if key in ignoreKeys:

--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -121,9 +121,9 @@ globalParameters["GenerateSourcesAndExit"] = False  # Exit after kernel source g
 globalParameters["ExitOnFails"] = (
     1  # 1: Exit after benchmark run if failures detected.  2: Exit during benchmark run.
 )
-globalParameters["CpuThreads"] = (
-    -1
-)  # How many CPU threads to use for kernel generation.  0=no threading, -1 == nproc, N=min(nproc,N).  TODO - 0 sometimes fails with a kernel name error?  0 does not check error codes correctly
+# globalParameters["CpuThreads"] = (
+#     -1
+# )  # How many CPU threads to use for kernel generation.  0=no threading, -1 == nproc, N=min(nproc,N).  TODO - 0 sometimes fails with a kernel name error?  0 does not check error codes correctly
 globalParameters["NumWarmups"] = 0
 
 ########################################

--- a/tensilelite/Tensile/Common/Parallel.py
+++ b/tensilelite/Tensile/Common/Parallel.py
@@ -30,7 +30,9 @@ import time
 
 from joblib import Parallel, delayed
 
-from .Utilities import tqdm
+from .Utilities import tqdm, print1
+
+DEFAULT_CPU_PROCS: int = 64
 
 
 def joblibParallelSupportsGenerator():
@@ -41,22 +43,16 @@ def joblibParallelSupportsGenerator():
     return Version(joblibVer) >= Version("1.4.0")
 
 
-def CPUThreadCount(enable=True):
-    from .GlobalParameters import globalParameters
-
-    if not enable:
-        return 1
-    else:
-        if os.name == "nt":
-            cpu_count = os.cpu_count()
-        else:
-            cpu_count = len(os.sched_getaffinity(0))
-        cpuThreads = globalParameters["CpuThreads"]
-        if cpuThreads == -1:
-            return min(
-                cpu_count, 64
-            )  # Temporarily hack to fix oom issue, remove this after jenkin is fixed.
-        return min(cpu_count, cpuThreads)
+def CPUThreadCount(requestProcs: int):
+    cpuCount = os.cpu_count() if os.name == "nt" else len(os.sched_getaffinity(0))
+    print1("CPU Threads: {}".format(requestProcs))
+    return min(cpuCount, requestProcs)
+    # if cpuThreads == -1:
+    #     return min(
+    #         cpu_count, 64
+    #     )  # Temporarily hack to fix oom issue, remove this after jenkin is fixed.
+    # print1("Final CPU Threads: {}".format(cpu_count))
+    # return min(cpu_count, cpuThreads)
 
 
 def pcallWithGlobalParamsMultiArg(f, args, newGlobalParameters):
@@ -100,9 +96,8 @@ def ProcessingPool(enable=True, maxTasksPerChild=None):
     import multiprocessing
     import multiprocessing.dummy
 
-    threadCount = CPUThreadCount()
-
-    if (not enable) or threadCount <= 1:
+    threadCount = CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
+    if threadCount <= 1:
         return multiprocessing.dummy.Pool(1)
 
     if multiprocessing.get_start_method() == "spawn":
@@ -118,7 +113,7 @@ def ProcessingPool(enable=True, maxTasksPerChild=None):
         return multiprocessing.Pool(threadCount, maxtasksperchild=maxTasksPerChild)
 
 
-def ParallelMap(function, objects, message="", enable=True, method=None, maxTasksPerChild=None):
+def ParallelMap(function, objects, message="", enable=True, method=None, maxTasksPerChild=None, procs=None):
     """
     Generally equivalent to list(map(function, objects)), possibly executing in parallel.
 
@@ -130,12 +125,10 @@ def ParallelMap(function, objects, message="", enable=True, method=None, maxTask
              - `lambda x: x.imap` - lazy evaluation
              - `lambda x: x.imap_unordered` - lazy evaluation, does not preserve order of return value.
     """
-    from .GlobalParameters import globalParameters
-
-    threadCount = CPUThreadCount(enable)
+    threadCount = CPUThreadCount(procs) if procs else CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
     pool = ProcessingPool(enable, maxTasksPerChild)
 
-    if threadCount <= 1 and globalParameters["ShowProgressBar"]:
+    if threadCount <= 1:
         # Provide a progress bar for single-threaded operation.
         # This works for method=None, and for starmap.
         mapFunc = map
@@ -179,13 +172,11 @@ def ParallelMap(function, objects, message="", enable=True, method=None, maxTask
 
 
 def ParallelMapReturnAsGenerator(function, objects, message="", enable=True, multiArg=True):
-    from .GlobalParameters import globalParameters
 
-    threadCount = CPUThreadCount(enable)
+    threadCount = CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
     print("{0}Launching {1} threads...".format(message, threadCount))
 
-    if threadCount <= 1 and globalParameters["ShowProgressBar"]:
-        # Provide a progress bar for single-threaded operation.
+    if threadCount <= 1:
         callFunc = lambda args: function(*args) if multiArg else lambda args: function(args)
         return [callFunc(args) for args in tqdm(objects, message)]
 
@@ -209,14 +200,9 @@ def ParallelMap2(
     if return_as in ("generator", "generator_unordered") and not joblibParallelSupportsGenerator():
         return ParallelMapReturnAsGenerator(function, objects, message, enable, multiArg)
 
-    from .GlobalParameters import globalParameters
+    threadCount = CPUThreadCount(procs) if procs else CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
 
-    threadCount = procs if procs else CPUThreadCount(enable)
-
-    threadCount = CPUThreadCount(enable)
-
-    if threadCount <= 1 and globalParameters["ShowProgressBar"]:
-        # Provide a progress bar for single-threaded operation.
+    if threadCount <= 1:
         return [function(*args) if multiArg else function(args) for args in tqdm(objects, message)]
 
     countMessage = ""
@@ -232,7 +218,7 @@ def ParallelMap2(
     currentTime = time.time()
 
     pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
-    pargs = zip(objects, itertools.repeat(globalParameters))
+    pargs = zip(objects, itertools.repeat({}))
 
     if joblibParallelSupportsGenerator():
         rv = Parallel(n_jobs=threadCount, timeout=99999, return_as=return_as)(

--- a/tensilelite/Tensile/Common/Parallel.py
+++ b/tensilelite/Tensile/Common/Parallel.py
@@ -135,7 +135,7 @@ def ParallelMap(function, objects, message="", enable=True, method=None, maxTask
                 mapFunc = None
 
         if mapFunc is not None:
-            return list(mapFunc(function, tqdm(objects, message)))
+            return list(mapFunc(function, showProgress(objects, desc=message)))
 
     mapFunc = pool.map
     if method:
@@ -171,7 +171,7 @@ def ParallelMapReturnAsGenerator(function, objects, message="", enable=True, mul
 
     if threadCount <= 1:
         callFunc = lambda args: function(*args) if multiArg else lambda args: function(args)
-        return [callFunc(args) for args in tqdm(objects, message)]
+        return [callFunc(args) for args in showProgress(objects, desc=message)]
 
     with concurrent.futures.ProcessPoolExecutor(max_workers=threadCount) as executor:
         resultFutures = (executor.submit(function, *arg if multiArg else arg) for arg in objects)
@@ -196,7 +196,7 @@ def ParallelMap2(
     threadCount = CPUThreadCount(procs) if procs else CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
 
     if threadCount <= 1:
-        return [function(*args) if multiArg else function(args) for args in showProgress(objects, message)]
+        return [function(*args) if multiArg else function(args) for args in showProgress(objects, desc=message)]
 
     countMessage = ""
     try:
@@ -206,7 +206,7 @@ def ParallelMap2(
 
     if message != "":
         message += ": "
-    print("{0}Launching {1} threads{2}...".format(message, threadCount, countMessage))
+    print("# {0}Launching {1} processes{2}...".format(message, threadCount, countMessage))
     sys.stdout.flush()
     currentTime = time.time()
 
@@ -221,6 +221,6 @@ def ParallelMap2(
         )
 
     totalTime = time.time() - currentTime
-    print("{0}Done. ({1:.1f} secs elapsed)".format(message, totalTime))
+    print("# {0}Done. ({1:.1f} secs elapsed)".format(message, totalTime))
     sys.stdout.flush()
     return rv

--- a/tensilelite/Tensile/Common/Parallel.py
+++ b/tensilelite/Tensile/Common/Parallel.py
@@ -30,7 +30,7 @@ import time
 
 from joblib import Parallel, delayed
 
-from .Utilities import tqdm, print1
+from .Utilities import showProgress, print1
 
 DEFAULT_CPU_PROCS: int = 64
 
@@ -45,14 +45,7 @@ def joblibParallelSupportsGenerator():
 
 def CPUThreadCount(requestProcs: int):
     cpuCount = os.cpu_count() if os.name == "nt" else len(os.sched_getaffinity(0))
-    print1("CPU Threads: {}".format(requestProcs))
     return min(cpuCount, requestProcs)
-    # if cpuThreads == -1:
-    #     return min(
-    #         cpu_count, 64
-    #     )  # Temporarily hack to fix oom issue, remove this after jenkin is fixed.
-    # print1("Final CPU Threads: {}".format(cpu_count))
-    # return min(cpu_count, cpuThreads)
 
 
 def pcallWithGlobalParamsMultiArg(f, args, newGlobalParameters):
@@ -203,7 +196,7 @@ def ParallelMap2(
     threadCount = CPUThreadCount(procs) if procs else CPUThreadCount(DEFAULT_CPU_PROCS) if enable else 1
 
     if threadCount <= 1:
-        return [function(*args) if multiArg else function(args) for args in tqdm(objects, message)]
+        return [function(*args) if multiArg else function(args) for args in showProgress(objects, message)]
 
     countMessage = ""
     try:
@@ -217,16 +210,14 @@ def ParallelMap2(
     sys.stdout.flush()
     currentTime = time.time()
 
-    pcall = pcallWithGlobalParamsMultiArg if multiArg else pcallWithGlobalParamsSingleArg
-    pargs = zip(objects, itertools.repeat({}))
-
     if joblibParallelSupportsGenerator():
         rv = Parallel(n_jobs=threadCount, timeout=99999, return_as=return_as)(
-            delayed(pcall)(function, a, params) for a, params in pargs
+            delayed(function)(*o) if multiArg else delayed(function)(o) for o in objects
         )
     else:
+        assert False, "IS THIS EVER HIT?"
         rv = Parallel(n_jobs=threadCount, timeout=99999)(
-            delayed(pcall)(function, a, params) for a, params in pargs
+            delayed(function)(*o) if multiArg else delayed(function)(o) for o in objects
         )
 
     totalTime = time.time() - currentTime

--- a/tensilelite/Tensile/Common/Parallel.py
+++ b/tensilelite/Tensile/Common/Parallel.py
@@ -48,16 +48,6 @@ def CPUThreadCount(requestProcs: int):
     return min(cpuCount, requestProcs)
 
 
-def pcallWithGlobalParamsMultiArg(f, args, newGlobalParameters):
-    OverwriteGlobalParameters(newGlobalParameters)
-    return f(*args)
-
-
-def pcallWithGlobalParamsSingleArg(f, arg, newGlobalParameters):
-    OverwriteGlobalParameters(newGlobalParameters)
-    return f(arg)
-
-
 def apply_print_exception(item, *args):
     # print(item, args)
     try:
@@ -78,13 +68,6 @@ def apply_print_exception(item, *args):
         sys.stderr.flush()
 
 
-def OverwriteGlobalParameters(newGlobalParameters):
-    from . import GlobalParameters
-
-    GlobalParameters.globalParameters.clear()
-    GlobalParameters.globalParameters.update(newGlobalParameters)
-
-
 def ProcessingPool(enable=True, maxTasksPerChild=None):
     import multiprocessing
     import multiprocessing.dummy
@@ -94,13 +77,10 @@ def ProcessingPool(enable=True, maxTasksPerChild=None):
         return multiprocessing.dummy.Pool(1)
 
     if multiprocessing.get_start_method() == "spawn":
-        from . import GlobalParameters
 
         return multiprocessing.Pool(
             threadCount,
-            initializer=OverwriteGlobalParameters,
             maxtasksperchild=maxTasksPerChild,
-            initargs=(GlobalParameters.globalParameters,),
         )
     else:
         return multiprocessing.Pool(threadCount, maxtasksperchild=maxTasksPerChild)
@@ -215,7 +195,6 @@ def ParallelMap2(
             delayed(function)(*o) if multiArg else delayed(function)(o) for o in objects
         )
     else:
-        assert False, "IS THIS EVER HIT?"
         rv = Parallel(n_jobs=threadCount, timeout=99999)(
             delayed(function)(*o) if multiArg else delayed(function)(o) for o in objects
         )

--- a/tensilelite/Tensile/Common/Utilities.py
+++ b/tensilelite/Tensile/Common/Utilities.py
@@ -46,14 +46,14 @@ def setVerbosity(v: int):
 def getVerbosity():
     return _verbosity
 
-_showProgressBar = True
+_showProgressBar = False
 
 def setProgressBar(v: bool):
-    global _showProgress
-    _showProgress = v
+    global _showProgressBar
+    _showProgressBar = v
 
 def getProgressBar():
-    return _showProgress
+    return _showProgressBar
 
 ################################################################################
 # Printing

--- a/tensilelite/Tensile/Common/Utilities.py
+++ b/tensilelite/Tensile/Common/Utilities.py
@@ -239,12 +239,13 @@ class SpinnyThing:
         count: A counter to control the update frequency of the spinner.
         createTime: The timestamp when the spinner was created.
     """
-    def __init__(self, desc: str):
+    def __init__(self, desc: str, showTime=False):
         self.message: str = "# " + desc
         self.chars: List[str] = ['|', '/', '-', '\\']
         self.index: int = 0
         self.count: int = 0
         self.createTime: float = time.time()
+        self.showTime: bool = showTime
 
     def increment(self):
         """Increments the spinner's position and updates the display if necessary."""
@@ -265,9 +266,9 @@ class SpinnyThing:
         sys.stdout.flush()
 
         stopTime = time.time()
-        elapsedTime = stopTime - self.createTime
-
-        sys.stdout.write('\r' + self.message + f'... Done in {elapsedTime:.1f} secs\n')
+        if self.showTime:
+            sys.stdout.write(f" (took {stopTime - self.createTime:.1f} secs)")
+        sys.stdout.write('\n')
         sys.stdout.flush()
 
 

--- a/tensilelite/Tensile/Common/Utilities.py
+++ b/tensilelite/Tensile/Common/Utilities.py
@@ -33,10 +33,12 @@ from inspect import currentframe, getframeinfo
 from copy import deepcopy
 from enum import Enum
 from pathlib import Path
+from typing import List
 
 from Tensile import __version__
 
 _verbosity = 1
+_showProgress = True
 
 def setVerbosity(v: int):
     global _verbosity
@@ -148,26 +150,43 @@ def versionIsCompatible(queryVersionString):
     return True
 
 
-################################################################################
-# Progress Bar Printing
-# prints "||||" up to width
-################################################################################
 class ProgressBar:
-    def __init__(self, maxValue, width=80):
-        self.char = "|"
-        self.maxValue = maxValue
-        self.width = width
-        self.maxTicks = self.width - 7
+    """A class for displaying a progress bar in the console.
 
-        self.priorValue = 0
-        self.fraction = 0
-        self.numTicks = 0
-        self.createTime = time.time()
+    This class provides a simple way to display and update a progress bar in the console
+    to indicate the progress of a long-running operation. The progress bar can be updated
+    incrementally and supports displaying a completion message and time upon finishing.
+
+    Attributes:
+        char: The character used to fill the progress bar.
+        maxValue: The maximum value the progress bar can represent.
+        width: The total width of the progress bar, including borders.
+        maxTicks: The maximum number of ticks (fill characters) within the progress bar.
+        priorValue: The value of the progress bar during the last update.
+        fraction: The fraction of the progress bar that is filled.
+        numTicks: The current number of ticks (fill characters) in the progress bar.
+        createTime: The timestamp when the progress bar was created.
+        message: The message displayed alongside the progress bar.
+    """
+    def __init__(self, maxValue: int, desc: str, width=40):
+        self.char: str = '.'
+        self.maxValue: int = maxValue
+        self.width: int = width
+        self.maxTicks: int = self.width - 10  # Adjusted for better alignment
+
+        self.priorValue: int = 0
+        self.fraction: float = 0
+        self.numTicks: int = 0
+        self.createTime: float = time.time()
+
+        self.message: str = "# " + desc
 
     def increment(self, value=1):
+        """Increments the progress bar by a given value and updates the display."""
         self.update(self.priorValue + value)
 
     def update(self, value):
+        """Updates the progress bar to a specific value and refreshes the display."""
         currentFraction = 1.0 * value / self.maxValue
         currentNumTicks = int(currentFraction * self.maxTicks)
         if currentNumTicks > self.numTicks:
@@ -177,55 +196,92 @@ class ProgressBar:
         self.priorValue = value
 
     def printStatus(self):
-        sys.stdout.write("\r")
-        sys.stdout.write(
-            "[%-*s] %3d%%" % (self.maxTicks, self.char * self.numTicks, self.fraction * 100)
-        )
-        if self.numTicks == self.maxTicks:
-            stopTime = time.time()
-            sys.stdout.write(" (%-.1f secs elapsed)\n" % (stopTime - self.createTime))
+        """Prints the current status of the progress bar to the console."""
+        progress_bar = self.char * self.numTicks + ' ' * (self.maxTicks - self.numTicks)
+        status_msg = f"{self.message} {progress_bar} {self.fraction * 100:.1f}%"
+
+        if self.numTicks == 0:
+            sys.stdout.write(status_msg)
+        else:
+            sys.stdout.write('\r' + ' ' * len(status_msg) + '\r' + status_msg)
         sys.stdout.flush()
 
     def finish(self):
-        pass
+        """Marks the operation as done, cleans up the display, and prints the completion time."""
+        stopTime = time.time()
 
-
-class DataDirection(Enum):
-    NONE = (0,)
-    READ = (1,)
-    WRITE = 2
+        sys.stdout.write(f" (took {stopTime - self.createTime:.1f} secs)\n")
+        sys.stdout.flush()
 
 
 class SpinnyThing:
-    def __init__(self):
-        self.chars = ["|", "/", "-", "\\"]
-        self.index = 0
+    """A class to display a spinning indicator in the console for long-running operations.
 
-    def increment(self, value=1):
-        sys.stdout.write("\b" + self.chars[self.index])
+    This class provides a simple way to visually indicate that a long-running operation
+    is in progress by displaying a spinning character in the console. The spinner is
+    updated at regular intervals, and a completion message with the elapsed time is
+    displayed when the operation finishes.
+
+    Attributes:
+        msg: The message displayed alongside the spinner.
+        chars: The sequence of characters used for the spinner animation.
+        index: The current index in the `chars` list for the spinner.
+        count: A counter to control the update frequency of the spinner.
+        createTime: The timestamp when the spinner was created.
+    """
+    def __init__(self, desc: str):
+        self.message: str = "# " + desc
+        self.chars: List[str] = ['|', '/', '-', '\\']
+        self.index: int = 0
+        self.count: int = 0
+        self.createTime: float = time.time()
+
+    def increment(self):
+        """Increments the spinner's position and updates the display if necessary."""
+        self.count += 1
+        if self.count % 3 != 0:
+            return
+
+        sys.stdout.write('\r' + ' ' * (len(self.message) + 10))
+        sys.stdout.flush()
+
+        sys.stdout.write('\r' + self.message + " " + self.chars[self.index])
         sys.stdout.flush()
         self.index = (self.index + 1) % len(self.chars)
 
     def finish(self):
-        sys.stdout.write("\b*\n")
+        """Clears the spinner and displays a completion message with the elapsed time."""
+        sys.stdout.write('\r' + ' ' * (len(self.message) + 10))
+        sys.stdout.flush()
+
+        stopTime = time.time()
+        elapsedTime = stopTime - self.createTime
+
+        sys.stdout.write('\r' + self.message + f'... Done in {elapsedTime:.1f} secs\n')
         sys.stdout.flush()
 
 
-def iterate_progress(obj, *args, **kwargs):
-    try:
-        progress = ProgressBar(len(obj))
-    except TypeError:
-        progress = SpinnyThing()
+def showProgress(obj, *args, **kwargs):
+    if 'desc' not in kwargs:
+        printWarning("No message provided for TQDM progress bar/spinner")
+        kwargs['desc'] = 'Processing unknown function'
+    if 'total' in kwargs:
+        progress = ProgressBar(kwargs['total'], kwargs['desc'])
+    else:
+        try:
+            progress =  ProgressBar(len(obj), kwargs['desc'])
+        except TypeError:
+            progress = SpinnyThing(kwargs['desc'])
     for o in obj:
         yield o
         progress.increment()
     progress.finish()
 
 
-try:
-    from tqdm import tqdm
-except ImportError:
-    tqdm = iterate_progress
+class DataDirection(Enum):
+    NONE = (0,)
+    READ = (1,)
+    WRITE = 2
 
 
 def state(obj):

--- a/tensilelite/Tensile/Common/Utilities.py
+++ b/tensilelite/Tensile/Common/Utilities.py
@@ -38,7 +38,6 @@ from typing import List
 from Tensile import __version__
 
 _verbosity = 1
-_showProgress = True
 
 def setVerbosity(v: int):
     global _verbosity
@@ -46,6 +45,15 @@ def setVerbosity(v: int):
 
 def getVerbosity():
     return _verbosity
+
+_showProgressBar = True
+
+def setProgressBar(v: bool):
+    global _showProgress
+    _showProgress = v
+
+def getProgressBar():
+    return _showProgress
 
 ################################################################################
 # Printing
@@ -168,7 +176,7 @@ class ProgressBar:
         createTime: The timestamp when the progress bar was created.
         message: The message displayed alongside the progress bar.
     """
-    def __init__(self, maxValue: int, desc: str, width=40):
+    def __init__(self, maxValue: int, desc: str, width=40, showTime=False):
         self.char: str = '.'
         self.maxValue: int = maxValue
         self.width: int = width
@@ -178,8 +186,9 @@ class ProgressBar:
         self.fraction: float = 0
         self.numTicks: int = 0
         self.createTime: float = time.time()
+        self.showTime: bool = showTime
 
-        self.message: str = "# " + desc
+        self.message: str = desc
 
     def increment(self, value=1):
         """Increments the progress bar by a given value and updates the display."""
@@ -209,8 +218,9 @@ class ProgressBar:
     def finish(self):
         """Marks the operation as done, cleans up the display, and prints the completion time."""
         stopTime = time.time()
-
-        sys.stdout.write(f" (took {stopTime - self.createTime:.1f} secs)\n")
+        if self.showTime:
+            sys.stdout.write(f" (took {stopTime - self.createTime:.1f} secs)")
+        sys.stdout.write('\n')
         sys.stdout.flush()
 
 
@@ -261,18 +271,21 @@ class SpinnyThing:
         sys.stdout.flush()
 
 
-def showProgress(obj, *args, **kwargs):
-    if 'desc' not in kwargs:
-        printWarning("No message provided for TQDM progress bar/spinner")
-        kwargs['desc'] = 'Processing unknown function'
-    if 'total' in kwargs:
-        progress = ProgressBar(kwargs['total'], kwargs['desc'])
-    else:
-        try:
-            progress =  ProgressBar(len(obj), kwargs['desc'])
-        except TypeError:
-            progress = SpinnyThing(kwargs['desc'])
-    for o in obj:
+def showProgress(objs, *args, **kwargs):
+    if not getProgressBar():
+        yield from objs
+        return
+
+    desc = kwargs.get('desc', '#')
+    total = kwargs.get('total', None)
+    progress = None
+
+    try:
+        progress = ProgressBar(total or len(objs), desc)
+    except TypeError:
+        progress = SpinnyThing(desc)
+
+    for o in objs:
         yield o
         progress.increment()
     progress.finish()

--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -276,7 +276,7 @@ class LogicAnalyzer:
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       totalSolutions += len(solutionGroup)
-    for solutionGroupIdx in showProgress(range(0, len(solutionsList)):
+    for solutionGroupIdx in showProgress(range(0, len(solutionsList))):
       solutionGroup = solutionsList[solutionGroupIdx]
       self.numSolutionsPerGroup.append(len(solutionGroup))
       self.solutionGroupMap.append({})

--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -26,7 +26,7 @@ from pathlib import Path
 from typing import Dict
 from . import LibraryIO
 from . import SolutionSelectionLibrary
-from Tensile.Common import print1, print2, HR, printExit, \
+from Tensile.Common import print1, print2, HR, printExit, showProgress, \
   assignParameterWithDefault, ProgressBar, printWarning, ensurePath, \
   LIBRARY_LOGIC_DIR, BENCHMARK_DATA_DIR, getVerbosity, IsaInfo, DepthUConfig
 from Tensile.Common.GlobalParameters import defaultAnalysisParameters, globalParameters, startTime
@@ -276,8 +276,7 @@ class LogicAnalyzer:
     for solutionGroupIdx in range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       totalSolutions += len(solutionGroup)
-    progressBar = ProgressBar(totalSolutions)
-    for solutionGroupIdx in range(0, len(solutionsList)):
+    for solutionGroupIdx in showProgress(range(0, len(solutionsList)):
       solutionGroup = solutionsList[solutionGroupIdx]
       self.numSolutionsPerGroup.append(len(solutionGroup))
       self.solutionGroupMap.append({})
@@ -291,7 +290,6 @@ class LogicAnalyzer:
           sIdx = solutionsHash[solution]
 
         self.solutionGroupMap[solutionGroupIdx][solutionIdx] = sIdx
-        progressBar.increment()
     self.numSolutions = len(self.solutions)
     self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -190,8 +190,8 @@ def addCommonArguments(argParser):
         choices=["4", "5", "V4", "V5", "default"], action="store", default="4", help="HSA code-object version")
     argParser.add_argument("-v", "--verbose", action="store_true", \
         help="set PrintLevel=2")
-    argParser.add_argument("--show-progress", dest="ShowProgressBar", action="store_true", default=False, \
-        help="Show progress bars.")
+    argParser.add_argument("--hide-progress", dest="ShowProgressBar", action="store_false", default=True, \
+        help="Hide progress bars (shown by default).")
     argParser.add_argument("--debug", dest="debug", action="store_true", \
         help="set PrintLevel=2 and CMakeBuildType=Debug")
     argParser.add_argument("--short-names", dest="shortNames", action="store_true", \

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -493,6 +493,8 @@ def Tensile(userArgs):
 
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
+    procs = config["CpuThreads"]
+    assert procs > 0, f"CpuThreads must be > 0, found {procs}"
 
     executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, depthUConfig, device_id, procs)
 

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -37,7 +37,7 @@ from typing import Dict
 
 from Tensile import __version__
 from Tensile.Common import print1, printExit, printWarning, ensurePath, HR, isRhel8, \
-                           LIBRARY_LOGIC_DIR, setVerbosity, IsaInfo, makeDebugConfig, \
+                           LIBRARY_LOGIC_DIR, setVerbosity, setProgressBar, IsaInfo, makeDebugConfig, \
                            makeDepthUConfig, DebugConfig, DepthUConfig, IsaVersion, coVersionMap
 from Tensile.Common.Architectures import detectGlobalCurrentISA, isaToGfx
 from Tensile.Common.Capabilities import makeIsaInfoMap
@@ -190,6 +190,8 @@ def addCommonArguments(argParser):
         choices=["4", "5", "V4", "V5", "default"], action="store", default="4", help="HSA code-object version")
     argParser.add_argument("-v", "--verbose", action="store_true", \
         help="set PrintLevel=2")
+    argParser.add_argument("--show-progress", dest="ShowProgressBar", action="store_true", default=False, \
+        help="Show progress bars.")
     argParser.add_argument("--debug", dest="debug", action="store_true", \
         help="set PrintLevel=2 and CMakeBuildType=Debug")
     argParser.add_argument("--short-names", dest="shortNames", action="store_true", \
@@ -208,6 +210,7 @@ def addCommonArguments(argParser):
         action="store", default="yaml", help="select which logic format to use")
     argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
         action="store", default="yaml", help="select which library format to use")
+    argParser.add_argument("--jobs", "-j", dest="CpuThreads", type=int, help="Number of parallel jobs to launch")
     argParser.add_argument("--client-lock", default=None)
     argParser.add_argument("--prebuilt-client", default=None)
 
@@ -378,9 +381,11 @@ def Tensile(userArgs):
     altFormat = args.AlternateFormat
     useCache = args.useCache
     outputPath = Path(ensurePath(os.path.abspath(args.OutputPath)))
+    procs = args.CpuThreads
     print1(f"#  OutputPath: {str(outputPath)}")
 
     setVerbosity(2 if (args.debug or args.verbose) else 1)
+    setProgressBar(args.ShowProgressBar)
 
     if altFormat and len(configPaths) > 2:
         printExit("Only 1 or 2 config_files are accepted for the alternate config format: "
@@ -493,8 +498,8 @@ def Tensile(userArgs):
 
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
-    procs = config["CpuThreads"]
-    assert procs > 0, f"CpuThreads must be > 0, found {procs}"
+    if "CpuThreads" in globalParameters or "CpuThreads" in config:
+        printWarning("CpuThreads is no longer configurable from within Tensile configs, it must be set with `--jobs`")
 
     executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, depthUConfig, device_id, procs)
 

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -70,7 +70,8 @@ def executeStepsInConfig(
         cCompiler: str,
         debugConfig: DebugConfig,
         depthUConfig: DepthUConfig,
-        deviceId: int
+        deviceId: int,
+        procs: int
    ):
     """Conducts the steps in the provided ``config`` according to the Tensile workflow.
 
@@ -110,6 +111,7 @@ def executeStepsInConfig(
             deviceId,
             gfxName,
             isaInfoMap,
+            procs
         )
         print1("")
 
@@ -492,7 +494,7 @@ def Tensile(userArgs):
     if "MaxFileName" in globalParameters or "MaxFileName" in config:
         printWarning("MaxFileName is no longer configurable, it will be automatically set to 64")
 
-    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, depthUConfig, device_id)
+    executeStepsInConfig(config, outputPath, asmToolchain, srcToolchain, isaInfoMap, cCompiler, debugConfig, depthUConfig, device_id, procs)
 
 def TensileConfigPath(*args):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), "Configs", *args)

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -138,6 +138,13 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         help="Set printout verbosity level.",
     )
     argParser.add_argument(
+        "--show-progress",
+        dest="ShowProgressBar",
+        action="store_true",
+        default=False,
+        help="Show progress bars.",
+    )
+    argParser.add_argument(
         "--no-lazy-library-loading",
         dest="LazyLibraryLoading",
         action="store_false",
@@ -205,6 +212,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     arguments["LibraryFormat"] = args.LibraryFormat
     arguments["CpuThreads"] = args.CpuThreads
     arguments["PrintLevel"] = args.PrintLevel
+    arguments["ShowProgressBar"] = args.ShowProgressBar
     arguments["AsmDebug"] = args.AsmDebug
     arguments["BuildIdKind"] = args.BuildIdKind
     arguments["KeepBuildTmp"] = args.KeepBuildTmp

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -127,7 +127,6 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         "-j",
         dest="CpuThreads",
         type=int,
-        default=-1,
         help="Number of parallel jobs to launch.",
     )
     argParser.add_argument(
@@ -180,7 +179,7 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         action="store_true",
         default=False,
         help="Do not remove the temporary build directory (may required hundreds of GBs of space)",
-    ),
+    )
     argParser.add_argument(
         "--logic-filter",
         dest="LogicFilter",

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -49,6 +49,7 @@ from Tensile.Common import (
     printWarning,
     state,
     showProgress,
+    setProgressBar,
     setVerbosity,
     getVerbosity
 )
@@ -111,9 +112,7 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
     removeSolutions = []
     removeResults = []
 
-    for kernIdx, r in (
-        showProgress(enumerate(results)) if printLevel > 1 else enumerate(results)
-    ):
+    for kernIdx, r in enumerate(results):
         if r.err != 0:
             if not errorTolerant:
                 print(
@@ -134,11 +133,7 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
     for kern in removeKernels:
         kernels.remove(kern)
 
-    for solution in (
-        showProgress(solutions, "Finding invalid solutions")
-        if printLevel > 1
-        else solutions
-    ):
+    for solution in showProgress(solutions, desc="Finding invalid solutions"):
         solutionKernels = solution.getKernels()
         for kernel in solutionKernels:
             kName = getKeyNoInternalArgs(kernel, splitGSU)
@@ -253,7 +248,13 @@ def writeSolutionsAndKernels(
         itertools.repeat(kernelSerialNaming),
         asmKernels
     )
-    asmResults = ParallelMap2(processKernelSource, showProgress(asmIter), "Generating assembly kernels", return_as="list", procs=procs)
+    asmResults = ParallelMap2(
+        processKernelSource,
+        showProgress(asmIter),
+        "Generating assembly kernels",
+        return_as="list",
+        procs=procs
+    )
     removeInvalidSolutionsAndKernels(
         asmResults, asmKernels, solutions, errorTolerant, getVerbosity(), splitGSU
     )
@@ -471,10 +472,13 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
             for _, lazyLib in lib.lazyLibraries.items():
                 yield from libraryIter(lazyLib)
 
-    res = ParallelMap2(
-        LibraryIO.parseLibraryLogicFile, showProgress(fIter), "Loading Logics...", return_as="generator_unordered", procs=procs
-    )
-    for library in res:
+    for library in  ParallelMap2(
+        LibraryIO.parseLibraryLogicFile,
+        showProgress(fIter, total=len(logicFiles)),
+        "Loading logic files",
+        return_as="generator_unordered",
+        procs=procs
+    ):
         _, architectureName, _, _, _, newLibrary = library
 
         if architectureName == "":
@@ -550,6 +554,7 @@ def run():
 
     arguments = parseArguments()
     setVerbosity(arguments["PrintLevel"])
+    setProgressBar(arguments["ShowProgressBar"])
     outputPath = Path(ensurePath(os.path.abspath(arguments["OutputPath"])))
     cxxCompiler, _, offloadBundler, _, _ = validateToolchain(
         arguments["CxxCompiler"],

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -207,6 +207,7 @@ def writeSolutionsAndKernels(
     cmdlineArchs: List[str],
     kernelSerialNaming,
     kernelMinNaming,
+    procs: int,
     errorTolerant=False,
     generateSourcesAndExit=False,
     compress=True,
@@ -252,7 +253,7 @@ def writeSolutionsAndKernels(
         itertools.repeat(kernelSerialNaming),
         asmKernels
     )
-    asmResults = ParallelMap2(processKernelSource, asmIter, "Generating assembly kernels", return_as="list")
+    asmResults = ParallelMap2(processKernelSource, asmIter, "Generating assembly kernels", return_as="list", procs=procs)
     removeInvalidSolutionsAndKernels(
         asmResults, asmKernels, solutions, errorTolerant, getVerbosity(), splitGSU
     )
@@ -269,6 +270,7 @@ def writeSolutionsAndKernels(
         "Writing assembly kernels",
         return_as="list",
         multiArg=False,
+        procs=procs
     )
 
     writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
@@ -307,6 +309,7 @@ def writeSolutionsAndKernelsTCL(
     cmdlineArchs: List[str],
     kernelSerialNaming,
     kernelMinNaming,
+    procs: int,
     compress=True,
     useShortNames=False,
 ):
@@ -360,6 +363,7 @@ def writeSolutionsAndKernelsTCL(
         "Generating assembly kernels",
         multiArg=False,
         return_as="list"
+        procs=procs
     )
     buildAssemblyCodeObjectFiles(
         asmToolchain.linker,
@@ -434,7 +438,7 @@ def generateKernelObjectsFromSolutions(solutions):
 
 
 @timing
-def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInfoMap):
+def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInfoMap, procs: int):
 
     if ";" in args["Architecture"]:
         archs = args["Architecture"].split(";")  # user arg list format
@@ -468,7 +472,7 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
                 yield from libraryIter(lazyLib)
 
     for library in ParallelMap2(
-        LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator_unordered"
+        LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator_unordered", procs=procs
     ):
         _, architectureName, _, _, _, newLibrary = library
 
@@ -647,6 +651,7 @@ def run():
         archs,
         kernelSerialNaming,
         kernelMinNaming,
+        arguments["CpuThreads"],
         useShortNames=arguments["ShortNames"],
         compress=arguments["UseCompression"],
     )

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -48,7 +48,7 @@ from Tensile.Common import (
     printExit,
     printWarning,
     state,
-    tqdm,
+    showProgress,
     setVerbosity,
     getVerbosity
 )
@@ -112,7 +112,7 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
     removeResults = []
 
     for kernIdx, r in (
-        tqdm(enumerate(results)) if printLevel > 1 else enumerate(results)
+        showProgress(enumerate(results)) if printLevel > 1 else enumerate(results)
     ):
         if r.err != 0:
             if not errorTolerant:
@@ -135,7 +135,7 @@ def removeInvalidSolutionsAndKernels(results, kernels, solutions, errorTolerant,
         kernels.remove(kern)
 
     for solution in (
-        tqdm(solutions, "Finding invalid solutions")
+        showProgress(solutions, "Finding invalid solutions")
         if printLevel > 1
         else solutions
     ):
@@ -253,7 +253,7 @@ def writeSolutionsAndKernels(
         itertools.repeat(kernelSerialNaming),
         asmKernels
     )
-    asmResults = ParallelMap2(processKernelSource, asmIter, "Generating assembly kernels", return_as="list", procs=procs)
+    asmResults = ParallelMap2(processKernelSource, showProgress(asmIter), "Generating assembly kernels", return_as="list", procs=procs)
     removeInvalidSolutionsAndKernels(
         asmResults, asmKernels, solutions, errorTolerant, getVerbosity(), splitGSU
     )
@@ -266,7 +266,7 @@ def writeSolutionsAndKernels(
     compose = lambda *F: functools.reduce(lambda f, g: lambda x: f(g(x)), F)
     ret = ParallelMap2(
         compose(assemble, unaryWriteAssembly),
-        asmResults,
+        showProgress(asmResults),
         "Writing assembly kernels",
         return_as="list",
         multiArg=False,
@@ -359,10 +359,10 @@ def writeSolutionsAndKernelsTCL(
     compose = lambda *F: functools.reduce(lambda f, g: lambda x: f(g(x)), F)
     ret = ParallelMap2(
         compose(assemble, unaryWriteAssembly, unaryProcessKernelSource),
-        uniqueAsmKernels,
+        showProgress(uniqueAsmKernels),
         "Generating assembly kernels",
         multiArg=False,
-        return_as="list"
+        return_as="list",
         procs=procs
     )
     buildAssemblyCodeObjectFiles(
@@ -471,9 +471,10 @@ def generateLogicDataAndSolutions(logicFiles, args, assembler: Assembler, isaInf
             for _, lazyLib in lib.lazyLibraries.items():
                 yield from libraryIter(lazyLib)
 
-    for library in ParallelMap2(
-        LibraryIO.parseLibraryLogicFile, fIter, "Loading Logics...", return_as="generator_unordered", procs=procs
-    ):
+    res = ParallelMap2(
+        LibraryIO.parseLibraryLogicFile, showProgress(fIter), "Loading Logics...", return_as="generator_unordered", procs=procs
+    )
+    for library in res:
         _, architectureName, _, _, _, newLibrary = library
 
         if architectureName == "":
@@ -626,7 +627,7 @@ def run():
         print2("#   %s" % logicFile)
 
     solutions, masterLibraries = generateLogicDataAndSolutions(
-        logicFiles, arguments, asmToolchain.assembler, isaInfoMap
+        logicFiles, arguments, asmToolchain.assembler, isaInfoMap, arguments["CpuThreads"]
     )
 
     kernels, kernelHelperObjs, _ = generateKernelObjectsFromSolutions(solutions)

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -250,7 +250,7 @@ def writeSolutionsAndKernels(
     )
     asmResults = ParallelMap2(
         processKernelSource,
-        showProgress(asmIter),
+        showProgress(asmIter, total=len(asmKernels)),
         "Generating assembly kernels",
         return_as="list",
         procs=procs

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -28,11 +28,12 @@ import shutil
 import subprocess
 
 from pathlib import Path
+from timeit import default_timer as timer
 from typing import List, Union, NamedTuple
 
-from Tensile.Common import print2
+from Tensile.Common import print1, print2
 from Tensile.Common.Architectures import isaToGfx
-from ..SolutionStructs import Solution
+from Tensile.SolutionStructs import Solution
 
 from .Component import Assembler, Linker, Bundler
 
@@ -92,6 +93,8 @@ def buildAssemblyCodeObjectFiles(
         asmDir: The directory containing the assembly files.
         compress: Whether to compress the code object files.
     """
+    start = timer()
+    print1("Building assembly code object files...")
 
     extObj = ".o"
     extCo = ".co"
@@ -127,4 +130,6 @@ def buildAssemblyCodeObjectFiles(
           shutil.move(coFileRaw, coFile)
         coFiles.append(coFile)
 
+    stop = timer()
+    print1(f"Done. ({(stop-start):3.2f} secs elapsed)")
     return coFiles

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -30,7 +30,7 @@ from pathlib import Path
 from timeit import default_timer as timer
 from typing import List, Union, NamedTuple
 
-from ..Common import print1, ensurePath
+from Tensile.Common import print1, ensurePath
 
 from .Component import Compiler, Bundler
 
@@ -93,6 +93,7 @@ def buildSourceCodeObjectFiles(
         List of paths to the created code objects.
     """
     start = timer()
+    print1("Building source code object files...")
 
     tmpObjDir = Path(ensurePath(tmpObjDir))
     destDir = Path(ensurePath(destDir))
@@ -121,6 +122,5 @@ def buildSourceCodeObjectFiles(
         shutil.move(src, dst)
 
     stop = timer()
-    print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")
-
+    print1(f"Done. ({(stop-start):3.2f} secs elapsed)")
     return coPaths


### PR DESCRIPTION
This PR achieves the following:
1. Removes the final set of globals still remaining in Parallel.py
2. Improves command line handling of requested processes in Tensile and TensileCreateLibrary
3. Reinstates the progress bar as an opt-in flag with `--show-progress` for TensileCreateLibrary
4. Reinstates the progress bar as an opt-out flag with `--hide-progress` for Tensile
5. Minor printing improvements for timing results while building and benchmarking

This update leverages dependency injection and a safe global singleton pattern for improved testability and configuration management. It provides a read-only, globally accessible object, initialized by any application, for accessing key variables and functionalities.