### PR TITLE
Enable non-DTL loads in DTL tailloop for 16b/8b types

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -84,7 +84,6 @@ class ABMatrixInfo(MatrixInfo):
   numVgprValuPerBlock: int       = -1
   numVgprG2L: int                = -1
   numVgprG2LAllocated: int       = -1
-  numVgprG2LTailLoop: int        = -1
   numVgprG2LTailLoopAllocated: int= -1
   startVgprG2L: Optional[int]    = None
   numVgprLocalReadAddr:int       = -1
@@ -2984,9 +2983,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       module.add(moduleMacroG2lVgpr)
 
       # Check out VGPR for LW
-      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
-        moduleMacroDTLLWVgpr, vgprLW = self.tailLoopAllocDTLLWVgpr(kernel)
-        module.add(moduleMacroDTLLWVgpr)
+      moduleMacroDTLLWVgpr, vgprLW = self.tailLoopAllocDTLLWVgpr(kernel)
+      module.add(moduleMacroDTLLWVgpr)
 
       module.add(self.calculateLoopNumIter(kernel, tensorParametersA, tensorParametersB, -1))
       if self.states.actualSummationLoops==1:
@@ -3017,9 +3015,17 @@ class KernelWriter(metaclass=abc.ABCMeta):
       globalReadMode1st = 3 if tensorParameters1st["isSwizzled"] else globalReadMode1st
       globalReadMode2nd = 3 if tensorParameters2nd["isSwizzled"] else globalReadMode2nd
 
-      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
-        globalReadMode1st = 2
-        globalReadMode2nd = 2
+      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
+        if tc1 == 'A':
+          globalReadMode1st = 2
+        elif tc2 == 'A':
+          globalReadMode2nd = 2
+
+      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
+        if tc1 == 'B':
+          globalReadMode1st = 2
+        elif tc2 == 'B':
+          globalReadMode2nd = 2
 
       module.addComment1("Update M0 for DTLDS")
       moduleTmp = self.directToLdsM0Update(kernel, 1, tensorParameters1st)
@@ -3929,17 +3935,16 @@ class KernelWriter(metaclass=abc.ABCMeta):
     if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
       self.states.a.numVgprG2L = statesANumVgprG2L
       self.states.a.numVgprG2LAllocated = statesANumVgprG2LAllocated
-      self.states.a.numVgprG2LTailloop = self.states.a.numVgprG2L
       self.states.a.numVgprG2LTailloopAllocated = self.states.a.numVgprG2LAllocated
     else:
       self.states.a.numVgprG2L = 0
       self.states.a.numVgprG2LAllocated = 0
-      self.states.a.numVgprG2LTailloop = statesANumVgprG2L
       self.states.a.numVgprG2LTailloopAllocated = statesANumVgprG2LAllocated
     # using _ds_store_b8: need one more vgpr space to do lshr
     if tensorParametersA["localWriteInstruction"].blockWidth == 0.25:
       self.states.a.numVgprG2L = self.states.a.numVgprG2L * 2
-      self.states.a.numVgprG2LAllocated = self.states.a.numVgprG2LAllocated + numVgprG2LAllocatedLocal
+      self.states.a.numVgprG2LAllocated += numVgprG2LAllocatedLocal
+      self.states.a.numVgprG2LTailloopAllocated += numVgprG2LAllocatedLocal
     # double numVgprG2L if DirectToVgpr is enabled
     if kernel["DirectToVgprA"]:
       self.states.a.numVgprG2L *= 2
@@ -3970,18 +3975,16 @@ class KernelWriter(metaclass=abc.ABCMeta):
     if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
       self.states.b.numVgprG2L = statesBNumVgprG2L
       self.states.b.numVgprG2LAllocated = statesBNumVgprG2LAllocated
-      self.states.b.numVgprG2LTailloop = self.states.b.numVgprG2L
       self.states.b.numVgprG2LTailloopAllocated = self.states.b.numVgprG2LAllocated
     else:
       self.states.b.numVgprG2L = 0
       self.states.b.numVgprG2LAllocated = 0
-      self.states.b.numVgprG2LTailloop = statesBNumVgprG2L
       self.states.b.numVgprG2LTailloopAllocated = statesBNumVgprG2LAllocated
     # using _ds_store_b8: need one more vgpr space to do lshr
     if tensorParametersB["localWriteInstruction"].blockWidth == 0.25:
       self.states.b.numVgprG2L = self.states.b.numVgprG2L * 2
-      self.states.b.numVgprG2LAllocated = self.states.b.numVgprG2LAllocated + numVgprG2LAllocatedLocal
-
+      self.states.b.numVgprG2LAllocated += numVgprG2LAllocatedLocal
+      self.states.b.numVgprG2LTailloopAllocated += numVgprG2LAllocatedLocal
     # double numVgprG2L if DirectToVgpr is enabled
     if kernel["DirectToVgprB"]:
       self.states.b.numVgprG2L *= 2

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3969,7 +3969,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
     if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and (bpeMax * vwb < self.states.bpr):
       # This check is to reserve porential usage of VGPRs for gfx12 8-bit code gen
       # We should optimize the usage for better performance.
-      statesBNumVgprG2LAllocated = statesBNumVgprG2LAllocated * (int)(self.states.bpr/(bpeMax * vwb))
+      statesBNumVgprG2LAllocated = statesBNumVgprG2L * (int)(self.states.bpr/(bpeMax * vwb))
     else:
       statesBNumVgprG2LAllocated = statesBNumVgprG2L
     if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3015,13 +3015,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
       globalReadMode1st = 3 if tensorParameters1st["isSwizzled"] else globalReadMode1st
       globalReadMode2nd = 3 if tensorParameters2nd["isSwizzled"] else globalReadMode2nd
 
-      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
+      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]:
         if tc1 == 'A':
           globalReadMode1st = 2
         elif tc2 == 'A':
           globalReadMode2nd = 2
 
-      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
+      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]:
         if tc1 == 'B':
           globalReadMode1st = 2
         elif tc2 == 'B':
@@ -3076,13 +3076,13 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.oriLwaA = None # back up original local write address vgpr
       self.oriLwaB = None
       self.oriLwaM = None
-      if not kernel["NoLdsWriteCode"] or kernel["NonDTLTailLoop"]:
+      if not kernel["NoLdsWriteCode"] or kernel["NonDTLTailLoopA"] or kernel["NonDTLTailLoopB"]:
         # tail: local write
-        if not (kernel["DirectToLdsA"] and not kernel["NonDTLTailLoop"]):
+        if not (kernel["DirectToLdsA"] and not kernel["NonDTLTailLoopA"]):
           module.addComment1("local write a")
           tempLWCodeModA = self.localWriteDo(kernel, tensorParametersA)
           module.add(tempLWCodeModA)
-        if not (kernel["DirectToLdsB"] and not kernel["NonDTLTailLoop"]):
+        if not (kernel["DirectToLdsB"] and not kernel["NonDTLTailLoopB"]):
           module.addComment1("local write b")
           tempLWCodeModB = self.localWriteDo(kernel, tensorParametersB)
           module.add(tempLWCodeModB)
@@ -3098,7 +3098,7 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # tail: free G2L Vgpr
       module.add(self.tailLoopFreeVgpr(vgprG2L, moduleMacroG2lVgpr))
 
-      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
+      if (kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]) or (kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]):
         module.add(self.tailLoopFreeVgpr(vgprLW, moduleMacroDTLLWVgpr))
 
       # Check out VGPR for ALU
@@ -4026,9 +4026,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.a.numVgprLocalWriteSwapAddr = 0
     self.states.b.numVgprLocalWriteSwapAddr = 0
     self.states.m.numVgprLocalWriteSwapAddr = 0
-    self.states.a.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]) else 1 * self.states.rpla
-    self.states.b.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]) else 1 * self.states.rpla
+    self.states.a.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]) else 1 * self.states.rpla
+    self.states.b.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]) else 1 * self.states.rpla
 
+    # TODO: Refactor vgpr multiplier calculation
+    # based on comments here: https://github.com/ROCm/hipBLASLt/pull/2061/files#r2085714139
     if self.states.archCaps["DeviceLDS"] > 65536 and not kernel["StoreSwapAddr"]:
       need128K = kernel["LdsOffsetA_Blk"]>=131072 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"]
       need64K = kernel["LdsOffsetA_Blk"]>=65536 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"]

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -84,11 +84,14 @@ class ABMatrixInfo(MatrixInfo):
   numVgprValuPerBlock: int       = -1
   numVgprG2L: int                = -1
   numVgprG2LAllocated: int       = -1
