### PR TITLE
Enable MX datatype support on SLES Linuz (#1880)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,12 +256,6 @@ else()
     endif()
 endif()
 
-find_package(Boost REQUIRED)
-if(Boost_VERSION VERSION_LESS "1.74.0")
-    message(WARNING "Boost version ${Boost_VERSION} too old, not building RocRoller")
-    set(USE_ROCROLLER OFF)
-endif()
-
 if( LEGACY_HIPBLAS_DIRECT )
   find_package( hipblas REQUIRED CONFIG PATHS ${HIP_DIR} ${ROCM_PATH} /opt/rocm)
 else()

--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -114,16 +114,19 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       ../common/hipblaslt_init_device.cpp
       ${BLIS_CPP}
     )
-    
+
   # RocRoller integration
   include(FetchContent)
+  include(../cmake/Utilities.cmake)
   if(USE_ROCROLLER)
+      _save_var(BUILD_TESTING)
+      set(BUILD_TESTING OFF)
       add_definitions(-DUSE_ROCROLLER)
 
       FetchContent_Declare(
         mxDataGenerator
         GIT_REPOSITORY https://github.com/ROCm/mxDataGenerator.git
-        GIT_TAG 7a9778977f19111d3b9fc4497758df4aaa8165c5
+        GIT_TAG 12c016dc694139317feb2e23c59028fde70beaf4
       )
       FetchContent_MakeAvailable(mxDataGenerator)
 
@@ -134,6 +137,7 @@ if( BUILD_CLIENTS_BENCHMARKS OR BUILD_CLIENTS_TESTS)
       list(APPEND hipblaslt_test_bench_common
        ../common/mxDataGen.cpp
        )
+      _restore_var(BUILD_TESTING)
   endif()
 
   if( BUILD_CLIENTS_BENCHMARKS )

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -174,14 +174,14 @@ endif()
 include(FetchContent)
 if(USE_ROCROLLER)
   _save_var(BUILD_TESTING)
-  set(BUILD_CLIENTS OFF)
   _save_var(BUILD_CLIENTS)
+  set(BUILD_CLIENTS OFF)
   set(BUILD_TESTING OFF)
 
   FetchContent_Declare(
     rocRoller
     GIT_REPOSITORY https://github.com/ROCm/rocRoller.git
-    GIT_TAG 33fb58b76df640f98726b90a45fc5b9aa3e8af3b
+    GIT_TAG 34307b30956cac16e459db6cfdd3ba1f07c7e9b8
   )
   FetchContent_MakeAvailable(rocRoller)
   target_link_libraries(hipblaslt PRIVATE rocroller_interface)

--- a/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocroller_host.cpp
@@ -3,6 +3,7 @@
 #include "utility.hpp"
 
 #include <rocRoller/CommandSolution.hpp>
+#include <rocRoller/KernelGraph/CoordinateGraph/Dimension.hpp>
 #include <rocRoller/Operations/Command.hpp>
 #include <rocRoller/TensorDescriptor.hpp>
 


### PR DESCRIPTION
* Enable MX datatype support on SLES Linuz

* Update rocRoller commit

* Fix gtest header issues