### PR TITLE
Compile kernel helpers in parallel

### DIFF
--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -246,7 +246,6 @@ def writeBenchmarkFiles(
                                asmToolchain.assembler,
                                debugConfig,
                            )
-    print1(f"Found the following kernel helpers: {kernelHelperNames}")
 
     cmdLineArchs = [var for isa in isaInfoMap.keys() for var in gfxToVariants(isaToGfx(isa))]
     # cmdLineArchs = [variant isaToGfx(isa) for isa in isaInfoMap.keys() for gfxToVariants()]

--- a/tensilelite/Tensile/BenchmarkProblems.py
+++ b/tensilelite/Tensile/BenchmarkProblems.py
@@ -246,6 +246,7 @@ def writeBenchmarkFiles(
                                asmToolchain.assembler,
                                debugConfig,
                            )
+    print1(f"Found the following kernel helpers: {kernelHelperNames}")
 
     cmdLineArchs = [var for isa in isaInfoMap.keys() for var in gfxToVariants(isaToGfx(isa))]
     # cmdLineArchs = [variant isaToGfx(isa) for isa in isaInfoMap.keys() for gfxToVariants()]

--- a/tensilelite/Tensile/KernelWriterBase.py
+++ b/tensilelite/Tensile/KernelWriterBase.py
@@ -55,17 +55,17 @@ class KernelWriterBase(ABC):
 
 
   @abstractmethod
-  def getKernelName(self):
+  def getKernelName(self) -> str:
     pass
 
 
   @abstractmethod
-  def getHeaderFileString(self):
+  def getHeaderFileString(self) -> str:
     pass
 
 
   @abstractmethod
-  def getSourceFileString(self):
+  def getSourceFileString(self) -> str:
     pass
 
 

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -202,6 +202,8 @@ def addCommonArguments(argParser):
         action="store", default=ToolchainDefaults.OFFLOAD_BUNDLER, help="select which offload bundler to use")
     argParser.add_argument("--device-enumerator", dest="DeviceEnumerator", \
         action="store", default=ToolchainDefaults.DEVICE_ENUMERATOR, help="select which device enumerator to use")
