### PR TITLE
Fix #1845: Move max function into namespace to avoid name conflicts

### DIFF
--- a/tensilelite/Tensile/Source/ReductionTemplate.h
+++ b/tensilelite/Tensile/Source/ReductionTemplate.h
@@ -42,9 +42,12 @@ struct static_for
     }
 };
 
-constexpr size_t max(size_t a, size_t b)
+namespace reduction_tmp_util
 {
-    return (a > b) ? a : b;
+    constexpr size_t max(size_t a, size_t b)
+    {
+        return (a > b) ? a : b;
+    }
 }
 
 template <typename DataTypeCompute, typename DataTypeOut, size_t MT0, size_t MT1, size_t VW>
@@ -65,7 +68,7 @@ __device__ inline void
     int num_records       = strideJ * n * sizeof(DataTypeCompute);
     int num_records_bias  = m * sizeof(DataTypeOut);
 
-    constexpr size_t sumLength      = max((size_t)1, VW - 1);
+    constexpr size_t sumLength      = reduction_tmp_util::max((size_t)1, VW - 1);
     DataTypeCompute  sum[sumLength] = {0};
     if(idx + (VW - 1) < m)
     {
@@ -110,7 +113,7 @@ __device__ inline void
         {
             int              currRow   = row + i;
             int              rowStride = currRow * strideJ + voffset;
-            constexpr size_t tmpLength = max((size_t)1, VW - 1);
+            constexpr size_t tmpLength = reduction_tmp_util::max((size_t)1, VW - 1);
             DataTypeCompute  tmp[tmpLength];
             static_for<0, VW - 1>()([&](int vw) {
                 buffer_load<DataTypeCompute, sizeof(DataTypeCompute)>(


### PR DESCRIPTION
Move max function into namespace to avoid name conflicts