### PR TITLE
Add 6.4.1 changelog entry and bump version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Full documentation for hipBLASLt is available at [rocm.docs.amd.com/projects/hipBLASLt](https://rocm.docs.amd.com/projects/hipBLASLt/en/latest/index.html).
 
+## hipBLASLt 0.12.1 for ROCm 6.4.1
+
+### Resolved issues
+
+* Fixed an accuracy issue that occurred for some solutions using an `FP32` or `TF32` data type with a TT transpose.
+
 ## hipBLASLt 0.12.0 for ROCm 6.4.0
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,7 @@ if(HIPBLASLT_ENABLE_MARKER)
 endif()
 
 # Setup version
-set(VERSION_STRING "0.12.0")
+set(VERSION_STRING "0.12.1")
 rocm_setup_version(VERSION ${VERSION_STRING})
 set(hipblaslt_SOVERSION 0.12)
 


### PR DESCRIPTION
This adds a resolved issue to the 6.4.1 changelog (https://github.com/ROCm/hipBLASLt/pull/1867) and bumps the versioning to 0.12.1