### PR TITLE
Deterministic naming

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -37,8 +37,10 @@ from Tensile.KernelWriter import DebugConfig
 from Tensile.Toolchain.Component import Assembler
 from Tensile.SolutionStructs.Problem import ProblemType, ProblemSizes
 from Tensile.SolutionStructs.Solution import Solution
-from Tensile.SolutionStructs.Validators.MatrixInstruction import matrixInstructionToMIParameters, validateMIParameters
-from Tensile.SolutionStructs.Naming import getMinNaming, getNameMin, getSerialNaming, getNameFull, getKeyNoInternalArgs
+from Tensile.SolutionStructs.Validators.MatrixInstruction import matrixInstructionToMIParameters, \
+                                                                 validateMIParameters
+from Tensile.SolutionStructs.Naming import getSerialNaming, getKeyNoInternalArgs, getSolutionNameMin, \
+                                           getKernelNameMin
 
 from .BenchmarkStructs import BenchmarkProcess, constructForkPermutations
 from .Contractions import ProblemType as ContractionsProblemType
@@ -53,8 +55,6 @@ from Tensile.Common import HR, print1, print2, IsaInfo, IsaVersion, \
         BENCHMARK_PROBLEMS_DIR, BENCHMARK_DATA_DIR, DepthUConfig
 from Tensile.Common.Architectures import isaToGfx, gfxToVariants
 from Tensile.Common.GlobalParameters import globalParameters, startTime
-from Tensile.Common.RequiredParameters import getRequiredParametersMin
-
 
 
 def _generateForkedSolutions(problemType, constantParams, forkPermutations, assembler: Assembler, \
@@ -237,9 +237,7 @@ def writeBenchmarkFiles(
                 kernelHelperNames.add(kname)
 
     kernelSerialNaming = getSerialNaming(kernels)
-    kernelMinNaming = getMinNaming(kernels)
     kernelWriterAssembly = KernelWriterAssembly(
-                               kernelMinNaming,
                                kernelSerialNaming,
                                asmToolchain.assembler,
                                debugConfig,
@@ -260,17 +258,15 @@ def writeBenchmarkFiles(
                             debugConfig.splitGSU,
                             cmdLineArchs,
                             kernelSerialNaming,
-                            kernelMinNaming,
                             errorTolerant=True,
                             generateSourcesAndExit=globalParameters["GenerateSourcesAndExit"], # put in debug config
                             compress=False,
                             useShortNames=useShortNames
                         )
     # ^ this is where solutions is mutated
-    solutionMinNaming = getRequiredParametersMin()
     for s in solutions:
-        s["SolutionNameMin"] = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU)
-        s["KernelNameMin"]   = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU, True)
+        s["SolutionNameMin"] = getSolutionNameMin(solution, debugConfig.splitGSU)
+        s["KernelNameMin"]   = getKernelNameMin(solution, debugConfig.splitGSU)
 
     newLibraryDir = ensurePath(sourcePath / 'library')
     newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary")
@@ -283,7 +279,7 @@ def writeBenchmarkFiles(
                      depthUConfig,
                      isaInfoMap,
                  )
-    newLibrary.applyNaming(debugConfig.splitGSU, kernelMinNaming)
+    newLibrary.applyNaming(debugConfig.splitGSU)
     LibraryIO.write(newLibraryFile, state(newLibrary), globalParameters["LibraryFormat"])
 
     codeObjectFiles = [os.path.relpath(f, sourcePath) \
@@ -435,7 +431,7 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                 printExit(msg)
 
             for solution in solutions:
-                print2("#    ({}:{}) {}".format(0, 0, getNameFull(solution, debugConfig.splitGSU)))
+                print2("#    ({}:{}) {}".format(0, 0, getSolutionNameMin(solution, debugConfig.splitGSU)))
             print2(HR)
 
             # write benchmarkFiles
@@ -462,12 +458,11 @@ def _benchmarkProblemType(problemTypeConfig, problemSizeGroupConfig, problemSize
                     .format(len(solutions), prevCount ))
 
             # add SolutionIndex and SolutionNameMin into benchmark yaml
-            solutionMinNaming = getMinNaming(solutions)
             for i in range(0, len(solutions)):
                 solution = solutions[i]
                 solution["SolutionIndex"] = i
-                solution["SolutionNameMin"] = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU)
-                solution["KernelNameMin"]   = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU, True)
+                solution["SolutionNameMin"] = getSolutionNameMin(solution, debugConfig.splitGSU)
+                solution["KernelNameMin"]   = getKernelNameMin(solution, debugConfig.splitGSU)
         else:
             solutions = None
             print1("# Using cached solution data")

--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -53,6 +53,7 @@ from Tensile.Common import HR, print1, print2, IsaInfo, IsaVersion, \
         BENCHMARK_PROBLEMS_DIR, BENCHMARK_DATA_DIR, DepthUConfig
 from Tensile.Common.Architectures import isaToGfx, gfxToVariants
 from Tensile.Common.GlobalParameters import globalParameters, startTime
+from Tensile.Common.RequiredParameters import getRequiredParametersMin
 
 
 
@@ -266,6 +267,10 @@ def writeBenchmarkFiles(
                             useShortNames=useShortNames
                         )
     # ^ this is where solutions is mutated
+    solutionMinNaming = getRequiredParametersMin()
+    for s in solutions:
+        s["SolutionNameMin"] = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU)
+        s["KernelNameMin"]   = getNameMin(solution, solutionMinNaming, debugConfig.splitGSU, True)
 
     newLibraryDir = ensurePath(sourcePath / 'library')
     newLibraryFile = os.path.join(newLibraryDir, "TensileLibrary")

--- a/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/tensilelite/Tensile/Common/RequiredParameters.py
@@ -1,0 +1,101 @@
+################################################################################
+#
+# Copyright (C) 2025 Advanced Micro Devices, Inc. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell cop-
+# ies of the
+# Software, and to permit persons to whom the Software is furnished
+# to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IM-
+# PLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNE-
+# CTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+################################################################################
+
+from functools import lru_cache
+
+@lru_cache
+def getRequiredParametersMin() -> set:
+    return {
+        '1LDSBuffer',
+        'ActivationFuncCall',
+        'AssertFree0ElementMultiple',
+        'AssertFree1ElementMultiple',
+        'AssertSummationElementMultiple',
+        'ClusterLocalRead',
+        'ConvertAfterDS',
+        'DirectToVgprA',
+        'DirectToVgprB',
+        'ExpandPointerSwap',
+        'ForceDisableShadowInit',
+        'GlobalReadPerMfma',
+        'GlobalReadVectorWidthA',
+        'GlobalReadVectorWidthB',
+        'GlobalSplitU',
+        'GlobalSplitUAlgorithm',
+        'GlobalSplitUCoalesced',
+        'GlobalSplitUWorkGroupMappingRoundRobin',
+        'GroupLoadStore',
+        'ISA',
+        'InnerUnroll',
+        'Kernel',
+        'LdsBlockSizePerPadA',
+        'LdsBlockSizePerPadB',
+        'LdsBlockSizePerPadMetadata',
+        'LdsPadA',
+        'LdsPadB',
+        'LdsPadMetadata',
+        'LocalReadVectorWidth',
+        'LocalWritePerMfma',
+        'MIArchVgpr',
+        'MIWaveTile',
+        'MaxOccupancy',
+        'NonTemporal',
+        'NonTemporalA',
+        'NonTemporalB',
+        'NonTemporalC',
+        'NonTemporalD',
+        'NonTemporalMetadata',
+        'NumElementsPerBatchStore',
+        'NumLoadsCoalescedA',
+        'NumLoadsCoalescedB',
+        'OptNoLoadLoop',
+        'PrefetchGlobalRead',
+        'PrefetchLocalRead',
+        'PreloadKernArgs',
+        'ScheduleIterAlg',
+        'SourceSwap',
+        'StaggerU',
+        'StaggerUMapping',
+        'StaggerUStride',
+        'StorePriorityOpt',
+        'StoreRemapVectorWidth',
+        'StoreSyncOpt',
+        'StoreVectorWidth',
+        'StreamK',
+        'StreamKXCCMapping',
+        'TransposeLDS',
+        'UnrollLoopSwapGlobalReadOrder',
+        'Use64bShadowLimit',
+        'UseInstOffsetForGRO',
+        'UseSgprForGRO',
+        'VectorStore',
+        'VectorWidthA',
+        'VectorWidthB',
+        'WaveSeparateGlobalReadA',
+        'WaveSeparateGlobalReadB',
+        'WavefrontSize',
+        'WorkGroup',
+        'WorkGroupMapping',
+        'WorkGroupMappingXCC',
+        'WorkGroupMappingXCCGroup'
+    }

