### PR TITLE
Clean up for super build

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -80,7 +80,9 @@ set(ROCBLASLT_LIB_DIR "${HIPBLASLT_LIB_DIR}/src/amd_detail/rocblaslt")
 
 find_package(hip REQUIRED)
 if(HIPBLASLT_ENABLE_HOST)
-    find_package(hipblas-common REQUIRED)
+    if(NOT TARGET hip::hipblas-common)
+        find_package(hipblas-common REQUIRED)
+    endif()
     if(HIPBLASLT_ENABLE_BLIS)
         find_package(BLIS REQUIRED)
     endif()
@@ -146,7 +148,7 @@ if(HIPBLASLT_ENABLE_HOST)
 
     target_link_libraries(hipblaslt
         PUBLIC
-            roc::hipblas-common
+            hip::hipblas-common
             hip::device
         PRIVATE
             rocisa::rocisa-cpp

--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(hipblaslt-bench PRIVATE hipblaslt-clients-common)
 add_subdirectory(common)
 add_subdirectory(bench)
 
-if(BUILD_TESTING OR HIPBLSALT_BUILD_TESTING)
+if(BUILD_TESTING OR HIPBLASLT_BUILD_TESTING)
     find_package(GTest REQUIRED)
     add_executable(hipblaslt-test)
     if(rocm_smi_FOUND)

--- a/next-cmake/cmake/hipblaslt_python.cmake
+++ b/next-cmake/cmake/hipblaslt_python.cmake
@@ -57,7 +57,7 @@ function(hipblaslt_configure_bundled_python_command python_binary_dir)
         "PYTHONPATH=${_python_path}"
         "PATH=${_path}"
         --
-        "${Python3_EXECUTABLE}" -P
+        "${Python3_EXECUTABLE}"
     )
     message(STATUS "Python build command: ${_python_command}")
     set(HIPBLASLT_PYTHON_COMMAND "${_python_command}" PARENT_SCOPE)

--- a/next-cmake/device-library/extops/CMakeLists.txt
+++ b/next-cmake/device-library/extops/CMakeLists.txt
@@ -64,19 +64,18 @@ foreach(arch IN LISTS archs)
             "${CMAKE_CURRENT_BINARY_DIR}/A_H_H_256_4_${arch}.s"
             "${CMAKE_CURRENT_BINARY_DIR}/A_H_S_256_4_${arch}.s"
             "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_256_4_${arch}.s"
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} LayerNormGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/L_256_4_1_${arch}.s" -w 256 -c 4 --sweep-once 1 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} LayerNormGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/L_256_4_0_${arch}.s" -w 256 -c 4 --sweep-once 0 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} SoftmaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/S_8_32_${arch}.s" -m 8 -n 32 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} SoftmaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/S_16_16_${arch}.s" -m 16 -n 16 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} SoftmaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/S_4_64_${arch}.s" -m 4 -n 64 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} SoftmaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/S_2_128_${arch}.s" -m 2 -n 128 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} SoftmaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/S_1_256_${arch}.s" -m 1 -n 256 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_256_4_${arch}.s" -t S -d S -w 256 -c 4 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/A_H_H_256_4_${arch}.s" -t H -d H -w 256 -c 4 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/A_H_S_256_4_${arch}.s" -t H -d S -w 256 -c 4 --arch ${arch}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_256_4_${arch}.s" -t S -d H -w 256 -c 4 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/LayerNormGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/L_256_4_1_${arch}.s" -w 256 -c 4 --sweep-once 1 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/LayerNormGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/L_256_4_0_${arch}.s" -w 256 -c 4 --sweep-once 0 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/SoftmaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/S_8_32_${arch}.s" -m 8 -n 32 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/SoftmaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/S_16_16_${arch}.s" -m 16 -n 16 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/SoftmaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/S_4_64_${arch}.s" -m 4 -n 64 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/SoftmaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/S_2_128_${arch}.s" -m 2 -n 128 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/SoftmaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/S_1_256_${arch}.s" -m 1 -n 256 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_256_4_${arch}.s" -t S -d S -w 256 -c 4 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/A_H_H_256_4_${arch}.s" -t H -d H -w 256 -c 4 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/A_H_S_256_4_${arch}.s" -t H -d S -w 256 -c 4 --arch ${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_256_4_${arch}.s" -t S -d H -w 256 -c 4 --arch ${arch}
         COMMENT "Creating Layer Norm, Softmax and Amax Assembly for ${arch}"
