### PR TITLE
Default environment variable to empty in tox.ini

### DIFF
--- a/tensilelite/tox.ini
+++ b/tensilelite/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest-xdist>=1.32.0
     filelock
 setenv =
-    TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC}
+    TENSILE_CLIENT_STATIC = {env:TENSILE_CLIENT_STATIC:}
     PYTHONPATH = {envdir}/rocisa/lib
 commands =
     mkdir -p {envdir}/rocisa


### PR DESCRIPTION
- defaults the env variable TENSILE_CLIENT_STATIC to empty in tox.ini file