### PR TITLE
Cross compile in Tensile

### DIFF
--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -471,16 +471,16 @@ def Tensile(userArgs):
     )
 
     if "ISA" in args.global_parameters:
-        isa = args.global_parameters["ISA"]
-        isa = IsaVersion(isa[0], isa[1], isa[2])
+        isaList = [IsaVersion(isa[0], isa[1], isa[2]) for isa in args.global_parameters["ISA"]]
+        
     else:
-        isa = detectGlobalCurrentISA(device_id, enumerator)
+        isaList = [detectGlobalCurrentISA(device_id, enumerator)]
 
-    if isa == IsaVersion(9,5,0):
+    if IsaVersion(9,5,0) in isaList:
         printWarning("HardwareMonitor currently disabled for gfx950")
         globalParameters["HardwareMonitor"] = False
 
-    isaInfoMap = makeIsaInfoMap([isa], cxxCompiler)
+    isaInfoMap = makeIsaInfoMap(isaList, cxxCompiler)
     assignGlobalParameters(config.get("GlobalParameters", {}), isaInfoMap)
 
     overrideParameters = argUpdatedGlobalParameters(args)

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -470,11 +470,17 @@ def Tensile(userArgs):
         offloadBundler,
     )
 
-    currentIsa = detectGlobalCurrentISA(device_id, enumerator)
-    if currentIsa == IsaVersion(9,5,0):
+    if "ISA" in args.global_parameters:
+        isa = args.global_parameters["ISA"]
+        isa = IsaVersion(isa[0], isa[1], isa[2])
+    else:
+        isa = detectGlobalCurrentISA(device_id, enumerator)
+
+    if isa == IsaVersion(9,5,0):
         printWarning("HardwareMonitor currently disabled for gfx950")
         globalParameters["HardwareMonitor"] = False
-    isaInfoMap = makeIsaInfoMap([currentIsa], cxxCompiler)
+
+    isaInfoMap = makeIsaInfoMap([isa], cxxCompiler)
     assignGlobalParameters(config.get("GlobalParameters", {}), isaInfoMap)
 
     overrideParameters = argUpdatedGlobalParameters(args)


### PR DESCRIPTION
Sometimes it is of interest to generate and build asm kernels in the context of Tensile for a target other than what is detected as the current target (i.e. cross compile). This PR adds the logic necessary to provide that behavior.