### PR TITLE
Parallel kernel helpers working for gfx1101

### DIFF
--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -62,6 +62,7 @@ from Tensile.KernelWriterAssembly import KernelWriterAssembly
 from Tensile.KernelWriterBase import (
     KERNEL_HELPER_FILENAME_CPP,
     KERNEL_HELPER_FILENAME_H,
+    KernelWriterBase
 )
 from Tensile.SolutionLibrary import MasterSolutionLibrary
 from Tensile.SolutionStructs import Solution
@@ -71,7 +72,7 @@ from Tensile.Toolchain.Validators import (
     ToolchainDefaults,
     validateToolchain,
 )
-from Tensile.Toolchain.Component import Assembler
+from Tensile.Toolchain.Component import Assembler, Compiler
 from Tensile.Utilities.Decorators.Profile import profile
 from Tensile.Utilities.Decorators.Timing import timing
 
@@ -186,6 +187,94 @@ def writeAssembly(asmPath: Union[Path, str], result: KernelCodeGenResult):
     return path, isa, wfsize
 
 
+def writeHelper(outputPath: Path, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> str:
+    """
+    Write kernel helper source and header files.
+
+    Args:
+        outputPath: Base path where files will be written
+        kernelHelperObj: Kernel helper object with source and header content
+        khoNames: List of all kernel helper object names for dependency resolution
+
+    Returns:
+        The path to the generated source file
+    """
+    name = kernelHelperObj.getKernelName()
+    sourceFilename = f"{name}.cpp"
+    headerFilename = f"{name}.h"
+    kernelsDir = Path(outputPath) / "Kernels"
+
+    if not kernelsDir.exists():
+        kernelsDir.mkdir(parents=True, exist_ok=True)
+
+    kernelSourcePath = str(kernelsDir / sourceFilename)
+    kernelHeaderPath = str(kernelsDir / headerFilename)
+
+    includes = _getRequiredIncludes(name, kernelHelperObj, khoNames)
+
+    with open(kernelHeaderPath, "w", encoding="utf-8") as kernelHeaderFile, \
+         open(kernelSourcePath, "w", encoding="utf-8") as kernelSourceFile:
+
+        for file in (kernelSourceFile, kernelHeaderFile):
+            file.write(CHeader)
+
+        kernelSourceFile.write(f"#include \"{name}.h\"\n")
+
+        kernelHeaderFile.write("#pragma once\n")
+        kernelHeaderFile.write("#include <hip/hip_runtime.h>\n")
+        kernelHeaderFile.write("#include <hip/hip_ext.h>\n\n")
+        kernelHeaderFile.write("#include \"KernelHeader.h\"\n\n")
+
+        for include in includes:
+            kernelHeaderFile.write(f"#include \"Kernels/{include}.h\"\n")
+
+        err, src = kernelHelperObj.getSourceFileString()
+        if err:
+            printWarning(f"Invalid kernel: {name} (error code {err})")
+
+        kernelSourceFile.write(src)
+        kernelHeaderFile.write(kernelHelperObj.getHeaderFileString())
+
+    return kernelSourcePath
+
+
+def _getRequiredIncludes(name: str, kernelHelperObj: KernelWriterBase, khoNames: List[str]) -> set:
+    """
+    Determine the required includes for a kernel helper.
+
+    Args:
+        name: Kernel helper name
+        khoNames: List of all kernel helper object names
+        kernelHelperObj: The kernel helper object to analyze
+
+    Returns:
+        List of kernel helper names to include
+    """
+    includes = set()
+
+    # Add enum includes for non-enum helpers
+    if "Enum" not in name:
+        includes.update(n for n in khoNames if "Enum" in n)
+
+        # Include gradient activation enums for gradient helpers
+        hasGradient = hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient"
+        if hasGradient:
+            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
+
+    # Include activation helpers
+    hasActivation = ("TensileActivation_S" in name or "TensileActivation_I" in name)
+    if not hasActivation and "Enum" not in name:
+        includes.update(n for n in khoNames if "TensileActivation_" in n)
+
+    # Include gradient activation helpers
+    hasGradientActivation = "TensileGradientActivation_S" in name
+    if not hasGradientActivation and "Enum" not in name:
+        if hasattr(kernelHelperObj, "actGradientPrefix") and kernelHelperObj.actGradientPrefix == "Gradient":
+            includes.update(n for n in khoNames if "TensileGradientActivation_" in n)
+
+    return includes
+
+
 def writeHelpers(
     outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H
 ):
@@ -241,6 +330,8 @@ def writeSolutionsAndKernels(
     objectTmpPath = ensurePath(
         buildTmpPath / "code_object_tmp"
     )  # Temp path for HSA code object files (.hsaco)
+    kernelsIncludePath = outputPath / "Kernels"
+    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
 
     asmKernels = [k for k in kernels if k["KernelLanguage"] == "Assembly"]
 
@@ -287,8 +378,8 @@ def writeSolutionsAndKernels(
         multiArg=False,
     )
 
-    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-    srcKernelFile = Path(outputPath) / "Kernels.cpp"
+    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+    srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
 
     if not generateSourcesAndExit:
         codeObjectFiles += buildAssemblyCodeObjectFiles(
@@ -300,15 +391,15 @@ def writeSolutionsAndKernels(
             assemblyTmpPath,
             compress,
         )
-        buildSourceCodeObjectFiles(
-            srcToolchain.compiler,
-            srcToolchain.bundler,
-            destLibPath,
-            objectTmpPath,
-            outputPath,
-            srcKernelFile,
-            cmdlineArchs,
+        compile = functools.partial(srcToolchain.Compiler.__call__, str(kernelsIncludePath))
+        ret = ParallelMap2(
+            [(arch, f, str(Path(f).with_suffix("")) + f"{arch}") for f in srcFiles for arch in cmdlineArchs],
+            "Building kernel helpers",
+            return_as="list",
+            multiArg=False,
         )
+        for arch in cmdlineArchs:
+            srcToolchain.compiler.link([str(Path(s + "_{arch}").with_suffix("o")) for s in srcFiles], f"Kernels_{arch}.hsaco")
 
     return codeObjectFiles, numKernels
 
@@ -334,6 +425,10 @@ def writeSolutionsAndKernelsTCL(
     objectTmpPath = ensurePath(
         buildTmpPath / "code_object_tmp"
     )  # Temp path for HSA code object files (.hsaco)
+    kernelsIncludePath = outputPath / "Kernels"
+    kernelsIncludePath.mkdir(parents=True, exist_ok=True)
+    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+    srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
 
     asmKernels = [k for k in kernels if k["KernelLanguage"] == "Assembly"]
 
@@ -371,27 +466,19 @@ def writeSolutionsAndKernelsTCL(
         multiArg=False,
         return_as="list"
     )
-    buildAssemblyCodeObjectFiles(
-        asmToolchain.linker,
-        asmToolchain.bundler,
-        globalParameters["ROCmLdPath"],
-        asmKernels,
-        destLibPath,
-        assemblyTmpPath,
-        compress,
+    khoNames = [kho.getKernelName() for kho in kernelHelperObjs]
+    srcFiles = [writeHelper(outputPath, helper, khoNames) for helper in kernelHelperObjs]
+    unaryCompile = functools.partial(srcToolchain.compiler.compile, str(kernelsIncludePath))
+    state = [(arch, f, str(Path(f + "_{arch}").with_suffix(".o"))) for f in srcFiles for arch in cmdlineArchs]
+    ret = ParallelMap2(
+        unaryCompile,
+        state,
+        "Building kernel helpers",
+        return_as="list",
+        multiArg=False,
     )
-
-    writeHelpers(outputPath, kernelHelperObjs, KERNEL_HELPER_FILENAME_CPP, KERNEL_HELPER_FILENAME_H)
-    srcKernelFile = Path(outputPath) / "Kernels.cpp"
-    buildSourceCodeObjectFiles(
-        srcToolchain.compiler,
-        srcToolchain.bundler,
-        destLibPath,
-        objectTmpPath,
-        outputPath,
-        srcKernelFile,
-        cmdlineArchs,
-    )
+    for arch in cmdlineArchs:
+        srcToolchain.compiler.link([str(Path(s + "_{arch}").with_suffix(".o")) for s in srcFiles], f"Kernels_{arch}.hsaco")
 
     return len(uniqueAsmKernels)
 
@@ -581,9 +668,10 @@ def run():
     arguments = parseArguments()
     setVerbosity(arguments["PrintLevel"])
     outputPath = Path(ensurePath(os.path.abspath(arguments["OutputPath"])))
-    cxxCompiler, _, offloadBundler, _, _ = validateToolchain(
+    cxxCompiler, _, ldLld, offloadBundler, _, _ = validateToolchain(
         arguments["CxxCompiler"],
         arguments["CCompiler"],
+        ToolchainDefaults.LD_LLD,
         arguments["OffloadBundler"],
         arguments["Assembler"],
         ToolchainDefaults.HIP_CONFIG,
@@ -608,6 +696,7 @@ def run():
     srcToolchain = makeSourceToolchain(
         cxxCompiler,
         offloadBundler,
+        ldLld,
         arguments["AsanBuild"],
         arguments["BuildIdKind"],
         save_temps=False
@@ -662,7 +751,6 @@ def run():
     )
     stop_glds = timer()
     print(f"Time to load yaml files (s): {(stop_glds-start_glds):3.2f}")
-
 
     kernels = generateKernelObjectsFromSolutions(solutions)
     kernelHelperObjs = generateKernelHelperObjects(kernels, str(asmToolchain.assembler.path), isaInfoMap)

--- a/tensilelite/Tensile/Toolchain/Component.py
+++ b/tensilelite/Tensile/Toolchain/Component.py
@@ -43,7 +43,7 @@ def _invoke(args: List[str], desc: str=""):
   Return:
       subprocess output
   """
-  #print1(f"{desc}: {' '.join(args)}")
+  print(f"{desc}: {' '.join(args)}")
   try:
       out = check_output(args, stderr=STDOUT)
   except CalledProcessError as err:
@@ -87,7 +87,10 @@ def get_rocm_version() -> str:
     Return:
         ROCm version string
     """
-    return _getVersion(ToolchainDefaults.HIP_CONFIG, "--version", r'(.+)')
+    try:
+        return _getVersion(ToolchainDefaults.HIP_CONFIG, "--version", r'(.+)')
+    except:
+        return None
 
 
 class Component:
@@ -204,29 +207,33 @@ class Compiler(Component):
         Invokes the compiler on the provided arguments
     """
 
-    def __init__(self, compiler_path: Path, build_id_kind: str, asan_build: bool=False, save_temps: bool=False):
+    def __init__(self, compiler_path: Path, ldlld_path: Path, build_id_kind: str, asan_build: bool=False, save_temps: bool=False):
         """Constructs and instance of a Compiler."""
         super(Compiler, self).__init__(compiler_path)
 
-        self.default_args = [
+        self.default_args_hip = [
             *split(environ.get("Tensile_CXX_COMPILER_LAUNCHER", "")),
              compiler_path,
-            "-D__HIP_HCC_COMPAT_MODE__=1",
-            "--offload-device-only",
-            "-x", "hip", "-O3",
-            "-Xoffload-linker", f"--build-id={build_id_kind}",
-            "-std=c++17",
+             "-x", "hip", "-D__HIP_HCC_COMPAT_MODE__", "-fgpu-rdc", "-O3", "-std=c++17", "--offload-device-only", "-emit-llvm"
+        ]
+        self.default_args_cc1 = [
+            *split(environ.get("Tensile_CXX_COMPILER_LAUNCHER", "")),
+             compiler_path,
+            "-cc1", "-triple", "amdgcn-amd-amdhsa", "-fcuda-is-device", "-fgpu-rdc", "-O3", "-emit-obj"
         ]
 
+        self.default_args_ldlld = [str(ldlld_path), "-shared"]
+
         if asan_build:
-            self.default_args.extend(["-fsanitize=address", "-shared-libasan", "-fuse-ld=lld"])
+            self.default_args_hip.extend(["-fsanitize=address", "-shared-libasan", "-fuse-ld=lld"])
         if save_temps:
-            self.default_args.append("--save-temps")
-        if os_name == "nt":                                                    # should we use fPIIC on all arches?
-            self.default_args.extend(["-fms-extensions", "-fms-compatibility", "-fPIC", "-Wno-deprecated-declarations"])
+            self.default_args_hip.append("--save-temps")
 
+    def compile(self, include_path: str, args: tuple):
+        """Helper to dispatch to call operator"""
+        return self(include_path, *args)
 
-    def __call__(self, include_path: str, target_list: List[str], srcPath: str, destPath: str):
+    def __call__(self, include_path: str, target: str, srcPath: str, destPath: str):
         """Compiles a source file into an object file.
 
         Args:
@@ -237,11 +244,37 @@ class Compiler(Component):
         Raises:
             RuntimeError: If the compilation command fails.
         """
-        archFlags = [f"--offload-arch={gfx}" for gfx in target_list]
+
         args = [
-            *(self.default_args), "-I", include_path, *archFlags, srcPath, "-c", "-o", destPath
+            *(self.default_args_hip), "-I", f"{include_path}/..", f"--offload-arch={target}", "-c", srcPath, "-o", f"{destPath}.bc"
         ]
-        return _invoke(args, f"Compiling HIP source kernels into objects (.cpp -> .o)")
+
+        _invoke(args, f"Compiling HIP source kernels into byte code (.cpp -> .bc)")
+
+        args = [
+            *(self.default_args_cc1), "-target-cpu", target, "-o", destPath, "-x", "ir", f"{destPath}.bc"
+        ]
+
+        return _invoke(args, f"Compiling HIP byte code into objects (.bc -> .o)")
+
+    def link(self, srcPaths: List[str], destPath: str):
+        """Links object files into a code object file.
+
+        Args:
+            srcPaths: A list of paths to object files.
+            destPath: A destination path for the generated code object file.
+        Raises:
+            RuntimeError: If linker invocation fails.
+        """
+        if os_name == "nt":
+            # Use args file on Windows b/c the command may exceed the limit of 8191 characters
+            with open(Path.cwd() / "clang_args.txt", "wt") as file:
+                file.write(" ".join(srcPaths).replace('\\', '\\\\'))
+            args = [*(self.default_args_ldlld), "-o", destPath, "@clang_args.txt"]
+        else:
+            args = [*(self.default_args_ldlld), *srcPaths, "-o", destPath]
+        return _invoke(args, "Linking kernel helper objects into hsa code object (*.o -> .hsaco)")
+
 
 
 class Bundler(Component):
@@ -365,7 +398,6 @@ class Linker(Component):
         else:
             args = [*(self.default_args), *srcPaths, "-o", destPath]
         return _invoke(args, "Linking assembly object files into code object (*.o -> .co)")
-
 
 # class DeviceEnumerator(Component):
 #     """

--- a/tensilelite/Tensile/Toolchain/Source.py
+++ b/tensilelite/Tensile/Toolchain/Source.py
@@ -38,8 +38,8 @@ class SourceToolchain(NamedTuple):
    bundler: Bundler
 
 
-def makeSourceToolchain(compiler_path, bundler_path, asan_build=False, build_id_kind="sha1", save_temps=False):
-   compiler = Compiler(compiler_path, build_id_kind, asan_build, save_temps)
+def makeSourceToolchain(compiler_path, bundler_path, ldlld_path, asan_build=False, build_id_kind="sha1", save_temps=False):
+   compiler = Compiler(compiler_path, ldlld_path, build_id_kind, asan_build, save_temps)
    bundler = Bundler(bundler_path)
    return SourceToolchain(compiler, bundler)
 

--- a/tensilelite/Tensile/Toolchain/Validators.py
+++ b/tensilelite/Tensile/Toolchain/Validators.py
@@ -110,6 +110,7 @@ def _posixSearchPaths() -> List[Path]:
 class ToolchainDefaults(NamedTuple):
     CXX_COMPILER = osSelect(linux="amdclang++", windows="clang++.exe")
     C_COMPILER = osSelect(linux="amdclang", windows="clang.exe")
+    LD_LLD = osSelect(linux="ld.lld", windows="ld.lld")
     OFFLOAD_BUNDLER = osSelect(linux="clang-offload-bundler", windows="clang-offload-bundler.exe")
     DEVICE_ENUMERATOR = osSelect(linux="rocm_agent_enumerator" if isRhel8() else "amdgpu-arch", windows="hipinfo")
     ASSEMBLER = osSelect(linux="amdclang++", windows="clang++.exe")
@@ -135,6 +136,17 @@ def supportedCCompiler(compiler: str) -> bool:
     """
     return _supportedComponent(compiler, ["amdclang", "clang"])
 
+def supportedLdLld(ldlld: str) -> bool:
+    """
+    Determine if ld.lld is supported by Tensile.
+
+    Args:
+        compiler: The name of a compiler to test for support.
+
+    Return:
+        If supported True; otherwise, False.
+    """
+    return _supportedComponent(ldlld, ["ld.lld"])
 
 def supportedCxxCompiler(compiler: str) -> bool:
     """
@@ -217,6 +229,7 @@ def _validateExecutable(file: str, searchPaths: List[Path]) -> str:
     if not any((
         supportedCxxCompiler(file),
         supportedCCompiler(file),
+        supportedLdLld(file),
         supportedOffloadBundler(file),
         supportedHip(file),
         supportedDeviceEnumerator(file)


### PR DESCRIPTION
Previously, the hipblaslt build system would code gen a single Kernels.cpp file in the tensile output directory. When building for gfx942 or all architectures, it can take up to 70 minutes to compile this file as it is large and we cannot parallelize over a single file. This patch enables writing the kernel helpers into individual files rather than single file and then parallelizes compiling each of files.