### PR TITLE
Windows compatibility changes for C++ code.

### DIFF
--- a/clients/common/blis_interface.cpp
+++ b/clients/common/blis_interface.cpp
@@ -29,7 +29,7 @@
 
 void setup_blis()
 {
-#ifndef WIN32
+#ifndef _WIN32
     bli_init();
 #endif
 }

--- a/clients/common/hipblaslt_init_device.cpp
+++ b/clients/common/hipblaslt_init_device.cpp
@@ -116,7 +116,7 @@ __device__ int8_t random_hpl(size_t idx)
 }
 
 template <typename T>
-void hipblaslt_init_device(ABC                      abc,
+void hipblaslt_init_device(ABC_dims                 abc,
                            hipblaslt_initialization init,
                            bool                     is_nan,
                            T*                       A,
@@ -140,11 +140,11 @@ void hipblaslt_init_device(ABC                      abc,
         switch(init)
         {
         case hipblaslt_initialization::rand_int:
-            if(abc == ABC::A || abc == ABC::C)
+            if(abc == ABC_dims::A || abc == ABC_dims::C)
                 fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
                     return random_int<T>(idx);
                 });
-            else if(abc == ABC::B)
+            else if(abc == ABC_dims::B)
             {
                 stride = std::max(lda * N, stride);
                 fill_batch(A, M, N, lda, stride, batch_count, [stride, lda](size_t idx) -> T {
@@ -158,14 +158,14 @@ void hipblaslt_init_device(ABC                      abc,
             break;
         case hipblaslt_initialization::trig_float:
             stride = std::max(lda * N, stride);
-            if(abc == ABC::A || abc == ABC::C)
+            if(abc == ABC_dims::A || abc == ABC_dims::C)
                 fill_batch(A, M, N, lda, stride, batch_count, [M, N, stride, lda](size_t idx) -> T {
                     auto b = idx / stride;
                     auto j = (idx - b * stride) / lda;
                     auto i = (idx - b * stride) - j * lda;
                     return T(sin(double(i + j * M + b * M * N)));
                 });
-            else if(abc == ABC::B)
+            else if(abc == ABC_dims::B)
                 fill_batch(A, M, N, lda, stride, batch_count, [M, N, stride, lda](size_t idx) -> T {
                     auto b = idx / stride;
                     auto j = (idx - b * stride) / lda;
@@ -179,15 +179,15 @@ void hipblaslt_init_device(ABC                      abc,
             });
             break;
         case hipblaslt_initialization::special:
-            if(abc == ABC::A)
+            if(abc == ABC_dims::A)
                 fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
                     return T(hipblasLtHalf(65280.0));
                 });
-            else if(abc == ABC::B)
+            else if(abc == ABC_dims::B)
                 fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
                     return T(hipblasLtHalf(0.0000607967376708984375));
                 });
-            else if(abc == ABC::C)
+            else if(abc == ABC_dims::C)
                 fill_batch(A, M, N, lda, stride, batch_count, [](size_t idx) -> T {
                     return T(pseudo_random_device(idx) % 10 + 1.f);
                 });
@@ -213,7 +213,7 @@ void hipblaslt_init_device(ABC                      abc,
     }
 }
 
-void hipblaslt_init_device(ABC                      abc,
+void hipblaslt_init_device(ABC_dims                 abc,
                            hipblaslt_initialization init,
                            bool                     is_nan,
                            void*                    A,

--- a/clients/common/hipblaslt_parse_data.cpp
+++ b/clients/common/hipblaslt_parse_data.cpp
@@ -37,13 +37,16 @@
 // Parse YAML data
 static std::string hipblaslt_parse_yaml(const std::string& yaml)
 {
+    // TODO: This function is inherently unsafe because it returns a string vs an open
+    // file handle which will block further colliding creates. See comments in
+    // hipblaslt_tempname() and under no circumstances copy this to new code.
     std::string tmp     = hipblaslt_tempname();
     auto        exepath = hipblaslt_exepath();
     auto        cmd     = exepath + "hipblaslt_gentest.py --template " + exepath
                + "hipblaslt_template.yaml -o " + tmp + " " + yaml;
     hipblaslt_cerr << cmd << std::endl;
 
-#ifdef WIN32
+#ifdef _WIN32
     int status = std::system(cmd.c_str());
     if(status == -1)
         exit(EXIT_FAILURE);

--- a/clients/gtest/hipblaslt_test.cpp
+++ b/clients/gtest/hipblaslt_test.cpp
@@ -30,7 +30,7 @@
 #include <cstdlib>
 #include <exception>
 #include <regex>
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #define strcasecmp(A, B) _stricmp(A, B)
 #else
@@ -135,7 +135,7 @@ static thread_local struct
     volatile sig_atomic_t enabled = false;
 
     // sigjmp_buf describing stack frame to go back to
-#ifndef WIN32
+#ifndef _WIN32
     sigjmp_buf sigjmp_buf_;
 #else
     jmp_buf sigjmp_buf_;
@@ -161,7 +161,7 @@ extern "C" void hipblaslt_test_signal_handler(int sig)
         return;
     }
 
-#ifndef WIN32
+#ifndef _WIN32
     // If this is an alarm timeout, we abort
     if(sig == SIGALRM)
     {
@@ -180,7 +180,7 @@ extern "C" void hipblaslt_test_signal_handler(int sig)
     // it is better than crashing.
     t_handler.signal = sig;
     errno            = saved_errno;
-#ifndef WIN32
+#ifndef _WIN32
     siglongjmp(t_handler.sigjmp_buf_, true);
 #else
     longjmp(t_handler.sigjmp_buf_, true);
@@ -190,7 +190,7 @@ extern "C" void hipblaslt_test_signal_handler(int sig)
 // Set up signal handlers
 void hipblaslt_test_sigaction()
 {
-#ifndef WIN32
+#ifndef _WIN32
     struct sigaction act;
     act.sa_flags = 0;
     sigfillset(&act.sa_mask);
@@ -219,7 +219,7 @@ void catch_signals_and_exceptions_as_failures(std::function<void()> test, bool s
     // Save the current handler (to allow nested calls to this function)
     auto old_handler = t_handler;
 
-#ifndef WIN32
+#ifndef _WIN32
     // Set up the return point, and handle siglongjmp returning back to here
     if(sigsetjmp(t_handler.sigjmp_buf_, true))
     {
@@ -237,7 +237,7 @@ void catch_signals_and_exceptions_as_failures(std::function<void()> test, bool s
 #endif
     else
     {
-#ifndef WIN32
+#ifndef _WIN32
         // Alarm to detect deadlocks or hangs
         if(set_alarm)
             alarm(test_timeout);
@@ -260,7 +260,7 @@ void catch_signals_and_exceptions_as_failures(std::function<void()> test, bool s
         }
     }
 
-#ifndef WIN32
+#ifndef _WIN32
     // Cancel the alarm if it was set
     if(set_alarm)
         alarm(0);

--- a/clients/include/TensorDataManipulation.hpp
+++ b/clients/include/TensorDataManipulation.hpp
@@ -29,6 +29,10 @@
 #include <iosfwd>
 #include <memory>
 #include <vector>
+#ifdef _WIN32
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 namespace Tensor
 {

--- a/clients/include/datatype_interface.hpp
+++ b/clients/include/datatype_interface.hpp
@@ -27,6 +27,8 @@
 #pragma once
 #include <hipblaslt/hipblaslt.h>
 
+#include <map>
+
 union computeTypeInterface
 {
     float         f32;

--- a/clients/include/hipblaslt_arguments.hpp
+++ b/clients/include/hipblaslt_arguments.hpp
@@ -296,7 +296,7 @@ struct Arguments
     // Function to read Arguments data from stream
     friend std::istream& operator>>(std::istream& str, Arguments& arg);
 
-#ifdef WIN32
+#ifdef _WIN32
     // Clang specific code
     template <typename T>
     friend hipblaslt_internal_ostream& operator<<(hipblaslt_internal_ostream& os,

--- a/clients/include/hipblaslt_init.hpp
+++ b/clients/include/hipblaslt_init.hpp
@@ -36,14 +36,14 @@
 #include <omp.h>
 #include <vector>
 
-enum class ABC
+enum class ABC_dims
 {
     A,
     B,
     C
 };
 
-void hipblaslt_init_device(ABC                      abc,
+void hipblaslt_init_device(ABC_dims                 ABC_dims,
                            hipblaslt_initialization init,
                            bool                     is_nan,
                            void*                    A,

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -29,6 +29,7 @@
 #include "TensorDataManipulation.hpp"
 #include "allclose.hpp"
 #include "cblas_interface.hpp"
+#include "efficiency_monitor.hpp"
 #include "flops.hpp"
 #include "hipBuffer.hpp"
 #include "hipblaslt_datatype2string.hpp"
@@ -40,7 +41,6 @@
 #include "mxDataGen.hpp"
 #include "near.hpp"
 #include "norm.hpp"
-#include "efficiency_monitor.hpp"
 #include "unit.hpp"
 #include "utility.hpp"
 #include <cstddef>
@@ -49,6 +49,7 @@
 #include <hipblaslt/hipblaslt-ext.hpp>
 #include <hipblaslt/hipblaslt.h>
 #include <map>
+#include <numeric>
 #include <omp.h>
 #include <set>
 
@@ -1815,16 +1816,16 @@ void testing_matmul_with_bias(const Arguments& arg,
         else
         {
 #endif
-            hipblaslt_init_device(ABC::A,
-                              arg.initialization,
-                              alpha_isnan_type(arg, Talpha),
-                              dA[i].buf(),
-                              A_row[i],
-                              A_col[i],
-                              (arg.swizzle_a) ? A_row[i] : lda[i],
-                              TiA,
-                              (arg.swizzle_a) ? A_row[i] * A_col[i] : stride_a[i],
-                              num_batches[i]);
+            hipblaslt_init_device(ABC_dims::A,
+                                  arg.initialization,
+                                  alpha_isnan_type(arg, Talpha),
+                                  dA[i].buf(),
+                                  A_row[i],
+                                  A_col[i],
+                                  (arg.swizzle_a) ? A_row[i] : lda[i],
+                                  TiA,
+                                  (arg.swizzle_a) ? A_row[i] * A_col[i] : stride_a[i],
+                                  num_batches[i]);
 #ifdef USE_ROCROLLER
         }
         if(arg.scaleB == hipblaslt_scaling_format::Block)
@@ -1865,20 +1866,20 @@ void testing_matmul_with_bias(const Arguments& arg,
         else
         {
 #endif
-            hipblaslt_init_device(ABC::B,
-                              arg.initialization,
-                              alpha_isnan_type(arg, Talpha),
-                              dB[i].buf(),
-                              B_row[i],
-                              B_col[i],
-                              ldb[i],
-                              TiB,
-                              stride_b[i],
-                              num_batches[i]);
+            hipblaslt_init_device(ABC_dims::B,
+                                  arg.initialization,
+                                  alpha_isnan_type(arg, Talpha),
+                                  dB[i].buf(),
+                                  B_row[i],
+                                  B_col[i],
+                                  ldb[i],
+                                  TiB,
+                                  stride_b[i],
+                                  num_batches[i]);
 #ifdef USE_ROCROLLER
         }
 #endif
-        hipblaslt_init_device(ABC::C,
+        hipblaslt_init_device(ABC_dims::C,
                               arg.initialization,
                               beta_isnan_type(arg, Talpha),
                               dC[i].buf(),

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -155,7 +155,7 @@ endif()
 # Target link libraries
 if(NOT BUILD_CUDA)
 # Target link libraries
-  target_link_libraries(hipblaslt PRIVATE hip::device ${DL_LIB})
+  target_link_libraries(hipblaslt PRIVATE hip::device ${CMAKE_DL_LIBS})
 endif()
 
 if(HIPBLASLT_ENABLE_MARKER)

--- a/library/include/hipblaslt/hipblaslt-ext.hpp
+++ b/library/include/hipblaslt/hipblaslt-ext.hpp
@@ -415,7 +415,7 @@ namespace hipblaslt_ext
             strideE2; //!< The aux batch stride. Only works if mode is set to aux related epilogues.
         float act0; //!< The activation value 1. Some activations might use it.
         float act1; //!< The activation value 2.
-        int   activationType; //!< The activation type.  Only works if mode is set to activation related epilogues.
+        int activationType; //!< The activation type.  Only works if mode is set to activation related epilogues.
     } __attribute__((packed));
 
     /*! \ingroup types_module
@@ -425,8 +425,8 @@ namespace hipblaslt_ext
     {
     public:
         HIPBLASLT_EXPORT virtual ~GemmInstance(){};
-        HIPBLASLT_EXPORT               GemmInstance(const GemmInstance& rhs) = delete;
-        HIPBLASLT_EXPORT GemmInstance& operator=(const GemmInstance& rhs)    = delete;
+        GemmInstance(const GemmInstance& rhs)                             = delete;
+        GemmInstance&                  operator=(const GemmInstance& rhs) = delete;
         HIPBLASLT_EXPORT               GemmInstance(GemmInstance&& rhs) noexcept;
         HIPBLASLT_EXPORT GemmInstance& operator=(GemmInstance&& rhs) noexcept;
 
@@ -771,9 +771,9 @@ namespace hipblaslt_ext
                                        void*                   D,
                                        hipblasLtMatrixLayout_t matD);
 
-        HIPBLASLT_EXPORT       Gemm(const Gemm&) = delete;
+        Gemm(const Gemm&) = delete;
         HIPBLASLT_EXPORT       Gemm(Gemm&&) noexcept;
-        HIPBLASLT_EXPORT Gemm& operator=(const Gemm&) = delete;
+        Gemm&                  operator=(const Gemm&) = delete;
         HIPBLASLT_EXPORT Gemm& operator=(Gemm&&) noexcept;
 
         /*! \ingroup library_module
@@ -1027,9 +1027,9 @@ namespace hipblaslt_ext
                                               hipDataType          typeC,
                                               hipDataType          typeD,
                                               hipblasComputeType_t typeCompute);
-        HIPBLASLT_EXPORT              GroupedGemm(const GroupedGemm&) = delete;
+        GroupedGemm(const GroupedGemm&) = delete;
         HIPBLASLT_EXPORT              GroupedGemm(GroupedGemm&&) noexcept;
-        HIPBLASLT_EXPORT GroupedGemm& operator=(const GroupedGemm&) = delete;
+        GroupedGemm&                  operator=(const GroupedGemm&) = delete;
         HIPBLASLT_EXPORT GroupedGemm& operator=(GroupedGemm&&) noexcept;
 
         /*! \ingroup library_module

--- a/library/src/amd_detail/hipblaslt-ext-op-internal.hpp
+++ b/library/src/amd_detail/hipblaslt-ext-op-internal.hpp
@@ -32,8 +32,8 @@
 #include <Tensile/msgpack/MessagePack.hpp>
 #include <algorithm>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
-#include <libgen.h>
 #include <msgpack.hpp>
 #include <sstream>
 #include <stdexcept>
@@ -660,7 +660,7 @@ namespace hipblaslt_ext
         explicit ExtOpMasterLibrary(const std::string& libPath)
             : libPath(libPath)
         {
-            libDir = std::string(dirname(&this->libPath[0]));
+            libDir = std::filesystem::path(this->libPath).parent_path().string();
             load(libPath);
         }
 

--- a/library/src/amd_detail/hipblaslt-ext.cpp
+++ b/library/src/amd_detail/hipblaslt-ext.cpp
@@ -300,7 +300,7 @@ namespace hipblaslt_ext
     class GemmTuningV2::GemmTuningImpl
     {
     public:
-        u_int16_t splitK = 0;
+        uint16_t  splitK = 0;
         int16_t   wgm    = 0;
     };
 
@@ -325,7 +325,7 @@ namespace hipblaslt_ext
     GemmTuningV2::GemmTuningV2(GemmTuningV2&& tuning)            = default;
     GemmTuningV2& GemmTuningV2::operator=(GemmTuningV2&& tuning) = default;
 
-    void GemmTuningV2::setSplitK(u_int16_t splitK)
+    void GemmTuningV2::setSplitK(uint16_t splitK)
     {
         pimpl->splitK = splitK;
     }
@@ -335,7 +335,7 @@ namespace hipblaslt_ext
         pimpl->wgm = wgm;
     }
 
-    u_int16_t GemmTuningV2::getSplitK() const
+    uint16_t GemmTuningV2::getSplitK() const
     {
         return pimpl->splitK;
     }

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
@@ -403,7 +403,8 @@ std::string rocblaslt_internal_get_arch_name();
 // for internal use of testing existence of path
 bool rocblaslt_internal_test_path(const std::string&);
 
-std::string rocblaslt_internal_get_so_path(const std::string& keyword);
+// Gets the absolute path of the so/dll/exe containing this function.
+std::string rocblaslt_internal_get_so_path();
 
 void rocblaslt_log_error(const char* func, const char* var, const char* msg);
 #endif

--- a/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
+++ b/library/src/amd_detail/rocblaslt/src/CMakeLists.txt
@@ -146,8 +146,6 @@ if(NOT Tensile_SKIP_BUILD)
     add_subdirectory(kernels)
 endif()
 
-set(DL_LIB dl)
-
 # rocBLASLt source
 target_sources(
   hipblaslt

--- a/library/src/amd_detail/rocblaslt/src/include/logging.h
+++ b/library/src/amd_detail/rocblaslt/src/include/logging.h
@@ -44,9 +44,12 @@
 #include <sys/types.h>
 #include <tuple>
 #include <type_traits>
-#include <unistd.h>
 #include <unordered_map>
 #include <utility>
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 /************************************************************************************
  * Profile kernel arguments

--- a/library/src/amd_detail/rocblaslt/src/utility.cpp
+++ b/library/src/amd_detail/rocblaslt/src/utility.cpp
@@ -25,7 +25,18 @@
  *******************************************************************************/
 #include "utility.hpp"
 #include <sys/types.h>
+#include <time.h>
+
+#ifdef _WIN32
+#include <process.h>
+#else
 #include <unistd.h>
+#endif
+
+#include <iostream>
+#include <memory>
+#include <string>
+
 std::ostream* get_logger_os()
 {
     LoggerSingleton& s = LoggerSingleton::getInstance();

--- a/library/src/hipblaslt_ostream.cpp
+++ b/library/src/hipblaslt_ostream.cpp
@@ -30,7 +30,7 @@ static void hipblaslt_abort_once [[noreturn]] ();
 #include <fcntl.h>
 #include <iostream>
 #include <type_traits>
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -52,7 +52,7 @@ static void hipblaslt_abort_once [[noreturn]] ();
 // Abort function which is called only once by hipblaslt_abort
 static void hipblaslt_abort_once()
 {
-#ifndef WIN32
+#ifndef _WIN32
     // Make sure the alarm and abort actions are default
     signal(SIGALRM, SIG_DFL);
     signal(SIGABRT, SIG_DFL);
@@ -108,7 +108,7 @@ std::shared_ptr<hipblaslt_internal_ostream::worker> hipblaslt_internal_ostream::
                       && std::is_same<decltype(file_id_t::st_ino), decltype(stat::st_ino)>{},
                   "struct stat and file_id_t are not layout-compatible");
 
-#ifndef WIN32
+#ifndef _WIN32
     // Get the device ID and inode, to detect common files
     if(fstat(fd, &statbuf))
     {
@@ -226,7 +226,7 @@ void hipblaslt_internal_ostream::worker::send(std::string str)
     // The future indicating when the operation has completed
     auto future = promise.get_future();
 
-#ifdef WIN32
+#ifdef _WIN32
     // Passing an empty string will make the worker thread exit.
     // The below flag will be used to handle worker thread exit condition for Windows
     bool empty_string = str.empty();
@@ -247,7 +247,7 @@ void hipblaslt_internal_ostream::worker::send(std::string str)
     }
 
 // Wait for the task to be completed, to ensure flushed IO
-#ifdef WIN32
+#ifdef _WIN32
     if(empty_string)
         // Occassionaly this thread is not getting the promise set by the 'worker' thread during exit condition.
         // Added a timed wait to exit after one second, if we do not get the promise from worker thread.
@@ -313,7 +313,7 @@ void hipblaslt_internal_ostream::worker::thread_function()
 hipblaslt_internal_ostream::worker::worker(int fd)
 {
     // The worker duplicates the file descriptor (RAII)
-#ifdef WIN32
+#ifdef _WIN32
     fd = _dup(fd);
 #else
     fd = fcntl(fd, F_DUPFD_CLOEXEC, 0);

--- a/library/src/include/hipblaslt_ostream.hpp
+++ b/library/src/include/hipblaslt_ostream.hpp
@@ -47,7 +47,7 @@
 #include <sys/stat.h>
 #include <thread>
 #include <utility>
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <iostream>
 #include <sstream>

--- a/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
+++ b/tensilelite/Tensile/Source/client/include/DataInitialization.hpp
@@ -2601,13 +2601,25 @@ namespace TensileLite
         template <>
         inline Float8 DataInitialization::getValue<Float8, InitMode::RandomNarrow>()
         {
+#if _WIN32
+            //msvc's STL implementation follows [rand.req.genl](1.5), so Float8 as template arg
+            //is not allowed
+            return Float8(rocm_random_narrow_range<float>{}());
+#else
             return rocm_random_narrow_range<Float8>{}();
+#endif
         }
 
         template <>
         inline BFloat8 DataInitialization::getValue<BFloat8, InitMode::RandomNarrow>()
         {
+#if _WIN32
+            //msvc's STL implementation follows [rand.req.genl](1.5), so BFloat8 as template arg
+            //is not allowed
+            return BFloat8(rocm_random_narrow_range<float>{}());
+#else
             return rocm_random_narrow_range<BFloat8>{}();
+#endif
         }
 
         template <>

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
@@ -32,8 +32,9 @@
 #include <Tensile/MasterSolutionLibrary.hpp>
 #include <Tensile/PlaceholderLibrary.hpp>
 //Replace std::regex, as it crashes when matching long lines(GCC Bug #86164).
-#ifdef WIN32
+#ifdef _WIN32
 #include "shlwapi.h"
+#pragma comment(lib, "shlwapi.lib")
 #else
 #include <fnmatch.h>
 #endif
@@ -73,7 +74,7 @@ namespace TensileLite
                     for(auto condition : ctx->preloaded)
                     {
                         std::string pattern = RegexPattern(condition);
-#ifdef WIN32
+#ifdef _WIN32
                         if(PathMatchSpecA(lib.filePrefix.c_str(), pattern.c_str()))
 #else
                         if(fnmatch(pattern.c_str(), lib.filePrefix.c_str(), 0) == 0)

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -2285,7 +2285,9 @@ namespace TensileLite
         gsuTemp++;
 
         name += "_PostGSU"
-                + std::to_string(std::min((unsigned long)gsuTemp, sizeMapping.globalSplitUPGR));
+                + std::to_string(
+                    std::min(static_cast<decltype(sizeMapping.globalSplitUPGR)>(gsuTemp),
+                             sizeMapping.globalSplitUPGR));
 
         name += "_VW" + std::to_string(vw);
 

--- a/tensilelite/Tensile/Source/lib/source/MLPNet.cpp
+++ b/tensilelite/Tensile/Source/lib/source/MLPNet.cpp
@@ -26,6 +26,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <iostream>
 #include <numeric>
 #include <stdexcept>

--- a/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
+++ b/tensilelite/Tensile/Source/lib/source/hip/HipSolutionAdapter.cpp
@@ -35,7 +35,7 @@
 #include <Tensile/hip/HipUtils.hpp>
 
 //@TODO add alternative for windows
-#ifndef WIN32
+#ifndef _WIN32
 #include <glob.h>
 #endif
 #include <regex>

--- a/tensilelite/rocisa/rocisa/src/helper.cpp
+++ b/tensilelite/rocisa/rocisa/src/helper.cpp
@@ -27,7 +27,7 @@
 // Windows. The alternatives are switched at a whole-file level. Please do
 // not use inline/fine-grained ifdefs.
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #include <windows.h>
 // windows.h must be loaded before other windows headers.


### PR DESCRIPTION
Includes findings/fixes from #1864.

Fixes all portability issues that resulted in compilation errors in C++ code. There are still warnings and some possible functional issues which need more work, but this is a first step we should commit. This patch was written/tested in a combined tree that is capable of building on Windows, and we need to verify that any rewritten paths do not regress Posix. With this and new CMake patches, the project compiles on Windows. It has some linkage issues on the tests which need further investigation (we have another branch with some of these findings/workarounds).

Several additional changes from the above:

* Rewrote shared library finding code to be based on resolving a library by address vs scanning for a named library. While the code for both is not identical on Windows/Posix, the same semantics for such a helper are directly available.
* Rewrote a number of things for clarity and to use std::filesystem vs use of low level path and string munging.
* Removed several conditional `#ifdef _WIN32` when the branches could be expressed in a portable manner.

Explanations for some changes:

* `s/ABC/ABC_dims/`: `ABC` is used as a bareword in Windows headers.
* `s/WIN32/_WIN32/`: `_WIN32` is the modern/correct way to detect if compiling on Windows. It is defined in all cases whereas `WIN32` is only defined in some situations.
* `ssize_t` is non-standard. In the place it is used, did the usual typedef from the `SSIZE_T` type that windows provides in its headers.
* `portable_uniform_int_distribution` template specializations instead of direct use of `std::uniform_int_distribution` enables compilation on standards compliant C++ standard libs, which do not include char specializations (includes MSVC but also some others).
* Remove non-standard `DL_LIB` ways to include `-ldl` on Posix. That is what `CMAKE_DL_LIBS` is for.
* Remove HIPBLASLT_EXPORT from all deleted members. This is illegal and was not being caught in Posix builds.
* Replace `libgen.h` with `std::filesystem` equivalents. We should not allow `libgen.h` in new code.
* `u_int16_t` is not a real/standard type. Use `uint16_t`.
* Rewrite some unreadably nested ifdefs in initialization code to use normal if statements and compile both paths vs leaving some compilation paths only for certain build configurations. We should enforce this as a coding convention.