--- a/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/tensilelite/Tensile/Common/RequiredParameters.py
@@ -24,6 +24,7 @@
 from functools import lru_cache
 from .ValidParameters import validParameters
 
+
 @lru_cache
 def getRequiredParametersFull() -> set:
     return frozenset(validParameters.keys())

--- a/tensilelite/Tensile/Common/RequiredParameters.py
+++ b/tensilelite/Tensile/Common/RequiredParameters.py
@@ -22,10 +22,16 @@
 ################################################################################
 
 from functools import lru_cache
+from .ValidParameters import validParameters
+
+@lru_cache
+def getRequiredParametersFull() -> set:
+    return frozenset(validParameters.keys())
+
 
 @lru_cache
 def getRequiredParametersMin() -> set:
-    return {
+    return frozenset({
         '1LDSBuffer',
         'ActivationFuncCall',
         'AssertFree0ElementMultiple',
@@ -40,10 +46,7 @@ def getRequiredParametersMin() -> set:
         'GlobalReadPerMfma',
         'GlobalReadVectorWidthA',
         'GlobalReadVectorWidthB',
-        'GlobalSplitU',
         'GlobalSplitUAlgorithm',
-        'GlobalSplitUCoalesced',
-        'GlobalSplitUWorkGroupMappingRoundRobin',
         'GroupLoadStore',
         'ISA',
         'InnerUnroll',
@@ -57,7 +60,6 @@ def getRequiredParametersMin() -> set:
         'LocalReadVectorWidth',
         'LocalWritePerMfma',
         'MIArchVgpr',
-        'MIWaveTile',
         'MaxOccupancy',
         'NonTemporal',
         'NonTemporalA',
@@ -74,9 +76,6 @@ def getRequiredParametersMin() -> set:
         'PreloadKernArgs',
         'ScheduleIterAlg',
         'SourceSwap',
-        'StaggerU',
-        'StaggerUMapping',
-        'StaggerUStride',
         'StorePriorityOpt',
         'StoreRemapVectorWidth',
         'StoreSyncOpt',
@@ -95,7 +94,4 @@ def getRequiredParametersMin() -> set:
         'WaveSeparateGlobalReadB',
         'WavefrontSize',
         'WorkGroup',
-        'WorkGroupMapping',
-        'WorkGroupMappingXCC',
-        'WorkGroupMappingXCCGroup'
-    }
+    })

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -42,7 +42,7 @@ from .AsmMemoryInstruction import MemoryInstruction
 from .Activation import ActivationModule
 from .Common import printWarning, roundUp, print2, DebugConfig, DataDirection, \
   INDEX_CHARS, IsaVersion
-from Tensile.SolutionStructs.Naming import getKernelName
+from Tensile.SolutionStructs.Naming import getKernelNameMin
 from Tensile.Toolchain.Component import Assembler
 
 import abc
@@ -369,12 +369,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
   ##############################################################################
   def __init__(
       self,
-      kernelMinNaming,
       kernelSerialNaming,
       assembler: Assembler,
       debugConfig: DebugConfig,
     ):
-    self.kernelMinNaming = kernelMinNaming
     self.kernelSerialNaming = kernelSerialNaming
     self.assembler = assembler
     self.debugConfig = debugConfig
@@ -3270,7 +3268,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     ti.setKernel(version, kernel["WavefrontSize"])
 
     self.consts = ConstValues()
-    self.states = StateValues(version=version, kernel=kernel, kernelName=getKernelName(self.kernelMinNaming, self.debugConfig.splitGSU, kernel))
+    self.states = StateValues(version=version, kernel=kernel, kernelName=getKernelNameMin(kernel, self.debugConfig.splitGSU))
     self.vgprs  = StateVgprs()
     self.sgprs  = collections.OrderedDict()
     self.codes  = CodeModules()
@@ -5436,7 +5434,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     pass
 
   def getHeaderFileString(self, kernel):
-    kernelName = getKernelName(self.kernelMinNaming, self.debugConfig.splitGSU, kernel)
+    kernelName = getKernelNameMin(kernel, self.debugConfig.splitGSU)
     fileString = "" # CHeader
     fileString += "extern const unsigned char %s_coba[]; // code object byte array\n" % kernelName
 

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -93,16 +93,15 @@ class KernelWriterAssembly(KernelWriter):
   ##############################################################################
   def __init__(
       self,
-      kernelMinNaming,
       kernelSerialNaming,
       assembler: Assembler,
       debugConfig: DebugConfig,
     ):
-    super(KernelWriterAssembly, self).__init__(kernelMinNaming, kernelSerialNaming, assembler, debugConfig)
+    super(KernelWriterAssembly, self).__init__(kernelSerialNaming, assembler, debugConfig)
 
 
   def _getCustomKernelSource(self, useShortNames, kernel, CustomKernelDirectory):
-    kernelName = getKernelFileBase(useShortNames, self.debugConfig.splitGSU, self.kernelMinNaming, self.kernelSerialNaming, kernel)
+    kernelName = getKernelFileBase(useShortNames, self.debugConfig.splitGSU, self.kernelSerialNaming, kernel)
     with open(os.path.join(CustomKernelDirectory, (kernelName + ".s"))) as f:
       rocmVersion = self.assembler.rocm_version
       if not (rocmVersion.major >= 6 and rocmVersion.patch >= 32650):

--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -30,7 +30,7 @@ from Tensile.Common import print1, print2, HR, printExit, \
   assignParameterWithDefault, ProgressBar, printWarning, ensurePath, \
   LIBRARY_LOGIC_DIR, BENCHMARK_DATA_DIR, getVerbosity, IsaInfo, DepthUConfig
 from Tensile.Common.GlobalParameters import defaultAnalysisParameters, globalParameters, startTime
-from Tensile.SolutionStructs.Naming import getMinNaming, getNameMin, getNameFull
+from Tensile.SolutionStructs.Naming import getKernelNameMin, getSolutionNameMin, getSolutionNameFull
 
 from copy import deepcopy
 from sys import stdout
@@ -72,14 +72,12 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
     solutions = problemSizeGroup[4]
     problemSizesList.append(problemSizes)
     solutionsList.append(solutions)
-    solutionMinNaming = getMinNaming(solutions)
     print1("# Read: %s" % (solutionsFileName))
     print2("# ProblemSizes: %s" % problemSizes)
     print2("# Solutions:")
     solutionIdx = 0
     for solution in solutions:
-      print2("#  (%u) %s" % (solutionIdx, getNameMin(solution, \
-          solutionMinNaming, splitGSU)))
+      print2("#  (%u) %s" % (solutionIdx, getSolutionNameMin(solution, splitGSU)))
       solutionIdx += 1
     print2(HR)
 
@@ -128,9 +126,9 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
   for i in range(0, len(logicAnalyzer.solutions)):
     s = logicAnalyzer.solutions[i]
     s["SolutionIndex"] = i
