### PR TITLE
Add rocisa path into the setup.py

### DIFF
--- a/tensilelite/MANIFEST.in
+++ b/tensilelite/MANIFEST.in
@@ -1,5 +1,5 @@
 recursive-include Tensile *.py *.h *.hpp *.cpp *.txt *.cmake *.yaml
-recursive-include rocisa/rocisa/include *.hpp
+recursive-include rocisa *.cpp *.hpp *.txt
 recursive-include Tensile/CustomKernels *.s
 include Tensile/bin/Tensile Tensile/bin/TensileCreateLibrary
 include Tensile/Ops/gen_assembly.sh

--- a/tensilelite/setup.py
+++ b/tensilelite/setup.py
@@ -53,7 +53,7 @@ setup(
   license="MIT",
   install_requires=readRequirementsFromTxt(),
   python_requires='>=3.5',
-  packages=["Tensile", "rocisa/rocisa"],
+  packages=["Tensile", "rocisa"],
   package_data={ "Tensile": ["Tensile/cmake/*"] },
   data_files=[ ("cmake", ["Tensile/cmake/TensileConfig.cmake", "Tensile/cmake/TensileConfigVersion.cmake"]) ],
   include_package_data=True,


### PR DESCRIPTION
 * this is used to let other library who also uses tensilelite as a backend, can download the rocisa
 
 For hipsparselt to build correctly with rocisa enabled.
 https://github.com/ROCm/hipSPARSELt/pull/229