### PR TITLE
add rocTracer include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ endif()
 
 if(HIPBLASLT_ENABLE_MARKER)
   find_library(rocTracer roctx64)
+  find_path(ROCTRACER_INCLUDE_DIR "roctracer/roctx.h")
   if(NOT rocTracer)
     message(FATAL_ERROR "roctracer not found, but HIPBLASLT_ENABLE_MARKER is enabled")
   endif()

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -159,7 +159,8 @@ if(NOT BUILD_CUDA)
 endif()
 
 if(HIPBLASLT_ENABLE_MARKER)
-  target_link_libraries(hipblaslt PRIVATE -lroctx64)
+  target_include_directories(hipblaslt PRIVATE ${ROCTRACER_INCLUDE_DIR})
+  target_link_libraries(hipblaslt PRIVATE ${rocTracer})
 endif()
 
 if( NOT BUILD_CUDA AND NOT LEGACY_HIPBLAS_DIRECT )

--- a/tensilelite/Tensile/Source/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/CMakeLists.txt
@@ -34,6 +34,7 @@ option(Tensile_ENABLE_MARKER "ENable roctx marker in Tensile" OFF)
 
 if(Tensile_ENABLE_MARKER)
     find_library(rocTracer roctx64)
+    find_path(ROCTRACER_INCLUDE_DIR "roctracer/roctx.h")
     if(NOT rocTracer)
         message(FATAL_ERROR "roctracer not found, but Tensile_ENABLE_MARKER is enabled")
     endif()

--- a/tensilelite/Tensile/Source/client/CMakeLists.txt
+++ b/tensilelite/Tensile/Source/client/CMakeLists.txt
@@ -65,7 +65,8 @@ target_include_directories(TensileClient PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/inc
 target_link_libraries(TensileClient PRIVATE TensileHost Boost::program_options Boost::filesystem rocm_smi)
 
 if(Tensile_ENABLE_MARKER)
-    target_link_libraries(TensileClient PRIVATE -lroctx64)
+    target_include_directories(TensileClient PRIVATE ${ROCTRACER_INCLUDE_DIR})
+    target_link_libraries(TensileClient PRIVATE ${rocTracer})
 endif()
 
 if(TENSILE_USE_OPENMP)


### PR DESCRIPTION
In [spack](https://github.com/spack/spack) all of the ROCm Packages are installed in seperate paths so the roctracer include directory needs to be explicitly added.