### PR TITLE
Remove unnecessary deepcopy in BenchmarkStructs.py

### DIFF
--- a/tensilelite/Tensile/BenchmarkStructs.py
+++ b/tensilelite/Tensile/BenchmarkStructs.py
@@ -270,18 +270,17 @@ def constructForkPermutations(forkParams, paramGroups):
         permutation = {}
         pIdx = i
         for name, v in myParams.items():
-            values = deepcopy(v)
             valueIdx = pIdx % len(v)
+            entry = deepcopy(v[valueIdx])
 
             # groups have multiple parameters to update
             if "_group" in name:
-                entry = values[valueIdx]
                 for n2, v2 in entry.items():
                     permutation[n2] = v2
             else:
-                permutation[name] = values[valueIdx]
+                permutation[name] = entry
 
-            pIdx //= len(values)
+            pIdx //= len(v)
         forkPermutations.append(permutation)
 
     return forkPermutations


### PR DESCRIPTION
When generating the 'forkPermutations', 'constructForkPermutations' does a deepcopy of all values for a given parameter even if we use only one value (valueIdx) at a time. 
When the given parameter is a long list of lists (MIs) this will take a long time.
Changing it to only do the deepcopy for each entry speeds things up considerably. E.g. with 368 MI groups the timings are 93s (orig) vs 0.9s (this PR).