### PR TITLE
[windows] Find hipblaslt library with posix directory layout.

### DIFF
--- a/library/src/amd_detail/hipblaslt-ext-op.cpp
+++ b/library/src/amd_detail/hipblaslt-ext-op.cpp
@@ -163,22 +163,10 @@ namespace
             return libPath;
         }
 
-        auto                  soPath = rocblaslt_internal_get_so_path();
-        std::filesystem::path libPath(std::filesystem::path(soPath).parent_path());
-
-        auto pathIfExists = [](std::filesystem::path p) -> std::optional<std::filesystem::path> {
-            if(std::filesystem::exists(p))
-                return p;
-            return {};
-        };
-
-        if(auto p
-           = pathIfExists(libPath / ".." / "Tensile" / "library" / "hipblasltExtOpLibrary.dat"))
-            return p->string();
-        if(auto p = pathIfExists(libPath / "library" / "hipblasltExtOpLibrary.dat"))
-            return p->string();
-        if(auto p = pathIfExists(libPath / "hipblaslt" / "library" / "hipblasltExtOpLibrary.dat"))
-            return p->string();
+        auto path = rocblaslt_find_library_relative_path(
+            std::filesystem::path("hipblasltExtOpLibrary.dat"));
+        if(path)
+            return path->string();
 
         return DEFAULT_EXT_OP_LIBRARY_PATH;
     }

--- a/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
+++ b/library/src/amd_detail/rocblaslt/include/rocblaslt-auxiliary.h
@@ -33,6 +33,8 @@
 #define _ROCBLASLT_AUXILIARY_H_
 
 #include "rocblaslt-types.h"
+#include <filesystem>
+#include <optional>
 #include <stdint.h>
 #include <vector>
 
@@ -405,6 +407,21 @@ bool rocblaslt_internal_test_path(const std::string&);
 
 // Gets the absolute path of the so/dll/exe containing this function.
 std::string rocblaslt_internal_get_so_path();
+
+// Finds a path relative to the hipblaslt "library" directory, and returns the full path
+// if it exists.
+// Without `default_lib_dir` specified, this will first attempt to locate a plausible
+// library directory relative to the hosting shared library. On Windows, this will
+// search the containing "bin" directory and its sibling "lib" directory. Searching
+// the "bin" directory is for backwards compatibility with the original Windows
+// build system and should be considered deprecated in favor of the standard Posix
+// layout.
+// If `default_lib_dir` is given, then no shared library relative search heuristic
+// is used and the given directory is taken verbatim.
+std::optional<std::filesystem::path>
+    rocblaslt_find_library_relative_path(const std::optional<std::filesystem::path>& relpath,
+                                         const std::optional<std::filesystem::path>& default_lib_dir
+                                         = std::nullopt);
 
 void rocblaslt_log_error(const char* func, const char* var, const char* msg);
 #endif

--- a/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
+++ b/library/src/amd_detail/rocblaslt/src/rocblaslt_transform.cpp
@@ -53,23 +53,10 @@ namespace
             = "/opt/rocm/lib/hipblaslt/library/hipblasltTransform.hsaco";
 #endif
 
-        std::string           soPath = rocblaslt_internal_get_so_path();
-        std::filesystem::path libPath(std::filesystem::path(soPath).parent_path());
-
-        auto pathIfExists = [](std::filesystem::path p) -> std::optional<std::filesystem::path> {
-            if(std::filesystem::exists(p))
-                return p;
-            return {};
-        };
-
-        if(auto p
-           = pathIfExists(libPath / ".." / "Tensile" / "library" / "hipblasltTransform.hsaco"))
-            return *p;
-        if(auto p = pathIfExists(libPath / "library" / "hipblasltTransform.hsaco"))
-            return *p;
-        if(auto p = pathIfExists(libPath / "hipblaslt" / "library" / "hipblasltTransform.hsaco"))
-            return *p;
-
+        auto path = rocblaslt_find_library_relative_path(
+            std::filesystem::path("hipblasltTransform.hsaco"));
+        if(path)
+            return *path;
         return std::filesystem::path(DEFAULT_CO_PATH);
     }
 

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -767,7 +767,8 @@ namespace
             "--bias_type",
             hipDataType_to_bench_string(tensile2HipType(problem.bias().dataType())),
             problem.useE() ? "--aux_type" : "",