+  numVgprG2LTailLoop: int        = -1
+  numVgprG2LTailLoopAllocated: int= -1
   startVgprG2L: Optional[int]    = None
   numVgprLocalReadAddr:int       = -1
   startVgprLocalReadAddr: int    = -1
   numVgprLocalWriteAddr: int     = -1
   startVgprLocalWriteAddr: int   = -1
+  numVgprLocalWriteAddrTailLoop: int= -1
   numVgprGlobalReadOffsets: int  = -1
   startVgprGlobalReadOffset: int = -1
   numVgprLocalReadSwapAddr: int  = -1
@@ -2980,6 +2983,11 @@ class KernelWriter(metaclass=abc.ABCMeta):
       moduleMacroG2lVgpr, vgprG2L = self.tailLoopAllocG2LVgpr(kernel)
       module.add(moduleMacroG2lVgpr)
 
+      # Check out VGPR for LW
+      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
+        moduleMacroDTLLWVgpr, vgprLW = self.tailLoopAllocDTLLWVgpr(kernel)
+        module.add(moduleMacroDTLLWVgpr)
+
       module.add(self.calculateLoopNumIter(kernel, tensorParametersA, tensorParametersB, -1))
       if self.states.actualSummationLoops==1:
         module.addComment1("remove stagger offsets for tail loop")
@@ -3008,6 +3016,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       globalReadMode1st = 3 if tensorParameters1st["isSwizzled"] else globalReadMode1st
       globalReadMode2nd = 3 if tensorParameters2nd["isSwizzled"] else globalReadMode2nd
+
+      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
+        globalReadMode1st = 2
+        globalReadMode2nd = 2
 
       module.addComment1("Update M0 for DTLDS")
       moduleTmp = self.directToLdsM0Update(kernel, 1, tensorParameters1st)
@@ -3047,6 +3059,10 @@ class KernelWriter(metaclass=abc.ABCMeta):
       module.add(self._wait(kernel, tensorParameters1st, tensorParameters2nd, 0, -1, -1, "2wait for global read"))
       module.add(self._syncThreads(kernel))
 
+      # init local write offsets to nondtl loads in tail loop.
+      module.add(self.lwaInitAddressesForDTLTailLoop(kernel, tensorParameters1st))
+      module.add(self.lwaInitAddressesForDTLTailLoop(kernel, tensorParameters2nd))
+
       # the following read/write addresses could be modified in recalcLocal(Read|Write)Addresses due to policy change
       self.oriLraA = None # back up original local read address vgpr
       self.oriLraB = None
@@ -3054,14 +3070,16 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.oriLwaA = None # back up original local write address vgpr
       self.oriLwaB = None
       self.oriLwaM = None
-      if not kernel["NoLdsWriteCode"]:
+      if not kernel["NoLdsWriteCode"] or kernel["NonDTLTailLoop"]:
         # tail: local write
-        module.addComment1("local write a")
-        tempLWCodeModA = self.localWriteDo(kernel, tensorParametersA)
-        module.add(tempLWCodeModA)
-        module.addComment1("local write b")
-        tempLWCodeModB = self.localWriteDo(kernel, tensorParametersB)
-        module.add(tempLWCodeModB)
+        if not (kernel["DirectToLdsA"] and not kernel["NonDTLTailLoop"]):
+          module.addComment1("local write a")
+          tempLWCodeModA = self.localWriteDo(kernel, tensorParametersA)
+          module.add(tempLWCodeModA)
+        if not (kernel["DirectToLdsB"] and not kernel["NonDTLTailLoop"]):
+          module.addComment1("local write b")
+          tempLWCodeModB = self.localWriteDo(kernel, tensorParametersB)
+          module.add(tempLWCodeModB)
       # change local read policy from wider local read to one unit of K at a time
       # DirectToVgpr case, use original wider local read instead of recalculating local read address
       if not (kernel["DirectToVgprA"] or kernel["DirectToVgprB"]):
@@ -3073,6 +3091,9 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
       # tail: free G2L Vgpr
       module.add(self.tailLoopFreeVgpr(vgprG2L, moduleMacroG2lVgpr))
+
+      if (kernel["DirectToLdsA"] or kernel["DirectToLdsB"]) and kernel["NonDTLTailLoop"]:
+        module.add(self.tailLoopFreeVgpr(vgprLW, moduleMacroDTLLWVgpr))
 
       # Check out VGPR for ALU
       valuResources = self.tailLoopAllocValuVgpr(kernel, tensorParametersA, tensorParametersB, tPM)
@@ -3891,22 +3912,30 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.a.numVgprG2L = 0
     numVgprG2LAllocatedLocal = 0
 
