### PR TITLE
[next-cmake] Fix a typo in README.rst

### DIFF
--- a/next-cmake/README.rst
+++ b/next-cmake/README.rst
@@ -83,6 +83,7 @@ Options
 -------
 
 *CMake options*:
+
 * `CMAKE_BUILD_TYPE`: Any of Release, Debug, RelWithDebInfo, MinSizeRel
 * `CMAKE_INSTALL_PREFIX`: Base installation directory
 * `CMAKE_PREFIX_PATH`: Find package search path (consider setting to ``$ROCM_PATH``)


### PR DESCRIPTION
Fixes the CMake options bulleted list