-            problem.useE() ? hipDataType_to_bench_string(tensile2HipType(problem.e().dataType())) : "",
+            problem.useE() ? hipDataType_to_bench_string(tensile2HipType(problem.e().dataType()))
+                           : "",
             problem.getParams().gsu() ? "--splitk" : "",
             problem.getParams().gsu() ? std::to_string(problem.getParams().gsu()) : "",
             problem.getParams().wgm() ? "--wgm" : "",
@@ -1077,7 +1078,9 @@ namespace
             "--bias_type",
             hipDataType_to_bench_string(tensile2HipType(problem.gemms[0].bias().dataType())),
             problem.gemms[0].useE() ? "--aux_type" : "",
-            problem.gemms[0].useE() ? hipDataType_to_bench_string(tensile2HipType(problem.gemms[0].e().dataType())) : "",
+            problem.gemms[0].useE()
+                ? hipDataType_to_bench_string(tensile2HipType(problem.gemms[0].e().dataType()))
+                : "",
             problem.gemms[0].getParams().gsu() ? "--splitk" : "",
             problem.gemms[0].getParams().gsu() ? std::to_string(problem.gemms[0].getParams().gsu())
                                                : "",
@@ -1929,34 +1932,20 @@ namespace
             {
                 // Find the location of librocblaslt.so
                 // Fall back on hard-coded path if static library or not found
+                std::optional<std::filesystem::path> default_lib_path;
                 if(staticLib)
                 {
-                    path = HIPBLASLT_LIB_PATH;
+                    default_lib_path = HIPBLASLT_LIB_PATH;
                 }
-                else
+                if(auto maybe_path = rocblaslt_find_library_relative_path(
+                       /*relpath=*/std::nullopt, default_lib_path))
+                    path = std::move(*maybe_path);
+                // Optionally, look for a `processor` sub-directory under the library path.
                 {
-                    auto hipblaslt_so_path
-                        = std::filesystem::path(rocblaslt_internal_get_so_path());
-                    path = hipblaslt_so_path.parent_path();
+                    auto processor_path = path / processor;
+                    if(std::filesystem::exists(processor_path))
+                        path = std::move(processor_path);
                 }
-
-                auto pathIfExists
-                    = [](std::filesystem::path p) -> std::optional<std::filesystem::path> {
-                    if(std::filesystem::exists(p))
-                        return p;
-                    return {};
-                };
-
-                // Find the location of the libraries
-                if(auto p = pathIfExists(path / ".." / "Tensile" / "library"))
-                    path = *p;
-                else if(auto p = pathIfExists(path / "library"))
-                    path = *p;
-                else
-                    path = path / "hipblaslt" / "library";
-
-                if(auto p = pathIfExists(path / processor))
-                    path = *p;
 
                 if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
                 {

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Serialization/PlaceholderLibrary.hpp
@@ -60,8 +60,14 @@ namespace TensileLite
                     lib.solutionsGuard  = ctx->solutionsGuard;
 
                     //Extract directory where TensileLibrary.dat/yaml file is located
+                    //TODO: Consider refactoring this to use filesystem::path handling instead
+                    //of string munging.
                     lib.libraryDirectory = ctx->filename;
-                    size_t directoryPos  = ctx->filename.rfind('/');
+                    size_t directoryPos  = ctx->filename.rfind('/'); // Posix style
+#ifdef _WIN32
+                    if(directoryPos == std::string::npos)
+                        directoryPos = ctx->filename.rfind('\\'); // Windows style
+#endif
                     if(directoryPos != std::string::npos)
                         lib.libraryDirectory.resize(directoryPos + 1);
                     else


### PR DESCRIPTION
Prior to this patch, hipblaslt would install its library under lib/hipblaslt, which matches the Posix layout, but it was hard-coded to only search adjacent to the hipblaslt.dll file (which on Windows, is in the bin directory). For some reason, some existing Windows build logic does expect to find it in the bin directory, and I am left to assume that some out of tree patches exist that munge things into that form. That behavior has been retained, but on Windows, we now first search the sibling `lib` directory, assuming that the default layout of ROCM is the same on all platforms (which is the case we are enforcing going forward).

* The last time this code was touched, ellosel recommended that we remove the library finding redundancy by introducing a helper.
* Refactored the three call sites to use a new common helper.
* Fixed up some raw string-based path handling that was requiring a '/' in the path and defaulting silently to the PWD if not (!!!). This has been causing many issues on Windows builds and people have been dumping code objects into the bin directory to compensate.
* While writing the common utility, I moved the current standard directory layout to the top of the search list (it was being searched last, after old layouts).

Tested on Windows with TheRock.