-    s["SolutionNameMin"] = getNameMin(s, solutionMinNaming, splitGSU)
-    s["KernelNameMin"]   = getNameMin(s, solutionMinNaming, splitGSU, True)
-    print1("(%2u) %s : %s" % (i, getNameMin(s, solutionMinNaming, splitGSU), getNameFull(s, splitGSU)))
+    s["SolutionNameMin"] = getSolutionNameMin(s, splitGSU)
+    s["KernelNameMin"]   = getKernelNameMin(s, splitGSU)
+    print1("(%2u) %s : %s" % (i, s["SolutionNameMin"], getSolutionNameFull(s, splitGSU)))
 
   if enableTileSelection:
     validSelectionSolutions = SolutionSelectionLibrary.analyzeSolutionSelection(problemType, selectionFileNameList, \
@@ -162,8 +160,8 @@ def analyzeProblemType(problemType, problemSizeGroups, inputParameters, libraryL
       (validSolution, validSolutionInfo) = validSelectionSolution
       selectionSolutionIndex = solutionsStartIndex + i
       selectionSolutionsIds.add(selectionSolutionIndex)
-      validSolution["SolutionNameMin"] = getNameMin(validSolution, solutionMinNaming, splitGSU)
-      validSolution["KernelNameMin"]   = getNameMin(validSolution, solutionMinNaming, splitGSU, True)
+      validSolution["SolutionNameMin"] = getSolutionNameMin(validSolution, splitGSU)
+      validSolution["KernelNameMin"]   = getKernelNameMin(validSolution, splitGSU)
       validSolution["Ideals"] = validSolutionInfo
       selectionSolutions.append(validSolution)
 
@@ -293,14 +291,11 @@ class LogicAnalyzer:
         self.solutionGroupMap[solutionGroupIdx][solutionIdx] = sIdx
         progressBar.increment()
     self.numSolutions = len(self.solutions)
-    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(getNameMin(solution, \
-          self.solutionMinNaming, self.splitGSU))
-      self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
-          solution["MacroTile1"]))
+      self.solutionNames.append(getSolutionNameMin(solution, self.self.splitGSU))
+      self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], solution["MacroTile1"]))
     self.flopsPerMac = self.problemType["DataType"].flopsPerMac()
 
     # merge problem sizes from size groups
@@ -1120,12 +1115,10 @@ class LogicAnalyzer:
     for i in range(0, oldNumSolutions):
       if i != removeSolutionIdx:
         self.solutions.append(oldSolutions[i])
-    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(getNameMin(solution, \
-          self.solutionMinNaming, self.splitGSU))
+      self.solutionNames.append(getSolutionNameMin(solution, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
           solution["MacroTile1"]))
     self.numSolutions = len(self.solutions)
@@ -1171,12 +1164,10 @@ class LogicAnalyzer:
       else:
         removeSolutionIdxList.append(i)
 
-    self.solutionMinNaming = getMinNaming(self.solutions)
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(getNameMin(solution, \
-          self.solutionMinNaming, self.splitGSU))
+      self.solutionNames.append(getSolutionNameMin(solution, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], \
           solution["MacroTile1"]))
     self.numSolutions = len(self.solutions)

--- a/tensilelite/Tensile/LibraryLogic.py
+++ b/tensilelite/Tensile/LibraryLogic.py
@@ -294,7 +294,7 @@ class LogicAnalyzer:
     self.solutionNames = []
     self.solutionTiles = []
     for solution in self.solutions:
-      self.solutionNames.append(getSolutionNameMin(solution, self.self.splitGSU))
+      self.solutionNames.append(getSolutionNameMin(solution, self.splitGSU))
       self.solutionTiles.append("%ux%u"%(solution["MacroTile0"], solution["MacroTile1"]))
     self.flopsPerMac = self.problemType["DataType"].flopsPerMac()
 

--- a/tensilelite/Tensile/SolutionLibrary.py
+++ b/tensilelite/Tensile/SolutionLibrary.py
@@ -31,7 +31,7 @@ from . import Contractions
 from .SolutionStructs import Solution as OriginalSolution
 from Tensile.Common import state, IsaInfo, DepthUConfig
 from Tensile.Common.Architectures import gfxToIsa
-from Tensile.SolutionStructs.Naming import getMinNaming, getNameMin
+from Tensile.SolutionStructs.Naming import getSolutionNameMin, getKernelNameMin
 
 class SingleSolutionLibrary:
     Tag = "Single"
@@ -545,14 +545,10 @@ class MasterSolutionLibrary:
             rv["version"] = self.version
         return rv
 
-    def applyNaming(self, splitGSU: bool, naming=None):
-        if naming is None:
-            kernels = itertools.chain(s.originalSolution.getKernels() for s in self.solutions.values())
-            naming = getMinNaming(kernels)
-
+    def applyNaming(self, splitGSU: bool):
         for s in list(self.solutions.values()):
-            s.name = getNameMin(s.originalSolution.getKernels()[0], naming, splitGSU)
-            s.kernelName = getNameMin(s.originalSolution.getKernels()[0], naming, splitGSU, True)
+            s.name = getSolutionNameMin(s.originalSolution.getKernels()[0], splitGSU)
+            s.kernelName = getKernelNameMin(s.originalSolution.getKernels()[0], splitGSU)
 
     def remapSolutionIndicesStartingFrom(self, curIndex):
         reIndexMap = {}

--- a/tensilelite/Tensile/SolutionSelectionLibrary.py
+++ b/tensilelite/Tensile/SolutionSelectionLibrary.py
@@ -22,7 +22,7 @@
 #
 ################################################################################
 
-from Tensile.SolutionStructs.Naming import getNameMin
+from Tensile.SolutionStructs.Naming import getSolutionNameMin, getKernelNameMin
 
 import csv
 
@@ -60,7 +60,7 @@ def updateIfGT(theDictionary, theKey, theValue):
       theDictionary[theKey] = theValue
 
 
-def updateValidSolutions(validSolutions, analyzerSolutions, solutionMinNaming):
+def updateValidSolutions(validSolutions, analyzerSolutions):
   solutionsStartIndex = len(analyzerSolutions)
   validSelectionSolutionsIncluded = []
   validSelectionSolutionsRemainder = []
@@ -90,8 +90,8 @@ def updateValidSolutions(validSolutions, analyzerSolutions, solutionMinNaming):
     selectionSolutionIndex = solutionsStartIndex + i
     selectionSolutionsIds.add(selectionSolutionIndex)
     splitGSU = False # this is a reminder that we need to add this in to the function signature
-    validSolution["SolutionNameMin"] = getNameMin(validSolution, solutionMinNaming, splitGSU)
-    validSolution["KernelNameMin"]   = getNameMin(validSolution, solutionMinNaming, splitGSU, True)
+    validSolution["SolutionNameMin"] = getSolutionNameMin(validSolution, splitGSU)
+    validSolution["KernelNameMin"]   = getKernelNameMin(validSolution, splitGSU)
     validSolution["Ideals"] = validSolutionInfo
     selectionSolutions.append(validSolution)
 

--- a/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -27,7 +27,7 @@ from typing import List
 
 from Tensile.Common.Constants import MAX_FILENAME_LENGTH
 from Tensile.Common.ValidParameters import validParameters
-from Tensile.Common.RequiredParameters import getRequiredParametersMin
+from Tensile.Common.RequiredParameters import getRequiredParametersMin, getRequiredParametersFull
 
 from .Problem import ProblemType
 
@@ -37,6 +37,57 @@ def getMinNaming(objs: list):
   if len(nonCKObjs) == 0:
     return {}
   return getRequiredParametersMin()
+
+
+#def getMinNaming(objs: list):
+#  nonCKObjs = [obj for obj in objs if not ("CustomKernelName" in obj and obj["CustomKernelName"])]
+#  # early return
+#  if len(nonCKObjs) == 0:
+#    return {}
+#  # determine keys
+#  requiredParameters = {}
+#  if hasattr(nonCKObjs[0], "_state"):
+#    keys = list(nonCKObjs[0]._state.keys())
+#  else:
+#    keys = list(nonCKObjs[0].keys())
+#  # only 1, rather than name being nothing, it'll be everything
+#  if len(nonCKObjs) == 1:
+#    for key in keys:
+#      if key in list(validParameters.keys()):
+#        requiredParameters[key] = False
+#  else:
+#    for key in keys:
+#      required = False
+#      if key in list(validParameters.keys()):
+#        for i in range(1, len(nonCKObjs)):
+#          if nonCKObjs[0][key] != nonCKObjs[i][key]:
+#            required = True
+#            break
+#      if required:
+#        requiredParameters[key] = True
+#      else:
+#        requiredParameters[key] = False
+#  requiredParameters["GlobalSplitU"] = True
+#  requiredParameters["WorkGroupMapping"] = True
+#  if "MatrixInstM" in nonCKObjs[0]._state:
+#    # Use MIWaveGroup and MIWaveTile instead of WG and MT
+#    requiredParameters["MIWaveTile"]  = True
+#    requiredParameters["ThreadTile"]  = False
+#  requiredParameters["ProblemType"]       = False # always prepended
+#  requiredParameters["MacroTile0"]        = False # always prepended
+#  requiredParameters["MacroTile1"]        = False # always prepended
+#  requiredParameters["DepthU"]            = False # always prepended
+#  requiredParameters["MatrixInstruction"] = False # always prepended
+#  requiredParameters["MatrixInstM"]       = False # always prepended
+#  requiredParameters["MatrixInstN"]       = False # always prepended
+#  requiredParameters["MatrixInstK"]       = False # always prepended
+#  requiredParameters["MatrixInstB"]       = False # always prepended
+#  requiredParameters["MatrixInstBM"]      = False # always prepended
+#  requiredParameters["MatrixInstBN"]      = False # always prepended
+#  requiredParameters["CustomKernelName"]  = False # Will not affect naming
+#  requiredParameters["Kernel"]            = True  # distinguish kernels from solutions
+#                                                  # for single-source compilation
+#  return requiredParameters
 
 
 def getKeyNoInternalArgs(state, splitGSU: bool):
