### PR TITLE
Sparse, when compressing matrix at client, if cpuInput.current is not set use cpuInput.valid instead.

### DIFF
--- a/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
+++ b/tensilelite/Tensile/Source/client/source/DataInitialization.cpp
@@ -1485,7 +1485,7 @@ namespace TensileLite
                                        .pristine[problem.metadata().dataType()];
                     initGPUSparseInput(pUnit.gpuInput.current.get(),
                                        pUnitM.gpuInput.current.get(),
-                                       pUnit.cpuInput.current.get(),
+                                       m_cpuPtrs.empty() ? pUnit.cpuInput.valid.get() : pUnit.cpuInput.current.get(),
                                        problem.sparse() == 2 ? problem.b() : problem.a(),
                                        problem.compressed(),
                                        problem.metadata(),


### PR DESCRIPTION
 * cpuInput.current will be set when validation is enabled.