### PR TITLE
Extop dependencies

### DIFF
--- a/library/src/amd_detail/rocblaslt/src/extops/CMakeLists.txt
+++ b/library/src/amd_detail/rocblaslt/src/extops/CMakeLists.txt
@@ -143,7 +143,7 @@ foreach(arch IN LISTS archs)
 endforeach()
 
 add_custom_target(ExtOpCp ALL
-    DEPENDS ${dat_depends}
+    DEPENDS ${dat_depends} TENSILE_LIBRARY_TARGET
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.co" ${PROJECT_BINARY_DIR}/Tensile/library
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.dat" ${PROJECT_BINARY_DIR}/Tensile/library
     COMMENT "Copying ExtOp Library"

--- a/library/src/amd_detail/rocblaslt/src/extops/CMakeLists.txt
+++ b/library/src/amd_detail/rocblaslt/src/extops/CMakeLists.txt
@@ -33,7 +33,7 @@ list(REMOVE_DUPLICATES archs)
 
 set(python_venv_executable "${VIRTUALENV_BIN_DIR}/${VIRTUALENV_PYTHON_EXENAME}")
 set(python_launch_prefix "PYTHONPATH=${PROJECT_BINARY_DIR}/lib" "${python_venv_executable}")
-set(dat_deps "")
+set(dat_depends "")
 foreach(arch IN LISTS archs)
     add_library(ExtOpObj_${arch} OBJECT)
     add_dependencies(ExtOpObj_${arch} rocisa)
@@ -134,16 +134,16 @@ foreach(arch IN LISTS archs)
         COMMAND_EXPAND_LISTS
     )
     add_custom_target(ExtOpLibrary_${arch} ALL
-        DEPENDS ${dat_deps} ${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co
+        DEPENDS ${dat_depends} ${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co
         COMMAND ${python_launch_prefix} ExtOpCreateLibrary.py --src=${CMAKE_CURRENT_BINARY_DIR} --co=${CMAKE_CURRENT_BINARY_DIR}/extop_${arch}.co --output=${CMAKE_CURRENT_BINARY_DIR} --arch=${arch}
         COMMENT "Creating hipblasltExtOpLibrary.dat"
         WORKING_DIRECTORY ${ops_path}
     )
-    list(APPEND dat_deps "ExtOpLibrary_${arch}")
+    list(APPEND dat_depends "ExtOpLibrary_${arch}")
 endforeach()
 
 add_custom_target(ExtOpCp ALL
-    DEPENDS TENSILE_LIBRARY_TARGET
+    DEPENDS ${dat_depends}
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.co" ${PROJECT_BINARY_DIR}/Tensile/library
     COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/*.dat" ${PROJECT_BINARY_DIR}/Tensile/library
     COMMENT "Copying ExtOp Library"


### PR DESCRIPTION
The dependencies in extop makefile assumed that the tensile create library command would take longer to exectute. This is not the case for one-off builds with a single logic file. This PR corrects this issue.