### PR TITLE
[cmake-next] Make final tweaks needed to build as part of TheRock.

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -33,6 +33,7 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
+include(hipblaslt_python)
 
 set(HIPBLASLT_ENABLE_DEVICE ON CACHE BOOL "Build hipBLASLt device libraries.")
 set(HIPBLASLT_ENABLE_CLIENT ON CACHE BOOL "Build hipBLASLt client apps.")
@@ -41,6 +42,8 @@ cmake_dependent_option(HIPBLASLT_ENABLE_HOST "Build hipBLASLt host library." ON 
 if(HIPBLASLT_ENABLE_CLIENT)
     set(HIPBLASLT_BUILD_TESTING ON CACHE BOOL "Build hipblaslt client tests.")
     set(HIPBLASLT_ENABLE_SAMPLES ON CACHE BOOL "Build client samples.")
+    # rocm-smi is not presently available on Windows so we do not require it.
+    cmake_dependent_option(HIPBLASLT_REQUIRE_ROCM_SMI "Require rocm_smi." ON "NOT WIN32" OFF)
 endif()
 
 if(HIPBLASLT_ENABLE_HOST)
@@ -81,9 +84,15 @@ if(HIPBLASLT_ENABLE_HOST)
         find_package(BLIS REQUIRED)
     endif()
 endif()
+if(HIPBLASLT_REQUIRE_ROCM_SMI)
+    find_package(rocm_smi REQUIRED)
+else()
+    find_package(rocm_smi)
+endif()
 if(HIPBLASLT_ENABLE_CLIENT)
     #find_package(Threads REQUIRED) # TODO: We don't fail to build or link without Threads remove?
-    find_package(cblas REQUIRED)
+    find_package(BLAS REQUIRED)
+    find_package(LAPACK REQUIRED)
 endif()
 if(HIPBLASLT_ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)
@@ -106,11 +115,23 @@ endif()
 if(HIPBLASLT_ENABLE_DEVICE)
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
     if(HIPBLASLT_BUNDLE_PYTHON_DEPS)
-    set(HIPBLASLT_PYTHON_COMMAND 
-        "cmake -E env PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/rocisa -- ${Python3_EXECUTABLE}" 
-        CACHE STRING "Command for invoking tensile python sripts")
+        # Build the rocisa python extension.
+        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../tensilelite/rocisa"
+            "${CMAKE_CURRENT_BINARY_DIR}/rocisa_pyext")
+        set(HIPBLASLT_PYTHON_DEPS "rocisa")
+        # TODO: The rocisa build explicitly sets the LIBRARY_OUTPUT_DIR to the
+        # (top-level!) CMAKE_BINARY_DIR/lib directory. This is not a great idea
+        # and should be removed/changed to a locally scoped directory. However,
+        # that is hard to do while this is all glued together with the old venv
+        # setup. In the meantime, the directory passed here must match the
+        # what is set there. Failure to do so will cause a ModuleNotFoundError
+        # trying to load rocisa.
+        hipblaslt_configure_bundled_python_command("${CMAKE_BINARY_DIR}/lib")
     else()
-        set(HIPBLASLT_PYTHON_COMMAND "${Python3_EXECUTABLE}" CACHE STRING "Command for invoking tensile python sripts")
+        # Just pass through to the found python executable and trust that the
+        # user set it up properly.
+        set(HIPBLASLT_PYTHON_COMMAND "${Python3_EXECUTABLE}")
+        set(HIPBLASLT_PYTHON_DEPS)
     endif()
 endif()
 if(HIPBLASLT_ENABLE_HOST)
@@ -176,7 +197,7 @@ if(HIPBLASLT_ENABLE_HOST)
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/host-library
     )
 
-    add_subdirectory(rocisa)
+    add_subdirectory(rocisa/rocisa-cpp)
     add_subdirectory(host-library)
 endif()
 

--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -44,7 +44,10 @@ if(HIPBLASLT_ENABLE_BLIS)
     target_link_libraries(hipblaslt-clients-common PRIVATE BLIS::BLIS)
 endif()
 
