### PR TITLE
fix lds padding vgpr alignment

### DIFF
--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -3833,7 +3833,7 @@ class KernelWriterAssembly(KernelWriter):
 
     # LdsBlockSizePerPad: add padding
     if kernel["LdsBlockSizePerPad%s"%tc] != 0 and kernel["LdsPad%s"%tc] != 0:
-      tmpVgpr = self.vgprPool.checkOut(1)
+      tmpVgpr = self.vgprPool.checkOutAligned(2, 2)
       tmpVgprRes = ContinuousRegister(tmpVgpr, 2)
       module.add(vectorStaticDivide(tmpVgpr, destVgpr, kernel["LdsBlockSizePerPad%s"%tc], tmpVgprRes, \
         "padding %u per block %u" % (kernel["LdsPad%s"%tc] * tP["bpeDS"], kernel["LdsBlockSizePerPad%s"%tc])))

--- a/tensilelite/Tensile/Tests/common/gemm/fp32_nt.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/fp32_nt.yaml
@@ -1,0 +1,78 @@
+TestParameters:
+  marks: [skip-gfx1100, skip-gfx1101, skip-gfx1102, skip-gfx1200, skip-gfx1201] # not supported yet
+
+GlobalParameters:
+  MinimumRequiredVersion: 4.14.0
+  SleepPercent: 50
+  NumElementsToValidate: 128
+  DataInitTypeBeta: 0
+  DataInitTypeAlpha: 1
+  NewClient: 2
+  CSVExportWinner: 1
+  CSVMergeSameProblemID: 1
+  Device: 0
+
+BenchmarkProblems:
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: s
+      TransposeA: 0
+      TransposeB: 1
+      UseBeta: True
+      Batched: True
+      UseBias: 1
+      Batched: True
+      Activation: True
+      UseScaleAlphaVec: 1
+
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16,16,4, 1, 1, 2, 3, 2, 2] # 64 x 96
+
+        - PrefetchGlobalRead: [2]
+        - PrefetchLocalRead: [1]
+        - DepthU: [32]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - GlobalReadVectorWidthA: [-1]
+        - GlobalReadVectorWidthB: [-1]
+        - LocalReadVectorWidth: [-1]
+        - TransposeLDS: [-1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - LdsPadA: [-1]
+        - LdsPadB: [-1]
+        - StaggerU: [16]
+        - StaggerUStride: [-1]
+        - WorkGroupMapping: [1]
+        - StaggerUMapping: [0]
+        - 1LDSBuffer: [-1]
+        - WorkGroupMappingXCC: [8]
+        - WorkGroupMappingXCCGroup: [-1]
+        - GlobalSplitU: [1]
+        - GlobalSplitUAlgorithm: ["MultipleBuffer"]
+        - GlobalReadPerMfma: [1]
+        - LocalWritePerMfma: [-1]
+        - StoreRemapVectorWidth: [0]
+        - StoreVectorWidth: [-1]
+        - SourceSwap: [1]
+        - NumElementsPerBatchStore: [16]
+        - ClusterLocalRead: [1]
+        - NonTemporalA: [0]
+        - NonTemporalB: [0]
+        - DirectToVgprA: [1]
+        - DirectToVgprB: [0]
+        - WorkGroup: [[32,4,4]]
+
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Exact: [255, 255, 1, 255]
+        - BiasTypeArgs: ['s']
+        - ActivationArgs:
+          - [Enum: none]


### PR DESCRIPTION
Fix a RuntimeError happened when tuning f32 NT:
```
RuntimeError: Error with Assembling assembly source code into object file (.s -> .o): b'/Workspace/hipBLASLt/tensilelite/builds/build_f32_NT/1_BenchmarkProblems/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_00/00_Final/source/build_tmp/SOURCE/assembly/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_MT64x96x32_GI0srgNPFEUaJ2mdus-IBeu4sZgSp28Xsa5gxx9Cm9w=.s:616:1: error: invalid register class: vgpr tuples must be 64 bit aligned\nv_lshrrev_b64 v[25:26], 33, v[25:26]               // padding 64 per block 384\n^\n/Workspace/hipBLASLt/tensilelite/builds/build_f32_NT/1_BenchmarkProblems/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_00/00_Final/source/build_tmp/SOURCE/assembly/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_MT64x96x32_GI0srgNPFEUaJ2mdus-IBeu4sZgSp28Xsa5gxx9Cm9w=.s:877:1: error: invalid register class: vgpr tuples must be 64 bit aligned\nv_lshrrev_b64 v[25:26], 33, v[25:26]               // padding 64 per block 384\n^\n'
Failed command: /opt/rocm-6.5.0/bin/amdclang++ -x assembler --target=amdgcn-amd-amdhsa  -mcode-object-version=4 -c -mcpu=gfx942 -mwavefrontsize64 /Workspace/hipBLASLt/tensilelite/builds/build_f32_NT/1_BenchmarkProblems/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_00/00_Final/source/build_tmp/SOURCE/assembly/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_MT64x96x32_GI0srgNPFEUaJ2mdus-IBeu4sZgSp28Xsa5gxx9Cm9w=.s -o /Workspace/hipBLASLt/tensilelite/builds/build_f32_NT/1_BenchmarkProblems/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_00/00_Final/source/build_tmp/SOURCE/assembly/Cijk_Ailk_Bjlk_S_B_Bias_SAV_UserArgs_MT64x96x32_GI0srgNPFEUaJ2mdus-IBeu4sZgSp28Xsa5gxx9Cm9w=.o
```