-    if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
-      bpeMax = tensorParametersA["bpeDS"] if kernel["ConvertAfterDS"] else max(tensorParametersA["bpeGR"], tensorParametersA["bpe"])
-      self.states.a.numVgprG2L = roundUp((kernel["NumLoadsCoalescedA"] * kernel["NumLoadsPerpendicularA"] * \
+
+    bpeMax = tensorParametersA["bpeDS"] if kernel["ConvertAfterDS"] else max(tensorParametersA["bpeGR"], tensorParametersA["bpe"])
+    statesANumVgprG2L = roundUp((kernel["NumLoadsCoalescedA"] * kernel["NumLoadsPerpendicularA"] * \
         kernel["GlobalReadVectorWidthA"] * bpeMax) / (float)(self.states.bpr))
-      tpA      = self.states.bpr if bpeMax * vwa < self.states.bpr else bpeMax * vwa
-      tpALocal = self.states.bpr if tensorParametersA["bpe"] * vwa < self.states.bpr else tensorParametersA["bpe"] * vwa
-      numVgprG2LAllocatedLocal = roundUp((kernel["NumLoadsCoalescedA"] * kernel["NumLoadsPerpendicularA"] * \
+    tpA      = self.states.bpr if bpeMax * vwa < self.states.bpr else bpeMax * vwa
+    tpALocal = self.states.bpr if tensorParametersA["bpe"] * vwa < self.states.bpr else tensorParametersA["bpe"] * vwa
+    numVgprG2LAllocatedLocal = roundUp((kernel["NumLoadsCoalescedA"] * kernel["NumLoadsPerpendicularA"] * \
         tpALocal) / (float)(self.states.bpr))
-      if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and (bpeMax * vwa < self.states.bpr):
-        # This check is to reserve porential usage of VGPRs for gfx12 8-bit code gen
-        # We should optimize the usage for better performance.
-        self.states.a.numVgprG2LAllocated = self.states.a.numVgprG2L * (int)(self.states.bpr/(bpeMax * vwa))
-      else:
-        self.states.a.numVgprG2LAllocated = self.states.a.numVgprG2L
+    if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and (bpeMax * vwa < self.states.bpr):
+      # This check is to reserve porential usage of VGPRs for gfx12 8-bit code gen
+      # We should optimize the usage for better performance.
+      statesANumVgprG2LAllocated = statesANumVgprG2L * (int)(self.states.bpr/(bpeMax * vwa))
     else:
+      statesANumVgprG2LAllocated = statesANumVgprG2L
+    if not kernel["DirectToLdsA"] or self.do["KeepDirectToLdsAlloc"]:
+      self.states.a.numVgprG2L = statesANumVgprG2L
+      self.states.a.numVgprG2LAllocated = statesANumVgprG2LAllocated
+      self.states.a.numVgprG2LTailloop = self.states.a.numVgprG2L
+      self.states.a.numVgprG2LTailloopAllocated = self.states.a.numVgprG2LAllocated
+    else:
+      self.states.a.numVgprG2L = 0
       self.states.a.numVgprG2LAllocated = 0
+      self.states.a.numVgprG2LTailloop = statesANumVgprG2L
+      self.states.a.numVgprG2LTailloopAllocated = statesANumVgprG2LAllocated
     # using _ds_store_b8: need one more vgpr space to do lshr
     if tensorParametersA["localWriteInstruction"].blockWidth == 0.25:
       self.states.a.numVgprG2L = self.states.a.numVgprG2L * 2
@@ -3924,22 +3953,30 @@ class KernelWriter(metaclass=abc.ABCMeta):
 
     self.states.b.numVgprG2L = 0
     numVgprG2LAllocatedLocal = 0
-    if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
-      bpeMax = tensorParametersB["bpeDS"] if kernel["ConvertAfterDS"] else max(tensorParametersB["bpeGR"], tensorParametersB["bpe"])
-      self.states.b.numVgprG2L = roundUp((kernel["NumLoadsCoalescedB"] * kernel["NumLoadsPerpendicularB"] * \
+
+    bpeMax = tensorParametersB["bpeDS"] if kernel["ConvertAfterDS"] else max(tensorParametersB["bpeGR"], tensorParametersB["bpe"])
+    statesBNumVgprG2L = roundUp((kernel["NumLoadsCoalescedB"] * kernel["NumLoadsPerpendicularB"] * \
         kernel["GlobalReadVectorWidthB"] * bpeMax) / (float)(self.states.bpr))
-      tpB      = self.states.bpr if bpeMax * vwb < self.states.bpr else bpeMax * vwb
-      tpBLocal = self.states.bpr if tensorParametersB["bpe"] * vwb < self.states.bpr else tensorParametersB["bpe"] * vwb
-      numVgprG2LAllocatedLocal = roundUp((kernel["NumLoadsCoalescedB"] * kernel["NumLoadsPerpendicularB"] * \
+    tpB      = self.states.bpr if bpeMax * vwb < self.states.bpr else bpeMax * vwb
+    tpBLocal = self.states.bpr if tensorParametersB["bpe"] * vwb < self.states.bpr else tensorParametersB["bpe"] * vwb
+    numVgprG2LAllocatedLocal = roundUp((kernel["NumLoadsCoalescedB"] * kernel["NumLoadsPerpendicularB"] * \
         tpBLocal) / (float)(self.states.bpr))
-      if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and (bpeMax * vwb < self.states.bpr):
-        # This check is to reserve porential usage of VGPRs for gfx12 8-bit code gen
-        # We should optimize the usage for better performance.
-        self.states.b.numVgprG2LAllocated = self.states.b.numVgprG2L * (int)(self.states.bpr/(bpeMax * vwb))
-      else:
-        self.states.b.numVgprG2LAllocated = self.states.b.numVgprG2L
+    if (self.states.archCaps["HasEccHalf"] or not self.states.asmCaps["HasWMMA_V1"]) and (bpeMax * vwb < self.states.bpr):
+      # This check is to reserve porential usage of VGPRs for gfx12 8-bit code gen
+      # We should optimize the usage for better performance.
+      statesBNumVgprG2LAllocated = statesBNumVgprG2LAllocated * (int)(self.states.bpr/(bpeMax * vwb))
     else:
+      statesBNumVgprG2LAllocated = statesBNumVgprG2L
+    if not kernel["DirectToLdsB"] or self.do["KeepDirectToLdsAlloc"]:
+      self.states.b.numVgprG2L = statesBNumVgprG2L
+      self.states.b.numVgprG2LAllocated = statesBNumVgprG2LAllocated
+      self.states.b.numVgprG2LTailloop = self.states.b.numVgprG2L
+      self.states.b.numVgprG2LTailloopAllocated = self.states.b.numVgprG2LAllocated
+    else:
+      self.states.b.numVgprG2L = 0
       self.states.b.numVgprG2LAllocated = 0
+      self.states.b.numVgprG2LTailloop = statesBNumVgprG2L
+      self.states.b.numVgprG2LTailloopAllocated = statesBNumVgprG2LAllocated
     # using _ds_store_b8: need one more vgpr space to do lshr
     if tensorParametersB["localWriteInstruction"].blockWidth == 0.25:
       self.states.b.numVgprG2L = self.states.b.numVgprG2L * 2
@@ -3986,6 +4023,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.a.numVgprLocalWriteSwapAddr = 0
     self.states.b.numVgprLocalWriteSwapAddr = 0
     self.states.m.numVgprLocalWriteSwapAddr = 0
+    self.states.a.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]) else 1 * self.states.rpla
+    self.states.b.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]) else 1 * self.states.rpla
 
     if self.states.archCaps["DeviceLDS"] > 65536 and not kernel["StoreSwapAddr"]:
       need128K = kernel["LdsOffsetA_Blk"]>=131072 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"]
@@ -3993,16 +4032,20 @@ class KernelWriter(metaclass=abc.ABCMeta):
       if need128K or kernel["LdsNumElementsAlignedA"]>=131072:
         self.states.a.numVgprLocalReadAddr *= 3
         self.states.a.numVgprLocalWriteAddr *= 3
+        self.states.a.numVgprLocalWriteAddrTailLoop *= 3
       elif need64K or kernel["LdsNumElementsAlignedA"]>=65536:
         self.states.a.numVgprLocalReadAddr *= 2
         self.states.a.numVgprLocalWriteAddr *= 2
+        self.states.a.numVgprLocalWriteAddrTailLoop *= 2
 
       if need128K or kernel["LdsNumElementsAlignedB"]>=131072:
         self.states.b.numVgprLocalReadAddr *= 3
         self.states.b.numVgprLocalWriteAddr *= 3
+        self.states.b.numVgprLocalWriteAddrTailLoop *= 3
       elif need64K or kernel["LdsNumElementsAlignedB"]>=65536:
         self.states.b.numVgprLocalReadAddr *= 2
         self.states.b.numVgprLocalWriteAddr *= 2
+        self.states.b.numVgprLocalWriteAddrTailLoop *= 2
 
       if need128K or kernel["LdsNumElementsAlignedMetadata"]>=131072:
         self.states.m.numVgprLocalReadAddr *= 3

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3078,14 +3078,12 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.oriLwaM = None
       if not kernel["NoLdsWriteCode"] or kernel["NonDTLTailLoopA"] or kernel["NonDTLTailLoopB"]:
         # tail: local write
-        if not (kernel["DirectToLdsA"] and not kernel["NonDTLTailLoopA"]):
-          module.addComment1("local write a")
-          tempLWCodeModA = self.localWriteDo(kernel, tensorParametersA)
-          module.add(tempLWCodeModA)
-        if not (kernel["DirectToLdsB"] and not kernel["NonDTLTailLoopB"]):
-          module.addComment1("local write b")
-          tempLWCodeModB = self.localWriteDo(kernel, tensorParametersB)
-          module.add(tempLWCodeModB)
+        module.addComment1("local write a")
+        tempLWCodeModA = self.localWriteDo(kernel, tensorParametersA)
+        module.add(tempLWCodeModA)
+        module.addComment1("local write b")
+        tempLWCodeModB = self.localWriteDo(kernel, tensorParametersB)
+        module.add(tempLWCodeModB)
       # change local read policy from wider local read to one unit of K at a time
       # DirectToVgpr case, use original wider local read instead of recalculating local read address
       if not (kernel["DirectToVgprA"] or kernel["DirectToVgprB"]):
@@ -3098,8 +3096,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
       # tail: free G2L Vgpr
       module.add(self.tailLoopFreeVgpr(vgprG2L, moduleMacroG2lVgpr))
 
-      if (kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]) or (kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]):
-        module.add(self.tailLoopFreeVgpr(vgprLW, moduleMacroDTLLWVgpr))
+      # tail: free Vgpr for local writes
+      module.add(self.tailLoopFreeVgpr(vgprLW, moduleMacroDTLLWVgpr))
 
       # Check out VGPR for ALU
       valuResources = self.tailLoopAllocValuVgpr(kernel, tensorParametersA, tensorParametersB, tPM)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4125,6 +4125,28 @@ class KernelWriterAssembly(KernelWriter):
                          comment="xor both lds buffer offsets to enable swapping"))
     return module
 
+
+  def lwaInitAddressesForDTLTailLoop(self, kernel, tP):
+    module = Module("lwaInitAddressesForDTLTailLoop")
+
+    tc = tP["tensorChar"]
+    waveSize = kernel["WavefrontSize"]
+    if kernel["DirectToLds%c"%tc] and kernel["NonDTLTailLoop"]:
+      module.addComment0("Set local write offsets for %c to be same as DTL %uB load"%(tc, kernel["GlobalReadVectorWidth%c"%tc] * tP["bpe"]))
+      module.add(VAndB32(dst=vgpr("LocalWriteAddr%c"%tc), src0=(waveSize - 1), src1=vgpr("Serial"), comment="Serial % wavesize"))
+      module.add(VLShiftLeftB32(dst=vgpr("LocalWriteAddr%c"%tc), shiftHex=hex(log2(kernel["GlobalReadVectorWidth%c"%tc] * tP["bpe"])), src=vgpr("LocalWriteAddr%c"%tc), comment=""))
+      module.add(VAddU32(dst=vgpr("LocalWriteAddr%s"%tc), src0=sgpr("LocalWriteAddr%c"%tc), src1=vgpr("LocalWriteAddr%s"%tc), \
+                         comment="" ))
+      numLw = 0
+      if tP["isA"]:
+        numLw = self.states.a.numVgprLocalWriteAddrTailLoop
+      elif tP["isB"]:
+        numLw = self.states.b.numVgprLocalWriteAddrTailLoop
+      for i in range(1,numLw):
+        module.add(VAddU32(dst=vgpr("LocalWriteAddr%s + %s"%(tc, i)), src0=(i * 0x10000), \
+                           src1=vgpr("LocalWriteAddr%s"%tc), comment="" ))
+    return module
+
   ##############################################################################
   # openShadowInit
   # Label after prefetches are launched.  This is present even if ShadowInit not