-target_link_libraries(hipblaslt-clients-common PUBLIC roc::hipblaslt lapack)
+target_link_libraries(hipblaslt-clients-common PUBLIC
+    roc::hipblaslt
+    ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
+)
 target_compile_definitions(hipblaslt-clients-common PRIVATE CLIENTS_NO_FORTRAN) # necessary?
 
 target_link_libraries(hipblaslt-bench PRIVATE hipblaslt-clients-common)
@@ -57,7 +60,13 @@ add_subdirectory(bench)
 if(BUILD_TESTING OR HIPBLSALT_BUILD_TESTING)
     find_package(GTest REQUIRED)
     add_executable(hipblaslt-test)
-    target_link_libraries(hipblaslt-test PRIVATE hipblaslt-clients-common GTest::gtest rocm_smi64)
+    if(rocm_smi_FOUND)
+        target_link_libraries(hipblaslt-test PRIVATE rocm_smi64)
+    endif()
+    target_link_libraries(hipblaslt-test PRIVATE hipblaslt-clients-common
+        ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
+        GTest::gtest
+    )
     if(HIPBLASLT_ENABLE_BLIS)
         target_link_libraries(hipblaslt-test PRIVATE BLIS::BLIS) # necessary?
     endif()

--- a/next-cmake/clients/common/src/CMakeLists.txt
+++ b/next-cmake/clients/common/src/CMakeLists.txt
@@ -41,3 +41,7 @@ if(HIPBLASLT_ENABLE_BLIS)
             "${_CMAKE_CURRENT_SOURCE_DIR}/blis_interface.cpp"
     )
 endif()
+
+if(rocm_smi_FOUND)
+    target_link_libraries(hipblaslt-clients-common PRIVATE rocm_smi64)
+endif()

--- a/next-cmake/cmake/hipblaslt_python.cmake
+++ b/next-cmake/cmake/hipblaslt_python.cmake
@@ -1,0 +1,64 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+# Sets the HIPBLASLT_PYTHON_COMMAND variable in the parent scope such that it
+# can invoke the Python interpreter valid for the build parameters. Because
+# this may involve a multi token list, it must be used without quotes in
+# COMMAND lists.
+function(hipblaslt_configure_bundled_python_command python_binary_dir)
+    # Set up a python command which sets PYTHONPATH and copies the current
+    # PATH to the build time invocation, invoking python with the -P option
+    # to enable additional environment protections.
+    if(WIN32)
+        set(_ds "$<SEMICOLON>")
+    else()
+        set(_ds ":")
+    endif()
+    set(_python_path
+        # TODO: Order is important because the tensilelite directory incorrectly
+        # contains a "rocisa" directory which could be incorrectly inferred
+        # to be a namespace package. That tree should be re-organized to have
+        # a discrete python src dir.
+        "${python_binary_dir}"
+        # TODO: This should not need to traverse to the parent directory once
+        # moved to the root.
+        "${hipblaslt_SOURCE_DIR}/../tensilelite"
+    )
+    list(JOIN _python_path "${_ds}" _python_path)
+
+    # Capture the configure time path so that the build environment is always
+    # fixed to what we saw at configure time.
+    set(_path "$ENV{PATH}")
+    if(WIN32)
+        string(REPLACE ";" "${_ds}" _path "${_path}")
+    endif()
+    set(_python_command
+        "${CMAKE_COMMAND}" -E env
+        "PYTHONPATH=${_python_path}"
+        "PATH=${_path}"
+        --
+        "${Python3_EXECUTABLE}" -P
+    )
+    message(STATUS "Python build command: ${_python_command}")
+    set(HIPBLASLT_PYTHON_COMMAND "${_python_command}" PARENT_SCOPE)
+endfunction()

