### PR TITLE
Skip clock reset if rocm-smi is not available.

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_auxiliary.cpp
@@ -28,6 +28,9 @@
 #include <Windows.h>
 #include <io.h>
 #include <libloaderapi.h>
+
+// Remove defines that conflict locally.
+#undef CONST
 #else
 #define _GNU_SOURCE
 #include <dlfcn.h>

--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -549,7 +549,14 @@ def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
         globalParameters["CmakeCCompiler"] = os.environ.get("CMAKE_C_COMPILER")
 
     globalParameters["ROCmBinPath"] = os.path.join(globalParameters["ROCmPath"], "bin")
-    globalParameters["ROCmSMIPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm-smi")
+    try:
+        globalParameters["ROCmSMIPath"] = locateExe(globalParameters["ROCmBinPath"], "rocm-smi")
+    except OSError:
+        if os.name == "nt":
+            # rocm-smi is not presently supported on Windows so do not require it.
+            pass
+        else:
+            raise
     globalParameters["ROCmLdPath"] = locateExe(
         os.path.join(globalParameters["ROCmPath"], "lib/llvm/bin"),
         "ld.lld" if os.name != "nt" else "ld.lld.exe"
@@ -627,10 +634,13 @@ def setupRestoreClocks():
     import atexit
 
     def restoreClocks():
+        # Clocks will only be pinned if rocm-smi is available, therefore
+        # we only need to restore if found.
         if globalParameters["PinClocks"]:
             rsmi = globalParameters["ROCmSMIPath"]
-            subprocess.call([rsmi, "-d", "0", "--resetclocks"])
-            subprocess.call([rsmi, "-d", "0", "--setfan", "50"])
+            if rsmi is not None:
+                subprocess.call([rsmi, "-d", "0", "--resetclocks"])
+                subprocess.call([rsmi, "-d", "0", "--setfan", "50"])
 
     atexit.register(restoreClocks)
 


### PR DESCRIPTION
* Pinning clocks was already conditioned on this, so the cleanup logic should also be.
* Also removes a windows.h `#define` that was causing trouble.