### PR TITLE
Do not leak hip::device

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -149,11 +149,12 @@ if(HIPBLASLT_ENABLE_HOST)
     target_link_libraries(hipblaslt
         PUBLIC
             hip::hipblas-common
-            hip::device
         PRIVATE
+            hip::device
             rocisa::rocisa-cpp
             ${CMAKE_DL_LIBS}
     )
+
     if(HIPBLASLT_ENABLE_OPENMP)
         target_link_libraries(hipblaslt PRIVATE OpenMP::OpenMP_CXX)
     endif()

--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -44,13 +44,21 @@ if(HIPBLASLT_ENABLE_BLIS)
     target_link_libraries(hipblaslt-clients-common PRIVATE BLIS::BLIS)
 endif()
 
-target_link_libraries(hipblaslt-clients-common PUBLIC
-    roc::hipblaslt
-    ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
+target_link_libraries(hipblaslt-clients-common
+    PUBLIC
+        roc::hipblaslt
+        ${LAPACK_LIBRARIES} 
+        ${BLAS_LIBRARIES}
+    PRIVATE
+        hip::device
 )
 target_compile_definitions(hipblaslt-clients-common PRIVATE CLIENTS_NO_FORTRAN) # necessary?
 
-target_link_libraries(hipblaslt-bench PRIVATE hipblaslt-clients-common)
+target_link_libraries(hipblaslt-bench 
+    PRIVATE
+        hip::device
+        hipblaslt-clients-common
+)
 
 # TODO: Still haven't added hipblaslt-bench-groupedgemm-fixed-mk and related targets
 
@@ -63,9 +71,13 @@ if(BUILD_TESTING OR HIPBLASLT_BUILD_TESTING)
     if(rocm_smi_FOUND)
         target_link_libraries(hipblaslt-test PRIVATE rocm_smi64)
     endif()
-    target_link_libraries(hipblaslt-test PRIVATE hipblaslt-clients-common
-        ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}
-        GTest::gtest
+    target_link_libraries(hipblaslt-test 
+        PRIVATE
+            hip::device
+            hipblaslt-clients-common
+            ${LAPACK_LIBRARIES}
+            ${BLAS_LIBRARIES}
+            GTest::gtest
     )
     if(HIPBLASLT_ENABLE_BLIS)
         target_link_libraries(hipblaslt-test PRIVATE BLIS::BLIS) # necessary?

--- a/next-cmake/clients/samples/CMakeLists.txt
+++ b/next-cmake/clients/samples/CMakeLists.txt
@@ -28,11 +28,8 @@ add_library(sample-helper INTERFACE)
 if(HIPBLASLT_ENABLE_BLIS)
     target_link_libraries(sample-helper INTERFACE BLIS::BLIS)
 endif()
+target_link_libraries(sample-helper INTERFACE hip::device)
 
-#if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-#    # GCC or hip-clang needs specific flags to turn on f16c intrinsics
-#    target_compile_options(sample-helper INTERFACE -mf16c) # necessary?
-#endif()
 target_compile_features(sample-helper INTERFACE cxx_std_17)
 
 target_sources(sample-helper


### PR DESCRIPTION
hiblaslt was leaking device compile options to host compilers. It no longer does that by:

- moving hip::device to PRIVATE linkage
- updating clients to link against hip::device

Fixes: https://github.com/ROCm/TheRock/issues/498