### PR TITLE
Add rocisa to requirements

### DIFF
--- a/tensilelite/requirements-dev.txt
+++ b/tensilelite/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r ./requirements.txt
+./rocisa
+memory_profiler

--- a/tensilelite/requirements.txt
+++ b/tensilelite/requirements.txt
@@ -7,4 +7,3 @@ joblib>=1.1.1; python_version < '3.8'
 simplejson
 ujson
 orjson
-./rocisa

--- a/tensilelite/requirements.txt
+++ b/tensilelite/requirements.txt
@@ -7,3 +7,4 @@ joblib>=1.1.1; python_version < '3.8'
 simplejson
 ujson
 orjson
+./rocisa


### PR DESCRIPTION
Adds rocisa to the requirements.txt file so developers can setup environment with:

```
pip install -r requirements-dev.txt
```