### PR TITLE
do not restrict CPU count

### DIFF
--- a/tensilelite/Tensile/Common/Parallel.py
+++ b/tensilelite/Tensile/Common/Parallel.py
@@ -56,9 +56,8 @@ def CPUThreadCount(enable=True):
             cpu_count = len(os.sched_getaffinity(0))
         cpuThreads = globalParameters["CpuThreads"]
         if cpuThreads == -1:
-            return min(
-                cpu_count, 64
-            )  # Temporarily hack to fix oom issue, remove this after jenkin is fixed.
+            return cpu_count
+
         return min(cpu_count, cpuThreads)
 
 


### PR DESCRIPTION
We no longer need to restrict cpu count in Parallel.py to 64 to prevent RAM overconsumption.