### PR TITLE
[cmake-next] Fix various issues in exports.

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -153,7 +153,7 @@ if(HIPBLASLT_ENABLE_HOST)
             ${CMAKE_DL_LIBS}
     )
     if(HIPBLASLT_ENABLE_OPENMP)
-        target_link_libraries(hipblaslt PUBLIC OpenMP::OpenMP_CXX)
+        target_link_libraries(hipblaslt PRIVATE OpenMP::OpenMP_CXX)
     endif()
 
     target_compile_features(hipblaslt PUBLIC cxx_std_17) # I would like to make this configurable
@@ -178,9 +178,9 @@ if(HIPBLASLT_ENABLE_HOST)
     endif()
     if(HIPBLASLT_ENABLE_MSGPACK)
         if(msgpack-cxx_FOUND)
-            target_link_libraries(hipblaslt PUBLIC msgpack-cxx)
+            target_link_libraries(hipblaslt PRIVATE msgpack-cxx)
         else()
-            target_link_libraries(hipblaslt PUBLIC msgpackc)
+            target_link_libraries(hipblaslt PRIVATE msgpackc)
         endif()
         target_compile_definitions(hipblaslt PRIVATE TENSILE_MSGPACK)
     endif()
@@ -217,14 +217,19 @@ endif()
 if(HIPBLASLT_ENABLE_HOST)
     install(TARGETS hipblaslt rocisa-cpp
         EXPORT hipblaslt-targets
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT hipBLASLt_Runtime
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        COMPONENT hipBLASLt_Development
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        COMPONENT hipBLASLt_Runtime
-        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        COMPONENT hipBLASLt_Development
+        LIBRARY
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            COMPONENT hipBLASLt_Runtime
+        ARCHIVE
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            COMPONENT hipBLASLt_Development
+        RUNTIME
+            DESTINATION "${CMAKE_INSTALL_BINDIR}"
+            COMPONENT hipBLASLt_Runtime
+        PUBLIC_HEADER
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+            COMPONENT hipBLASLt_Development
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     )
     install(
         EXPORT hipblaslt-targets
@@ -243,29 +248,26 @@ if(HIPBLASLT_ENABLE_HOST)
         FILES
             "${CMAKE_CURRENT_BINARY_DIR}/host-library/include/hipblaslt/hipblaslt-export.h"
             "${CMAKE_CURRENT_BINARY_DIR}/host-library/include/hipblaslt/hipblaslt-version.h"
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         COMPONENT hipBLASLt_Development
     )
-    install(
-        FILES "${CMAKE_CURRENT_SOURCE_DIR}/cmake/FindBLIS.cmake"
-        DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/hipblaslt
-        COMPONENT hipBLASLt_Development
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config-version.cmake"
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion
     )
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipblaslt-config.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake" @ONLY)
     install(FILES
         "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config-version.cmake"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../cmake/hipblaslt-config.cmake"
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipblaslt
+        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hipblaslt"
         COMPONENT hipBLASLt_Development
     )
     install(
         FILES "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md"
         DESTINATION "${CMAKE_INSTALL_DOCDIR}"
         COMPONENT hipBLASLt_Docs
-    )
-    write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config-version.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
     )
 
     if(HIPBLASLT_ENABLE_DEVICE)
@@ -278,7 +280,7 @@ if(HIPBLASLT_ENABLE_HOST)
 
     if(HIPBLASLT_ENABLE_CLIENT)
         install(
-            TARGETS hipblaslt-bench hipblaslt-clients-common
+            TARGETS hipblaslt-bench
             EXPORT hipblaslt-targets
             COMPONENT hipBLASLt_Runtime
         )

--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -29,7 +29,7 @@ set(TEMP_TENSILE_CLIENT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tensilelit
 set(TEMP_TENSILELITE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../tensilelite")
 
 add_executable(hipblaslt-bench)
-add_library(hipblaslt-clients-common)
+add_library(hipblaslt-clients-common STATIC)
 
 target_include_directories(hipblaslt-clients-common
     PUBLIC

--- a/next-cmake/cmake/hipblaslt-config.cmake.in
+++ b/next-cmake/cmake/hipblaslt-config.cmake.in
@@ -1,0 +1,28 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+include(CMakeFindDependencyMacro)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../share/cmake/hipblaslt")
+find_dependency(hip)
+find_dependency(hipblas-common)
+
+include("${CMAKE_CURRENT_LIST_DIR}/hipblaslt-targets.cmake")


### PR DESCRIPTION
* Downgrade OpenMP, msgpack to PRIVATE deps of hipblaslt.
* Fix syntax error in install TARGETS directive (`INCLUDES DESTINATION` does not take components and was including the literal "COMPONENT" and "hipBLASLt_Development" as interface include directories).
* Quote a few things to avoid possibility of parse issues.
* Fork hipblaslt-config.cmake and strip all private deps from it.
* Do not export `hipblaslt-clients-common` and make it explicitly STATIC.

With this, TheRock projects that are downstream of hipblaslt build properly.