--- a/next-cmake/device-library/CMakeLists.txt
+++ b/next-cmake/device-library/CMakeLists.txt
@@ -33,7 +33,7 @@ if(HIPBLASLT_DEVICE_JOBS)
 endif()
 set(output_dir "${CMAKE_CURRENT_BINARY_DIR}/Tensile")
 set(TENSILE_CREATE_LIBRARY_COMMAND
-    ${TENSILELITE_DIR}/Tensile/bin/TensileCreateLibrary
+    ${HIPBLASLT_PYTHON_COMMAND} -m Tensile.TensileCreateLibrary
     ${TENSILE_BUILD_OPTS}
     "${CMAKE_CURRENT_SOURCE_DIR}/../../library"
     ${output_dir}
@@ -44,6 +44,7 @@ add_custom_command(
     COMMENT "Building device libraries..."
     COMMAND ${TENSILE_CREATE_LIBRARY_COMMAND}
     OUTPUT "${output_dir}/library"
+    DEPENDS ${HIPBLASLT_PYTHON_DEPS}
 )
 
 add_custom_target(tensilelite-device-libraries ALL

--- a/next-cmake/device-library/extops/CMakeLists.txt
+++ b/next-cmake/device-library/extops/CMakeLists.txt
@@ -77,6 +77,7 @@ foreach(arch IN LISTS archs)
         COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_256_4_${arch}.s" -t S -d H -w 256 -c 4 --arch ${arch}
         COMMENT "Creating Layer Norm, Softmax and Amax Assembly for ${arch}"
         WORKING_DIRECTORY ${ops_dir}
+        DEPENDS ${HIPBLASLT_PYTHON_DEPS}
     )
     if(arch STREQUAL "gfx942")
         add_custom_command(
@@ -91,6 +92,7 @@ foreach(arch IN LISTS archs)
             COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8N_256_4_${arch}.s" -t S -d H -s B8N -w 256 -c 4 --arch ${arch}
             COMMENT "Creating Extra Amax Assembly for gfx942"
             WORKING_DIRECTORY ${ops_dir}
+            DEPENDS ${HIPBLASLT_PYTHON_DEPS}
         )
         target_sources(extop-obj-${arch}
             PRIVATE
@@ -113,6 +115,7 @@ foreach(arch IN LISTS archs)
             COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8_256_4_${arch}.s" -t S -d H -s B8 -w 256 -c 4 --arch ${arch}
             COMMENT "Creating Extra Amax Assembly for gfx950"
             WORKING_DIRECTORY ${ops_dir}
+            DEPENDS ${HIPBLASLT_PYTHON_DEPS}
         )
         target_sources(extop-obj-${arch}
             PRIVATE
@@ -132,7 +135,7 @@ foreach(arch IN LISTS archs)
     )
     list(APPEND extop_cp_depends "extop-library-${arch}")
     add_custom_target(extop-library-${arch}
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co
+        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co ${HIPBLASLT_PYTHON_DEPS}
         COMMAND ${HIPBLASLT_PYTHON_COMMAND} ExtOpCreateLibrary.py --src=${CMAKE_CURRENT_BINARY_DIR} --co=${output_dir}/extop_${arch}.co --output=${output_dir} --arch=${arch}
         COMMENT "Creating hipblasltExtOpLibrary.dat for ${arch}"
         WORKING_DIRECTORY ${ops_dir}

--- a/tensilelite/Tensile/TensileCreateLibrary/__main__.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/__main__.py
@@ -1,0 +1,4 @@
+from Tensile.TensileCreateLibrary import run
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
* Lets us drop all TheRock patches for hipBLASLt.
* Fixes the bundled python build mode:
  * Adds the tensilelite source directory.
  * Adds a __main__.py file so that TensileCreateLibrary can be invoked with `python -m Tensile.TensileCreateLibrary` instead of the hacks that were in place before. (this should let the bin/TensileCreateLibrary be dropped for the normal build since the console script should just work now, whereas it was pointing to a non executable package)
  * Propagates the configure time PATH to build time, making builds resilient to being invoked from a different shell environment.
  * Adds dependencies on the rocisa build to all Python invocations.
* Ports the BLAS/LAPACK finding patch to the new build system and removes hardcoded library deps on specific BLAS/LAPACK libraries.
* Fixes rocm_smi package finding (I suspect this was being tested on a system with some /opt/rocm state which was letting this work before?).
* Uses `${CMAKE_COMMAND}` instead of loose `cmake`.

With this, the hipblaslt build runs start to finish in a single ninja invocation. Null configure/build on my machine with a hot ccache is 34s for gfx1100 (56s with cold ccache -- I think more caching could easily be achieved with the build setup like this).