@@ -4542,11 +4564,15 @@ class KernelWriterAssembly(KernelWriter):
     if not kernel["DirectToVgprA"]:
       if ("ULSGRODoubleG2L" in kernel) and kernel["ULSGRODoubleG2L"] == 1:
         numG2LA = self.states.a.numVgprG2LAllocated*2
+      elif kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
+        numG2LA = self.states.a.numVgprG2LTailloopAllocated
       else:
         numG2LA = self.states.a.numVgprG2LAllocated
     if not kernel["DirectToVgprB"]:
       if ("ULSGRODoubleG2L" in kernel) and kernel["ULSGRODoubleG2L"] == 1:
         numG2LB = self.states.b.numVgprG2LAllocated*2
+      elif kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
+        numG2LB = self.states.b.numVgprG2LTailloopAllocated
       else:
         numG2LB = self.states.b.numVgprG2LAllocated
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
@@ -4565,14 +4591,37 @@ class KernelWriterAssembly(KernelWriter):
       imod.addComment0("Check out VGPR (numG2LA,numG2LB,numG2LMetadata) = (%d,%d,%d)"%(numG2LA,numG2LB,numG2LMetadata))
     if numG2LA > 0:
       imod.add(RegSet("v", "vgprG2LA_BASE", vgprBase))
-      imod.add(self.moduleVgprMacroG2LA)
+      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
+        imod.add(RegSet("v", "vgprG2LA", "vgprG2LA_BASE", 0))
+      else:
+        imod.add(self.moduleVgprMacroG2LA)
     if numG2LB > 0:
       imod.add(RegSet("v", "vgprG2LB_BASE", vgprBase + numG2LA))
-      imod.add(self.moduleVgprMacroG2LB)
+      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
+        imod.add(RegSet("v", "vgprG2LB", "vgprG2LB_BASE", 0))
+      else:
+        imod.add(self.moduleVgprMacroG2LB)
     if numG2LMetadata > 0:
       imod.add(RegSet("v", "vgprG2LMetadata", vgprBase + numG2LA + numG2LB))
 
     return imod, vgprBase
+
+  def tailLoopAllocDTLLWVgpr(self, kernel):
+    imod     = Module("tailLoopAllocDTLLWVgpr")
+    vgprBase = -1
+    numLWA   = self.states.a.numVgprLocalWriteAddrTailLoop
+    numLWB   = self.states.b.numVgprLocalWriteAddrTailLoop
+
+    if numLWA + numLWB > 0:
+      vgprBase = self.vgprPool.checkOutAligned(numLWA + numLWB, 2)
+      imod.addComment0("Check out VGPR (numLWA,numLWB) = (%d,%d)"%(numLWA,numLWB))
+    if numLWA > 0:
+      imod.add(RegSet("v", "vgprLocalWriteAddrA", vgprBase))
+    if numLWB > 0:
+      imod.add(RegSet("v", "vgprLocalWriteAddrB", vgprBase + numLWA))
+
+    return imod, vgprBase
+
 
   def tailLoopAllocDTVVgpr(self, kernel, tensorParametersA, tensorParametersB):
     imodA     = Module("tailLoopAllocDTVVgprA")
@@ -7471,7 +7520,7 @@ class KernelWriterAssembly(KernelWriter):
       isGlc = bool(tP["NonTemporal"] & 0x1)
       isSlc = bool(tP["NonTemporal"] & 0x2)
       isNT  = bool(tP["NonTemporal"] & 0x4)
-      isLds = True if kernel["DirectToLds%s"%tc] else False
+      isLds = True if (kernel["DirectToLds%s"%tc] and not kernel["NonDTLTailLoop"]) else False
 
       directToLdsLoads = 0
       if doTailOpt == 2 and behavior == "LOAD":
@@ -7550,14 +7599,7 @@ class KernelWriterAssembly(KernelWriter):
                   #   numElementsPerLoad = 2
                   # elif self.states.archCaps["HasEccHalf"]:
                   #   destVgprHi = self.vgprPool.checkOut(1, 'destVgprHi')
-                  if (not tP["isM"]) and kernel["DirectToLds%c"%tc] and (not tP["tlu"]) and tP["glvw"]>=4 and kernel["AssertSummationElementMultiple"] % 4 == 0:
-                    # Pack four byte values into a single load dword (for DTL only for now)
-                    numElementsPerLoad = 4
-                    dataIsByte = False
-                  else:
-                    dataIsByte = True
-
-                  if (not tP["isM"]) and kernel["DirectToLds%c"%tc] and (not tP["tlu"]) and tP["glvw"]>=4 and kernel["AssertSummationElementMultiple"] % 4 == 0:
+                  if (not tP["isM"]) and isLds and (not tP["tlu"]) and tP["glvw"]>=4 and kernel["AssertSummationElementMultiple"] % 4 == 0:
                     if tP["glvw"] == 4:
                       # Pack four byte values into a single load dword (for DTL only for now)
                       numElementsPerLoad = 4
@@ -7590,9 +7632,11 @@ class KernelWriterAssembly(KernelWriter):
                       eccOffset = _getEccOffset(tP["globalReadInstruction"].totalWidth, bpr=self.states.bpr, bpe=eccBpe, \
                         glvw=tP["glvw"], idx=loopCnt, numVgprG2L=numVgprG2L)
                 elif dataType.isHalf() or dataType.isBFloat16():
-                  if tP["glvw"]>1 and kernel["AssertSummationElementMultiple"] % 2 == 0:
+                  if tP["glvw"]>1 and kernel["AssertSummationElementMultiple"] % 2 == 0 and not isLds:
                   # Pack two FP16 values into a single load dword x2
                     numElementsPerLoad = 2
+                  elif isLds and kernel["AssertSummationElementMultiple"] % 2 == 0:
+                    numElementsPerLoad = kernel["GlobalReadVectorWidth%c"%tc]
                   elif self.states.archCaps["HasEccHalf"]:
                     # In some cards, loading half types into register will zero out
                     # the other half. Therefore we need to load into a separate register
@@ -7645,7 +7689,7 @@ class KernelWriterAssembly(KernelWriter):
                   if not kernel["_UseSgprForGRO"]:
                     soffset = "0"
                   # instruction offset with Sgpr for GRO
-                  elif kernel["DirectToLds%s"%tc] and kernel["UseInstOffsetForGRO"]:
+                  elif isLds and kernel["UseInstOffsetForGRO"]:
                     soffset = sgpr("ScalarGlobalReadOffset%s+%u"%(tc, graIdx))
                   # Sgpr for GRO
                   else:
@@ -7661,7 +7705,7 @@ class KernelWriterAssembly(KernelWriter):
                     soffset_prev = soffset
                     soffset = "0"
 
-                  if kernel["DirectToLds%s"%tc]:
+                  if isLds:
                     # need to increment ldsInc only once per each loopCnt
                     # this is pre count up, so increment it at r == 0
                     if r == 0:
@@ -7710,7 +7754,7 @@ class KernelWriterAssembly(KernelWriter):
                       # Pack two FP16 values into a single load dword x2
                       r += 1 # skip next element since we loaded 2X here
                       comment = "load packed 2X half buffer value"
-                    elif not kernel["DirectToLds%s"%tc]:
+                    elif not isLds:
                       hi16=loopCnt%2 if tP["glvw"]==1 else r%2
                       comment="load one buffer value"
 
@@ -7721,7 +7765,7 @@ class KernelWriterAssembly(KernelWriter):
                       # Pack two FP16 values into a single load dword x2
                     #  r += 1 # skip next element since we loaded 2X here
                     #  comment = "load packed 2X half buffer value"