@@ -56,23 +107,26 @@ def getKeyNoInternalArgs(state, splitGSU: bool):
   state_copy["GlobalSplitUWorkGroupMappingRoundRobin"] = "M"
   return state_copy
 
+#def getNameFull(state, splitGSU: bool):
+#  requiredParameters = {}
+#  for key in state:
+#    if key in list(validParameters.keys()):
+#      requiredParameters[key] = True
+#  if "MatrixInstM" in state:
+#    # Use MIWaveGroup and MIWaveTile instead of WG and MT
+#    requiredParameters["MIWaveTile"]  = True
+#    requiredParameters["ThreadTile"]  = False
+#  return getNameMin(state, requiredParameters, splitGSU)
+
 
 def getNameFull(state, splitGSU: bool):
-  # requiredParameters = set()
-  # for key in state:
-  #   if key in list(validParameters.keys()):
-  #     requiredParameters[key] = True
-  # if "MatrixInstM" in state:
-  #   # Use MIWaveGroup and MIWaveTile instead of WG and MT
-  #   requiredParameters["MIWaveTile"]  = True
-  #   requiredParameters["ThreadTile"]  = False
-  requiredParameters = getRequiredParametersMin()
-  return getNameMin(state, requiredParameters, splitGSU)
+  return getNameMin(state, getRequiredParametersFull(), splitGSU)
 
 
 @lru_cache(maxsize=None)
 def getParameterNameAbbreviation( name: str ):
   return ''.join(c for c in name if c.isupper())
+
 
 @ lru_cache(maxsize=None)
 def getPrimitiveParameterValueAbbreviation(key, value):
@@ -113,69 +167,111 @@ def getParameterValueAbbreviation(key, value):
     raise Exception(f"Parameter {key}={value} is new object type ({type(value)})")
 
 
-def getNameMin(state, requiredParameters, splitGSU: bool, ignoreInternalArgs = False):
+
+# def getNameMin(state, requiredParameters, splitGSU: bool, ignoreInternalArgs = False):
+#   if "CustomKernelName" in state and state["CustomKernelName"]:
+#     return state["CustomKernelName"]
+
+#   components = []
+#   backup = state["ProblemType"]["GroupedGemm"]
+#   if ignoreInternalArgs:
+#     state["ProblemType"]["GroupedGemm"] = False
+#   if "ProblemType" in state:
+#     components.append(f'{str(state["ProblemType"])}')
+#     # name += str(state["ProblemType"]) + "_"
+#   if ignoreInternalArgs:
+#     state["ProblemType"]["GroupedGemm"] = backup
+#   if "MacroTile0" in state \
+#       and "MacroTile1" in state \
+#       and "DepthU" in state:
+#     components.append(f'{getParameterNameAbbreviation("MacroTile")}{state["MacroTile0"]}x{state["MacroTile1"]}x{state["DepthU"]}')
+#   if "MatrixInstM" in state:
+#     components.append(f'{getParameterNameAbbreviation("MatrixInstruction")}{state["MatrixInstM"]}x{state["MatrixInstN"]}x{state["MatrixInstB"]}')
+#   backup = state["GlobalSplitU"]
+#   if ignoreInternalArgs:
+#     if splitGSU:
+#       state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
+#     elif state["GlobalSplitU"] > 0:
+#       requiredParameters["GlobalSplitU"] = False
+#     requiredParameters["WorkGroupMapping"] = False
+#     requiredParameters["WorkGroupMappingXCC"] = False
+#     requiredParameters["WorkGroupMappingXCCGroup"] = False
+#     requiredParameters["StaggerU"] = False
+#     requiredParameters["StaggerUStride"] = False
+#     requiredParameters["StaggerUMapping"] = False
+#     requiredParameters["GlobalSplitUCoalesced"] = False
+#     requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
+#   useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
+#   if 'MatrixInstM' in state:
+#     requiredParameters["MIWaveTile"] = True
+#     requiredParameters["ThreadTile"] = False
+#   else:
+#     requiredParameters["MIWaveTile"] = False
+#     requiredParameters["ThreadTile"] = True
+#   components.append('SN')
+#   for key in sorted(state.keys()):
+#     if key in requiredParameters and key[0] != '_':
+#       if requiredParameters[key] and key != "CustomKernelName":
+#         components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
+#   state["GlobalSplitU"] = backup
+#   requiredParameters["GlobalSplitU"] = True
+#   requiredParameters["WorkGroupMapping"] = True
+#   requiredParameters["WorkGroupMappingXCC"] = True
+#   requiredParameters["WorkGroupMappingXCCGroup"] = True
+#   requiredParameters["StaggerU"] = True
+#   requiredParameters["StaggerUStride"] = True
+#   requiredParameters["StaggerUMapping"] = True
+#   requiredParameters["GlobalSplitUCoalesced"] = True
+#   requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
+#   requiredParameters["MIWaveTile"] = useWaveTile
+#   requiredParameters["ThreadTile"] = useThreadTile
+#   return '_'.join(components)
+
+
+def getNameMin(state, requiredParameters: frozenset, splitGSU: bool, ignoreInternalArgs = False):
   if "CustomKernelName" in state and state["CustomKernelName"]:
     return state["CustomKernelName"]
-
+  problem = deepcopy(state["ProblemType"])
+  requiredParametersTemp = set(requiredParameters.union(["GlobalSplitU"]))
+  gsu = state["GlobalSplitU"]
+  if ignoreInternalArgs:
+    problem["GroupedGemm"] = False
+    if splitGSU:
+      state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
+    elif state["GlobalSplitU"] > 0:
+      requiredParametersTemp.discard("GlobalSplitU")
+  else:
+    requiredParametersTemp = requiredParametersTemp.union(["WorkGroupMapping",
+                                                           "WorkGroupMappingXCC",
+                                                           "WorkGroupMappingXCCGroup",
+                                                           "StaggerU",
+                                                           "StaggerUStride",
+                                                           "StaggerUMapping",
+                                                           "GlobalSplitUCoalesced",
+                                                           "GlobalSplitUWorkGroupMappingRoundRobin"])
   components = []
-  backup = state["ProblemType"]["GroupedGemm"]
-  if ignoreInternalArgs:
-    state["ProblemType"]["GroupedGemm"] = False
   if "ProblemType" in state:
-    components.append(f'{str(state["ProblemType"])}')
-    # name += str(state["ProblemType"]) + "_"
-  if ignoreInternalArgs:
-    state["ProblemType"]["GroupedGemm"] = backup
+    components.append(f'{str(problem)}')
+
+    
   if "MacroTile0" in state \
       and "MacroTile1" in state \
       and "DepthU" in state:
     components.append(f'{getParameterNameAbbreviation("MacroTile")}{state["MacroTile0"]}x{state["MacroTile1"]}x{state["DepthU"]}')
+
   if "MatrixInstM" in state:
     components.append(f'{getParameterNameAbbreviation("MatrixInstruction")}{state["MatrixInstM"]}x{state["MatrixInstN"]}x{state["MatrixInstB"]}')
