### PR TITLE
[Fix the build rpath for rpm packaging]

### DIFF
--- a/clients/CMakeLists.txt
+++ b/clients/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(OpenMP)
 
 if (TARGET OpenMP::OpenMP_CXX)
   set( COMMON_LINK_LIBS "OpenMP::OpenMP_CXX")
-  list( APPEND COMMON_LINK_LIBS "-L${HIP_CLANG_ROOT}/lib;-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+  list( APPEND COMMON_LINK_LIBS "-L${HIP_CLANG_ROOT}/lib")
 endif()
 
 if (TARGET Threads::Threads)

--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -98,6 +98,8 @@ target_link_libraries( hipblaslt-bench PRIVATE ${COMMON_LINK_LIBS} )
 
 set_target_properties( hipblaslt-bench PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+  BUILD_RPATH "${HIP_CLANG_ROOT}/lib"
+  INSTALL_RPATH "$ORIGIN/../llvm/lib"
 )
 
 add_dependencies( hipblaslt-bench hipblaslt-common )

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -120,6 +120,8 @@ set_target_properties( hipblaslt-test PROPERTIES
   IMPORT_SUFFIX ".lib"
   LINKER_LANGUAGE CXX
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/staging"
+  BUILD_RPATH "${HIP_CLANG_ROOT}/lib"
+  INSTALL_RPATH "$ORIGIN/../llvm/lib"
 )
 
 set( HIPBLASLT_TEST_DATA "${PROJECT_BINARY_DIR}/staging/hipblaslt_gtest.data")


### PR DESCRIPTION
The build rpath set by COMMON_LINK_LIBS will be ignored during the install process. Use set_target_properties() to prepend it to the build rpath list.