### PR TITLE
[Tensile] Fix type of XCC and CU in generated yaml is not correct

### DIFF
--- a/tensilelite/Tensile/Utilities/tensile_generator/tensile_config_generator.py
+++ b/tensilelite/Tensile/Utilities/tensile_generator/tensile_config_generator.py
@@ -115,6 +115,8 @@ if CU is None:
         CU = int(match.group('COMPUTE_UNIT').strip())
     else:
         raise RuntimeError("Failed to get compute unit from rocminfo, please specific CU environment variable.")
+else:
+    CU = int(CU)
 
 XCC = os.environ.get("XCC", None)
 if ArchitectureName == 'gfx942':
@@ -124,6 +126,8 @@ if ArchitectureName == 'gfx942':
             XCC = int(res.stdout.decode("utf-8").strip())
         else:
             raise FileNotFoundError(f"{NUM_INST} not found, please specific XCC environment variable.")
+    else:
+        XCC = int(XCC)
     DeviceNames = ["Device 0049", "Device 0050"]
     ScheduleName = "aquavanjaram"
 elif ArchitectureName == 'gfx90a':


### PR DESCRIPTION
The type of CU/XCC is `str` when setting CU and XCC through environmental variable. It will cause problem when running tensile. We should convert it to `int` when using environmental variable set CU/XCC.
![image](https://github.com/user-attachments/assets/b035153d-7650-4ad2-a021-dee261c44560)

![image](https://github.com/user-attachments/assets/660bcb40-3375-4358-8d61-f572cc4c69b5)