-                    if not kernel["DirectToLds%s"%tc]:
+                    if not isLds:
                       hi8  = (loopCnt%4) %2 if tP["glvw"]==1 else (r%4) %2
                       hi16 = False if tP["glvw"]==1 else (r%4)//2
                       comment="load one buffer value"
@@ -7756,6 +7800,7 @@ class KernelWriterAssembly(KernelWriter):
                           module.add(SBranch(labelName=jumpLabel.getLabelName(), comment=""))
                   else:
                     if (doTailOpt == 0) or (doTailOpt == 2 and behavior == "LOAD" and r >= rStart and r < rEnd):
+
                       module.add(self.chooseGlobalRead(True, \
                                 bpl, destVgpr=loadVgpr, \
                                 addr0=vgpr(offsetVgpr), addr1=sgpr("Srd%s"%tc, 4), \
@@ -7769,7 +7814,7 @@ class KernelWriterAssembly(KernelWriter):
                     codeMod.add(VAddU32(dst=vgpr(offsetVgpr), src0=vgpr(offsetVgpr), src1=soffset_prev, comment="mirror unroll: restore GRO=GRO+SGRO"))
                     module.add(codeMod)
 
-                  if kernel["DirectToLds%s"%tc] and kernel["UseInstOffsetForGRO"]:
+                  if isLds and kernel["UseInstOffsetForGRO"]:
                     instOffsetInc += ldsInc
 
                 else: # Not buffer load, ie 'flat' load
@@ -9345,7 +9390,7 @@ class KernelWriterAssembly(KernelWriter):
         localWriteCode.add(SBarrier(comment="dump LDS"))
         localWriteCode.add(self.getCmpAssert(self.asmAssert.ne, sgpr("WorkGroup0"),1))
 
-    if (not kernel["DirectToLds%s"%tc]):
+    if (not kernel["DirectToLds%s"%tc]) or (kernel["NonDTLTailLoop"] and self.states.inTailLoop):
       if not ((tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]):
         localWriteBody(tP)
       if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4131,7 +4131,7 @@ class KernelWriterAssembly(KernelWriter):
 
     tc = tP["tensorChar"]
     waveSize = kernel["WavefrontSize"]
-    if kernel["DirectToLds%c"%tc] and kernel["NonDTLTailLoop"]:
+    if kernel["DirectToLds%c"%tc] and kernel["NonDTLTailLoop%s"%tc]:
       module.addComment0("Set local write offsets for %c to be same as DTL %uB load"%(tc, kernel["GlobalReadVectorWidth%c"%tc] * tP["bpe"]))
       module.add(VAndB32(dst=vgpr("LocalWriteAddr%c"%tc), src0=(waveSize - 1), src1=vgpr("Serial"), comment="Serial % wavesize"))
       module.add(VLShiftLeftB32(dst=vgpr("LocalWriteAddr%c"%tc), shiftHex=hex(log2(kernel["GlobalReadVectorWidth%c"%tc] * tP["bpe"])), src=vgpr("LocalWriteAddr%c"%tc), comment=""))
@@ -4587,13 +4587,13 @@ class KernelWriterAssembly(KernelWriter):
       imod.addComment0("Check out VGPR (numG2LA,numG2LB,numG2LMetadata) = (%d,%d,%d)"%(numG2LA,numG2LB,numG2LMetadata))
     if numG2LA > 0:
       imod.add(RegSet("v", "vgprG2LA_BASE", vgprBase))
-      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
+      if kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]:
         imod.add(RegSet("v", "vgprG2LA", "vgprG2LA_BASE", 0))
       else:
         imod.add(self.moduleVgprMacroG2LA)
     if numG2LB > 0:
       imod.add(RegSet("v", "vgprG2LB_BASE", vgprBase + numG2LA))
-      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
+      if kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]:
         imod.add(RegSet("v", "vgprG2LB", "vgprG2LB_BASE", 0))
       else:
         imod.add(self.moduleVgprMacroG2LB)
@@ -4611,9 +4611,9 @@ class KernelWriterAssembly(KernelWriter):
     if numLWA + numLWB > 0:
       vgprBase = self.vgprPool.checkOutAligned(numLWA + numLWB, 2)
       imod.addComment0("Check out VGPR (numLWA,numLWB) = (%d,%d)"%(numLWA,numLWB))
-    if numLWA > 0 and (kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]):
+    if numLWA > 0 and (kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]):
       imod.add(RegSet("v", "vgprLocalWriteAddrA", vgprBase))
-    if numLWB > 0 and (kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]):
+    if numLWB > 0 and (kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]):
       imod.add(RegSet("v", "vgprLocalWriteAddrB", vgprBase + numLWA))
 
     return imod, vgprBase
@@ -7516,7 +7516,7 @@ class KernelWriterAssembly(KernelWriter):
       isGlc = bool(tP["NonTemporal"] & 0x1)
       isSlc = bool(tP["NonTemporal"] & 0x2)
       isNT  = bool(tP["NonTemporal"] & 0x4)
-      isLds = True if (kernel["DirectToLds%s"%tc] and not kernel["NonDTLTailLoop"]) else False
+      isLds = True if (kernel["DirectToLds%s"%tc] and not kernel["NonDTLTailLoop%s"%tc]) else False
 
       directToLdsLoads = 0
       if doTailOpt == 2 and behavior == "LOAD":
@@ -9388,7 +9388,8 @@ class KernelWriterAssembly(KernelWriter):
 
     # Enable local write if not DTL or using nonDTL loads in tail loop
     if (not kernel["DirectToLds%s"%tc]) or \
-       ((tP["isA"] or tP["isB"]) and kernel["NonDTLTailLoop"] and self.states.inTailLoop):
+       (((tP["isA"] and kernel["NonDTLTailLoopA"]) or \
+        (tP["isB"] and kernel["NonDTLTailLoopB"])) and self.states.inTailLoop):
       # Skip local write if DTVA or DTVB
       if not ((tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]):
         localWriteBody(tP)

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -4563,18 +4563,14 @@ class KernelWriterAssembly(KernelWriter):
     numG2LMetadata  = 0
     if not kernel["DirectToVgprA"]:
       if ("ULSGRODoubleG2L" in kernel) and kernel["ULSGRODoubleG2L"] == 1:
-        numG2LA = self.states.a.numVgprG2LAllocated*2
-      elif kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]:
-        numG2LA = self.states.a.numVgprG2LTailloopAllocated
+        numG2LA = self.states.a.numVgprG2LTailloopAllocated*2
       else:
-        numG2LA = self.states.a.numVgprG2LAllocated
+        numG2LA = self.states.a.numVgprG2LTailloopAllocated
     if not kernel["DirectToVgprB"]:
       if ("ULSGRODoubleG2L" in kernel) and kernel["ULSGRODoubleG2L"] == 1:
-        numG2LB = self.states.b.numVgprG2LAllocated*2
-      elif kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]:
-        numG2LB = self.states.b.numVgprG2LTailloopAllocated
+        numG2LB = self.states.b.numVgprG2LTailloopAllocated*2
       else:
-        numG2LB = self.states.b.numVgprG2LAllocated
+        numG2LB = self.states.b.numVgprG2LTailloopAllocated
     if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:
       numG2LMetadata = self.states.m.numVgprG2LAllocated
 
@@ -4615,9 +4611,9 @@ class KernelWriterAssembly(KernelWriter):
     if numLWA + numLWB > 0:
       vgprBase = self.vgprPool.checkOutAligned(numLWA + numLWB, 2)
       imod.addComment0("Check out VGPR (numLWA,numLWB) = (%d,%d)"%(numLWA,numLWB))
-    if numLWA > 0:
+    if numLWA > 0 and (kernel["DirectToLdsA"] and kernel["NonDTLTailLoop"]):
       imod.add(RegSet("v", "vgprLocalWriteAddrA", vgprBase))
-    if numLWB > 0:
+    if numLWB > 0 and (kernel["DirectToLdsB"] and kernel["NonDTLTailLoop"]):
       imod.add(RegSet("v", "vgprLocalWriteAddrB", vgprBase + numLWA))
 
     return imod, vgprBase
@@ -9390,7 +9386,10 @@ class KernelWriterAssembly(KernelWriter):
         localWriteCode.add(SBarrier(comment="dump LDS"))
         localWriteCode.add(self.getCmpAssert(self.asmAssert.ne, sgpr("WorkGroup0"),1))
 
