### PR TITLE
Port rocisa to Windows.

### DIFF
--- a/tensilelite/rocisa/CMakeLists.txt
+++ b/tensilelite/rocisa/CMakeLists.txt
@@ -70,6 +70,7 @@ nanobind_add_module(rocisa NOMINSIZE NB_SUPPRESS_WARNINGS
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/container.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/count.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/enum.cpp
+                        ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/helper.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/label.cpp
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/macro.cpp
                         ${ROCISAINST_SOURCE}

--- a/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -21,16 +21,17 @@
  *
  * ************************************************************************ */
 #pragma once
+#include <algorithm>
+#include <array>
 #include <stdexcept>
 #include <string>
-#include <sys/wait.h>
-#include <unistd.h>
 #include <vector>
-#ifdef __GNUG__
-#include <cxxabi.h>
-#endif
 
 using IsaVersion = std::array<int, 3>;
+
+std::pair<int, std::string>
+    run(const std::vector<char*>& cmd, const std::string& input, bool debug = false);
+std::string demangle(const char* name);
 
 inline std::string getGfxNameTuple(const IsaVersion& isaVersion)
 {
@@ -47,52 +48,6 @@ inline std::string getGfxNameTuple(const IsaVersion& isaVersion)
            + int_to_hex[isaVersion[2]];
 }
 
-inline std::pair<int, std::string>
-    run(const std::vector<char*>& cmd, const std::string& input, bool debug = false)
-{
-    int   p[2];
-    pid_t pid;
-    if(pipe(p) == -1)
-    {
-        throw std::runtime_error("cmd failed!");
-    }
-
-    pid = fork();
-    if(pid == 0)
-    {
-        close(p[1]);
-        dup2(p[0], STDIN_FILENO);
-        if(!debug)
-        {
-            dup2(p[0], STDERR_FILENO);
-            dup2(p[0], STDOUT_FILENO);
-        }
-        close(p[0]);
-        execvp(cmd[0], cmd.data());
-        perror("execvp");
-        exit(1);
-    }
-    else
-    {
-        close(p[0]);
-        write(p[1], input.c_str(), input.size());
-        close(p[1]);
-        char        buf[128] = {0};
-        std::string result;
-        read(p[0], buf, 128);
-        result += buf;
-        int rcode;
-        waitpid(pid, &rcode, 0);
-        if(WIFEXITED(rcode))
-        {
-            rcode = WEXITSTATUS(rcode);
-        }
-        return {rcode, result};
-    }
-    // Should not go here.
-    return {0, "0"};
-}
-
 template <typename T>
 bool checkInList(const T& a, const std::vector<T> b)
 {
@@ -103,18 +58,4 @@ template <typename T>
 bool checkNotInList(const T& a, const std::vector<T> b)
 {
     return std::find(b.begin(), b.end(), a) == b.end();
-}
-
-inline std::string demangle(const char* name)
-{
-    std::string result = name;
-#ifdef __GNUG__
-    int   status    = -1;
-    char* demangled = abi::__cxa_demangle(name, nullptr, nullptr, &status);
-    result          = (status == 0) ? demangled : name;
-    free(demangled);
-#else
-#error "Windows not supported"
-#endif
-    return result;
 }

--- a/tensilelite/rocisa/rocisa/include/helper.hpp
+++ b/tensilelite/rocisa/rocisa/include/helper.hpp
@@ -30,7 +30,7 @@
 using IsaVersion = std::array<int, 3>;
 
 std::pair<int, std::string>
-    run(const std::vector<char*>& cmd, const std::string& input, bool debug = false);
+            run(const std::vector<char*>& cmd, const std::string& input, bool debug = false);
 std::string demangle(const char* name);
 
 inline std::string getGfxNameTuple(const IsaVersion& isaVersion)

--- a/tensilelite/rocisa/rocisa/include/label.hpp
+++ b/tensilelite/rocisa/rocisa/include/label.hpp
@@ -21,8 +21,10 @@
  *
  * ************************************************************************ */
 #pragma once
+#include <algorithm>
 #include <map>
 #include <stdexcept>
+#include <string>
 #include <time.h>
 
 #define LABEL_NAME_LENGTH 17

--- a/tensilelite/rocisa/rocisa/src/code.cpp
+++ b/tensilelite/rocisa/rocisa/src/code.cpp
@@ -155,10 +155,10 @@ void init_code(nb::module_ m)
         // nanobind cannot reliably bind the same method signatures that differ
         // only by const-ness, so indirectly bind via a lambda. This manifests
         // as a mangled name clash on Windows.
-        .def("addItems", [](rocisa::Module& self,
-                            const std::vector<std::shared_ptr<rocisa::Item>>& items) {
-            self.addItems(items);
-        })
+        .def("addItems",
+             [](rocisa::Module& self, const std::vector<std::shared_ptr<rocisa::Item>>& items) {
+                 self.addItems(items);
+             })
         .def("appendModule", &rocisa::Module::appendModule)
         .def("addModuleAsFlatItems", &rocisa::Module::addModuleAsFlatItems)
         .def("findIndex", &rocisa::Module::findIndex)
@@ -175,10 +175,10 @@ void init_code(nb::module_ m)
         // nanobind cannot reliably bind the same method signatures that differ
         // only by const-ness, so indirectly bind via a lambda. This manifests
         // as a mangled name clash on Windows.
-        .def("setItems", [](rocisa::Module& self,
-                            const std::vector<std::shared_ptr<rocisa::Item>>& items) {
-            self.setItems(items);
-        })
+        .def("setItems",
+             [](rocisa::Module& self, const std::vector<std::shared_ptr<rocisa::Item>>& items) {
+                 self.setItems(items);
+             })
         .def("items", &rocisa::Module::items)
         .def("itemsSize", &rocisa::Module::itemsSize)
         .def("replaceItem", &rocisa::Module::replaceItem)

--- a/tensilelite/rocisa/rocisa/src/code.cpp
+++ b/tensilelite/rocisa/rocisa/src/code.cpp
@@ -152,7 +152,13 @@ void init_code(nb::module_ m)
         .def("setInlineAsmPrintMode", &rocisa::Module::setInlineAsmPrintMode)
         .def("addSpaceLine", &rocisa::Module::addSpaceLine)
         .def("add", &rocisa::Module::add, nb::arg("item"), nb::arg("pos") = -1)
-        .def("addItems", &rocisa::Module::addItems)
+        // nanobind cannot reliably bind the same method signatures that differ
+        // only by const-ness, so indirectly bind via a lambda. This manifests
+        // as a mangled name clash on Windows.
+        .def("addItems", [](rocisa::Module& self,
+                            const std::vector<std::shared_ptr<rocisa::Item>>& items) {
+            self.addItems(items);
+        })
         .def("appendModule", &rocisa::Module::appendModule)
         .def("addModuleAsFlatItems", &rocisa::Module::addModuleAsFlatItems)
         .def("findIndex", &rocisa::Module::findIndex)
@@ -166,7 +172,13 @@ void init_code(nb::module_ m)
         .def("count", &rocisa::Module::count)
         .def("getItem", &rocisa::Module::getItem)
         .def("setItem", &rocisa::Module::setItem)
-        .def("setItems", &rocisa::Module::setItems)
+        // nanobind cannot reliably bind the same method signatures that differ
+        // only by const-ness, so indirectly bind via a lambda. This manifests
+        // as a mangled name clash on Windows.
+        .def("setItems", [](rocisa::Module& self,
+                            const std::vector<std::shared_ptr<rocisa::Item>>& items) {
+            self.setItems(items);
+        })
         .def("items", &rocisa::Module::items)
         .def("itemsSize", &rocisa::Module::itemsSize)
         .def("replaceItem", &rocisa::Module::replaceItem)

--- a/tensilelite/rocisa/rocisa/src/helper.cpp
+++ b/tensilelite/rocisa/rocisa/src/helper.cpp
@@ -29,31 +29,39 @@
 
 #ifdef WIN32
 
-#include <windows.h>
 #include <dbghelp.h>
+#include <windows.h>
 
 // Linker hint to ensure dbghelp.lib is linked.
 #pragma comment(lib, "dbghelp.lib")
 
-std::pair<int, std::string>
-    run(const std::vector<char*>& cmd, const std::string& input, bool debug)
+std::pair<int, std::string> run(const std::vector<char*>& cmd, const std::string& input, bool debug)
 {
-    struct State {
-        State() {
+    struct State
+    {
+        State()
+        {
             ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
         }
-        ~State() {
-            if (hChildStd_OUT_Rd) CloseHandle(hChildStd_OUT_Rd);
-            if (hChildStd_OUT_Wr) CloseHandle(hChildStd_OUT_Wr);
-            if (hChildStd_IN_Rd) CloseHandle(hChildStd_IN_Rd);
-            if (hChildStd_IN_Wr) CloseHandle(hChildStd_IN_Wr);
-            if (piProcInfo.hProcess) CloseHandle(piProcInfo.hProcess);
-            if (piProcInfo.hThread) CloseHandle(piProcInfo.hThread);
+        ~State()
+        {
+            if(hChildStd_OUT_Rd)
+                CloseHandle(hChildStd_OUT_Rd);
+            if(hChildStd_OUT_Wr)
+                CloseHandle(hChildStd_OUT_Wr);
+            if(hChildStd_IN_Rd)
+                CloseHandle(hChildStd_IN_Rd);
+            if(hChildStd_IN_Wr)
+                CloseHandle(hChildStd_IN_Wr);
+            if(piProcInfo.hProcess)
+                CloseHandle(piProcInfo.hProcess);
+            if(piProcInfo.hThread)
+                CloseHandle(piProcInfo.hThread);
         }
         HANDLE hChildStd_OUT_Rd = NULL;
         HANDLE hChildStd_OUT_Wr = NULL;
-        HANDLE hChildStd_IN_Rd = NULL;
-        HANDLE hChildStd_IN_Wr = NULL;
+        HANDLE hChildStd_IN_Rd  = NULL;
+        HANDLE hChildStd_IN_Wr  = NULL;
 
         PROCESS_INFORMATION piProcInfo;
     };
@@ -61,31 +69,32 @@ std::pair<int, std::string>
 
     // Windows implementation using CreateProcess and pipes.
     SECURITY_ATTRIBUTES saAttr;
-    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
-    saAttr.bInheritHandle = TRUE;
+    saAttr.nLength              = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle       = TRUE;
     saAttr.lpSecurityDescriptor = NULL;
 
     // Create a pipe for the child process's STDOUT.
-    if (!CreatePipe(&state.hChildStd_OUT_Rd, &state.hChildStd_OUT_Wr, &saAttr, 0))
+    if(!CreatePipe(&state.hChildStd_OUT_Rd, &state.hChildStd_OUT_Wr, &saAttr, 0))
         throw std::runtime_error("Stdout pipe creation failed");
     // Ensure the read handle is NOT inherited.
-    if (!SetHandleInformation(state.hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0))
+    if(!SetHandleInformation(state.hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0))
         throw std::runtime_error("Stdout SetHandleInformation failed");
 
     // Create a pipe for the child process's STDIN.
-    if (!CreatePipe(&state.hChildStd_IN_Rd, &state.hChildStd_IN_Wr, &saAttr, 0))
+    if(!CreatePipe(&state.hChildStd_IN_Rd, &state.hChildStd_IN_Wr, &saAttr, 0))
         throw std::runtime_error("Stdin pipe creation failed");
-    if (!SetHandleInformation(state.hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0))
+    if(!SetHandleInformation(state.hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0))
         throw std::runtime_error("Stdin SetHandleInformation failed");
 
     // Build a command-line string from the vector of arguments.
-    if (cmd.empty() || cmd.back() != nullptr) {
+    if(cmd.empty() || cmd.back() != nullptr)
+    {
         throw std::runtime_error("Expected non-empty null terminated list of args");
     }
     std::string commandLine;
-    for (size_t i = 0; i < cmd.size() - 1; ++i)
+    for(size_t i = 0; i < cmd.size() - 1; ++i)
     {
-        if (i > 0)
+        if(i > 0)
             commandLine += " ";
         std::string arg(cmd[i]);
         // Quote the argument if it contains spaces.
@@ -93,7 +102,7 @@ std::pair<int, std::string>
         // things like embedded quotation marks, etc. Since it is being used
         // to invoke controlled tools, we do not expect this and do not guard
         // against it.
-        if (arg.find(' ') != std::string::npos)
+        if(arg.find(' ') != std::string::npos)
             commandLine += "\"" + arg + "\"";
         else
             commandLine += arg;
@@ -104,9 +113,9 @@ std::pair<int, std::string>
 
     STARTUPINFOA siStartInfo;
     ZeroMemory(&siStartInfo, sizeof(STARTUPINFOA));
-    siStartInfo.cb = sizeof(STARTUPINFOA);
+    siStartInfo.cb        = sizeof(STARTUPINFOA);
     siStartInfo.hStdInput = state.hChildStd_IN_Rd;
-    if (!debug)
+    if(!debug)
     {
         siStartInfo.hStdOutput = state.hChildStd_OUT_Wr;
         siStartInfo.hStdError  = state.hChildStd_OUT_Wr;
@@ -118,17 +127,16 @@ std::pair<int, std::string>
     }
     siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
 
-    if (!CreateProcessA(
-            NULL,
-            cmdLineMutable.data(),
-            NULL,
-            NULL,
-            TRUE,
-            0,
-            NULL,
-            NULL,
-            &siStartInfo,
-            &state.piProcInfo))
+    if(!CreateProcessA(NULL,
+                       cmdLineMutable.data(),
+                       NULL,
+                       NULL,
+                       TRUE,
+                       0,
+                       NULL,
+                       NULL,
+                       &siStartInfo,
+                       &state.piProcInfo))
     {
         std::string message("CreateProcess failed: ");
         message.append(commandLine);
@@ -136,11 +144,14 @@ std::pair<int, std::string>
     }
 
     // Write to child's stdin and close to signal EOF
-    if (!input.empty())
+    if(!input.empty())
     {
         DWORD written = 0;
-        if(!WriteFile(state.hChildStd_IN_Wr, input.data(), static_cast<DWORD>(input.size()), 
-            &written, nullptr))
+        if(!WriteFile(state.hChildStd_IN_Wr,
+                      input.data(),
+                      static_cast<DWORD>(input.size()),
+                      &written,
+                      nullptr))
         {
             std::string message("Failed to write to child's stdin: ");
             message.append(commandLine);
@@ -154,36 +165,36 @@ std::pair<int, std::string>
     state.hChildStd_IN_Rd = NULL;
 
     std::string result;
-    char buffer[128];
-    DWORD readBytes = 0;
-    while (true)
+    char        buffer[128];
+    DWORD       readBytes = 0;
+    while(true)
     {
         // See how many bytes are waiting (non‐blocking)
         DWORD available = 0;
-        if (!PeekNamedPipe(state.hChildStd_OUT_Rd, nullptr, 0, nullptr, &available, nullptr))
-         {
+        if(!PeekNamedPipe(state.hChildStd_OUT_Rd, nullptr, 0, nullptr, &available, nullptr))
+        {
             DWORD err = GetLastError();
             throw std::runtime_error("PeekNamedPipe failed with error " + std::to_string(err));
-         }
+        }
 
         // If no data is pending, check if the child has exited
-        if (available == 0)
+        if(available == 0)
         {
-            if (WaitForSingleObject(state.piProcInfo.hProcess, 0) == WAIT_OBJECT_0)
-                break;               // child is done and no more output
-            Sleep(1);                // back off briefly to avoid spinning
-            continue;                // retry
+            if(WaitForSingleObject(state.piProcInfo.hProcess, 0) == WAIT_OBJECT_0)
+                break; // child is done and no more output
+            Sleep(1); // back off briefly to avoid spinning
+            continue; // retry
         }
 
         // Read up to what's available (capped to buffer size)
-        DWORD toRead = (available < sizeof(buffer)) ? available : sizeof(buffer);
+        DWORD toRead    = (available < sizeof(buffer)) ? available : sizeof(buffer);
         DWORD bytesRead = 0;
-        BOOL success = ReadFile(state.hChildStd_OUT_Rd, buffer, toRead, &bytesRead, nullptr);
-        if (!success)
+        BOOL  success   = ReadFile(state.hChildStd_OUT_Rd, buffer, toRead, &bytesRead, nullptr);
+        if(!success)
         {
             DWORD err = GetLastError();
-            if (err == ERROR_BROKEN_PIPE)
-                break;               // pipe closed by child
+            if(err == ERROR_BROKEN_PIPE)
+                break; // pipe closed by child
             throw std::runtime_error("ReadFile failed with error " + std::to_string(err));
         }
 
@@ -198,15 +209,15 @@ std::pair<int, std::string>
     WaitForSingleObject(state.piProcInfo.hProcess, INFINITE);
     DWORD exitCode = 0;
     GetExitCodeProcess(state.piProcInfo.hProcess, &exitCode);
-    return { static_cast<int>(exitCode), result };
+    return {static_cast<int>(exitCode), result};
 }
 
 std::string demangle(const char* name)
 {
-    std::string result = name;
-    char demangledName[1024] = {0};
+    std::string result              = name;
+    char        demangledName[1024] = {0};
     // UNDNAME_COMPLETE flag produces the full undecorated name.
-    if (UnDecorateSymbolName(name, demangledName, sizeof(demangledName), UNDNAME_COMPLETE))
+    if(UnDecorateSymbolName(name, demangledName, sizeof(demangledName), UNDNAME_COMPLETE))
     {
         result = demangledName;
     }
@@ -221,9 +232,7 @@ std::string demangle(const char* name)
 #include <cxxabi.h>
 #endif
 
-
-std::pair<int, std::string>
-    run(const std::vector<char*>& cmd, const std::string& input, bool debug)
+std::pair<int, std::string> run(const std::vector<char*>& cmd, const std::string& input, bool debug)
 {
     int   p[2];
     pid_t pid;
@@ -270,13 +279,12 @@ std::pair<int, std::string>
 
 std::string demangle(const char* name)
 {
-    std::string result = name;
-    int   status    = -1;
-    char* demangled = abi::__cxa_demangle(name, nullptr, nullptr, &status);
-    result          = (status == 0) ? demangled : name;
+    std::string result    = name;
+    int         status    = -1;
+    char*       demangled = abi::__cxa_demangle(name, nullptr, nullptr, &status);
+    result                = (status == 0) ? demangled : name;
     free(demangled);
     return result;
 }
 
-#endif  // POSIX
-
+#endif // POSIX

--- a/tensilelite/rocisa/rocisa/src/helper.cpp
+++ b/tensilelite/rocisa/rocisa/src/helper.cpp
@@ -1,0 +1,282 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "helper.hpp"
+
+// This file includes platform specific helpers that differ between POSIX and
+// Windows. The alternatives are switched at a whole-file level. Please do
+// not use inline/fine-grained ifdefs.
+
+#ifdef WIN32
+
+#include <windows.h>
+#include <dbghelp.h>
+
+// Linker hint to ensure dbghelp.lib is linked.
+#pragma comment(lib, "dbghelp.lib")
+
+std::pair<int, std::string>
+    run(const std::vector<char*>& cmd, const std::string& input, bool debug)
+{
+    struct State {
+        State() {
+            ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
+        }
+        ~State() {
+            if (hChildStd_OUT_Rd) CloseHandle(hChildStd_OUT_Rd);
+            if (hChildStd_OUT_Wr) CloseHandle(hChildStd_OUT_Wr);
+            if (hChildStd_IN_Rd) CloseHandle(hChildStd_IN_Rd);
+            if (hChildStd_IN_Wr) CloseHandle(hChildStd_IN_Wr);
+            if (piProcInfo.hProcess) CloseHandle(piProcInfo.hProcess);
+            if (piProcInfo.hThread) CloseHandle(piProcInfo.hThread);
+        }
+        HANDLE hChildStd_OUT_Rd = NULL;
+        HANDLE hChildStd_OUT_Wr = NULL;
+        HANDLE hChildStd_IN_Rd = NULL;
+        HANDLE hChildStd_IN_Wr = NULL;
+
+        PROCESS_INFORMATION piProcInfo;
+    };
+    State state;
+
+    // Windows implementation using CreateProcess and pipes.
+    SECURITY_ATTRIBUTES saAttr;
+    saAttr.nLength = sizeof(SECURITY_ATTRIBUTES);
+    saAttr.bInheritHandle = TRUE;
+    saAttr.lpSecurityDescriptor = NULL;
+
+    // Create a pipe for the child process's STDOUT.
+    if (!CreatePipe(&state.hChildStd_OUT_Rd, &state.hChildStd_OUT_Wr, &saAttr, 0))
+        throw std::runtime_error("Stdout pipe creation failed");
+    // Ensure the read handle is NOT inherited.
+    if (!SetHandleInformation(state.hChildStd_OUT_Rd, HANDLE_FLAG_INHERIT, 0))
+        throw std::runtime_error("Stdout SetHandleInformation failed");
+
+    // Create a pipe for the child process's STDIN.
+    if (!CreatePipe(&state.hChildStd_IN_Rd, &state.hChildStd_IN_Wr, &saAttr, 0))
+        throw std::runtime_error("Stdin pipe creation failed");
+    if (!SetHandleInformation(state.hChildStd_IN_Wr, HANDLE_FLAG_INHERIT, 0))
+        throw std::runtime_error("Stdin SetHandleInformation failed");
+
+    // Build a command-line string from the vector of arguments.
+    if (cmd.empty() || cmd.back() != nullptr) {
+        throw std::runtime_error("Expected non-empty null terminated list of args");
+    }
+    std::string commandLine;
+    for (size_t i = 0; i < cmd.size() - 1; ++i)
+    {
+        if (i > 0)
+            commandLine += " ";
+        std::string arg(cmd[i]);
+        // Quote the argument if it contains spaces.
+        // Note that this can still fail to quote properly on more esoteric
+        // things like embedded quotation marks, etc. Since it is being used
+        // to invoke controlled tools, we do not expect this and do not guard
+        // against it.
+        if (arg.find(' ') != std::string::npos)
+            commandLine += "\"" + arg + "\"";
+        else
+            commandLine += arg;
+    }
+    // Create a mutable command-line buffer as required by CreateProcess.
+    std::vector<char> cmdLineMutable(commandLine.begin(), commandLine.end());
+    cmdLineMutable.push_back('\0');
+
+    STARTUPINFOA siStartInfo;
+    ZeroMemory(&siStartInfo, sizeof(STARTUPINFOA));
+    siStartInfo.cb = sizeof(STARTUPINFOA);
+    siStartInfo.hStdInput = state.hChildStd_IN_Rd;
+    if (!debug)
+    {
+        siStartInfo.hStdOutput = state.hChildStd_OUT_Wr;
+        siStartInfo.hStdError  = state.hChildStd_OUT_Wr;
+    }
+    else
+    {
+        siStartInfo.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+        siStartInfo.hStdError  = GetStdHandle(STD_ERROR_HANDLE);
+    }
+    siStartInfo.dwFlags |= STARTF_USESTDHANDLES;
+
+    if (!CreateProcessA(
+            NULL,
+            cmdLineMutable.data(),
+            NULL,
+            NULL,
+            TRUE,
+            0,
+            NULL,
+            NULL,
+            &siStartInfo,
+            &state.piProcInfo))
+    {
+        std::string message("CreateProcess failed: ");
+        message.append(commandLine);
+        throw std::runtime_error(std::move(message));
+    }
+
+    // Write to child's stdin and close to signal EOF
+    if (!input.empty())
+    {
+        DWORD written = 0;
+        if(!WriteFile(state.hChildStd_IN_Wr, input.data(), static_cast<DWORD>(input.size()), 
+            &written, nullptr))
+        {
+            std::string message("Failed to write to child's stdin: ");
+            message.append(commandLine);
+            throw std::runtime_error(std::move(message));
+        }
+    }
+
+    CloseHandle(state.hChildStd_IN_Wr);
+    state.hChildStd_IN_Wr = NULL;
+    CloseHandle(state.hChildStd_IN_Rd);
+    state.hChildStd_IN_Rd = NULL;
+
+    std::string result;
+    char buffer[128];
+    DWORD readBytes = 0;
+    while (true)
+    {
+        // See how many bytes are waiting (non‐blocking)
+        DWORD available = 0;
+        if (!PeekNamedPipe(state.hChildStd_OUT_Rd, nullptr, 0, nullptr, &available, nullptr))
+         {
+            DWORD err = GetLastError();
+            throw std::runtime_error("PeekNamedPipe failed with error " + std::to_string(err));
+         }
+
+        // If no data is pending, check if the child has exited
+        if (available == 0)
+        {
+            if (WaitForSingleObject(state.piProcInfo.hProcess, 0) == WAIT_OBJECT_0)
+                break;               // child is done and no more output
+            Sleep(1);                // back off briefly to avoid spinning
+            continue;                // retry
+        }
+
+        // Read up to what's available (capped to buffer size)
+        DWORD toRead = (available < sizeof(buffer)) ? available : sizeof(buffer);
+        DWORD bytesRead = 0;
+        BOOL success = ReadFile(state.hChildStd_OUT_Rd, buffer, toRead, &bytesRead, nullptr);
+        if (!success)
+        {
+            DWORD err = GetLastError();
+            if (err == ERROR_BROKEN_PIPE)
+                break;               // pipe closed by child
+            throw std::runtime_error("ReadFile failed with error " + std::to_string(err));
+        }
+
+        result.append(buffer, bytesRead);
+    }
+    CloseHandle(state.hChildStd_OUT_Wr);
+    state.hChildStd_OUT_Wr = NULL;
+    CloseHandle(state.hChildStd_OUT_Rd);
+    state.hChildStd_OUT_Rd = NULL;
+
+    // Wait for the child process to finish.
+    WaitForSingleObject(state.piProcInfo.hProcess, INFINITE);
+    DWORD exitCode = 0;
+    GetExitCodeProcess(state.piProcInfo.hProcess, &exitCode);
+    return { static_cast<int>(exitCode), result };
+}
+
+std::string demangle(const char* name)
+{
+    std::string result = name;
+    char demangledName[1024] = {0};
+    // UNDNAME_COMPLETE flag produces the full undecorated name.
+    if (UnDecorateSymbolName(name, demangledName, sizeof(demangledName), UNDNAME_COMPLETE))
+    {
+        result = demangledName;
+    }
+    return result;
+}
+
+#else
+// POSIX implementation.
+#include <sys/wait.h>
+#include <unistd.h>
+#ifdef __GNUG__
+#include <cxxabi.h>
+#endif
+
+
+std::pair<int, std::string>
+    run(const std::vector<char*>& cmd, const std::string& input, bool debug)
+{
+    int   p[2];
+    pid_t pid;
+    if(pipe(p) == -1)
+    {
+        throw std::runtime_error("cmd failed!");
+    }
+
+    pid = fork();
+    if(pid == 0)
+    {
+        close(p[1]);
+        dup2(p[0], STDIN_FILENO);
+        if(!debug)
+        {
+            dup2(p[0], STDERR_FILENO);
+            dup2(p[0], STDOUT_FILENO);
+        }
+        close(p[0]);
+        execvp(cmd[0], cmd.data());
+        perror("execvp");
+        exit(1);
+    }
+    else
+    {
+        close(p[0]);
+        write(p[1], input.c_str(), input.size());
+        close(p[1]);
+        char        buf[128] = {0};
+        std::string result;
+        read(p[0], buf, 128);
+        result += buf;
+        int rcode;
+        waitpid(pid, &rcode, 0);
+        if(WIFEXITED(rcode))
+        {
+            rcode = WEXITSTATUS(rcode);
+        }
+        return {rcode, result};
+    }
+    // Should not go here.
+    return {0, "0"};
+}
+
+std::string demangle(const char* name)
+{
+    std::string result = name;
+    int   status    = -1;
+    char* demangled = abi::__cxa_demangle(name, nullptr, nullptr, &status);
+    result          = (status == 0) ? demangled : name;
+    free(demangled);
+    return result;
+}
+
+#endif  // POSIX
+


### PR DESCRIPTION
* Adds some missing headers that the Windows STL is stricter about.
* Separates `run` and `demangle` from `helper.hpp` into a new translation unit and conditionally provides Windows or POSIX-ey versions. Adds some RAII safety and error handling above and beyond the contributed original Windows implementation.
* Works around an interaction between nanobind and the Windows ABI not being able to differentiate between generated member function trampolines that differ only by const-ness.