-  backup = state["GlobalSplitU"]
-  if ignoreInternalArgs:
-    if splitGSU:
-      state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
-    elif state["GlobalSplitU"] > 0:
-      requiredParameters.discard("GlobalSplitU")
-    requiredParameters.discard("WorkGroupMapping")
-    requiredParameters.discard("WorkGroupMappingXCC")
-    requiredParameters.discard("WorkGroupMappingXCCGroup")
-    requiredParameters.discard("StaggerU")
-    requiredParameters.discard("StaggerUStride")
-    requiredParameters.discard("StaggerUMapping")
-    requiredParameters.discard("GlobalSplitUCoalesced")
-    requiredParameters.discard("GlobalSplitUWorkGroupMappingRoundRobin")
-  useWaveTile, useThreadTile = "MIWaveTile" in requiredParameters, "ThreadTile" in requiredParameters
-  if 'MatrixInstM' in state:
-    requiredParameters.add("MIWaveTile")
-    requiredParameters.discard("ThreadTile")
+    requiredParametersTemp.add("MIWaveTile")
   else:
-    requiredParameters.discard("MIWaveTile")
-    requiredParameters.add("ThreadTile")
+    requiredParametersTemp.add("ThreadTile")
+
   components.append('SN')
   for key in sorted(state.keys()):
-    if key in requiredParameters and key[0] != '_':
+    if key in requiredParametersTemp and key[0] != '_':
       if key != "CustomKernelName":
         components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
-  state["GlobalSplitU"] = backup
-  requiredParameters.add("GlobalSplitU")
-  requiredParameters.add("WorkGroupMapping")
-  requiredParameters.add("WorkGroupMappingXCC")
-  requiredParameters.add("WorkGroupMappingXCCGroup")
-  requiredParameters.add("StaggerU")
-  requiredParameters.add("StaggerUStride")
-  requiredParameters.add("StaggerUMapping")
-  requiredParameters.add("GlobalSplitUCoalesced")
-  requiredParameters.add("GlobalSplitUWorkGroupMappingRoundRobin")
-  if useWaveTile:
-    requiredParameters.add("MIWaveTile")
-  else:
-    requiredParameters.discard("MIWaveTile")
-  if useThreadTile:
-    requiredParameters.add("ThreadTile")
-  else:
-    requiredParameters.discard("ThreadTile")
+  state["GlobalSplitU"] = gsu
+
   return '_'.join(components)
 
 

--- a/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -27,60 +27,16 @@ from typing import List
 
 from Tensile.Common.Constants import MAX_FILENAME_LENGTH
 from Tensile.Common.ValidParameters import validParameters
+from Tensile.Common.RequiredParameters import getRequiredParametersMin
 
 from .Problem import ProblemType
 
-########################################
-# create a dictionary with booleans on whether to include parameter in name
+
 def getMinNaming(objs: list):
   nonCKObjs = [obj for obj in objs if not ("CustomKernelName" in obj and obj["CustomKernelName"])]
-  # early return
   if len(nonCKObjs) == 0:
     return {}
-  # determine keys
-  requiredParameters = {}
-  if hasattr(nonCKObjs[0], "_state"):
-    keys = list(nonCKObjs[0]._state.keys())
-  else:
-    keys = list(nonCKObjs[0].keys())
-  # only 1, rather than name being nothing, it'll be everything
-  if len(nonCKObjs) == 1:
-    for key in keys:
-      if key in list(validParameters.keys()):
-        requiredParameters[key] = False
-  else:
-    for key in keys:
-      required = False
-      if key in list(validParameters.keys()):
-        for i in range(1, len(nonCKObjs)):
-          if nonCKObjs[0][key] != nonCKObjs[i][key]:
-            required = True
-            break
-      if required:
-        requiredParameters[key] = True
-      else:
-        requiredParameters[key] = False
-  requiredParameters["GlobalSplitU"] = True
-  requiredParameters["WorkGroupMapping"] = True
-  if "MatrixInstM" in nonCKObjs[0]._state:
-    # Use MIWaveGroup and MIWaveTile instead of WG and MT
-    requiredParameters["MIWaveTile"]  = True
-    requiredParameters["ThreadTile"]  = False
-  requiredParameters["ProblemType"]       = False # always prepended
-  requiredParameters["MacroTile0"]        = False # always prepended
-  requiredParameters["MacroTile1"]        = False # always prepended
-  requiredParameters["DepthU"]            = False # always prepended
-  requiredParameters["MatrixInstruction"] = False # always prepended
-  requiredParameters["MatrixInstM"]       = False # always prepended
-  requiredParameters["MatrixInstN"]       = False # always prepended
-  requiredParameters["MatrixInstK"]       = False # always prepended
-  requiredParameters["MatrixInstB"]       = False # always prepended
-  requiredParameters["MatrixInstBM"]      = False # always prepended
-  requiredParameters["MatrixInstBN"]      = False # always prepended
-  requiredParameters["CustomKernelName"]  = False # Will not affect naming
-  requiredParameters["Kernel"]            = True  # distinguish kernels from solutions
-                                                  # for single-source compilation
-  return requiredParameters
+  return getRequiredParametersMin()
 
 
 def getKeyNoInternalArgs(state, splitGSU: bool):
@@ -102,14 +58,15 @@ def getKeyNoInternalArgs(state, splitGSU: bool):
 
 
 def getNameFull(state, splitGSU: bool):
-  requiredParameters = {}
-  for key in state:
-    if key in list(validParameters.keys()):
-      requiredParameters[key] = True
-  if "MatrixInstM" in state:
-    # Use MIWaveGroup and MIWaveTile instead of WG and MT
-    requiredParameters["MIWaveTile"]  = True
-    requiredParameters["ThreadTile"]  = False
+  # requiredParameters = set()
+  # for key in state:
+  #   if key in list(validParameters.keys()):
+  #     requiredParameters[key] = True
+  # if "MatrixInstM" in state:
+  #   # Use MIWaveGroup and MIWaveTile instead of WG and MT
+  #   requiredParameters["MIWaveTile"]  = True
+  #   requiredParameters["ThreadTile"]  = False
+  requiredParameters = getRequiredParametersMin()
   return getNameMin(state, requiredParameters, splitGSU)
 
 