-    if (not kernel["DirectToLds%s"%tc]) or (kernel["NonDTLTailLoop"] and self.states.inTailLoop):
+    # Enable local write if not DTL or using nonDTL loads in tail loop
+    if (not kernel["DirectToLds%s"%tc]) or \
+       ((tP["isA"] or tP["isB"]) and kernel["NonDTLTailLoop"] and self.states.inTailLoop):
+      # Skip local write if DTVA or DTVB
       if not ((tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]):
         localWriteBody(tP)
       if kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]:

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -374,10 +374,8 @@ class Solution(collections.abc.Mapping):
     # Use nonDTL loads in DTL tail loop
     state["NonDTLTailLoopA"] = False
     state["NonDTLTailLoopB"] = False
-    is16bASEM2 = ((state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()) and \
-        state["AssertSummationElementMultiple"] % 2 != 0)
-    is8bASEM4 = ((state["ProblemType"]["DataType"].isInt8() or state["ProblemType"]["DataType"].is8bitFloat()) and \
-         state["AssertSummationElementMultiple"] % 4 != 0)
+    is16bASEM2 = (state["ProblemType"]["DataTypeA"].numBytes() == 2) and state["AssertSummationElementMultiple"] % 2 != 0
+    is8bASEM4  = (state["ProblemType"]["DataTypeB"].numBytes() == 1) and state["AssertSummationElementMultiple"] % 4 != 0
     if is16bASEM2 or is8bASEM4:
       state["NonDTLTailLoopA"] = not state["ProblemType"]["TLUA"]
       state["NonDTLTailLoopB"] = not state["ProblemType"]["TLUB"]
@@ -814,9 +812,6 @@ class Solution(collections.abc.Mapping):
       if state["LSC%c"%tc] * state["LSP%c"%tc] * numBytesAB != state["NumThreads"] * state["GlobalReadVectorWidth%c"%tc] * numBytesAB:
         reject(state, printRejectionReason, "can't use DirectToLds for LSC%c and LSP%c * bpe != NumThreads * GlobalReadVectorWidth%c * bpe%c > 4"%(tc, tc, tc, tc))
         return False
-
-    # so far, DirectToLds does not work well with PGR=2
-    # performance is not good and a lot of ds_read for DTL can cause scheduling issue(TODO: need fix)
 
     # so far, DirectToLds does not work with LRVW=2
     if state["LocalReadVectorWidth"] == 2:
@@ -2332,6 +2327,16 @@ class Solution(collections.abc.Mapping):
     # LDS (load size coalesced) * LSPA must load some multiple of 256 bytes.
     # No longer support loadX2/loadx4 .
     if state["DirectToLds"]:
+
+      bpeA = state["ProblemType"]["DataTypeA"].numBytes()
+      bpeB = state["ProblemType"]["DataTypeB"].numBytes()
+
+      # TODO: Currently DTL with input types of different size is not support. There are functional issues
+      # This needs to be fixed.
+      if bpeA != bpeB:
+        reject(state, printRejectionReason, "DirectToLds with inputs of different sized data types is not supported")
+        return False
+
       if (not state["DirectToVgprA"]) and Solution.isDirectToLdsDoable(state, 'A', isaInfoMap, printRejectionReason):
         state["DirectToLdsA"] = True
         state["LocalWriteUseSgprA"] = True

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -374,10 +374,17 @@ class Solution(collections.abc.Mapping):
     # Use nonDTL loads in DTL tail loop
     state["NonDTLTailLoopA"] = False
     state["NonDTLTailLoopB"] = False
-    is16bASEM2 = (state["ProblemType"]["DataTypeA"].numBytes() == 2) and state["AssertSummationElementMultiple"] % 2 != 0
-    is8bASEM4  = (state["ProblemType"]["DataTypeB"].numBytes() == 1) and state["AssertSummationElementMultiple"] % 4 != 0
-    if is16bASEM2 or is8bASEM4:
+
+    bpeA = state["ProblemType"]["DataTypeA"].numBytes()
+    bpeB = state["ProblemType"]["DataTypeB"].numBytes()
+    asem = state["AssertSummationElementMultiple"]
+    # For DTL, we use nonDTL loads in tail loop only if
+    # a partial 32b read is required to read the last few elements of a row/col of A/B
+    # i.e. ASEM * BPE % 4 != 0. In this case dword/dwordx4 DTL load will
+    # zero out the entire partial 32b read and cause accuracy issues.
+    if (asem * bpeA) % 4 != 0:
       state["NonDTLTailLoopA"] = not state["ProblemType"]["TLUA"]
+    if (asem * bpeB) % 4 != 0:
       state["NonDTLTailLoopB"] = not state["ProblemType"]["TLUB"]
 
     if (state["ISA"] != (9, 4, 2)) or \

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -372,12 +372,15 @@ class Solution(collections.abc.Mapping):
     state["tailLoopOptB"] = True
 
     # Use nonDTL loads in DTL tail loop
-    state["NonDTLTailLoop"] = False
-    if (((state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()) and \
-        state["AssertSummationElementMultiple"] % 2 != 0) or \
-        ((state["ProblemType"]["DataType"].isInt8() or state["ProblemType"]["DataType"].is8bitFloat()) and \
-         state["AssertSummationElementMultiple"] % 4 != 0)):
-      state["NonDTLTailLoop"] = True
+    state["NonDTLTailLoopA"] = False
+    state["NonDTLTailLoopB"] = False
+    is16bASEM2 = ((state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()) and \
+        state["AssertSummationElementMultiple"] % 2 != 0)
+    is8bASEM4 = ((state["ProblemType"]["DataType"].isInt8() or state["ProblemType"]["DataType"].is8bitFloat()) and \
+         state["AssertSummationElementMultiple"] % 4 != 0)
+    if is16bASEM2 or is8bASEM4:
+      state["NonDTLTailLoopA"] = not state["ProblemType"]["TLUA"]
+      state["NonDTLTailLoopB"] = not state["ProblemType"]["TLUB"]
 
     if (state["ISA"] != (9, 4, 2)) or \
        (state["ProblemType"]["Sparse"]) or \

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -845,6 +845,12 @@ class Solution(collections.abc.Mapping):
       reject(state, printRejectionReason, "DirectToLds%c does not work with TLU=False and bpe > bpr and DepthU//NumLoadsCoalesced%c < 8"%(tc, tc))
       return False
 
+    # TODO: Currently DTL with input types of different size is not support. There are functional issues
+    # This needs to be fixed.
+    if state["ProblemType"]["DataType%s"%tc].numBytes() != state["ProblemType"]["DataType"].numBytes():
+      reject(state, printRejectionReason, "DirectToLds%s with conversion to different sized data types is not supported"%tc)
+      return False
+
     # DTL + input type conversion
     if state["ProblemType"]["DataType%s"%tc] != state["ProblemType"]["DataType"]:
       if not state["ConvertAfterDS"]:
@@ -2334,15 +2340,6 @@ class Solution(collections.abc.Mapping):
     # LDS (load size coalesced) * LSPA must load some multiple of 256 bytes.
     # No longer support loadX2/loadx4 .
     if state["DirectToLds"]:
-
-      bpeA = state["ProblemType"]["DataTypeA"].numBytes()
-      bpeB = state["ProblemType"]["DataTypeB"].numBytes()
-
-      # TODO: Currently DTL with input types of different size is not support. There are functional issues
-      # This needs to be fixed.
-      if bpeA != bpeB:
-        reject(state, printRejectionReason, "DirectToLds with inputs of different sized data types is not supported")
-        return False
 
       if (not state["DirectToVgprA"]) and Solution.isDirectToLdsDoable(state, 'A', isaInfoMap, printRejectionReason):
         state["DirectToLdsA"] = True

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -371,6 +371,14 @@ class Solution(collections.abc.Mapping):
     state["tailLoopOptA"] = True
     state["tailLoopOptB"] = True
 
+    # Use nonDTL loads in DTL tail loop
+    state["NonDTLTailLoop"] = False
+    if (((state["ProblemType"]["DataType"].isHalf() or state["ProblemType"]["DataType"].isBFloat16()) and \
+        state["AssertSummationElementMultiple"] % 2 != 0) or \
+        ((state["ProblemType"]["DataType"].isInt8() or state["ProblemType"]["DataType"].is8bitFloat()) and \
+         state["AssertSummationElementMultiple"] % 4 != 0)):
+      state["NonDTLTailLoop"] = True
+
     if (state["ISA"] != (9, 4, 2)) or \
        (state["ProblemType"]["Sparse"]) or \
        (state["UseDotInstruction"]):

