### PR TITLE
Do not use GTEST_BOTH_LIBRARIES variable.

### DIFF
--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -57,10 +57,10 @@ target_include_directories( hipblaslt-test
     $<BUILD_INTERFACE:${HIP_INCLUDE_DIRS}>
     $<BUILD_INTERFACE:${BLAS_INCLUDE_DIR}>
     $<BUILD_INTERFACE:${BLIS_INCLUDE_DIR}> # may be blank if not used
-    $<BUILD_INTERFACE:${GTEST_INCLUDE_DIRS}>
 )
 message("BLIS_INCLUDE_DIR=" ${BLIS_INCLUDE_DIR})
-target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} ${GTEST_BOTH_LIBRARIES} roc::hipblaslt )
+target_link_libraries( hipblaslt-test PRIVATE ${BLAS_LIBRARY} 
+  GTest::gtest GTest::gtest_main roc::hipblaslt )
 
 if( NOT BUILD_CUDA )
   target_link_libraries( hipblaslt-test PRIVATE hip::host hip::device )


### PR DESCRIPTION
* This is a legacy variable that is not recommended for modern use and is only available via the GTest find module, not the actual config provided by the package.
* Recommended usage is just to depend on the libraries.
* Also removes GTEST_INCLUDE_DIRS, since that is implicit in depending on the library.

Fixes https://github.com/ROCm/TheRock/issues/414