@@ -180,39 +137,45 @@ def getNameMin(state, requiredParameters, splitGSU: bool, ignoreInternalArgs = F
     if splitGSU:
       state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
     elif state["GlobalSplitU"] > 0:
-      requiredParameters["GlobalSplitU"] = False
-    requiredParameters["WorkGroupMapping"] = False
-    requiredParameters["WorkGroupMappingXCC"] = False
-    requiredParameters["WorkGroupMappingXCCGroup"] = False
-    requiredParameters["StaggerU"] = False
-    requiredParameters["StaggerUStride"] = False
-    requiredParameters["StaggerUMapping"] = False
-    requiredParameters["GlobalSplitUCoalesced"] = False
-    requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
-  useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
+      requiredParameters.discard("GlobalSplitU")
+    requiredParameters.discard("WorkGroupMapping")
+    requiredParameters.discard("WorkGroupMappingXCC")
+    requiredParameters.discard("WorkGroupMappingXCCGroup")
+    requiredParameters.discard("StaggerU")
+    requiredParameters.discard("StaggerUStride")
+    requiredParameters.discard("StaggerUMapping")
+    requiredParameters.discard("GlobalSplitUCoalesced")
+    requiredParameters.discard("GlobalSplitUWorkGroupMappingRoundRobin")
+  useWaveTile, useThreadTile = "MIWaveTile" in requiredParameters, "ThreadTile" in requiredParameters
   if 'MatrixInstM' in state:
-    requiredParameters["MIWaveTile"] = True
-    requiredParameters["ThreadTile"] = False
+    requiredParameters.add("MIWaveTile")
+    requiredParameters.discard("ThreadTile")
   else:
-    requiredParameters["MIWaveTile"] = False
-    requiredParameters["ThreadTile"] = True
+    requiredParameters.discard("MIWaveTile")
+    requiredParameters.add("ThreadTile")
   components.append('SN')
   for key in sorted(state.keys()):
     if key in requiredParameters and key[0] != '_':
-      if requiredParameters[key] and key != "CustomKernelName":
+      if key != "CustomKernelName":
         components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
   state["GlobalSplitU"] = backup
-  requiredParameters["GlobalSplitU"] = True
-  requiredParameters["WorkGroupMapping"] = True
-  requiredParameters["WorkGroupMappingXCC"] = True
-  requiredParameters["WorkGroupMappingXCCGroup"] = True
-  requiredParameters["StaggerU"] = True
-  requiredParameters["StaggerUStride"] = True
-  requiredParameters["StaggerUMapping"] = True
-  requiredParameters["GlobalSplitUCoalesced"] = True
-  requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
-  requiredParameters["MIWaveTile"] = useWaveTile
-  requiredParameters["ThreadTile"] = useThreadTile
+  requiredParameters.add("GlobalSplitU")
+  requiredParameters.add("WorkGroupMapping")
+  requiredParameters.add("WorkGroupMappingXCC")
+  requiredParameters.add("WorkGroupMappingXCCGroup")
+  requiredParameters.add("StaggerU")
+  requiredParameters.add("StaggerUStride")
+  requiredParameters.add("StaggerUMapping")
+  requiredParameters.add("GlobalSplitUCoalesced")
+  requiredParameters.add("GlobalSplitUWorkGroupMappingRoundRobin")
+  if useWaveTile:
+    requiredParameters.add("MIWaveTile")
+  else:
+    requiredParameters.discard("MIWaveTile")
+  if useThreadTile:
+    requiredParameters.add("ThreadTile")
+  else:
+    requiredParameters.discard("ThreadTile")
   return '_'.join(components)
 
 

--- a/tensilelite/Tensile/SolutionStructs/Naming.py
+++ b/tensilelite/Tensile/SolutionStructs/Naming.py
@@ -32,64 +32,6 @@ from Tensile.Common.RequiredParameters import getRequiredParametersMin, getRequi
 from .Problem import ProblemType
 
 
-def getMinNaming(objs: list):
-  nonCKObjs = [obj for obj in objs if not ("CustomKernelName" in obj and obj["CustomKernelName"])]
-  if len(nonCKObjs) == 0:
-    return {}
-  return getRequiredParametersMin()
-
-
-#def getMinNaming(objs: list):
-#  nonCKObjs = [obj for obj in objs if not ("CustomKernelName" in obj and obj["CustomKernelName"])]
-#  # early return
-#  if len(nonCKObjs) == 0:
-#    return {}
-#  # determine keys
-#  requiredParameters = {}
-#  if hasattr(nonCKObjs[0], "_state"):
-#    keys = list(nonCKObjs[0]._state.keys())
-#  else:
-#    keys = list(nonCKObjs[0].keys())
-#  # only 1, rather than name being nothing, it'll be everything
-#  if len(nonCKObjs) == 1:
-#    for key in keys:
-#      if key in list(validParameters.keys()):
-#        requiredParameters[key] = False
-#  else:
-#    for key in keys:
-#      required = False
-#      if key in list(validParameters.keys()):
-#        for i in range(1, len(nonCKObjs)):
-#          if nonCKObjs[0][key] != nonCKObjs[i][key]:
-#            required = True
-#            break
-#      if required:
-#        requiredParameters[key] = True
-#      else:
-#        requiredParameters[key] = False
-#  requiredParameters["GlobalSplitU"] = True
-#  requiredParameters["WorkGroupMapping"] = True
-#  if "MatrixInstM" in nonCKObjs[0]._state:
-#    # Use MIWaveGroup and MIWaveTile instead of WG and MT
-#    requiredParameters["MIWaveTile"]  = True
-#    requiredParameters["ThreadTile"]  = False
-#  requiredParameters["ProblemType"]       = False # always prepended
-#  requiredParameters["MacroTile0"]        = False # always prepended
-#  requiredParameters["MacroTile1"]        = False # always prepended
-#  requiredParameters["DepthU"]            = False # always prepended
-#  requiredParameters["MatrixInstruction"] = False # always prepended
-#  requiredParameters["MatrixInstM"]       = False # always prepended
-#  requiredParameters["MatrixInstN"]       = False # always prepended
-#  requiredParameters["MatrixInstK"]       = False # always prepended
-#  requiredParameters["MatrixInstB"]       = False # always prepended
-#  requiredParameters["MatrixInstBM"]      = False # always prepended
-#  requiredParameters["MatrixInstBN"]      = False # always prepended
-#  requiredParameters["CustomKernelName"]  = False # Will not affect naming
-#  requiredParameters["Kernel"]            = True  # distinguish kernels from solutions
-#                                                  # for single-source compilation
-#  return requiredParameters
-
-
 def getKeyNoInternalArgs(state, splitGSU: bool):
   state_copy = deepcopy(state)
   state_copy["ProblemType"]["GroupedGemm"] = False
@@ -106,21 +48,6 @@ def getKeyNoInternalArgs(state, splitGSU: bool):
   state_copy["GlobalSplitUCoalesced"] = "M"
   state_copy["GlobalSplitUWorkGroupMappingRoundRobin"] = "M"
   return state_copy
-
-#def getNameFull(state, splitGSU: bool):
-#  requiredParameters = {}
-#  for key in state:
-#    if key in list(validParameters.keys()):
-#      requiredParameters[key] = True
-#  if "MatrixInstM" in state:
-#    # Use MIWaveGroup and MIWaveTile instead of WG and MT
-#    requiredParameters["MIWaveTile"]  = True
-#    requiredParameters["ThreadTile"]  = False
-#  return getNameMin(state, requiredParameters, splitGSU)
-
-
-def getNameFull(state, splitGSU: bool):
-  return getNameMin(state, getRequiredParametersFull(), splitGSU)
 
 
 @lru_cache(maxsize=None)
@@ -167,78 +94,24 @@ def getParameterValueAbbreviation(key, value):
     raise Exception(f"Parameter {key}={value} is new object type ({type(value)})")
 
 
+def _getName(state, requiredParameters: frozenset, splitGSU: bool, ignoreInternalArgs):
 
-# def getNameMin(state, requiredParameters, splitGSU: bool, ignoreInternalArgs = False):
-#   if "CustomKernelName" in state and state["CustomKernelName"]:
-#     return state["CustomKernelName"]
-
-#   components = []
-#   backup = state["ProblemType"]["GroupedGemm"]
-#   if ignoreInternalArgs:
-#     state["ProblemType"]["GroupedGemm"] = False
-#   if "ProblemType" in state:
-#     components.append(f'{str(state["ProblemType"])}')
-#     # name += str(state["ProblemType"]) + "_"
-#   if ignoreInternalArgs:
-#     state["ProblemType"]["GroupedGemm"] = backup
-#   if "MacroTile0" in state \
-#       and "MacroTile1" in state \
-#       and "DepthU" in state:
-#     components.append(f'{getParameterNameAbbreviation("MacroTile")}{state["MacroTile0"]}x{state["MacroTile1"]}x{state["DepthU"]}')
-#   if "MatrixInstM" in state:
-#     components.append(f'{getParameterNameAbbreviation("MatrixInstruction")}{state["MatrixInstM"]}x{state["MatrixInstN"]}x{state["MatrixInstB"]}')
-#   backup = state["GlobalSplitU"]
-#   if ignoreInternalArgs:
-#     if splitGSU:
-#       state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
-#     elif state["GlobalSplitU"] > 0:
-#       requiredParameters["GlobalSplitU"] = False
-#     requiredParameters["WorkGroupMapping"] = False
-#     requiredParameters["WorkGroupMappingXCC"] = False
-#     requiredParameters["WorkGroupMappingXCCGroup"] = False
-#     requiredParameters["StaggerU"] = False
-#     requiredParameters["StaggerUStride"] = False
-#     requiredParameters["StaggerUMapping"] = False
-#     requiredParameters["GlobalSplitUCoalesced"] = False
-#     requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = False
-#   useWaveTile, useThreadTile = requiredParameters.get("MIWaveTile", False), requiredParameters.get("ThreadTile", False)
-#   if 'MatrixInstM' in state:
-#     requiredParameters["MIWaveTile"] = True
-#     requiredParameters["ThreadTile"] = False
-#   else:
-#     requiredParameters["MIWaveTile"] = False
-#     requiredParameters["ThreadTile"] = True
-#   components.append('SN')
-#   for key in sorted(state.keys()):
-#     if key in requiredParameters and key[0] != '_':
-#       if requiredParameters[key] and key != "CustomKernelName":
-#         components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
-#   state["GlobalSplitU"] = backup
-#   requiredParameters["GlobalSplitU"] = True
-#   requiredParameters["WorkGroupMapping"] = True
-#   requiredParameters["WorkGroupMappingXCC"] = True
-#   requiredParameters["WorkGroupMappingXCCGroup"] = True
-#   requiredParameters["StaggerU"] = True
-#   requiredParameters["StaggerUStride"] = True
-#   requiredParameters["StaggerUMapping"] = True
-#   requiredParameters["GlobalSplitUCoalesced"] = True
-#   requiredParameters["GlobalSplitUWorkGroupMappingRoundRobin"] = True
-#   requiredParameters["MIWaveTile"] = useWaveTile
-#   requiredParameters["ThreadTile"] = useThreadTile
-#   return '_'.join(components)
-
-
-def getNameMin(state, requiredParameters: frozenset, splitGSU: bool, ignoreInternalArgs = False):
   if "CustomKernelName" in state and state["CustomKernelName"]:
     return state["CustomKernelName"]
-  problem = deepcopy(state["ProblemType"])
-  requiredParametersTemp = set(requiredParameters.union(["GlobalSplitU"]))
-  gsu = state["GlobalSplitU"]
+
+  gsuBackup = state["GlobalSplitU"]
+  ggBackup = state["ProblemType"]["GroupedGemm"]
+
   if ignoreInternalArgs:
-    problem["GroupedGemm"] = False
+    state["ProblemType"]["GroupedGemm"] = False
     if splitGSU:
       state["GlobalSplitU"] = "M" if (state["GlobalSplitU"] > 1) else state["GlobalSplitU"]
-    elif state["GlobalSplitU"] > 0:
+
+
+  requiredParametersTemp = set(requiredParameters.union(["GlobalSplitU"]))
+
+  if ignoreInternalArgs:
+    if state["GlobalSplitU"] > 0:
       requiredParametersTemp.discard("GlobalSplitU")
   else:
     requiredParametersTemp = requiredParametersTemp.union(["WorkGroupMapping",
@@ -249,11 +122,8 @@ def getNameMin(state, requiredParameters: frozenset, splitGSU: bool, ignoreInter
                                                            "StaggerUMapping",
                                                            "GlobalSplitUCoalesced",
                                                            "GlobalSplitUWorkGroupMappingRoundRobin"])
-  components = []
-  if "ProblemType" in state:
-    components.append(f'{str(problem)}')
+  components = [f'{str(state["ProblemType"])}']
 
-    
   if "MacroTile0" in state \
       and "MacroTile1" in state \
       and "DepthU" in state:
@@ -267,10 +137,11 @@ def getNameMin(state, requiredParameters: frozenset, splitGSU: bool, ignoreInter
 
   components.append('SN')
   for key in sorted(state.keys()):
-    if key in requiredParametersTemp and key[0] != '_':
-      if key != "CustomKernelName":
+    if key[0] != '_' and key != "CustomKernelName" and key in requiredParametersTemp:
         components.append(f'{getParameterNameAbbreviation(key)}{getParameterValueAbbreviation(key, state[key])}')
-  state["GlobalSplitU"] = gsu
+
+  state["GlobalSplitU"] = gsuBackup
+  state["ProblemType"]["GroupedGemm"] = ggBackup
 
   return '_'.join(components)
 
@@ -314,8 +185,8 @@ def getNameSerial(state, serialNaming):
   return name
 
 
-def shortenFileBase(kernelMinNaming, splitGSU, kernel):
-  base = getKernelName(kernelMinNaming, splitGSU, kernel)
+def shortenFileBase(splitGSU, kernel):
+  base = getKernelNameMin(kernel, splitGSU)
   if len(base) <= MAX_FILENAME_LENGTH:
     return base
   import hashlib
@@ -328,16 +199,24 @@ def shortenFileBase(kernelMinNaming, splitGSU, kernel):
   return firstPart + secondPart
 
 
-def getKernelFileBase(useShortNames: bool, splitGSU: bool, kernelMinNaming, kernelSerialNaming, kernel):
+def getKernelFileBase(useShortNames: bool, splitGSU: bool, kernelSerialNaming, kernel):
   if "CustomKernelName" in kernel and kernel["CustomKernelName"]:
     fileBase = kernel["CustomKernelName"]
   elif useShortNames:
     fileBase = getNameSerial(kernel, kernelSerialNaming)
   else:
-    fileBase = shortenFileBase(kernelMinNaming, splitGSU, kernel)
+    fileBase = shortenFileBase(splitGSU, kernel)
   return fileBase
 
 
-def getKernelName(kernelMinNaming, splitGSU, kernel):
-  kernelName = getNameMin(kernel, kernelMinNaming, splitGSU, True)
-  return kernelName
+def getKernelNameMin(kernel, splitGSU: bool):
+  return _getName(kernel, getRequiredParametersMin(), splitGSU, True)
+
+
+def getSolutionNameMin(solution, splitGSU: bool):
+  return _getName(solution, getRequiredParametersMin(), splitGSU, False)
+
+
+def getSolutionNameFull(state, splitGSU: bool):
+  return _getName(state, getRequiredParametersFull(), splitGSU, False)
+

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -48,7 +48,7 @@ from Tensile.Common.GlobalParameters import defaultSolution, \
                                             defaultInternalSupportParams, \
                                             internalParameters
 from Tensile.CustomKernels import isCustomKernelConfig
-from Tensile.SolutionStructs.Naming import getNameFull
+from Tensile.SolutionStructs.Naming import getSolutionNameFull
 from Tensile.SolutionStructs.Problem import ProblemType
 from Tensile.Toolchain.Component import Assembler
 
@@ -3323,7 +3323,7 @@ class Solution(collections.abc.Mapping):
 
   def __str__(self):
     if self._name is None:
-      self._name = getNameFull(self._state, self.splitGSU)
+      self._name = getSolutionNameFull(self._state, self.splitGSU)
     return self._name
 
   def __repr__(self):

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -350,8 +350,6 @@ def writeSolutionsAndKernelsTCL(
         k["BaseName"] = base
         k.duplicate = True if base in visited else False
         duplicates += k.duplicate
-        if not k.duplicate:
-            print(getKernelNameMin(k, False))
         print2(f"Duplicate: {base}")
         visited.add(base)
     print1(f"Number of duplicate kernels: {duplicates}")

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -55,7 +55,7 @@ from Tensile.Common import (
 from Tensile.Common.Architectures import gfxToIsa, isaToGfx, SUPPORTED_GFX
 from Tensile.Common.Capabilities import makeIsaInfoMap
 from Tensile.Common.GlobalParameters import assignGlobalParameters, globalParameters
-from Tensile.SolutionStructs.Naming import getKernelFileBase, getKeyNoInternalArgs, getMinNaming, getSerialNaming
+from Tensile.SolutionStructs.Naming import getKernelFileBase, getKeyNoInternalArgs, getSerialNaming, getKernelNameMin
 
 from Tensile.CustomYamlLoader import load_logic_gfx_arch
 from Tensile.KernelWriterAssembly import KernelWriterAssembly
@@ -88,14 +88,14 @@ class KernelCodeGenResult(NamedTuple):
     wavefrontSize: int
 
 
-def processKernelSource(kernelWriterAssembly, data, useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, kernel) -> KernelCodeGenResult:
+def processKernelSource(kernelWriterAssembly, data, useShortNames, splitGSU, kernelSerialNaming, kernel) -> KernelCodeGenResult:
     """
     Generate source for a single kernel.
     Returns (error, source, header, kernelName).
     """
     kernelWriter = kernelWriterAssembly
     kernelWriter.setTensileInstructions(data)
-    asmFilename = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, kernel)
+    asmFilename = getKernelFileBase(useShortNames, splitGSU, kernelSerialNaming, kernel)
     err, src = kernelWriter.getSourceFileString(kernel, useShortNames)
     header = kernelWriter.getHeaderFileString(kernel)
     objFilename = kernel._state.get("codeObjectFile", None)
@@ -206,7 +206,6 @@ def writeSolutionsAndKernels(
     splitGSU: bool,
     cmdlineArchs: List[str],
     kernelSerialNaming,
-    kernelMinNaming,
     errorTolerant=False,
     generateSourcesAndExit=False,
     compress=True,
@@ -231,7 +230,7 @@ def writeSolutionsAndKernels(
     visited = set()
     duplicates = 0
     for k in asmKernels:
-        base = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, k)
+        base = getKernelFileBase(useShortNames, splitGSU, kernelSerialNaming, k)
         k.duplicate = True if base in visited else False
         if not k.duplicate:
             k["BaseName"] = base
@@ -248,7 +247,6 @@ def writeSolutionsAndKernels(
         itertools.repeat(rocisa.rocIsa.getInstance().getData()),
         itertools.repeat(useShortNames),
         itertools.repeat(splitGSU),
-        itertools.repeat(kernelMinNaming),
         itertools.repeat(kernelSerialNaming),
         asmKernels
     )
@@ -306,7 +304,6 @@ def writeSolutionsAndKernelsTCL(
     kernelWriterAssembly,
     cmdlineArchs: List[str],
     kernelSerialNaming,
-    kernelMinNaming,
     compress=True,
     useShortNames=False,
 ):
@@ -328,10 +325,12 @@ def writeSolutionsAndKernelsTCL(
     duplicates = 0
     splitGSU = False
     for k in asmKernels:
-        base = getKernelFileBase(useShortNames, splitGSU, kernelMinNaming, kernelSerialNaming, k)
+        base = getKernelFileBase(useShortNames, splitGSU, kernelSerialNaming, k)
         k["BaseName"] = base
         k.duplicate = True if base in visited else False
         duplicates += k.duplicate
+        if not k.duplicate:
+            print(getKernelNameMin(k, False))
         print2(f"Duplicate: {base}")
         visited.add(base)
     print1(f"Number of duplicate kernels: {duplicates}")
@@ -348,7 +347,6 @@ def writeSolutionsAndKernelsTCL(
         rocisa.rocIsa.getInstance().getData(),
         useShortNames,
         splitGSU,
-        kernelMinNaming,
         kernelSerialNaming
     )
 
@@ -627,9 +625,7 @@ def run():
 
     kernels, kernelHelperObjs, _ = generateKernelObjectsFromSolutions(solutions)
     kernelSerialNaming = getSerialNaming(kernels)
-    kernelMinNaming = getMinNaming(kernels)
     kernelWriterAssembly = KernelWriterAssembly(
-        kernelMinNaming,
         kernelSerialNaming,
         asmToolchain.assembler,
         DebugConfig(),
@@ -646,7 +642,6 @@ def run():
         kernelWriterAssembly,
         archs,
         kernelSerialNaming,
-        kernelMinNaming,
         useShortNames=arguments["ShortNames"],
         compress=arguments["UseCompression"],
     )
@@ -664,11 +659,11 @@ def run():
                 masterFile = os.path.join(newLibraryDir, "TensileLibrary_lazy_" + archName)
             else:
                 masterFile = os.path.join(newLibraryDir, "TensileLibrary_" + archName)
-            newMasterLibrary.applyNaming(splitGSU, kernelMinNaming)
+            newMasterLibrary.applyNaming(splitGSU)
             LibraryIO.write(masterFile, state(newMasterLibrary), arguments["LibraryFormat"])
             for name, lib in newMasterLibrary.lazyLibraries.items():
                 filename = os.path.join(newLibraryDir, name)
-                lib.applyNaming(splitGSU, kernelMinNaming)
+                lib.applyNaming(splitGSU)
                 LibraryIO.write(filename, state(lib), arguments["LibraryFormat"])
 
     if not arguments["KeepBuildTmp"]:

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -99,7 +99,7 @@ def buildAssemblyCodeObjectFiles(
 
     archKernelMap = collections.defaultdict(list)
     for k in kernels:
-      archKernelMap[tuple(k['ISA'])].append(k)
+      archKernelMap[tuple(k['ISA'])].add(k)
 
     coFiles = []
     for arch, archKernels in archKernelMap.items():
@@ -109,13 +109,13 @@ def buildAssemblyCodeObjectFiles(
       gfx = isaToGfx(arch)
 
       objectFiles = [str(asmDir / (k["BaseName"] + extObj)) for k in archKernels if 'codeObjectFile' not in k]
-      coFileMap = collections.defaultdict(list)
+      coFileMap = collections.defaultdict(set)
       if len(objectFiles):
         coFileMap[asmDir / ("TensileLibrary_"+ gfx + extCoRaw)] = objectFiles
       for kernel in archKernels:
         coName = kernel.get("codeObjectFile", None)
         if coName:
-          coFileMap[asmDir / (coName + extCoRaw)].append(str(asmDir / (kernel["BaseName"] + extObj)))
+          coFileMap[asmDir / (coName + extCoRaw)].add(str(asmDir / (kernel["BaseName"] + extObj)))
 
       for coFileRaw, objFiles in coFileMap.items():
         objFiles = _batchObjectFiles(ldPath, objFiles, coFileRaw)

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -99,7 +99,7 @@ def buildAssemblyCodeObjectFiles(
 
     archKernelMap = collections.defaultdict(list)
     for k in kernels:
-      archKernelMap[tuple(k['ISA'])].add(k)
+      archKernelMap[tuple(k['ISA'])].append(k)
 
     coFiles = []
     for arch, archKernels in archKernelMap.items():


### PR DESCRIPTION
This PR makes changes to the naming functionality in tensilelite such that naming function queries always return the same name regardless of the order that solutions/kernels are processed and/or the number of targets built. Previously, naming functions relied on a dictionary typically named `kernelNameMin` or `solutionNameMin` which was previously mutable. As a result, the number solutions processed and the order of processing would result in a different name. 

With these changes, for a given kernel/solution state, the computed names will always be the same. As a result, we can update the logic files in a subsequent PR to include the deterministic name. Computing a kernel name will not be required at runtime and we no longer need all solutions in memory at once to compute a consistent name. This will aide in providing updates to the build system to expose more parallelism and establish a means to extend logic file validation. It also enables reproduceable builds because the kernel names are the symbols in the co files and should be fixed from this point forward.

Some naming functions were replaced to provide more clarity in how they are intended to be used. The new naming functions and the previous definition include:

- `getKernelNameMin` -> `getNameMin(kernel, kernelMinNaming, splitGSU, True)`
- `getSolutionNameMin` ->  `getNameMin(kernel, kernelMinNaming, splitGSU, False)`
- `getSolutionNameFull` ->  `getNameMin(kernel, list(validParameters.keys()), splitGSU, False)`

Here is an example of how the names differ when building for just the 90a vs building for all

  
```
Same kernel but building for 90a vs all
90a
Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs_MT112x128x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_CLR1_EPS0_GRVWA2_GRVWB2_GSUAMB_K1_LBSPPA896_LBSPPB1024_LPA16_LPB16_LPM0_LRVW4_MIAV0_MIWT7_2_MO40_NTn1_NTA0_NTB0_NTC0_NTD0_NTM0_NEPBS2_NLCA7_NLCB1_PGR2_PLR1_SIA3_SS1_SPO1_SRVW0_SSO0_SVW1_TLDS0_USFGROn1_VSn1_VWA1_VWB2_WSGRA0_WSGRB0_WG16_16_1

all
Cijk_Ailk_Bjlk_BBS_BH_Bias_HAS_SAV_UserArgs_MT112x128x32_MI16x16x1_SN_LDSB0_AFC1_AFEM1_AFEM1_ASEM1_CLR1_CADS0_DTVA0_DTVB0_EPS0_FDSI0_GRPM1_GRVWA2_GRVWB2_GSUAMB_GLS0_ISA90a_IU1_K1_LBSPPA896_LBSPPB1024_LBSPPM0_LPA16_LPB16_LPM0_LRVW4_LWPMn1_MIAV0_MIWT7_2_MO40_NTn1_NTA0_NTB0_NTC0_NTD0_NTM0_NEPBS2_NLCA7_NLCB1_ONLL1_PGR2_PLR1_PKA1_SIA3_SS1_SPO1_SRVW0_SSO0_SVW1_SK0_SKXCCM0_TLDS0_ULSGRO0_USL1_UIOFGRO0_USFGROn1_VSn1_VWA1_VWB2_WSGRA0_WSGRB0_WS64_WG16_16_1
```

With the new naming scheme, we compared all of the co files for the 90a to ensure that the same number of kernels appear in each co file and that the symbol names were the same when compared to an `all` build. There were no differences in the kernel count or symbol names.