-        WORKING_DIRECTORY ${ops_dir}
         DEPENDS ${HIPBLASLT_PYTHON_DEPS}
     )
     if(arch STREQUAL "gfx942")
@@ -86,12 +85,11 @@ foreach(arch IN LISTS archs)
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8N_256_4_${arch}.s"
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8N_256_4_${arch}.s"
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8N_256_4_${arch}.s"
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_F8N_256_4_${arch}.s" -t S -d S -s F8N -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8N_256_4_${arch}.s" -t S -d S -s B8N -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8N_256_4_${arch}.s" -t S -d H -s F8N -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8N_256_4_${arch}.s" -t S -d H -s B8N -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_F8N_256_4_${arch}.s" -t S -d S -s F8N -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8N_256_4_${arch}.s" -t S -d S -s B8N -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8N_256_4_${arch}.s" -t S -d H -s F8N -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8N_256_4_${arch}.s" -t S -d H -s B8N -w 256 -c 4 --arch ${arch}
             COMMENT "Creating Extra Amax Assembly for gfx942"
-            WORKING_DIRECTORY ${ops_dir}
             DEPENDS ${HIPBLASLT_PYTHON_DEPS}
         )
         target_sources(extop-obj-${arch}
@@ -109,10 +107,10 @@ foreach(arch IN LISTS archs)
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8_256_4_${arch}.s"
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8_256_4_${arch}.s"
                 "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8_256_4_${arch}.s"
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_F8_256_4_${arch}.s" -t S -d S -s F8 -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8_256_4_${arch}.s" -t S -d S -s B8 -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8_256_4_${arch}.s" -t S -d H -s F8 -w 256 -c 4 --arch ${arch}
-            COMMAND ${HIPBLASLT_PYTHON_COMMAND} AMaxGenerator.py --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8_256_4_${arch}.s" -t S -d H -s B8 -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_F8_256_4_${arch}.s" -t S -d S -s F8 -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_S_B8_256_4_${arch}.s" -t S -d S -s B8 -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_F8_256_4_${arch}.s" -t S -d H -s F8 -w 256 -c 4 --arch ${arch}
+            COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/AMaxGenerator.py" --is-scale -o "${CMAKE_CURRENT_BINARY_DIR}/A_S_H_B8_256_4_${arch}.s" -t S -d H -s B8 -w 256 -c 4 --arch ${arch}
             COMMENT "Creating Extra Amax Assembly for gfx950"
             WORKING_DIRECTORY ${ops_dir}
             DEPENDS ${HIPBLASLT_PYTHON_DEPS}
@@ -136,9 +134,8 @@ foreach(arch IN LISTS archs)
     list(APPEND extop_cp_depends "extop-library-${arch}")
     add_custom_target(extop-library-${arch}
         DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co ${HIPBLASLT_PYTHON_DEPS}
-        COMMAND ${HIPBLASLT_PYTHON_COMMAND} ExtOpCreateLibrary.py --src=${CMAKE_CURRENT_BINARY_DIR} --co=${output_dir}/extop_${arch}.co --output=${output_dir} --arch=${arch}
+        COMMAND ${HIPBLASLT_PYTHON_COMMAND} "${ops_dir}/ExtOpCreateLibrary.py" --src=${CMAKE_CURRENT_BINARY_DIR} --co=${output_dir}/extop_${arch}.co --output=${output_dir} --arch=${arch}
         COMMENT "Creating hipblasltExtOpLibrary.dat for ${arch}"
-        WORKING_DIRECTORY ${ops_dir}
     )
 endforeach()
 


### PR DESCRIPTION
- Fixes typo in logic for including hipblsalt-test
- Removes -P in python command variable because the option requires python 3.11 or newer
- Use the hip::hipblas-common target as roc::hipblas-common was removed
- Check if hipblas-common target exists before attempting to find it