### PR TITLE
[next-cmake] Remove indirect dependencies

### DIFF
--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -80,8 +80,6 @@ if(BUILD_TESTING OR HIPBLASLT_BUILD_TESTING)
         PRIVATE
             hip::device
             hipblaslt-clients-common
-            ${LAPACK_LIBRARIES}
-            ${BLAS_LIBRARIES}
             GTest::gtest
     )
     if(HIPBLASLT_ENABLE_BLIS)


### PR DESCRIPTION
The `hipblaslt-test` does not directly depend on CBLAS (which is actually missing here) but dependes on `hipblaslt-clients-common` which publicy depends on BLAS, CBLAS and LAPACK.