### PR TITLE
Revert "Compile kernel helpers in parallel (#2003)"

### DIFF
--- a/tensilelite/Tensile/KernelWriterBase.py
+++ b/tensilelite/Tensile/KernelWriterBase.py
@@ -55,17 +55,17 @@ class KernelWriterBase(ABC):
 
 
   @abstractmethod
-  def getKernelName(self) -> str:
+  def getKernelName(self):
     pass
 
 
   @abstractmethod
-  def getHeaderFileString(self) -> str:
+  def getHeaderFileString(self):
     pass
 
 
   @abstractmethod
-  def getSourceFileString(self) -> str:
+  def getSourceFileString(self):
     pass
 
 

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -198,8 +198,6 @@ def addCommonArguments(argParser):
         action="store", default=ToolchainDefaults.OFFLOAD_BUNDLER, help="select which offload bundler to use")
     argParser.add_argument("--device-enumerator", dest="DeviceEnumerator", \
         action="store", default=ToolchainDefaults.DEVICE_ENUMERATOR, help="select which device enumerator to use")
-    argParser.add_argument("--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT)
-    argParser.add_argument("--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS)
     argParser.add_argument("--logic-format", dest="LogicFormat", choices=["yaml", "json"], \
         action="store", default="yaml", help="select which logic format to use")
     argParser.add_argument("--library-format", dest="LibraryFormat", choices=["yaml", "msgpack"], \
@@ -454,13 +452,9 @@ def Tensile(userArgs):
     cxxCompiler, \
     cCompiler, \
     offloadBundler, \
-    rocObjLs, \
-    rocObjExtract, \
     enumerator = validateToolchain(args.CxxCompiler,
                                    args.CCompiler,
                                    args.OffloadBundler,
-                                   args.RocObjLs,
-                                   args.RocObjExtract,
                                    ToolchainDefaults.DEVICE_ENUMERATOR)
     asmToolchain = makeAssemblyToolchain(
         cxxCompiler,
@@ -470,14 +464,11 @@ def Tensile(userArgs):
     srcToolchain = makeSourceToolchain(
         cxxCompiler,
         offloadBundler,
-        rocObjLs,
-        rocObjExtract,
-        64,  # TODO: make this configurable
     )
 
     if "ISA" in args.global_parameters:
         isaList = [IsaVersion(isa[0], isa[1], isa[2]) for isa in args.global_parameters["ISA"]]
-
+        
     else:
         isaList = [detectGlobalCurrentISA(device_id, enumerator)]
 

--- a/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/ParseArguments.py
@@ -73,12 +73,6 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
         "--assembler", dest="Assembler", action="store", default=ToolchainDefaults.ASSEMBLER
     )
     argParser.add_argument(
-        "--roc-obj-extract", dest="RocObjExtract", action="store", default=ToolchainDefaults.ROC_OBJ_EXTRACT
-    )
-    argParser.add_argument(
-        "--roc-obj-ls", dest="RocObjLs", action="store", default=ToolchainDefaults.ROC_OBJ_LS
-    )
-    argParser.add_argument(
         "--code-object-version",
         dest="CodeObjectVersion",
         choices=["4", "5", "V4", "V5", "default"],
@@ -216,8 +210,6 @@ def parseArguments(input: Optional[List[str]] = None) -> Dict[str, Any]:
     arguments["CxxCompiler"] = args.CxxCompiler
     arguments["CCompiler"] = args.CCompiler
     arguments["OffloadBundler"] = args.OffloadBundler
-    arguments["RocObjExtract"] = args.RocObjExtract
-    arguments["RocObjLs"] = args.RocObjLs
     arguments["Assembler"] = args.Assembler
     arguments["LogicPath"] = args.LogicPath
     arguments["LogicFilter"] = args.LogicFilter

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -63,7 +63,6 @@ from Tensile.KernelWriterAssembly import KernelWriterAssembly
 from Tensile.KernelWriterBase import (
     KERNEL_HELPER_FILENAME_CPP,
     KERNEL_HELPER_FILENAME_H,
-    KernelWriterBase,
 )
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
@@ -187,92 +186,33 @@ def writeAssembly(asmPath: Union[Path, str], result: KernelCodeGenResult):
 
     return path, isa, wfsize
 
-def writeHelper(outputPath: Path, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> str:
-    """
-    Write kernel helper source and header files.
 
-    Args:
-        outputPath: Base path where files will be written
-        kernelHelperObj: Kernel helper object with source and header content
-        khoNames: List of all kernel helper object names for dependency resolution
+def writeHelpers(
+    outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
+):
+    kernelSourceFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_CPP)
+    kernelHeaderFilename = os.path.join(os.path.normcase(outputPath), KERNEL_HELPER_FILENAME_H)
 
-    Returns:
-        The path to the generated source file
-    """
-    name = kernelHelperObj.getKernelName()
-    sourceFilename = f"{name}.cpp"
-    headerFilename = f"{name}.h"
-    kernelsDir = Path(outputPath) / "Kernels"
-
-    if not kernelsDir.exists():
-        kernelsDir.mkdir(parents=True, exist_ok=True)
-
-    kernelSourcePath = str(kernelsDir / sourceFilename)
-    kernelHeaderPath = str(kernelsDir / headerFilename)
-
-    includes = _getRequiredIncludes(name, kernelHelperObj, khoNames)
-
-    with open(kernelHeaderPath, "w", encoding="utf-8") as kernelHeaderFile, \
-         open(kernelSourcePath, "w", encoding="utf-8") as kernelSourceFile:
-
-        for file in (kernelSourceFile, kernelHeaderFile):
-            file.write(CHeader)
-
-        kernelSourceFile.write(f"#include \"{name}.h\"\n")
-
+    with open(kernelHeaderFilename, "w", encoding="utf-8") as kernelHeaderFile, open(
+        kernelSourceFilename, "w", encoding="utf-8"
+    ) as kernelSourceFile:
+        kernelSourceFile.write(CHeader)
+        kernelHeaderFile.write(CHeader)
+        kernelSourceFile.write('#include "Kernels.h"\n')
         kernelHeaderFile.write("#pragma once\n")
         kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
         kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
-        kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
+        kernelHeaderFile.write('#include "KernelHeader.h"\n\n')
+        HeaderText = ""
+        for ko in kernelHelperObjs:
+            kernelName = ko.getKernelName()
+            (err, src) = ko.getSourceFileString()
 
-        for include in includes:
-            kernelHeaderFile.write(f"#include \"Kernels/{include}.h\"\n")
-
-        err, src = kernelHelperObj.getSourceFileString()
-        if err:
-            printWarning(f"Invalid kernel: {name} (error code {err})")
-
-        kernelSourceFile.write(src)
-        kernelHeaderFile.write(kernelHelperObj.getHeaderFileString())
-
-    return kernelSourcePath
-
-
-def _getRequiredIncludes(name: str, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> set:
-    """
-    Determine the required includes for a kernel helper.
-
-    Args:
-        name: Kernel helper name
-        khoNames: List of all kernel helper object names
-        kernelHelperObj: The kernel helper object to analyze
-
-    Returns:
-        List of kernel helper names to include
-    """
-    includes = set()
-
-    # Add enum includes for non-enum helpers
-    if "Enum" not in name:
-        includes.update(n for n in khoNames if "Enum" in n)
-
-        # Include gradient activation enums for gradient helpers
-        hasGradient = hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient"
-        if hasGradient:
-            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
-
-    # Include activation helpers
-    hasActivation = ("TensileActivation_S" in name or "TensileActivation_I" in name)
-    if not hasActivation and "Enum" not in name:
-        includes.update(n for n in khoNames if "TensileActivation_" in n)
-
-    # Include gradient activation helpers
-    hasGradientActivation = "TensileGradientActivation_S" in name
-    if not hasGradientActivation and "Enum" not in name:
-        if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
-            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
-
-    return includes
+            kernelSourceFile.write(src)
+            if err:
+                print("*** warning: invalid kernel#%u" % kernelName)
+            HeaderText += ko.getHeaderFileString()
+        kernelHeaderFile.write(HeaderText)
 
 
 def writeSolutionsAndKernels(
@@ -302,8 +242,6 @@ def writeSolutionsAndKernels(
     objectTmpPath = ensurePath(
         buildTmpPath / "code_object_tmp"
     )  # Temp path for HSA code object files (.hsaco)
-    kernelsIncludePath = outputPath / "Kernels"
-    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
 
     asmKernels = [k for k in kernels if k["KernelLanguage"] == "Assembly"]
 
@@ -350,6 +288,9 @@ def writeSolutionsAndKernels(
         multiArg=False,
     )
 
+    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
+    srcKernelFile = Path(outputPath) / "Kernels.cpp"
+
     if not generateSourcesAndExit:
         codeObjectFiles += buildAssemblyCodeObjectFiles(
             asmToolchain.linker,
@@ -360,11 +301,15 @@ def writeSolutionsAndKernels(
             assemblyTmpPath,
             compress,
         )
-        khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
-        srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
-        kernelsLib = str(objectTmpPath / "Kernels.so")
-        srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
-        buildSourceCodeObjectFiles(srcToolchain, outputPath / "library", kernelsLib)
+        buildSourceCodeObjectFiles(
+            srcToolchain.compiler,
+            srcToolchain.bundler,
+            destLibPath,
+            objectTmpPath,
+            outputPath,
+            srcKernelFile,
+            cmdlineArchs,
+        )
 
     return codeObjectFiles, numKernels
 
@@ -437,12 +382,17 @@ def writeSolutionsAndKernelsTCL(
         compress,
     )
 
-    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
-    srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
-    kernelsLib = str(objectTmpPath / "Kernels.so")
-
-    srcToolchain.compiler(srcFiles, kernelsLib, str(outputPath), cmdlineArchs)
-    buildSourceCodeObjectFiles(srcToolchain, outputPath / "library", kernelsLib)
+    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
+    srcKernelFile = Path(outputPath) / "Kernels.cpp"
+    buildSourceCodeObjectFiles(
+        srcToolchain.compiler,
+        srcToolchain.bundler,
+        destLibPath,
+        objectTmpPath,
+        outputPath,
+        srcKernelFile,
+        cmdlineArchs,
+    )
 
     return len(uniqueAsmKernels)
 
@@ -633,15 +583,12 @@ def run():
     arguments = parseArguments()
     setVerbosity(arguments["PrintLevel"])
     outputPath = Path(ensurePath(os.path.abspath(arguments["OutputPath"])))
-
-    kernelsIncludePath = outputPath / "Kernels"
-    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
-
-    cxxCompiler, offloadBundler, ls, extract = validateToolchain(
+    cxxCompiler, _, offloadBundler, _, _ = validateToolchain(
         arguments["CxxCompiler"],
+        arguments["CCompiler"],
         arguments["OffloadBundler"],
-        arguments["RocObjLs"],
-        arguments["RocObjExtract"]
+        arguments["Assembler"],
+        ToolchainDefaults.HIP_CONFIG,
     )
 
     if ";" in arguments["Architecture"]:
@@ -663,9 +610,6 @@ def run():
     srcToolchain = makeSourceToolchain(
         cxxCompiler,
         offloadBundler,
-        ls,
-        extract,
-        arguments["CpuThreads"],
         arguments["AsanBuild"],
         arguments["BuildIdKind"],
         save_temps=False

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -32,28 +32,54 @@ from typing import List, Union, NamedTuple
 
 from ..Common import print1, ensurePath
 
-from .Component import Compiler, Bundler, RocObjLs, RocObjExtract
+from .Component import Compiler, Bundler
 
 class SourceToolchain(NamedTuple):
    compiler: Compiler
    bundler: Bundler
-   rocObjLs: RocObjLs
-   rocObjExtract: RocObjExtract
 
 
-def makeSourceToolchain(compiler_path, bundler_path, ls_path, extract_path, cpu_threads, asan_build=False, build_id_kind="sha1", save_temps=False):
-   compiler = Compiler(compiler_path, build_id_kind, cpu_threads, asan_build, save_temps)
+def makeSourceToolchain(compiler_path, bundler_path, asan_build=False, build_id_kind="sha1", save_temps=False):
+   compiler = Compiler(compiler_path, build_id_kind, asan_build, save_temps)
    bundler = Bundler(bundler_path)
-   ls = RocObjLs(ls_path)
-   extract = RocObjExtract(extract_path)
-   return SourceToolchain(compiler, bundler, ls, extract)
+   return SourceToolchain(compiler, bundler)
+
+
+def _computeSourceCodeObjectFilename(target: str, base: str, buildPath: Union[Path, str], arch: str) -> Union[Path, None]:
+    """Generates a code object file path using the target, base, and build path.
+
+    Args:
+        target: The target triple.
+        base: The base name for the output file (name without extension).
+        buildPath: The build directory path.
+
+    Returns:
+        Path to the code object file.
+    """
+    coPath = None
+    buildPath = Path(buildPath)
+    if "TensileLibrary" in base and "fallback" in base:
+        coPath = buildPath / "{0}_{1}.hsaco.raw".format(base, arch)
+    elif "TensileLibrary" in base:
+        variant = [t for t in ["", "xnack-", "xnack+"] if t in target][-1]
+        baseVariant = base + "-" + variant if variant else base
+        if arch in baseVariant:
+            coPath = buildPath / (baseVariant + ".hsaco.raw")
+    else:
+        coPath= buildPath / "{0}.so-000-{1}.hsaco.raw".format(base, arch)
+
+    return coPath
 
 
 def buildSourceCodeObjectFiles(
-        toolchain: SourceToolchain,
-        destPath: Path,
-        sharedObjPath: Union[Path, str]
-    ):
+        compiler: Compiler,
+        bundler: Bundler,
+        destDir: Union[Path, str],
+        tmpObjDir: Union[Path, str],
+        includeDir: Union[Path, str],
+        kernelPath: Union[Path, str],
+        cmdlineArchs: List[str]
+    ) -> List[str]:
     """Compiles a HIP source code file into a code object file.
 
     Args:
@@ -66,13 +92,35 @@ def buildSourceCodeObjectFiles(
     Returns:
         List of paths to the created code objects.
     """
+    start = timer()
 
-    for target, filename in toolchain.rocObjLs(sharedObjPath):
+    tmpObjDir = Path(ensurePath(tmpObjDir))
+    destDir = Path(ensurePath(destDir))
+    kernelPath = Path(kernelPath)
+
+    objFilename = kernelPath.stem + '.o'
+    coPathsRaw = []
+    coPaths= []
+
+    objPath = str(tmpObjDir / objFilename)
+    compiler(str(includeDir), cmdlineArchs, str(kernelPath), objPath)
+
+    for target in bundler.targets(objPath):
       match = re.search("gfx.*$", target)
       if match:
-        print(f"Generating Kernels.so for {target.split('-')[-1]}")
         arch = re.sub(":", "-", match.group())
-        toolchain.rocObjExtract(filename)
-        src = str(Path(sharedObjPath).parent / (str(Path(filename).name).replace("#","-").replace("=","").replace("&","-") + ".co"))
-        dst = str(destPath / f"Kernels.so-000-{arch}.hsaco")
+        coPathRaw = _computeSourceCodeObjectFilename(target, kernelPath.stem, tmpObjDir, arch)
+        if not coPathRaw: continue
+        bundler(target, objPath, str(coPathRaw))
+
+        coPath = str(destDir / coPathRaw.stem)
+        coPathsRaw.append(coPathRaw)
+        coPaths.append(coPath)
+
+    for src, dst in zip(coPathsRaw, coPaths):
         shutil.move(src, dst)
+
+    stop = timer()
+    print1(f"buildSourceCodeObjectFile time (s): {(stop-start):3.2f}")
+
+    return coPaths

--- a/tensilelite/Tensile/Toolchain/Validators.py
+++ b/tensilelite/Tensile/Toolchain/Validators.py
@@ -108,14 +108,12 @@ def _posixSearchPaths() -> List[Path]:
 
 
 class ToolchainDefaults(NamedTuple):
-    CXX_COMPILER= osSelect(linux="amdclang++", windows="clang++.exe")
-    C_COMPILER= osSelect(linux="amdclang", windows="clang.exe")
-    OFFLOAD_BUNDLER= osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
-    ROC_OBJ_EXTRACT= osSelect(linux="roc-obj-extract", windows="roc-obj-extract.exe")
-    ROC_OBJ_LS= osSelect(linux="roc-obj-ls", windows="roc-obj-ls.exe")
+    CXX_COMPILER = osSelect(linux="amdclang++", windows="clang++.exe")
+    C_COMPILER = osSelect(linux="amdclang", windows="clang.exe")
+    OFFLOAD_BUNDLER = osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
     DEVICE_ENUMERATOR = osSelect(linux="rocm_agent_enumerator" if isRhel8() else "amdgpu-arch", windows="hipinfo")
     ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
-    HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig")
+    HIP_CONFIG = osSelect(linux="hipconfig", windows="hipconfig.exe")
 
 
 def _supportedComponent(component: str, targets: List[str]) -> bool:
@@ -149,16 +147,6 @@ def supportedCxxCompiler(compiler: str) -> bool:
         If supported True; otherwise, False.
     """
     return _supportedComponent(compiler, ["amdclang++", "clang++"])
-
-
-def supportedBundler(bundler: str) -> bool:
-    """Determine if an offload bundler is supported by Tensile.
-    Args:
-        bundler: The name of an roc-obj-extract to test for support.
-    Return:
-        If supported True; otherwise, False.
-    """
-    return _supportedComponent(bundler, ["clang-offload-bundler"])
 
 
 def supportedOffloadBundler(bundler: str) -> bool:
@@ -202,26 +190,6 @@ def supportedDeviceEnumerator(enumerator: str) -> bool:
     return _supportedComponent(enumerator, ["rocm_agent_enumerator", "amdgpu-arch"])
 
 
-def supportedExtract(extract: str) -> bool:
-    """Determine if an object extracter is supported by Tensile.
-    Args:
-        extract: The name of an roc-obj-extract to test for support.
-    Return:
-        If supported True; otherwise, False.
-    """
-    return _supportedComponent(extract, [ToolchainDefaults.ROC_OBJ_EXTRACT])
-
-
-def supportedLs(ls: str) -> bool:
-    """Determine if an object lister is supported by Tensile.
-    Args:
-        ls: The name of an roc-obj-ls to test for support.
-    Return:
-        If supported True; otherwise, False.
-    """
-    return _supportedComponent(ls, [ToolchainDefaults.ROC_OBJ_LS])
-
-
 def _exeExists(file: Path) -> bool:
     """
     Check if a file exists and is executable.
@@ -247,13 +215,11 @@ def _validateExecutable(file: str, searchPaths: List[Path]) -> str:
         The validated executable with an absolute path.
     """
     if not any((
-        supportedCxxCompiler(file), 
-        supportedCCompiler(file), 
-        supportedBundler(file), 
-        supportedDeviceEnumerator(file),
-        supportedExtract(file), 
-        supportedLs(file), 
-        supportedHip(file)
+        supportedCxxCompiler(file),
+        supportedCCompiler(file),
+        supportedOffloadBundler(file),
+        supportedHip(file),
+        supportedDeviceEnumerator(file)
     )):
         raise ValueError(f"`{file}` is not a supported toolchain component on {'Windows' if os.name == 'nt' else 'Linux'}")
 


### PR DESCRIPTION
This reverts commit 5d6a428e336b99067b4ba8bf62cfb1a28d389623.

This patch breaks multiple downstream CIs due to different issues:

* External CI: missing CPAN deps and unexpected parse errors reading the roc-obj output.
* Windows: roc-obj-* are actually perl scripts and not EXE files. They aren't very automation friendly and will need special handling to use. Also, the hard-coded shared library suffixes look like they probably won't work on Windows, which minimally, does not name its files to end in `.so`. In addition, it looks like it has a stray change to the windows name to hipinfo.

Reading through the code, I think it is a good idea but we may want to iterate on the approach as it is doing some advanced stuff with tooling that isn't necessarily hardened for it. Would be good to get some more iterations on the review.