+    argParser.add_argument("--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT)
+    argParser.add_argument("--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS)
     argParser.add_argument("--logic-format", dest="LogicFormat", choices=["yaml", "json"], \
         action="store", default="yaml", help="select which logic format to use")
     argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
@@ -456,9 +458,13 @@ def Tensile(userArgs):
     cxxCompiler, \
     cCompiler, \
     offloadBundler, \
+    rocObjLs, \
+    rocObjExtract, \
     enumerator = validateToolchain(args.CxxCompiler,
                                    args.CCompiler,
                                    args.OffloadBundler,
+                                   args.RocObjLs,
+                                   args.RocObjExtract,
                                    ToolchainDefaults.DEVICE_ENUMERATOR)
     asmToolchain = makeAssemblyToolchain(
         cxxCompiler,
@@ -468,11 +474,14 @@ def Tensile(userArgs):
     srcToolchain = makeSourceToolchain(
         cxxCompiler,
         offloadBundler,
+        rocObjLs,
+        rocObjExtract,
+        64,  # TODO: make this configurable
     )
 
     if "ISA" in args.global_parameters:
         isaList = [IsaVersion(isa[0], isa[1], isa[2]) for isa in args.global_parameters["ISA"]]
-        
+
     else:
         isaList = [detectGlobalCurrentISA(device_id, enumerator)]
 

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -72,6 +72,8 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     argParser.add_argument(
         "--assembler", dest="Assembler", action="store", default=ToolchainDefaults.ASSEMBLER
     )
+    argParser.add_argument("--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT)
+    argParser.add_argument("--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS)
     argParser.add_argument(
         "--code-object-version",
         dest="CodeObjectVersion",
@@ -214,6 +216,8 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     arguments["CxxCompiler"] = args.CxxCompiler
     arguments["CCompiler"] = args.CCompiler
     arguments["OffloadBundler"] = args.OffloadBundler
+    arguments["RocObjExtract"] = args.RocObjExtract
+    arguments["RocObjLs"] = args.RocObjLs
     arguments["Assembler"] = args.Assembler
     arguments["LogicPath"] = args.LogicPath
     arguments["LogicFilter"] = args.LogicFilter

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -72,8 +72,12 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     argParser.add_argument(
         "--assembler", dest="Assembler", action="store", default=ToolchainDefaults.ASSEMBLER
     )
-    argParser.add_argument("--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT)
-    argParser.add_argument("--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS)
+    argParser.add_argument(
+        "--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT
+    )
+    argParser.add_argument(
+        "--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS
+    )
     argParser.add_argument(
         "--code-object-version",
         dest="CodeObjectVersion",

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -67,7 +67,7 @@ from Tensile.KernelWriterBase import (
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
 from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
-from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles, buildSourceCodeObjectFile
+from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles, buildSourceCodeObjectFilesNEW
 from Tensile.Toolchain.Validators import (
     ToolchainDefaults,
     validateToolchain,
@@ -186,13 +186,112 @@ def writeAssembly(asmPath: Union[Path, str], result: KernelCodeGenResult):
 
     return path, isa, wfsize
 
+def writeHelper(outputPath, kernelHelperObj, khoNames) -> str:
+    """
+    Write kernel helper source and header files.
 
-def writeHelper(outputPath, kernelHelperObj) -> str:
+    Args:
+        outputPath: Base path where files will be written
+        kernelHelperObj: Kernel helper object with source and header content
+        khoNames: List of all kernel helper object names for dependency resolution
+
+    Returns:
+        The path to the generated source file
+    """
+    name = kernelHelperObj.getKernelName()
+    sourceFilename = f"{name}.cpp"
+    headerFilename = f"{name}.h"
+    kernelsDir = Path(outputPath) / "Kernels"
+
+    if not kernelsDir.exists():
+        kernelsDir.mkdir(parents=True, exist_ok=True)
+
+    kernelSourcePath = str(kernelsDir / sourceFilename)
+    kernelHeaderPath = str(kernelsDir / headerFilename)
+
+    print1(f"Writing kernel helper: {kernelSourcePath}")
+
+    # Determine required includes based on kernel helper type
+    includes = _getRequiredIncludes(name, khoNames, kernelHelperObj)
+
+    with open(kernelHeaderPath, "w", encoding="utf-8") as kernelHeaderFile, \
+         open(kernelSourcePath, "w", encoding="utf-8") as kernelSourceFile:
+
+        # Write file headers
+        for file in (kernelSourceFile, kernelHeaderFile):
+            file.write(CHeader)
+
+        # Write source file includes
+        kernelSourceFile.write(f"#include \"{name}.h\"\n")
+
+        # Write header file standard includes
+        kernelHeaderFile.write("#pragma once\n")
+        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+        kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
+
+        # Write dependency includes
+        for include in includes:
+            kernelHeaderFile.write(f"#include \"Kernels/{include}.h\"\n")
+
+        # Write generated source and header content
+        err, src = kernelHelperObj.getSourceFileString()
+        kernelSourceFile.write(src)
+
+        if err:
+            printWarning(f"Invalid kernel: {name} (error code {err})")
+
+        kernelHeaderFile.write(kernelHelperObj.getHeaderFileString())
+
+    return kernelSourcePath
+
+def _getRequiredIncludes(name, khoNames, kernelHelperObj):
+    """
+    Determine the required includes for a kernel helper.
+
+    Args:
+        name: Kernel helper name
+        khoNames: List of all kernel helper object names
+        kernelHelperObj: The kernel helper object to analyze
+
+    Returns:
+        List of kernel helper names to include
+    """
+    includes = set()
+
+    # Add enum includes for non-enum helpers
+    if "Enum" not in name:
+        # Include all enum helpers
+        includes.update(n for n in khoNames if "Enum" in n)
+
+        # Include gradient activation enums for gradient helpers
+        hasGradient = hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient"
+        if hasGradient:
+            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
+
+    # Include activation helpers for non-activation-defining helpers
+    hasActivation = ("TensileActivation_S" in name or "TensileActivation_I" in name)
+    if not hasActivation and "Enum" not in name:
+        includes.update(n for n in khoNames if "TensileActivation_" in n)
+
+    # Include gradient activation helpers for non-gradient-activation-defining helpers
+    hasGradientActivation = "TensileGradientActivation_S" in name
+    if not hasGradientActivation and "Enum" not in name:
+        if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
+            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
+
+    return includes
+
+
+def writeHelperOld(outputPath, kernelHelperObj, khoNames) -> str:
     name = kernelHelperObj.getKernelName()
     KERNEL_HELPER_FILENAME_CPP = name + ".cpp"
     KERNEL_HELPER_FILENAME_H = name + ".h"
     kernelSourceFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_CPP)
     kernelHeaderFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_H)
+
+    print1(f"Writing kernel helper: {kernelSourceFilename}")
+
 
     with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, \
           open(kernelSourceFilename, "w", encoding="utf-8") as kernelSourceFile:
@@ -205,16 +304,28 @@ def writeHelper(outputPath, kernelHelperObj) -> str:
         kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
 
         if "Enum" not in name:
-            kernelHeaderFile.write("#include \"Kernels/TensileActivationEnum_S.h\"\n")
-            kernelHeaderFile.write("#include \"Kernels/TensileActivationEnum_I.h\"\n")
+            enumkhoNames = [n for n in khoNames if "Enum" in n]
+            for khoName in enumkhoNames:
+                kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
+
             if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
-                kernelHeaderFile.write("#include \"Kernels/TensileGradientActivationEnum_S.h\"\n")
+                actGradientEnumKhoName = [n for n in khoNames if "TensileGradientActivation_" in n]
+                for khoName in actGradientEnumKhoName:
+                    kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
+
+        # This includes kernel helpers that don't define their own activation functions
         if "TensileActivation_S" not in name and "TensileActivation_I" not in name and "Enum" not in name:
-            kernelHeaderFile.write("#include \"Kernels/TensileActivation_S_Hipblaslt_all.h\"\n")
-            kernelHeaderFile.write("#include \"Kernels/TensileActivation_I_Hipblaslt_all.h\"\n")
+            activationkhoName = [n for n in khoNames if "TensileActivation_" in n]
+            for khoName in activationkhoName:
+                kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
+
+        # This includes kernel helpers that don't define their own activation functions
+        # and need gradient activation functions
         if "TensileGradientActivation_S" not in name and "Enum" not in name:
             if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
-                kernelHeaderFile.write("#include \"Kernels/TensileGradientActivation_S_Hipblaslt_all.h\"\n")
+                actGradientkhoName = [n for n in khoNames if "TensileGradientActivation_" in n]
+                for khoName in actGradientkhoName:
+                    kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
 
         HeaderText = ""
         (err, src) = kernelHelperObj.getSourceFileString()
@@ -227,32 +338,32 @@ def writeHelper(outputPath, kernelHelperObj) -> str:
     return kernelSourceFilename
 
 
-def writeHelpers(
-    outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
-):
-    kernelSourceFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_CPP)
-    kernelHeaderFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_H)
+# def writeHelpers(
+#     outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
+# ):
+#     kernelSourceFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_CPP)
+#     kernelHeaderFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_H)
 
-    with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, open(
-        kernelSourceFilename, "w", encoding="utf-8"
-    ) as kernelSourceFile:
-        kernelSourceFile.write(CHeader)
-        kernelHeaderFile.write(CHeader)
-        kernelSourceFile.write('#include "Kernels.h"\n')
-        kernelHeaderFile.write("#pragma once\n")
-        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
-        kernelHeaderFile.write('#include "KernelHeader.h"\n\n')
-        HeaderText = ""
-        for ko in kernelHelperObjs:
-            kernelName = ko.getKernelName()
-            (err, src) = ko.getSourceFileString()
+#     with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, open(
+#         kernelSourceFilename, "w", encoding="utf-8"
+#     ) as kernelSourceFile:
+#         kernelSourceFile.write(CHeader)
+#         kernelHeaderFile.write(CHeader)
+#         kernelSourceFile.write('#include "Kernels.h"\n')
+#         kernelHeaderFile.write("#pragma once\n")
+#         kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+#         kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+#         kernelHeaderFile.write('#include "KernelHeader.h"\n\n')
+#         HeaderText = ""
+#         for ko in kernelHelperObjs:
+#             kernelName = ko.getKernelName()
+#             (err, src) = ko.getSourceFileString()
 
-            kernelSourceFile.write(src)
-            if err:
-                print("*** warning: invalid kernel#%u" % kernelName)
-            HeaderText += ko.getHeaderFileString()
-        kernelHeaderFile.write(HeaderText)
+#             kernelSourceFile.write(src)
+#             if err:
+#                 print("*** warning: invalid kernel#%u" % kernelName)
+#             HeaderText += ko.getHeaderFileString()
+#         kernelHeaderFile.write(HeaderText)
 
 
 def writeSolutionsAndKernels(
@@ -284,6 +395,8 @@ def writeSolutionsAndKernels(
     objectTmpPath = ensurePath(
         buildTmpPath / "code_object_tmp"
     )  # Temp path for HSA code object files (.hsaco)
+    kernelsIncludePath = outputPath / "Kernels"
+    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
 
     asmKernels = [k for k in kernels if k["KernelLanguage"] == "Assembly"]
 
@@ -332,8 +445,25 @@ def writeSolutionsAndKernels(
         multiArg=False,
     )
 
-    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-    srcKernelFile = Path(outputPath) / "Kernels.cpp"
+    # writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
+    # srcKernelFile = Path(outputPath) / "Kernels.cpp"
+
+    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+    srcFiles = []
+    for helper in kernelHelperObjs:
+        srcFile = writeHelper(outputPath, helper, khoNames)
+        srcFiles.append(srcFile)
+    # unaryWriteHelpers = functools.partial(writeHelper, outputPath)
+    # srcFiles = ParallelMap2(unaryWriteHelpers,
+    #                         kernelHelperObjs,
+    #                         "Generating Kernel Helper Source",
+    #                         multiArg=False,
+    #                         return_as="list")
+    kernelsLib = str(objectTmpPath / "Kernels.so")
+
+    print1(f"Writing kernels library: {kernelsLib}")
+
+    # return len(uniqueAsmKernels)
 
     if not generateSourcesAndExit:
         codeObjectFiles += buildAssemblyCodeObjectFiles(
@@ -345,15 +475,17 @@ def writeSolutionsAndKernels(
             assemblyTmpPath,
             compress,
         )
-        buildSourceCodeObjectFiles(
-            srcToolchain.compiler,
-            srcToolchain.bundler,
-            destLibPath,
-            objectTmpPath,
-            outputPath,
-            srcKernelFile,
-            cmdlineArchs,
-        )
+        srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
+        buildSourceCodeObjectFilesNEW(srcToolchain, outputPath / "library", kernelsLib)
+        # buildSourceCodeObjectFiles(
+        #     srcToolchain.compiler,
+        #     srcToolchain.bundler,
+        #     destLibPath,
+        #     objectTmpPath,
+        #     outputPath,
+        #     srcKernelFile,
+        #     cmdlineArchs,
+        # )
 
     return codeObjectFiles, numKernels
 
@@ -430,8 +562,7 @@ def writeSolutionsAndKernelsTCL(
         compress,
     )
 
-    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-
+    # writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
     unaryWriteHelpers = functools.partial(writeHelper, outputPath)
     srcFiles = ParallelMap2(unaryWriteHelpers,
                             kernelHelperObjs,
@@ -439,8 +570,10 @@ def writeSolutionsAndKernelsTCL(
                             multiArg=False,
                             return_as="list")
     kernelsLib = str(objectTmpPath / "Kernels.so")
+
+    print1(f"Writing kernels library: {kernelsLib}")
     srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
-    buildSourceCodeObjectFile(srcToolchain, outputPath / "library", kernelsLib)
+    buildSourceCodeObjectFilesNEW(srcToolchain, outputPath / "library", kernelsLib)
 
     return len(uniqueAsmKernels)
 

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -187,6 +187,46 @@ def writeAssembly(asmPath: Union[Path, str], result: KernelCodeGenResult):
     return path, isa, wfsize
 
 
+def writeHelper(outputPath, kernelHelperObj) -> str:
+    name = kernelHelperObj.getKernelName()
+    KERNEL_HELPER_FILENAME_CPP = name + ".cpp"
+    KERNEL_HELPER_FILENAME_H = name + ".h"
+    kernelSourceFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_CPP)
+    kernelHeaderFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_H)
+
+    with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, \
+          open(kernelSourceFilename, "w", encoding="utf-8") as kernelSourceFile:
+        kernelSourceFile.write(CHeader)
+        kernelHeaderFile.write(CHeader)
+        kernelSourceFile.write("#include \"{}.h\"\n".format(name))
+        kernelHeaderFile.write("#pragma once\n")
+        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+        kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
+
+        if "Enum" not in name:
+            kernelHeaderFile.write("#include \"Kernels/TensileActivationEnum_S.h\"\n")
+            kernelHeaderFile.write("#include \"Kernels/TensileActivationEnum_I.h\"\n")
+            if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
+                kernelHeaderFile.write("#include \"Kernels/TensileGradientActivationEnum_S.h\"\n")
+        if "TensileActivation_S" not in name and "TensileActivation_I" not in name and "Enum" not in name:
+            kernelHeaderFile.write("#include \"Kernels/TensileActivation_S_Hipblaslt_all.h\"\n")
+            kernelHeaderFile.write("#include \"Kernels/TensileActivation_I_Hipblaslt_all.h\"\n")
+        if "TensileGradientActivation_S" not in name and "Enum" not in name:
+            if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
+                kernelHeaderFile.write("#include \"Kernels/TensileGradientActivation_S_Hipblaslt_all.h\"\n")
+
+        HeaderText = ""
+        (err, src) = kernelHelperObj.getSourceFileString()
+        kernelSourceFile.write(src)
+        if err:
+            print("*** warning: invalid kernel#%u" % name)
+        HeaderText += kernelHelperObj.getHeaderFileString()
+        kernelHeaderFile.write(HeaderText)
+
+    return kernelSourceFilename
+
+
 def writeHelpers(
     outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
 ):

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -445,12 +445,8 @@ def writeSolutionsAndKernelsTCL(
         compress,
     )
 
-    unaryWriteHelpers = functools.partial(writeHelper, outputPath)
-    srcFiles = ParallelMap2(unaryWriteHelpers,
-                            kernelHelperObjs,
-                            "Generating Kernel Helper Source",
-                            multiArg=False,
-                            return_as="list")
+    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+    srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
     kernelsLib = str(objectTmpPath / "Kernels.so")
 
     srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -63,11 +63,12 @@ from Tensile.KernelWriterAssembly import KernelWriterAssembly
 from Tensile.KernelWriterBase import (
     KERNEL_HELPER_FILENAME_CPP,
     KERNEL_HELPER_FILENAME_H,
+    KernelWriterBase,
 )
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
 from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
-from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles, buildSourceCodeObjectFilesNEW
+from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles
 from Tensile.Toolchain.Validators import (
     ToolchainDefaults,
     validateToolchain,
@@ -186,7 +187,7 @@ def writeAssembly(asmPath: Union[Path, str], result: KernelCodeGenResult):
 
     return path, isa, wfsize
 
-def writeHelper(outputPath, kernelHelperObj, khoNames) -> str:
+def writeHelper(outputPath: Path, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> str:
     """
     Write kernel helper source and header files.
 
@@ -209,43 +210,35 @@ def writeHelper(outputPath, kernelHelperObj, khoNames) -> str:
     kernelSourcePath = str(kernelsDir / sourceFilename)
     kernelHeaderPath = str(kernelsDir / headerFilename)
 
-    print1(f"Writing kernel helper: {kernelSourcePath}")
-
-    # Determine required includes based on kernel helper type
-    includes = _getRequiredIncludes(name, khoNames, kernelHelperObj)
+    includes = _getRequiredIncludes(name, kernelHelperObj, khoNames)
 
     with open(kernelHeaderPath, "w", encoding="utf-8") as kernelHeaderFile, \
          open(kernelSourcePath, "w", encoding="utf-8") as kernelSourceFile:
 
-        # Write file headers
         for file in (kernelSourceFile, kernelHeaderFile):
             file.write(CHeader)
 
-        # Write source file includes
         kernelSourceFile.write(f"#include \"{name}.h\"\n")
 
-        # Write header file standard includes
         kernelHeaderFile.write("#pragma once\n")
         kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
         kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
         kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
 
-        # Write dependency includes
         for include in includes:
             kernelHeaderFile.write(f"#include \"Kernels/{include}.h\"\n")
 
-        # Write generated source and header content
         err, src = kernelHelperObj.getSourceFileString()
-        kernelSourceFile.write(src)
-
         if err:
             printWarning(f"Invalid kernel: {name} (error code {err})")
 
+        kernelSourceFile.write(src)
         kernelHeaderFile.write(kernelHelperObj.getHeaderFileString())
 
     return kernelSourcePath
 
-def _getRequiredIncludes(name, khoNames, kernelHelperObj):
+
+def _getRequiredIncludes(name: str, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> set:
     """
     Determine the required includes for a kernel helper.
 
@@ -261,7 +254,6 @@ def _getRequiredIncludes(name, khoNames, kernelHelperObj):
 
     # Add enum includes for non-enum helpers
     if "Enum" not in name:
-        # Include all enum helpers
         includes.update(n for n in khoNames if "Enum" in n)
 
         # Include gradient activation enums for gradient helpers
@@ -269,101 +261,18 @@ def _getRequiredIncludes(name, khoNames, kernelHelperObj):
         if hasGradient:
             includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
 
-    # Include activation helpers for non-activation-defining helpers
+    # Include activation helpers
     hasActivation = ("TensileActivation_S" in name or "TensileActivation_I" in name)
     if not hasActivation and "Enum" not in name:
         includes.update(n for n in khoNames if "TensileActivation_" in n)
 
-    # Include gradient activation helpers for non-gradient-activation-defining helpers
+    # Include gradient activation helpers
     hasGradientActivation = "TensileGradientActivation_S" in name
     if not hasGradientActivation and "Enum" not in name:
         if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
             includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
 
     return includes
-
-
-def writeHelperOld(outputPath, kernelHelperObj, khoNames) -> str:
-    name = kernelHelperObj.getKernelName()
-    KERNEL_HELPER_FILENAME_CPP = name + ".cpp"
-    KERNEL_HELPER_FILENAME_H = name + ".h"
-    kernelSourceFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_CPP)
-    kernelHeaderFilename = str(Path(outputPath) / "Kernels" / KERNEL_HELPER_FILENAME_H)
-
-    print1(f"Writing kernel helper: {kernelSourceFilename}")
-
-
-    with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, \
-          open(kernelSourceFilename, "w", encoding="utf-8") as kernelSourceFile:
-        kernelSourceFile.write(CHeader)
-        kernelHeaderFile.write(CHeader)
-        kernelSourceFile.write("#include \"{}.h\"\n".format(name))
-        kernelHeaderFile.write("#pragma once\n")
-        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
-        kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
-
-        if "Enum" not in name:
-            enumkhoNames = [n for n in khoNames if "Enum" in n]
-            for khoName in enumkhoNames:
-                kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
-
-            if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
-                actGradientEnumKhoName = [n for n in khoNames if "TensileGradientActivation_" in n]
-                for khoName in actGradientEnumKhoName:
-                    kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
-
-        # This includes kernel helpers that don't define their own activation functions
-        if "TensileActivation_S" not in name and "TensileActivation_I" not in name and "Enum" not in name:
-            activationkhoName = [n for n in khoNames if "TensileActivation_" in n]
-            for khoName in activationkhoName:
-                kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
-
-        # This includes kernel helpers that don't define their own activation functions
-        # and need gradient activation functions
-        if "TensileGradientActivation_S" not in name and "Enum" not in name:
-            if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
-                actGradientkhoName = [n for n in khoNames if "TensileGradientActivation_" in n]
-                for khoName in actGradientkhoName:
-                    kernelHeaderFile.write(f"#include \"Kernels/{khoName}.h\"\n")
-
-        HeaderText = ""
-        (err, src) = kernelHelperObj.getSourceFileString()
-        kernelSourceFile.write(src)
-        if err:
-            print("*** warning: invalid kernel#%u" % name)
-        HeaderText += kernelHelperObj.getHeaderFileString()
-        kernelHeaderFile.write(HeaderText)
-
-    return kernelSourceFilename
-
-
-# def writeHelpers(
-#     outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
-# ):
-#     kernelSourceFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_CPP)
-#     kernelHeaderFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_H)
-
-#     with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, open(
-#         kernelSourceFilename, "w", encoding="utf-8"
-#     ) as kernelSourceFile:
-#         kernelSourceFile.write(CHeader)
-#         kernelHeaderFile.write(CHeader)
-#         kernelSourceFile.write('#include "Kernels.h"\n')
-#         kernelHeaderFile.write("#pragma once\n")
-#         kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
-#         kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
-#         kernelHeaderFile.write('#include "KernelHeader.h"\n\n')
-#         HeaderText = ""
-#         for ko in kernelHelperObjs:
-#             kernelName = ko.getKernelName()
-#             (err, src) = ko.getSourceFileString()
-
-#             kernelSourceFile.write(src)
-#             if err:
-#                 print("*** warning: invalid kernel#%u" % kernelName)
-#             HeaderText += ko.getHeaderFileString()
-#         kernelHeaderFile.write(HeaderText)
 
 
 def writeSolutionsAndKernels(
@@ -445,26 +354,6 @@ def writeSolutionsAndKernels(
         multiArg=False,
     )
 
-    # writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-    # srcKernelFile = Path(outputPath) / "Kernels.cpp"
-
-    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
-    srcFiles = []
-    for helper in kernelHelperObjs:
-        srcFile = writeHelper(outputPath, helper, khoNames)
-        srcFiles.append(srcFile)
-    # unaryWriteHelpers = functools.partial(writeHelper, outputPath)
-    # srcFiles = ParallelMap2(unaryWriteHelpers,
-    #                         kernelHelperObjs,
-    #                         "Generating Kernel Helper Source",
-    #                         multiArg=False,
-    #                         return_as="list")
-    kernelsLib = str(objectTmpPath / "Kernels.so")
-
-    print1(f"Writing kernels library: {kernelsLib}")
-
-    # return len(uniqueAsmKernels)
-
     if not generateSourcesAndExit:
         codeObjectFiles += buildAssemblyCodeObjectFiles(
             asmToolchain.linker,
@@ -475,17 +364,11 @@ def writeSolutionsAndKernels(
             assemblyTmpPath,
             compress,
         )
+        khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+        srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
+        kernelsLib = str(objectTmpPath / "Kernels.so")
         srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
-        buildSourceCodeObjectFilesNEW(srcToolchain, outputPath / "library", kernelsLib)
-        # buildSourceCodeObjectFiles(
-        #     srcToolchain.compiler,
-        #     srcToolchain.bundler,
-        #     destLibPath,
-        #     objectTmpPath,
-        #     outputPath,
-        #     srcKernelFile,
-        #     cmdlineArchs,
-        # )
+        buildSourceCodeObjectFiles(srcToolchain, outputPath / "library", kernelsLib)
 
     return codeObjectFiles, numKernels
 
@@ -562,7 +445,6 @@ def writeSolutionsAndKernelsTCL(
         compress,
     )
 
-    # writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
     unaryWriteHelpers = functools.partial(writeHelper, outputPath)
     srcFiles = ParallelMap2(unaryWriteHelpers,
                             kernelHelperObjs,
@@ -571,7 +453,6 @@ def writeSolutionsAndKernelsTCL(
                             return_as="list")
     kernelsLib = str(objectTmpPath / "Kernels.so")
 
-    print1(f"Writing kernels library: {kernelsLib}")
     srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
     buildSourceCodeObjectFilesNEW(srcToolchain, outputPath / "library", kernelsLib)
 

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -454,7 +454,7 @@ def writeSolutionsAndKernelsTCL(
     kernelsLib = str(objectTmpPath / "Kernels.so")
 
     srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
-    buildSourceCodeObjectFilesNEW(srcToolchain, outputPath / "library", kernelsLib)
+    buildSourceCodeObjectFiles(srcToolchain, outputPath / "library", kernelsLib)
 
     return len(uniqueAsmKernels)
 

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -67,7 +67,7 @@ from Tensile.KernelWriterBase import (
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
 from Tensile.Toolchain.Assembly import makeAssemblyToolchain, buildAssemblyCodeObjectFiles
-from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles
+from Tensile.Toolchain.Source import makeSourceToolchain, SourceToolchain, buildSourceCodeObjectFiles, buildSourceCodeObjectFile
 from Tensile.Toolchain.Validators import (
     ToolchainDefaults,
     validateToolchain,
@@ -431,16 +431,16 @@ def writeSolutionsAndKernelsTCL(
     )
 
     writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-    srcKernelFile = Path(outputPath) / "Kernels.cpp"
-    buildSourceCodeObjectFiles(
-        srcToolchain.compiler,
-        srcToolchain.bundler,
-        destLibPath,
-        objectTmpPath,
-        outputPath,
-        srcKernelFile,
-        cmdlineArchs,
-    )
+
+    unaryWriteHelpers = functools.partial(writeHelper, outputPath)
+    srcFiles = ParallelMap2(unaryWriteHelpers,
+                            kernelHelperObjs,
+                            "Generating Kernel Helper Source",
+                            multiArg=False,
+                            return_as="list")
+    kernelsLib = str(objectTmpPath / "Kernels.so")
+    srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
+    buildSourceCodeObjectFile(srcToolchain, outputPath / "library", kernelsLib)
 
     return len(uniqueAsmKernels)
 
@@ -631,12 +631,15 @@ def run():
     arguments = parseArguments()
     setVerbosity(arguments["PrintLevel"])
     outputPath = Path(ensurePath(os.path.abspath(arguments["OutputPath"])))
-    cxxCompiler, _, offloadBundler, _, _ = validateToolchain(
+
+    kernelsIncludePath = outputPath / "Kernels"
+    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
+
+    cxxCompiler, offloadBundler, ls, extract = validateToolchain(
         arguments["CxxCompiler"],
-        arguments["CCompiler"],
         arguments["OffloadBundler"],
-        arguments["Assembler"],
-        ToolchainDefaults.HIP_CONFIG,
+        arguments["RocObjLs"],
+        arguments["RocObjExtract"]
     )
 
     if ";" in arguments["Architecture"]:
@@ -658,6 +661,9 @@ def run():
     srcToolchain = makeSourceToolchain(
         cxxCompiler,
         offloadBundler,
+        ls,
+        extract,
+        arguments["CpuThreads"],
         arguments["AsanBuild"],
         arguments["BuildIdKind"],
         save_temps=False

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -33,7 +33,7 @@ from typing import List
 from Tensile.Common import SemanticVersion, print1
 from .Validators import ToolchainDefaults, validateToolchain
 
-def _invoke(args: List[str], desc: str=""):
+def _invoke(args: List[str], desc: str="", working_dir=None):
   """Invokes a command with the provided arguments in a subprocess.
   Args:
       args: A list of arguments to pass to the subprocess.
@@ -45,10 +45,10 @@ def _invoke(args: List[str], desc: str=""):
   """
   #print1(f"{desc}: {' '.join(args)}")
   try:
-      out = check_output(args, stderr=STDOUT)
-  except CalledProcessError as err:
+      out = check_output(args, stderr=STDOUT, cwd=working_dir)
+  except:
       raise RuntimeError(
-          f"Error with {desc}: {err.output}\n"
+          #f"Error with {desc}: {err.output}\n"
           f"Failed command: {' '.join(args)}"
       )
   return out
@@ -74,6 +74,7 @@ def _getVersion(executable: str, versionFlag: str, regex: str) -> str:
         if match:
             result = match.group(1)
             return SemanticVersion(*[int(c.split("-")[0]) for c in result.split(".")[:3]])
+        return None
         raise Exception(f"No version from {output} matches regex {regex}")
     except Exception as e:
         raise RuntimeError(f"Failed to get version when calling {args}: {e}")
@@ -87,7 +88,10 @@ def get_rocm_version() -> str:
     Return:
         ROCm version string
     """
-    return _getVersion(ToolchainDefaults.HIP_CONFIG, "--version", r'(.+)')
+    try:
+        return _getVersion(ToolchainDefaults.HIP_CONFIG, "--version", r'(.+)')
+    except:
+        return None
 
 
 class Component:
@@ -204,18 +208,22 @@ class Compiler(Component):
         Invokes the compiler on the provided arguments
     """
 
-    def __init__(self, compiler_path: Path, build_id_kind: str, asan_build: bool=False, save_temps: bool=False):
+    def __init__(self, compiler_path: Path, build_id_kind: str, cpu_threads: int, asan_build: bool=False, save_temps: bool=False):
         """Constructs and instance of a Compiler."""
         super(Compiler, self).__init__(compiler_path)
 
         self.default_args = [
             *split(environ.get("Tensile_CXX_COMPILER_LAUNCHER", "")),
              compiler_path,
+            "-shared",
+            "-fPIC",
+            "-fgpu-rdc",
+            "-Xoffload-linker",
+            f"--build-id={build_id_kind}",
             "-D__HIP_HCC_COMPAT_MODE__=1",
-            "--offload-device-only",
             "-x", "hip", "-O3",
-            "-Xoffload-linker", f"--build-id={build_id_kind}",
             "-std=c++17",
+            f"-parallel-jobs={cpu_threads}"
         ]
 
         if asan_build:
@@ -225,8 +233,7 @@ class Compiler(Component):
         if os_name == "nt":                                                    # should we use fPIIC on all arches?
             self.default_args.extend(["-fms-extensions", "-fms-compatibility", "-fPIC", "-Wno-deprecated-declarations"])
 
-
-    def __call__(self, include_path: str, target_list: List[str], srcPath: str, destPath: str):
+    def __call__(self, src_paths: List[str], dest_path: str, include_path: str, gfxs: List[str]):
         """Compiles a source file into an object file.
 
         Args:
@@ -237,10 +244,12 @@ class Compiler(Component):
         Raises:
             RuntimeError: If the compilation command fails.
         """
-        archFlags = [f"--offload-arch={gfx}" for gfx in target_list]
-        args = [
-            *(self.default_args), "-I", include_path, *archFlags, srcPath, "-c", "-o", destPath
-        ]
+
+        args = list(self.default_args)
+        args += [f"--offload-arch={gfx}" for gfx in gfxs]
+        args += ["-I", include_path]
+        args += src_paths
+        args +=["-o", dest_path]
         return _invoke(args, f"Compiling HIP source kernels into objects (.cpp -> .o)")
 
 
@@ -367,36 +376,71 @@ class Linker(Component):
         return _invoke(args, "Linking assembly object files into code object (*.o -> .co)")
 
 
-# class DeviceEnumerator(Component):
-#     """
-#     ROCm amdgpu-arch or rocm_agent_enumerator class used to inspect system for current architecture.
+class RocObjLs(Component):
+    """
+    ROCm roc-obj-ls class used to list code objects.
 
-#     ...
+    ...
 
-#     Attributes
-#     ----------
-#     version : str
-#         the version of the component
-#     rocm_version : str
-#         the ROCm version
-#     path : str
-#         path to component
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    Methods
+    -------
+    __call__(self, srcPaths: List[str], destPath: str):
+        Invokes roc-obj-ls on the provided arguments
+    """
 
-#     Methods
-#     -------
-#     __call__(self)
-#         Invokes component.
-#     """
-#     def __init__(self, component_path: Path):
-#         """Constructs instance of SystemInterogator.
+    def __init__(self, ls_path: Path):
+        """Constructs and instance of roc-obj-ls."""
+        super(RocObjLs, self).__init__(ls_path)
 
-#         Args:
-#             component_path: The path to amdgpu-arch or rocm_agent_enumeraor.
-#         """
-#         super(Assembler, self).__init__(component_path)
-#         self._default_args = [str(component_path)]
+    def __call__(self, sharedObjFile):
+        """Lists the code objects in shared object.
 
-#     def __call__(self):
-#         """Run component without args to detect system settings."""
+        Args:
+            sharedObjFile: Name of object file to list.
 
-#         return _invoke(self._default_args, "running system inspection")
+        Returns:
+            List of objects embedded in shared object file.
+        """
+        args = [self._component_path, sharedObjFile]
+        return [e.strip().split()[1:] for e in _invoke(args, f"Listing code objects in shared object", Path(sharedObjFile).parent).decode().split("\n") if e.strip().split()[1:]]
+
+
+class RocObjExtract(Component):
+    """
+    ROCm roc-obj-extract class used to get code objects bundle from shared library.
+
+    ...
+
+    Attributes
+    ----------
+    version : str
+        the version of the component
+    rocm_version : str
+        the ROCm version
+    Methods
+    -------
+    __call__(self, srcPaths: List[str], destPath: str):
+        Invokes roc-obj-extract on the provided arguments
+    """
+
+    def __init__(self, extract_path: Path):
+        """Constructs and instance of roc-obj-extract."""
+        super(RocObjExtract, self).__init__(extract_path)
+
+    def __call__(self, filename: str):
+        """Extracts code objects from a shared object.
+
+        Args:
+            objFile: Name pf object file to extract.
+
+        Returns:
+            Code object file.
+        """
+        args = [self._component_path, filename]
+        return _invoke(args, f"Extracting code object.", Path(filename.replace("file:","")).parent)

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -48,7 +48,6 @@ def _invoke(args: List[str], desc: str="", working_dir=None):
       out = check_output(args, stderr=STDOUT, cwd=working_dir)
   except:
       raise RuntimeError(
-          #f"Error with {desc}: {err.output}\n"
           f"Failed command: {' '.join(args)}"
       )
   return out

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -396,7 +396,7 @@ class RocObjLs(Component):
 
     def __init__(self, ls_path: Path):
         """Constructs and instance of roc-obj-ls."""
-        super(RocObjLs, self).__init__(ls_path)
+        super(RocObjLs, self).__init__(ls_path, "-v")
 
     def __call__(self, sharedObjFile):
         """Lists the code objects in shared object.
@@ -431,7 +431,7 @@ class RocObjExtract(Component):
 
     def __init__(self, extract_path: Path):
         """Constructs and instance of roc-obj-extract."""
-        super(RocObjExtract, self).__init__(extract_path)
+        super(RocObjExtract, self).__init__(extract_path, "-v")
 
     def __call__(self, filename: str):
         """Extracts code objects from a shared object.

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -396,7 +396,8 @@ class RocObjLs(Component):
 
     def __init__(self, ls_path: Path):
         """Constructs and instance of roc-obj-ls."""
-        super(RocObjLs, self).__init__(ls_path, "-v")
+        # Use `-h` because roc-obj-ls doesn't have a version flag
+        super(RocObjLs, self).__init__(ls_path, "-h")
 
     def __call__(self, sharedObjFile):
         """Lists the code objects in shared object.
@@ -431,7 +432,9 @@ class RocObjExtract(Component):
 
     def __init__(self, extract_path: Path):
         """Constructs and instance of roc-obj-extract."""
-        super(RocObjExtract, self).__init__(extract_path, "-v")
+        # Use `-h` because roc-obj-extract doesn't have a version flag
+        # and will print  to stdout "Error: No arguments."
+        super(RocObjExtract, self).__init__(extract_path, "-h")
 
     def __call__(self, filename: str):
         """Extracts code objects from a shared object.

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -32,17 +32,21 @@ from typing import List, Union, NamedTuple
 
 from ..Common import print1, ensurePath
 
-from .Component import Compiler, Bundler
+from .Component import Compiler, Bundler, RocObjLs, RocObjExtract
 
 class SourceToolchain(NamedTuple):
    compiler: Compiler
    bundler: Bundler
+   rocObjLs: RocObjLs
+   rocObjExtract: RocObjExtract
 
 
-def makeSourceToolchain(compiler_path, bundler_path, asan_build=False, build_id_kind="sha1", save_temps=False):
-   compiler = Compiler(compiler_path, build_id_kind, asan_build, save_temps)
+def makeSourceToolchain(compiler_path, bundler_path, ls_path, extract_path, cpu_threads, asan_build=False, build_id_kind="sha1", save_temps=False):
+   compiler = Compiler(compiler_path, build_id_kind, cpu_threads, asan_build, save_temps)
    bundler = Bundler(bundler_path)
-   return SourceToolchain(compiler, bundler)
+   ls = RocObjLs(ls_path)
+   extract = RocObjExtract(extract_path)
+   return SourceToolchain(compiler, bundler, ls, extract)
 
 
 def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
@@ -124,3 +128,30 @@ def buildSourceCodeObjectFiles(
     print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")
 
     return coPaths
+
+
+def buildSourceCodeObjectFile(toolchain: SourceToolchain, 
+                              destPath: Union[Path, str], 
+                              sharedObjPath: Union[Path, str], ) -> List[str]:
+    """Compiles a HIP source code file into a code object file.
+
+    Args:
+        toolchain: The source toolchain.
+        destDir: The destination directory where HSA code object files are placed.
+        tmpObjDir: The directory where HIP source object files are created.
+        includeDir: The include directory path.
+        kernelPath: The path to the kernel source file.
+
+    Returns:
+        List of paths to the created code objects.
+    """
+
+    for target, filename in toolchain.rocObjLs(sharedObjPath):
+      match = re.search("gfx.*$", target)
+      if match:
+        print(f"Generating Kernels.co for {target.split('-')[-1]}")
+        arch = re.sub(":", "-", match.group())
+        toolchain.rocObjExtract(filename)
+        src = str(Path(sharedObjPath).parent / (str(Path(filename).name).replace("#","-").replace("=","").replace("&","-") + ".co"))
+        dst = str(destPath / f"Kernels.so-000-{arch}.hsaco")
+        shutil.move(src, dst)

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -130,8 +130,8 @@ def buildSourceCodeObjectFiles(
     return coPaths
 
 
-def buildSourceCodeObjectFile(toolchain: SourceToolchain, 
-                              destPath: Union[Path, str], 
+def buildSourceCodeObjectFilesNEW(toolchain: SourceToolchain,
+                              destPath: Union[Path, str],
                               sharedObjPath: Union[Path, str], ) -> List[str]:
     """Compiles a HIP source code file into a code object file.
 
@@ -147,6 +147,7 @@ def buildSourceCodeObjectFile(toolchain: SourceToolchain,
     """
 
     for target, filename in toolchain.rocObjLs(sharedObjPath):
+      print1(f"Processing {filename} for {target}")
       match = re.search("gfx.*$", target)
       if match:
         print(f"Generating Kernels.co for {target.split('-')[-1]}")

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -49,90 +49,11 @@ def makeSourceToolchain(compiler_path, bundler_path, ls_path, extract_path, cpu_
    return SourceToolchain(compiler, bundler, ls, extract)
 
 
-def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
-    """Generates a code object file path using the target, base, and build path.
-
-    Args:
-        target: The target triple.
-        base: The base name for the output file (name without extension).
-        buildPath: The build directory path.
-
-    Returns:
-        Path to the code object file.
-    """
-    coPath = None
-    buildPath = Path(buildPath)
-    if "TensileLibrary" in base and "fallback" in base:
-        coPath = buildPath / "{0}_{1}.hsaco.raw".format(base, arch)
-    elif "TensileLibrary" in base:
-        variant = [t for t in ["", "xnack-", "xnack+"] if t in target][-1]
-        baseVariant = base + "-" + variant if variant else base
-        if arch in baseVariant:
-            coPath = buildPath / (baseVariant + ".hsaco.raw")
-    else:
-        coPath= buildPath / "{0}.so-000-{1}.hsaco.raw".format(base, arch)
-
-    return coPath
-
-
 def buildSourceCodeObjectFiles(
-        compiler: Compiler,
-        bundler: Bundler,
-        destDir: Union[Path, str],
-        tmpObjDir: Union[Path, str],
-        includeDir: Union[Path, str],
-        kernelPath: Union[Path, str],
-        cmdlineArchs: List[str]
-    ) -> List[str]:
-    """Compiles a HIP source code file into a code object file.
-
-    Args:
-        toolchain: The source toolchain.
-        destDir: The destination directory where HSA code object files are placed.
-        tmpObjDir: The directory where HIP source object files are created.
-        includeDir: The include directory path.
-        kernelPath: The path to the kernel source file.
-
-    Returns:
-        List of paths to the created code objects.
-    """
-    start = timer()
-
-    tmpObjDir = Path(ensurePath(tmpObjDir))
-    destDir = Path(ensurePath(destDir))
-    kernelPath = Path(kernelPath)
-
-    objFilename = kernelPath.stem + '.o'
-    coPathsRaw = []
-    coPaths= []
-
-    objPath = str(tmpObjDir / objFilename)
-    compiler(str(includeDir), cmdlineArchs, str(kernelPath), objPath)
-
-    for target in bundler.targets(objPath):
-      match = re.search("gfx.*$", target)
-      if match:
-        arch = re.sub(":", "-", match.group())
-        coPathRaw = _computeSourceCodeObjectFilename(target, kernelPath.stem, tmpObjDir, arch)
-        if not coPathRaw: continue
-        bundler(target, objPath, str(coPathRaw))
-
-        coPath = str(destDir / coPathRaw.stem)
-        coPathsRaw.append(coPathRaw)
-        coPaths.append(coPath)
-
-    for src, dst in zip(coPathsRaw, coPaths):
-        shutil.move(src, dst)
-
-    stop = timer()
-    print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")
-
-    return coPaths
-
-
-def buildSourceCodeObjectFilesNEW(toolchain: SourceToolchain,
-                              destPath: Union[Path, str],
-                              sharedObjPath: Union[Path, str], ) -> List[str]:
+        toolchain: SourceToolchain,
+        destPath: Path,
+        sharedObjPath: Union[Path, str]
+    ):
     """Compiles a HIP source code file into a code object file.
 
     Args:
@@ -147,10 +68,9 @@ def buildSourceCodeObjectFilesNEW(toolchain: SourceToolchain,
     """
 
     for target, filename in toolchain.rocObjLs(sharedObjPath):
-      print1(f"Processing {filename} for {target}")
       match = re.search("gfx.*$", target)
       if match:
-        print(f"Generating Kernels.co for {target.split('-')[-1]}")
+        print(f"Generating Kernels.so for {target.split('-')[-1]}")
         arch = re.sub(":", "-", match.group())
         toolchain.rocObjExtract(filename)
         src = str(Path(sharedObjPath).parent / (str(Path(filename).name).replace("#","-").replace("=","").replace("&","-") + ".co"))


### PR DESCRIPTION
The kernel helpers were previously being code-generated into a monolithic file, Kernels.cpp. This update separates the kernel helpers into independent files, thereby allowing the build generator to parallelize compilation. The effect of this change scales with the number of kernel helpers, which has been seen to grow when building for bloated targets such as gfx942.

**For all targets (i.e. install.sh -c)**:

- Pipeline build time before: 2h45m
- Pipeline build time after: 1h45