--- a/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/dtl.yaml
@@ -78,7 +78,7 @@ BenchmarkProblems:
         - LocalReadVectorWidth: [4]
         - DirectToLds: [1]
         #- StreamK: [0,3]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [1, 2]
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
@@ -166,7 +166,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToLds: [1]
         #- StreamK: [0,3]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [1, 2]
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
@@ -254,7 +254,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToLds: [1]
         #- StreamK: [0,3]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [1, 2]
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
@@ -341,7 +341,7 @@ BenchmarkProblems:
         #- LocalReadVectorWidth: [4,8]
         - DirectToLds: [1]
         #- StreamK: [0,3]
-        - AssertSummationElementMultiple: [2]
+        - AssertSummationElementMultiple: [1, 2]
         - DirectToVgprA: [0,1]
         - DirectToVgprB: [0,1]
         - Groups:
@@ -744,7 +744,7 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [4]
+        - AssertSummationElementMultiple: [1, 4]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:

--- a/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -25,7 +25,7 @@ GlobalParameters:
 BenchmarkProblems:
 
   ########################################
-  # F8F8S TN DTL
+  # F8HS TN DTL
   ########################################
   -
     - # ProblemType
@@ -76,8 +76,131 @@ BenchmarkProblems:
         - StorePriorityOpt: [0]
         - VectorStore: [-1]
         - StoreSyncOpt: [0]
-        - LdsPadA: [0, 8, 16]
-        - LdsPadB: [0, 8, 16]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [0]
+        - GlobalSplitU: [1,2]
+        #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
+        - SourceSwap: [1]#[0, 1]
+        - LocalReadVectorWidth: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 4]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[19], [19], [1], [1,3,12]]
+          - Range: [[31], [31], [1], [1,7,72]]
+          - Range: [[127], [127], [1], [128,4,140]]
+          - Range: [[13], [17], [1], [258, 3, 512]]
+          - Exact: [256, 256, 1, 64]
+          - Exact: [256, 256, 1, 128]
+          - Exact: [256, 256, 1, 320]
+
+  ########################################
+  # F8HHS TT DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DataTypeB: f8
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 0 # 1
+      Batched: True
+      Activation: False
+      ActivationHPA: False
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
+          - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [16]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 2]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[63], [127], [1], [1,63,512]]
+
+  ########################################
+  # F8B8HS TN DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: f8b8
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 0
+      UseBeta: True
+      Batched: True
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          - [16, 16, 128, 1,  1,   1, 1,  1,1 ]
+          - [32, 32, 64, 1,  1,   1, 1,  1,1 ]
+          - [16, 16, 128, 1,  1,   4, 4,  2,2 ]
+          - [32, 32, 64, 1,  1,   2, 2,  2,2 ]
+          - [32, 32, 64, 1,  1,   3, 2,  2,2 ]
+          - [32, 32, 64, 1,  1,   2, 3,  2,2 ]
+          - [16, 16, 128, 1,  1,   3, 2,  2,2 ]
+          - [16, 16, 128, 1,  1,   2, 3,  2,2 ]
+        - WorkGroup:
+          - [16,16,1]
+        - GlobalReadVectorWidthA: [4, 16]
+        - GlobalReadVectorWidthB: [4, 16]
+        - PrefetchGlobalRead: [1,2]
+        - PrefetchLocalRead: [1,2]
+        - ClusterLocalRead: [1]
+        - NumElementsPerBatchStore: [0]
+        - DepthU: [128]
+        - VectorWidthA: [-1]
+        - VectorWidthB: [-1]
+        - MIArchVgpr: [0]
+        - LocalWritePerMfma: [-1]
+        - StaggerU: [4]
+        - StaggerUStride: [256]
+        #- StaggerUMapping: [2]
+        - WorkGroupMapping: [1]
+        - ScheduleIterAlg: [3]
+        #- ExpandPointerSwap: [0,1]
+        - LdsBlockSizePerPadA: [-1]
+        - LdsBlockSizePerPadB: [-1]
+        - StorePriorityOpt: [0]
+        - VectorStore: [-1]
+        - StoreSyncOpt: [0]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
@@ -89,15 +212,10 @@ BenchmarkProblems:
       BenchmarkFinalParameters:
         - ProblemSizes:
           - Range: [[16,9,34],   [16,9,34], [1], [1,3,12]]
-          - Range: [[16,9,34],   [16,9,34], [1], [1,7,72]]
-          - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
-          - Range: [[13],   [17], [1], [258, 3, 512]]
-          - Exact: [256, 256, 1, 64]
-          - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
 
   ########################################
-  # F8F8S NN DTL
+  # F8HS NN DTL
   ########################################
   -
     - # ProblemType
@@ -146,8 +264,8 @@ BenchmarkProblems:
         - StorePriorityOpt: [0]
         - VectorStore: [-1]
         - StoreSyncOpt: [0]
