### PR TITLE
Enabling LDS>64K for LocalReadVALU

### DIFF
--- a/tensilelite/Tensile/Components/LocalRead.py
+++ b/tensilelite/Tensile/Components/LocalRead.py
@@ -92,12 +92,16 @@ class LocalReadVALU(LocalRead):
                     #     tP["bpe"], \
                     #     paramList[-1]))
                 # paramTuple = tuple(paramList)
+                num = paramList[0] //65536
+                paramList[0] = paramList[0] - num * 65536
+                srcVgpr=vgpr("LocalReadAddr%s+%d"%(tc,num))
+
                 if numOffsets == 1:
                     ds = DSModifiers(na=1, offset=paramList[0])
                 if numOffsets == 2:
                     ds = DSModifiers(na=2, offset0=paramList[0], offset1=paramList[1])
                 LocalReadX = instruction.getInst()
-                localReadCode.add(LocalReadX(dst=destVgpr, src=vgpr("LocalReadAddr%s"%tc), ds=ds))
+                localReadCode.add(LocalReadX(dst=destVgpr, src=srcVgpr, ds=ds))
                 valuIdx += blockWidth
 
                 # TODO - handle vector-load


### PR DESCRIPTION
Previously only MFMA Local Read was enabled and tested to use LDS>64K. However, while testing dot2_bf16 kernel we realized LocalReadVALU was not enabled to handle LDS>64K by adjusting offsets and using 2 or 3 base registers instead of just 1 as ds_read/write instruction can support maximum 64K of address offsets.