### PR TITLE
[next-cmake] Add rocm cmake

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -28,12 +28,26 @@ cmake_minimum_required(VERSION 3.25.0)
 project(hipblaslt VERSION 0.15.0 LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rocm-cmake/share/rocmcmakebuildtools/cmake")
 
+include(ROCMInstallTargets)
+include(ROCMSetupVersion)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 include(GenerateExportHeader)
 include(CMakeDependentOption)
 include(hipblaslt_python)
+
+rocm_setup_version(VERSION ${PROJECT_VERSION})
+set(hipblaslt_SOVERSION 0.15)
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    if(WIN32)
+      set(CMAKE_INSTALL_PREFIX "C:/hipSDK" CACHE PATH "Install path prefix." FORCE)
+    else()
+      set(CMAKE_INSTALL_PREFIX "/opt/rocm" CACHE PATH "Install path prefix." FORCE)
+    endif()
+endif()
 
 set(HIPBLASLT_ENABLE_DEVICE ON CACHE BOOL "Build hipBLASLt device libraries.")
 set(HIPBLASLT_ENABLE_CLIENT ON CACHE BOOL "Build hipBLASLt client apps.")
@@ -47,7 +61,7 @@ if(HIPBLASLT_ENABLE_CLIENT)
 endif()
 
 if(HIPBLASLT_ENABLE_HOST)
-    set(HIPBLASLT_BUILD_SHARED ON CACHE BOOL "Build the hipblaslt library as shared vs static")
+    set(HIPBLASLT_BUILD_SHARED_LIBS ON CACHE BOOL "Build the hipblaslt library as shared vs static")
     set(HIPBLASLT_ENABLE_HIP ON CACHE BOOL "Use the HIP runtime.")
     set(HIPBLASLT_ENABLE_MSGPACK ON CACHE BOOL "Use msgpack for parsing configuration files.")
     set(HIPBLASLT_ENABLE_OPENMP ON CACHE BOOL "Use OpenMP to improve performance.")
@@ -55,6 +69,8 @@ if(HIPBLASLT_ENABLE_HOST)
     set(HIPBLASLT_ENABLE_ROCROLLER OFF CACHE BOOL "Use RocRoller library.")
     set(HIPBLASLT_ENABLE_BLIS ON CACHE BOOL "Enable BLIS support.") # I don't know that we can build with this OFF
     set(HIPBLASLT_ENABLE_LAZY_LOAD ON CACHE BOOL "Enable lazy loading of runtime code oject files to reduce ram usage.")
+    set(HIPBLASLT_ENABLE_SEPARATE_ARCHITECTURES ON CACHE BOOL "Build architecture specific libraries.")
+    set(HIPBLASLT_ENABLE_MARKER ON CACHE BOOL "Use the marker library.")
 endif()
 
 if(HIPBLASLT_ENABLE_DEVICE)
@@ -78,6 +94,7 @@ mark_as_advanced(CMAKE_INSTALL_RPATH_USE_LINK_PATH)
 
 set(TEMP_TENSILE_HOST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../tensilelite/Tensile/Source/lib")
 set(HIPBLASLT_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../library")
+set(HIPBLASLT_CLIENTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../clients")
 set(ROCBLASLT_LIB_DIR "${HIPBLASLT_LIB_DIR}/src/amd_detail/rocblaslt")
 
 find_package(hip REQUIRED)
@@ -88,6 +105,9 @@ if(HIPBLASLT_ENABLE_HOST)
     if(HIPBLASLT_ENABLE_BLIS)
         find_package(BLIS REQUIRED)
     endif()
+    if(HIPBLASLT_ENABLE_MARKER)
+        find_library(rocTracer roctx64 REQUIRED)
+    endif()
 endif()
 if(HIPBLASLT_REQUIRE_ROCM_SMI)
     find_package(rocm_smi REQUIRED)
@@ -95,7 +115,6 @@ else()
     find_package(rocm_smi)
 endif()
 if(HIPBLASLT_ENABLE_CLIENT)
-    #find_package(Threads REQUIRED) # TODO: We don't fail to build or link without Threads remove?
     find_package(BLAS REQUIRED)
     find_package(LAPACK REQUIRED)
 endif()
@@ -104,7 +123,7 @@ if(HIPBLASLT_ENABLE_OPENMP)
 endif()
 if(HIPBLASLT_ENABLE_MSGPACK)
     # See: https://github.com/msgpack/msgpack-c/wiki/Q%26A#how-to-support-both-msgpack-c-c-version-5x-and-6x-
-    # Prefer 6.x (msgpack-cxx) as that is what we bundle in the build.
+    # Prefer 6.x (msgpack-cxx)
     find_package(msgpack-cxx CONFIG)
     if(msgpack-cxx_FOUND)
         message(STATUS "Found msgpack-cxx (>=6.x)")
@@ -140,7 +159,7 @@ if(HIPBLASLT_ENABLE_DEVICE)
     endif()
 endif()
 if(HIPBLASLT_ENABLE_HOST)
-    if(HIPBLASLT_BUILD_SHARED)
+    if(HIPBLASLT_BUILD_SHARED_LIBS)
         add_library(hipblaslt SHARED)
     else()
         add_library(hipblaslt STATIC)
@@ -172,15 +191,13 @@ if(HIPBLASLT_ENABLE_HOST)
     )
 
     if(HIPBLASLT_ENABLE_LAZY_LOAD)
-        target_compile_definitions(hipblaslt
-            PRIVATE
-                ROCBLASLT_TENSILE_LAZY_LOAD
-        )
+        target_compile_definitions(hipblaslt PRIVATE ROCBLASLT_TENSILE_LAZY_LOAD)
     endif()
 
     if(HIPBLASLT_ENABLE_HIP)
         target_compile_definitions(hipblaslt PRIVATE TENSILE_USE_HIP)
     endif()
+
     if(HIPBLASLT_ENABLE_MSGPACK)
         if(msgpack-cxx_FOUND)
             target_link_libraries(hipblaslt PRIVATE msgpack-cxx)
@@ -188,6 +205,10 @@ if(HIPBLASLT_ENABLE_HOST)
             target_link_libraries(hipblaslt PRIVATE msgpackc)
         endif()
         target_compile_definitions(hipblaslt PRIVATE TENSILE_MSGPACK)
+    endif()
+
+    if(HIPBLASLT_ENABLE_MARKER)
+        target_compile_definitions(hipblaslt PRIVATE HIPBLASLT_ENABLE_MARKER)
     endif()
 
     target_include_directories(hipblaslt
@@ -219,29 +240,12 @@ if(HIPBLASLT_ENABLE_CLIENT)
     add_subdirectory(clients)
 endif()
 
+
 if(HIPBLASLT_ENABLE_HOST)
-    install(TARGETS hipblaslt rocisa-cpp
-        EXPORT hipblaslt-targets
-        LIBRARY
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            COMPONENT hipBLASLt_Runtime
-        ARCHIVE
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            COMPONENT hipBLASLt_Development
-        RUNTIME
-            DESTINATION "${CMAKE_INSTALL_BINDIR}"
-            COMPONENT hipBLASLt_Runtime
-        PUBLIC_HEADER
-            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-            COMPONENT hipBLASLt_Development
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-    )
-    install(
-        EXPORT hipblaslt-targets
-        NAMESPACE roc::
-        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hipblaslt
-    )
+    # work around code object stripping failure if using /usr/bin/strip
+    set(CPACK_RPM_SPEC_MORE_DEFINE "%define __strip /opt/rocm/llvm/bin/llvm-strip") # need to generalize this
     get_target_property(hipblaslt_public_headers roc::hipblaslt INTERFACE_SOURCES)
+
     install(
         FILES ${hipblaslt_public_headers}
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/hipblaslt"
@@ -256,150 +260,168 @@ if(HIPBLASLT_ENABLE_HOST)
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
         COMPONENT hipBLASLt_Development
     )
-    write_basic_package_version_file(
-        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config-version.cmake"
-        VERSION ${PROJECT_VERSION}
-        COMPATIBILITY SameMajorVersion
-    )
-    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/hipblaslt-config.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake" @ONLY)
-    install(FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config-version.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/hipblaslt-config.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hipblaslt"
-        COMPONENT hipBLASLt_Development
-    )
-    install(
-        FILES "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md"
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
-        COMPONENT hipBLASLt_Docs
-    )
 
-    if(HIPBLASLT_ENABLE_DEVICE)
-        install(
-            DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/Tensile/library"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/hipblaslt"
-            COMPONENT hipBLASLt_Runtime
-        )
-    endif()
+    rocm_install_targets(TARGETS hipblaslt)
 
-    if(HIPBLASLT_ENABLE_CLIENT)
-        install(
-            TARGETS hipblaslt-bench
-            EXPORT hipblaslt-targets
-            COMPONENT hipBLASLt_Runtime
-        )
-        if(BUILD_TESTING OR HIPBLASLT_BUILD_TESTING)
-            install(
-                TARGETS hipblaslt-test
-                EXPORT hipblaslt-targets
-                COMPONENT hipBLASLt_Runtime
-            )
-            install(
-                FILES "${CMAKE_CURRENT_BINARY_DIR}/clients/hipblaslt_gtest.data"
-                DESTINATION "${CMAKE_INSTALL_BINDIR}"
-                COMPONENT hipBLASLt_Runtime
-            )
-        endif()
-        if(HIPBLASLT_ENABLE_SAMPLES)
-            install(
-                TARGETS
-                    sample_hipblaslt_gemm
-                    sample_hipblaslt_gemm_ext
-                    sample_hipblaslt_gemm_batched
-                    sample_hipblaslt_gemm_batched_ext
-                    sample_hipblaslt_gemm_tuning_splitk_ext
-                    sample_hipblaslt_gemm_bias
-                    sample_hipblaslt_gemm_bias_ext
-                    sample_hipblaslt_gemm_get_all_algos
-                    sample_hipblaslt_gemm_get_all_algos_ext
-                    sample_hipblaslt_gemm_get_algo_by_index_ext
-                    sample_hipblaslt_gemm_alphavec_ext
-                    sample_hipblaslt_gemm_gelu_aux_bias
-                    sample_hipblaslt_gemm_gelu_aux_bias_ext
-                    sample_hipblaslt_gemm_amax
-                    sample_hipblaslt_gemm_amax_ext
-                    sample_hipblaslt_gemm_amax_with_scale
-                    sample_hipblaslt_gemm_amax_with_scale_ext
-                    sample_hipblaslt_gemm_bgradb
-                    sample_hipblaslt_gemm_ext_bgradb
-                    sample_hipblaslt_gemm_dgelu_bgrad
-                    sample_hipblaslt_gemm_dgelu_bgrad_ext
-                    sample_hipblaslt_gemm_is_tuned_ext
-                    sample_hipblaslt_gemm_tuning_wgm_ext
-                    sample_hipblaslt_gemm_with_scale_a_b
-                    sample_hipblaslt_gemm_with_scale_a_b_ext
-                    sample_hipblaslt_groupedgemm_ext
-                    sample_hipblaslt_groupedgemm_fixed_mk_ext
-                    sample_hipblaslt_groupedgemm_get_all_algos_ext
-                    sample_hipblaslt_gemm_mix_precision
-                    sample_hipblaslt_gemm_mix_precision_ext
-                    sample_hipblaslt_gemm_mix_precision_with_amax_ext
-                    sample_hipblaslt_gemm_attr_tciA_tciB
-                    sample_hipblaslt_ext_op_layernorm
-                    sample_hipblaslt_ext_op_amax
-                    sample_hipblaslt_ext_op_amax_with_scale
-                    sample_hipblaslt_gemm_with_TF32
-                    sample_hipblaslt_gemm_swizzle_a
-                    sample_hipblaslt_gemm_bias_swizzle_a_ext
-                    sample_hipblaslt_weight_swizzle_padding
-                    sample_hipblaslt_gemm_swish_bias
-                EXPORT hipblaslt-targets
-                COMPONENT hipBLASLt_Runtime
-            )
-        endif()
-    endif()
-
-    set(CPACK_PACKAGE_NAME "hipBLASLt")
-    set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")
-    set(CPACK_PACKAGE_CONTACT "hipBLASLt Maintainer <hipblaslt-maintainer@amd.com>")
-    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "HIP library for GEMM operation with extended functionality")
-    set(CPACK_PACKAGE_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-    set(CPACK_PACKAGE_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-    set(CPACK_PACKAGE_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-    set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
-    set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_LIST_DIR}/../LICENSE.md)
-    set(CPACK_RESOURCE_FILE_README ${CMAKE_CURRENT_LIST_DIR}/../README.md)
-    set(CPACK_VERBATIM_VARIABLES YES)
-    set(CPACK_COMPONENTS_ALL "hipBLASLt_Runtime;hipBLASLt_Development;hipBLASLt_Docs")
-
-    set(CPACK_COMPONENTS_GROUPING IGNORE)
-
-    set(CPACK_DEB_COMPONENT_INSTALL ON)
-    set(CPACK_DEBIAN_FILE_NAME "DEB-DEFAULT")
-    set(CPACK_DEBIAN_HIPBLASLT_RUNTIME_PACKAGE_NAME "hipblaslt")
-    set(CPACK_DEBIAN_HIPBLASLT_RUNTIME_PACKAGE_SECTION "runtime")
-    set(CPACK_DEBIAN_HIPBLASLT_DEVELOPMENT_PACKAGE_NAME "hipblaslt-dev")
-    set(CPACK_DEBIAN_HIPBLASLT_DOCS_PACKAGE_NAME "hipblaslt-docs")
-    set(CPACK_DEBIAN_PACKAGE_PROVIDES "hipblaslt (= ${PROJECT_VERSION})")
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "hipblas-common (>=1.0)")
-
-    set(CPACK_RPM_COMPONENT_INSTALL ON)
-    set(CPACK_RPM_FILE_NAME "RPM-DEFAULT")
-    set(CPACK_RPM_HIPBLASLT_RUNTIME_PACKAGE_NAME "hipblaslt")
-    set(CPACK_RPM_HIPBLASLT_DEVELOPMENT_PACKAGE_NAME "hipblaslt-devel")
-    set(CPACK_RPM_HIPBLASLT_DOCS_PACKAGE_NAME "hipblaslt-docs")
-    set(CPACK_RPM_HIPBLASLT_RUNTIME_PACKAGE_REQUIRES "hipblaslt (= ${PROJECT_VERSION})")
-    set(CPACK_RPM_PACKAGE_PROVIDES "hipblaslt (= ${PROJECT_VERSION})")
-    set(CPACK_RPM_PACKAGE_DEPENDS "hipblas-common (>=1.0)")
-    
-    include(CPack)
-    
-    cpack_add_component(hipBLASLt_Runtime
-        DISPLAY_NAME "Runtime"
-        DESCRIPTION "Runtime libraries for hipBLASLt"
-        # GROUP Runtime
-        REQUIRED
-    )
-    cpack_add_component(hipBLASLt_Development
-        DISPLAY_NAME "Development"
-        DESCRIPTION "Headers and CMake files for hipBLASLt"
-        # GROUP Development
-        DEPENDS hipBLASLt_Runtime
-    )
-    cpack_add_component(hipBLASLt_Docs
-        DISPLAY_NAME "Documentation"
-        DESCRIPTION "Documentation for hipBLASLt"
-        # GROUP Documentation
+    rocm_export_targets(
+        TARGETS roc::hipblaslt
+        DEPENDS PACKAGE hip
+        DEPENDS PACKAGE hipblas-common
+        NAMESPACE roc::
     )
 endif()
+
+if(HIPBLASLT_ENABLE_DEVICE)
+    if(WIN32)
+        set(HIPBLASLT_TENSILE_LIBRARY_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}hipblaslt/bin" CACHE PATH "path to tensile library")
+    else()
+        set(HIPBLASLT_TENSILE_LIBRARY_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}${CMAKE_INSTALL_LIBDIR}/hipblaslt" CACHE PATH "path to tensile library")
+    endif()
+    rocm_install(
+        DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Tensile/library
+        DESTINATION ${HIPBLASLT_TENSILE_LIBRARY_DIR}
+        COMPONENT devel #may need to conditionally set this
+    )
+endif()
+
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.md")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+
+if(NOT CPACK_PACKAGING_INSTALL_PREFIX)
+    set(CPACK_PACKAGING_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+endif()
+
+include(ROCMCreatePackage)
+include(ROCMClients)
+
+#set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "\${CPACK_PACKAGING_INSTALL_PREFIX}" "\${CPACK_PACKAGING_INSTALL_PREFIX}/include" "\${CPACK_PACKAGING_INSTALL_PREFIX}/lib")
+
+set(GFORTRAN_RPM "libgfortran4")
+set(GFORTRAN_DEB "libgfortran4")
+if(CLIENTS_OS STREQUAL "centos" OR CLIENTS_OS STREQUAL "rhel")
+    if(CLIENTS_OS_VERSION VERSION_GREATER_EQUAL "8")
+        set(GFORTRAN_RPM "libgfortran")
+    endif()
+elseif(CLIENTS_OS STREQUAL "ubuntu" AND CLIENTS_OS_VERSION VERSION_GREATER_EQUAL "20.04")
+    set(GFORTRAN_DEB "libgfortran5")
+elseif(CLIENTS_OS STREQUAL "mariner" OR CLIENTS_OS STREQUAL "azurelinux")
+    set(GFORTRAN_RPM "gfortran")
+endif()
+
+if(HIPBLASLT_ENABLE_CLIENT)
+    rocm_install(
+        FILES 
+            "${HIPBLASLT_CLIENTS_DIR}/include/hipblaslt_common.yaml"
+            "${HIPBLASLT_CLIENTS_DIR}/include/hipblaslt_template.yaml"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT clients-common
+    )
+    rocm_install(
+        PROGRAMS "${HIPBLASLT_CLIENTS_DIR}/common/hipblaslt_gentest.py"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT clients-common
+    )
+    rocm_install(TARGETS hipblaslt-bench COMPONENT benchmarks)
+    rocm_install(
+        FILES "${HIPBLASLT_CLIENTS_DIR}/benchmarks/sequence.yaml"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT benchmarks
+    )
+
+    if(HIPBLASLT_ENABLE_MARKER)
+        rocm_package_add_dependencies(DEPENDS "roctracer >= 1.0.0")
+    endif()
+
+    if(NOT CLIENTS_OS)
+        rocm_set_os_id(CLIENTS_OS)
+        string(TOLOWER "${CLIENTS_OS}" CLIENTS_OS)
+        rocm_read_os_release(CLIENTS_OS_VERSION VERSION_ID)
+    endif()
+
+    rocm_package_setup_component(clients)
+    rocm_package_setup_client_component(clients-common)
+    rocm_package_setup_client_component(benchmarks
+        DEPENDS
+        COMPONENT clients-common
+        DEB "${GFORTRAN_DEB}"
+        RPM "${GFORTRAN_RPM}"
+    )
+
+endif()
+
+if(HIPBLASLT_BUILD_TESTING OR BUILD_TESTING)
+    rocm_install(
+        TARGETS hipblaslt-test
+        COMPONENT tests
+    )
+    rocm_install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/clients/hipblaslt_gtest.data"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT tests
+    )
+    rocm_package_setup_client_component(tests
+        DEPENDS
+        COMPONENT clients-common
+        DEB "${GFORTRAN_DEB}"
+        RPM "${GFORTRAN_RPM}"
+    )
+endif()
+
+if(HIPBLASLT_ENABLE_SAMPLES)
+    install(
+        TARGETS
+            sample_hipblaslt_gemm
+            sample_hipblaslt_gemm_ext
+            sample_hipblaslt_gemm_batched
+            sample_hipblaslt_gemm_batched_ext
+            sample_hipblaslt_gemm_tuning_splitk_ext
+            sample_hipblaslt_gemm_bias
+            sample_hipblaslt_gemm_bias_ext
+            sample_hipblaslt_gemm_get_all_algos
+            sample_hipblaslt_gemm_get_all_algos_ext
+            sample_hipblaslt_gemm_get_algo_by_index_ext
+            sample_hipblaslt_gemm_alphavec_ext
+            sample_hipblaslt_gemm_gelu_aux_bias
+            sample_hipblaslt_gemm_gelu_aux_bias_ext
+            sample_hipblaslt_gemm_amax
+            sample_hipblaslt_gemm_amax_ext
+            sample_hipblaslt_gemm_amax_with_scale
+            sample_hipblaslt_gemm_amax_with_scale_ext
+            sample_hipblaslt_gemm_bgradb
+            sample_hipblaslt_gemm_ext_bgradb
+            sample_hipblaslt_gemm_dgelu_bgrad
+            sample_hipblaslt_gemm_dgelu_bgrad_ext
+            sample_hipblaslt_gemm_is_tuned_ext
+            sample_hipblaslt_gemm_tuning_wgm_ext
+            sample_hipblaslt_gemm_with_scale_a_b
+            sample_hipblaslt_gemm_with_scale_a_b_ext
+            sample_hipblaslt_groupedgemm_ext
+            sample_hipblaslt_groupedgemm_fixed_mk_ext
+            sample_hipblaslt_groupedgemm_get_all_algos_ext
+            sample_hipblaslt_gemm_mix_precision
+            sample_hipblaslt_gemm_mix_precision_ext
+            sample_hipblaslt_gemm_mix_precision_with_amax_ext
+            sample_hipblaslt_gemm_attr_tciA_tciB
+            sample_hipblaslt_ext_op_layernorm
+            sample_hipblaslt_ext_op_amax
+            sample_hipblaslt_ext_op_amax_with_scale
+            sample_hipblaslt_gemm_with_TF32
+            sample_hipblaslt_gemm_swizzle_a
+            sample_hipblaslt_gemm_bias_swizzle_a_ext
+            sample_hipblaslt_weight_swizzle_padding
+            sample_hipblaslt_gemm_swish_bias
+        RUNTIME
+        COMPONENT samples
+        DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/hipblaslt-samples
+    )
+    rocm_package_setup_client_component(samples)
+endif()
+
+set(HIPBLASLT_CONFIG_DIR "\${CPACK_PACKAGING_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" CACHE PATH "Path placed into ldconfig file")
+rocm_create_package(
+    NAME hipblaslt
+    DESCRIPTION "HIP library for GEMM operations with extended functionality"
+    MAINTAINER "hipBLASLt Maintainer <hipblaslt-maintainer@amd.com>"
+    LDCONFIG
+    LDCONFIG_DIR ${HIPBLASLT_CONFIG_DIR}
+)


### PR DESCRIPTION
- Restore usage of rocm-cmake.
- continue using Dependencies.cmake to pull in rocm-cmake.