-        - LdsPadA: [-1, 0, 8, 16]
-        - LdsPadB: [-1, 0, 8, 16]
+        - LdsPadA: [-1, 0, 8]
+        - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
@@ -158,13 +276,64 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [1,3,72]]
-          - Range: [[16,9,34],   [16,9,34], [1], [64,3,72]]
-          - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
+          - Range: [[19], [19], [1], [1,3,12]]
+          - Range: [[31], [31], [1], [1,7,72]]
+          - Range: [[127], [127], [1], [128,4,140]]
           - Range: [[13],   [17], [1], [258, 3, 512]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
+
+  ########################################
+  # F8HHS NN DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DataTypeA: f8
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 0
+      TransposeB: 0
+      UseBeta: True
+      UseBias: 0 # 1
+      Batched: True
+      Activation: False
+      ActivationHPA: False
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
+          - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [16]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - AssertSummationElementMultiple: [1, 2]
+        - LdsPadA: [0, 8]
+        - LdsPadB: [0, 8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
+          - Range: [[63], [127], [1], [1,31,512]]
 
   ########################################
   # F8F8S TT DTL
@@ -216,8 +385,8 @@ BenchmarkProblems:
         - StorePriorityOpt: [0]
         - VectorStore: [-1]
         - StoreSyncOpt: [0]
-        - LdsPadA: [-1, 0, 8, 16]
-        - LdsPadB: [-1, 0, 8, 16]
+        - LdsPadA: [-1, 0, 8]
+        - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [0]
         - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
@@ -228,9 +397,9 @@ BenchmarkProblems:
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [1,1,12]]
-          - Range: [[16,9,34],   [16,9,34], [1], [64,7,72]]
-          - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
+          - Range: [[19], [19], [1], [1,3,12]]
+          - Range: [[31], [31], [1], [1,7,72]]
+          - Range: [[127], [127], [1], [128,4,140]]
           - Range: [[13],   [17], [1], [258, 3, 512]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
@@ -261,7 +430,6 @@ BenchmarkProblems:
         - MatrixInstruction:
           #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
-          - [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
@@ -289,7 +457,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
+          - Range: [[65], [123], [1], [1,123,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -317,7 +485,6 @@ BenchmarkProblems:
         - MatrixInstruction:
           #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
-          - [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
@@ -345,7 +512,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
+          - Range: [[47], [97], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -373,7 +540,6 @@ BenchmarkProblems:
         - MatrixInstruction:
           #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
-          - [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
@@ -401,7 +567,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
+          - Range: [[18], [99], [1], [1,31,512]]
 
   ########################################
   # HHS TT DTL
@@ -428,7 +594,6 @@ BenchmarkProblems:
         - MatrixInstruction:
           #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
-          - [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
           - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
           - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
@@ -446,7 +611,6 @@ BenchmarkProblems:
         - LdsPadA: [8]
         - LdsPadB: [8]
         - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1, 2]
         - SourceSwap: [1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:

--- a/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -79,7 +79,7 @@ BenchmarkProblems:
         - LdsPadA: [0, 8, 16]
         - LdsPadB: [0, 8, 16]
         - 1LDSBuffer: [0]
-        #- GlobalSplitU: [1,2]
+        - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
@@ -91,6 +91,7 @@ BenchmarkProblems:
           - Range: [[16,9,34],   [16,9,34], [1], [1,3,12]]
           - Range: [[16,9,34],   [16,9,34], [1], [1,7,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
+          - Range: [[13],   [17], [1], [258, 3, 512]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -148,7 +149,7 @@ BenchmarkProblems:
         - LdsPadA: [-1, 0, 8, 16]
         - LdsPadB: [-1, 0, 8, 16]
         - 1LDSBuffer: [0]
-        #- GlobalSplitU: [1,2]
+        - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
@@ -160,6 +161,7 @@ BenchmarkProblems:
           - Range: [[16,9,34],   [16,9,34], [1], [1,3,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [64,3,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
+          - Range: [[13],   [17], [1], [258, 3, 512]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -217,7 +219,7 @@ BenchmarkProblems:
         - LdsPadA: [-1, 0, 8, 16]
         - LdsPadB: [-1, 0, 8, 16]
         - 1LDSBuffer: [0]
-        #- GlobalSplitU: [1,2]
+        - GlobalSplitU: [1,2]
         #- GlobalSplitUAlgorithm: ["MultipleBuffer", "MultipleBufferSingleKernel"]
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
@@ -229,6 +231,7 @@ BenchmarkProblems:
           - Range: [[16,9,34],   [16,9,34], [1], [1,1,12]]
           - Range: [[16,9,34],   [16,9,34], [1], [64,7,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
+          - Range: [[13],   [17], [1], [258, 3, 512]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 320]
@@ -277,7 +280,7 @@ BenchmarkProblems:
         - LdsPadA: [0, 8]
         - LdsPadB: [0, 8]
         - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
+        - GlobalSplitU: [1, 2]
         - SourceSwap: [1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -286,7 +289,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
+          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -333,7 +336,7 @@ BenchmarkProblems:
         - LdsPadA: [-1, 0, 8]
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
+        - GlobalSplitU: [1, 2]
         - SourceSwap: [1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -342,7 +345,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
+          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -389,7 +392,7 @@ BenchmarkProblems:
         - LdsPadA: [-1, 0, 8]
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [-1]
-        - GlobalSplitU: [1]
+        - GlobalSplitU: [1, 2]
         - SourceSwap: [1]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
@@ -398,5 +401,55 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
-          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
+          - Range: [[9,37,256], [3,37,256], [1], [1,31,512]]
+
+  ########################################
+  # HHS TT DTL
+  ########################################
+  -
+    - # ProblemType
+      OperationType: GEMM
+      DataType: h
+      DestDataType: h
+      ComputeDataType: s
+      HighPrecisionAccumulate: True
+      TransposeA: 1
+      TransposeB: 1
+      UseBeta: True
+      UseBias: 0 # 1
+      Batched: True
+      Activation: False
+      ActivationHPA: False
+    - # BenchmarkProblemSizeGroup - Standard - All problem
+      InitialSolutionParameters:
+      BenchmarkCommonParameters:
+        - KernelLanguage: ["Assembly"]
+      ForkParameters:
+        - MatrixInstruction:
+          #- [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
+          - [32, 32, 16, 1, 1, 4, 4, 2, 2 ]
+          - [32, 32, 16, 1, 1, 2, 2, 2, 2 ]
+          - [16, 16, 32, 1, 1, 8, 8, 2, 2 ]
+          - [16, 16, 32, 1, 1, 1, 1, 2, 2 ]
+          - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
+          - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
+        - PrefetchGlobalRead: [1, 2]
+        - PrefetchLocalRead: [1, 2]
+        - DepthU: [64]
+        - ScheduleIterAlg: [3]
+        - ExpandPointerSwap: [0]
+        - TransposeLDS: [1] #0,1
+        - LocalReadVectorWidth: [8]
+        - GlobalReadVectorWidthA: [8]
+        - GlobalReadVectorWidthB: [8]
+        - DirectToLds: [1]
+        - LdsPadA: [8]
+        - LdsPadB: [8]
+        - 1LDSBuffer: [-1]
+        - GlobalSplitU: [1, 2]
+        - SourceSwap: [1]
+      BenchmarkJoinParameters:
+      BenchmarkFinalParameters:
+        - ProblemSizes:
           - Range: [[4096], [8192], [1], [64,64,384]]
+

--- a/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
+++ b/tensilelite/Tensile/Tests/common/gemm/gfx950/dtl.yaml
@@ -84,12 +84,12 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [4]
+        - AssertSummationElementMultiple: [1, 4]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [4,4,12]]
-          - Range: [[16,9,34],   [16,9,34], [1], [64,4,72]]
+          - Range: [[16,9,34],   [16,9,34], [1], [1,3,12]]
+          - Range: [[16,9,34],   [16,9,34], [1], [1,7,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
@@ -153,12 +153,12 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [4]
+        - AssertSummationElementMultiple: [1, 4]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [4,4,12]]
-          - Range: [[16,9,34],   [16,9,34], [1], [64,4,72]]
+          - Range: [[16,9,34],   [16,9,34], [1], [1,3,72]]
+          - Range: [[16,9,34],   [16,9,34], [1], [64,3,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
@@ -222,12 +222,12 @@ BenchmarkProblems:
         - SourceSwap: [1]#[0, 1]
         - LocalReadVectorWidth: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [4]
+        - AssertSummationElementMultiple: [1, 4]
       BenchmarkJoinParameters:
       BenchmarkFinalParameters:
         - ProblemSizes:
-          - Range: [[16,9,34],   [16,9,34], [1], [4,4,12]]
-          - Range: [[16,9,34],   [16,9,34], [1], [64,4,72]]
+          - Range: [[16,9,34],   [16,9,34], [1], [1,1,12]]
+          - Range: [[16,9,34],   [16,9,34], [1], [64,7,72]]
           - Range: [[16,9,34],   [16,9,34], [1], [128,4,140]]
           - Exact: [256, 256, 1, 64]
           - Exact: [256, 256, 1, 128]
@@ -264,7 +264,7 @@ BenchmarkProblems:
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
           - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
         - PrefetchGlobalRead: [1, 2]
-        - PrefetchLocalRead: [2]
+        - PrefetchLocalRead: [1, 2]
         - DepthU: [64]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0]
@@ -273,7 +273,7 @@ BenchmarkProblems:
         - GlobalReadVectorWidthA: [8]
         - GlobalReadVectorWidthB: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [64]
+        - AssertSummationElementMultiple: [1, 2]
         - LdsPadA: [0, 8]
         - LdsPadB: [0, 8]
         - 1LDSBuffer: [-1]
@@ -286,6 +286,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
+          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -319,7 +320,7 @@ BenchmarkProblems:
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
           - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
         - PrefetchGlobalRead: [1, 2]
-        - PrefetchLocalRead: [2]
+        - PrefetchLocalRead: [1, 2]
         - DepthU: [64]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0]
@@ -328,7 +329,7 @@ BenchmarkProblems:
         - GlobalReadVectorWidthA: [8]
         - GlobalReadVectorWidthB: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [64]
+        - AssertSummationElementMultiple: [1, 2]
         - LdsPadA: [-1, 0, 8]
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [-1]
@@ -341,6 +342,7 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
+          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
           - Exact: [4096, 8192, 1, 128]
 
   ########################################
@@ -374,7 +376,7 @@ BenchmarkProblems:
           - [16, 16, 32, 1, 1, 2, 3, 2, 2 ]
           - [32, 32, 16, 1, 1, 3, 2, 2, 2 ]
         - PrefetchGlobalRead: [1, 2]
-        - PrefetchLocalRead: [2]
+        - PrefetchLocalRead: [1, 2]
         - DepthU: [64]
         - ScheduleIterAlg: [3]
         - ExpandPointerSwap: [0]
@@ -383,7 +385,7 @@ BenchmarkProblems:
         - GlobalReadVectorWidthA: [8]
         - GlobalReadVectorWidthB: [8]
         - DirectToLds: [1]
-        - AssertSummationElementMultiple: [64]
+        - AssertSummationElementMultiple: [1, 2]
         - LdsPadA: [-1, 0, 8]
         - LdsPadB: [-1, 0, 8]
         - 1LDSBuffer: [-1]
@@ -396,4 +398,5 @@ BenchmarkProblems:
           - Exact: [256, 256, 1, 128]
           - Exact: [256, 256, 1, 256]
           - Exact: [256, 256, 1, 512]
+          - Range: [[9,17,256], [3,17,256], [1], [1,31,512]]
           - Range: [[4096], [8192], [1], [64,64,384]]


### PR DESCRIPTION
This PR enables DTL tail loop code to use non-DTL loads. 
 - Added subroutines to allocate vgprs for local write offsets and G2L for DTL tail loop.
 - Compute local write offsets to match lds write offsets used in corresponding DTL loads 