### PR TITLE
Detected CU-Fallback case and then overwrite xcc values.

### DIFF
--- a/library/src/amd_detail/hipblaslt-ext-op-internal.hpp
+++ b/library/src/amd_detail/hipblaslt-ext-op-internal.hpp
@@ -65,6 +65,11 @@ namespace hipblaslt_ext
             return ss.str();
         }
 
+        bool isFallbackForHW(TensileLite::Hardware const&) const override
+        {
+            return false;
+        }
+
         std::uint32_t getTileM() const
         {
             return tileM;
@@ -254,6 +259,11 @@ namespace hipblaslt_ext
             return ss.str();
         }
 
+        bool isFallbackForHW(TensileLite::Hardware const&) const override
+        {
+            return false;
+        }
+
         std::uint32_t getNumWorkitems() const
         {
             return numWorkitems;
@@ -418,6 +428,11 @@ namespace hipblaslt_ext
                << "(" << TensileLite::ToString(datatype) << ", "
                << TensileLite::ToString(outDatatype) << ")";
             return ss.str();
+        }
+
+        bool isFallbackForHW(TensileLite::Hardware const&) const override
+        {
+            return false;
         }
 
         std::uint32_t getNumWorkitems() const

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2488,6 +2488,20 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         else
         {
+            data->problem.setParams().setWGMXCC(0);
+            if(solution->isFallbackForHW(*hardware))
+            {
+                if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+                {
+                    std::ostringstream msg;
+                    msg << "The solution is a cu-fallback for current HW. Use XCC=1 kernelArg."
+                        << std::endl;
+                    log_info(__func__, msg.str());
+                }
+                // set XCC=1 to param when this is a fallback solution
+                data->problem.setParams().setWGMXCC(1);
+            }
+
             auto kernels = solution->solve(data->problem, GetTensileInputs(prob), *hardware);
             // Remove this after supports getting comgr buffers from hip.
             bool isPreloaded = false;
@@ -2749,6 +2763,20 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
             else
             {
                 data->problem.setParams().resetInternalArgs();
+            }
+
+            data->problem.setParams().setWGMXCC(0);
+            if(solution->isFallbackForHW(*hardware))
+            {
+                if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+                {
+                    std::ostringstream msg;
+                    msg << "The solution is a cu-fallback for current HW. Use XCC=1 kernelArg."
+                        << std::endl;
+                    log_info(__func__, msg.str());
+                }
+                // set XCC=1 to param when this is a fallback solution
+                data->problem.setParams().setWGMXCC(1);
             }
 
             data->inputs.ws = workspace;
@@ -3563,21 +3591,19 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
             return rocblaslt_status_invalid_value;
         }
 
-        bool fallbackCU = solution->isFallbackForHW(*hardware);
-        if(fallbackCU)
+        tensile_prob.setParams().setFallbackStatus(false);
+        if(solution->isFallbackForHW(*hardware))
         {
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
             {
                 std::ostringstream msg;
-                msg << "Testing solution is a CU-Fallback for current Hardware. SetXCC to 1."
+                msg << "The solution is a cu-fallback for current HW. Use XCC=1 for predicate."
                     << std::endl;
-                // msg << "\tCurrent HW: " << hardware->description() << std::endl;
                 log_info(__func__, msg.str());
             }
-            // TODO- restore if this solution is eventually not supported (or we do an init everytime)
-            tensile_prob.setParams().setFallbackStatus(true);
-            tensile_prob.setParams().setWGMXCC(1);
-        }
+            // set this flag for SW predicate
+            tensile_prob.setParams().setFallbackStatus(true);            
+        }        
 
         if(!(*solution->problemPredicate)(tensile_prob))
         {

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -2488,8 +2488,9 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
         }
         else
         {
-            data->problem.setParams().setWGMXCC(0);
-            if(solution->isFallbackForHW(*hardware))
+            // cu-fallback detection
+            bool isCUFallback = solution->isFallbackForHW(*hardware);
+            if(isCUFallback)
             {
                 if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
                 {
@@ -2498,9 +2499,9 @@ rocblaslt_status runContractionProblem(rocblaslt_handle                   handle
                         << std::endl;
                     log_info(__func__, msg.str());
                 }
-                // set XCC=1 to param when this is a fallback solution
-                data->problem.setParams().setWGMXCC(1);
             }
+            // set XCC=1 to param when this is a fallback solution
+            data->problem.setParams().setWGMXCC((isCUFallback ? 1 : 0));
 
             auto kernels = solution->solve(data->problem, GetTensileInputs(prob), *hardware);
             // Remove this after supports getting comgr buffers from hip.
@@ -2765,8 +2766,9 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                 data->problem.setParams().resetInternalArgs();
             }
 
-            data->problem.setParams().setWGMXCC(0);
-            if(solution->isFallbackForHW(*hardware))
+            // cu-fallback detection
+            bool isCUFallback = solution->isFallbackForHW(*hardware);
+            if(isCUFallback)
             {
                 if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
                 {
@@ -2775,9 +2777,9 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                         << std::endl;
                     log_info(__func__, msg.str());
                 }
-                // set XCC=1 to param when this is a fallback solution
-                data->problem.setParams().setWGMXCC(1);
             }
+            // set XCC=1 to param when this is a fallback solution
+            data->problem.setParams().setWGMXCC((isCUFallback ? 1 : 0));
 
             data->inputs.ws = workspace;
 
@@ -2815,6 +2817,25 @@ rocblaslt_status makeArgument(rocblaslt_handle             handle,
                 {
                     data->problem.gemms[i].setParams().resetInternalArgs();
                 }
+            }
+
+            // cu-fallback detection
+            bool isCUFallback = solution->isFallbackForHW(*hardware);
+            if(isCUFallback)
+            {
+                if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+                {
+                    std::ostringstream msg;
+                    msg << "The solution is a cu-fallback for current HW. Use XCC=1 kernelArg."
+                        << std::endl;
+                    log_info(__func__, msg.str()); // set xcc to 1 in the for-loop below
+                }
+            }
+            uint16_t xcc_param = isCUFallback ? 1 : 0;
+            for(size_t i = 0; i < data->problem.gemms.size(); i++)
+            {
+                // set XCC=1 to param when this is a fallback solution
+                data->problem.gemms[i].setParams().setWGMXCC(xcc_param);
             }
 
             for(int i = 0; i < data->inputs.grouped.size(); i++)
@@ -3574,7 +3595,22 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
         {
             tensile_prob.setParams().resetInternalArgs();
         }
-        
+
+        // cu-fallback detection
+        bool isCUFallback = solution->isFallbackForHW(*hardware);
+        if(isCUFallback)
+        {
+            if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+            {
+                std::ostringstream msg;
+                msg << "The solution is a cu-fallback for current HW. Use XCC=1 for predicate."
+                    << std::endl;
+                log_info(__func__, msg.str());
+            }
+        }
+        // set this flag for SW predicate
+        tensile_prob.setParams().setFallbackStatus(isCUFallback);
+
         TensileLite::Task task(*hardware, tensile_prob, *solution);
         tensile_prob.setWorkspaceSize(algo->max_workspace_bytes);
         if(!(*solution->hardwarePredicate)(*hardware))
@@ -3590,21 +3626,6 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
             log_error(__func__, "Solution is not supported");
             return rocblaslt_status_invalid_value;
         }
-
-        tensile_prob.setParams().setFallbackStatus(false);
-        if(solution->isFallbackForHW(*hardware))
-        {
-            if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
-            {
-                std::ostringstream msg;
-                msg << "The solution is a cu-fallback for current HW. Use XCC=1 for predicate."
-                    << std::endl;
-                log_info(__func__, msg.str());
-            }
-            // set this flag for SW predicate
-            tensile_prob.setParams().setFallbackStatus(true);            
-        }        
-
         if(!(*solution->problemPredicate)(tensile_prob))
         {
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
@@ -3670,12 +3691,26 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
 
         bool isSupported  = true;
         bool isNormalGemm = true;
+        // cu-fallback detection
+        bool isCUFallback = solution->isFallbackForHW(*hardware);
+        if(isCUFallback)
+        {
+            if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+            {
+                std::ostringstream msg;
+                msg << "The solution is a cu-fallback for current HW. Use XCC=1 for predicate."
+                    << std::endl;
+                log_info(__func__, msg.str()); // will set status in the for-loop below
+            }
+        }
         auto problemWs = solution->requiredWorkspaceSizeGroupedGemm(tensile_prob.gemms, *hardware);
         for(int i = 0; i < tensile_prob.gemms.size(); i++)
         {
             tensile_prob.gemms[i].setWorkspaceSize(algo->max_workspace_bytes);
             tensile_prob.gemms[i].setWorkspaceSizeGroupedGemm(problemWs);
             tensile_prob.gemms[i].setGroupedGemmCount(tensile_prob.gemms.size());
+            // set this flag for SW predicate
+            tensile_prob.gemms[i].setParams().setFallbackStatus(isCUFallback);
         }
         for(int i = 0; i < tensile_prob.gemms.size(); i++)
         {

--- a/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
+++ b/library/src/amd_detail/rocblaslt/src/tensile_host.cpp
@@ -3562,6 +3562,23 @@ rocblaslt_status isSolutionSupported(rocblaslt_handle       handle,
             log_error(__func__, "Solution is not supported");
             return rocblaslt_status_invalid_value;
         }
+
+        bool fallbackCU = solution->isFallbackForHW(*hardware);
+        if(fallbackCU)
+        {
+            if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)
+            {
+                std::ostringstream msg;
+                msg << "Testing solution is a CU-Fallback for current Hardware. SetXCC to 1."
+                    << std::endl;
+                // msg << "\tCurrent HW: " << hardware->description() << std::endl;
+                log_info(__func__, msg.str());
+            }
+            // TODO- restore if this solution is eventually not supported (or we do an init everytime)
+            tensile_prob.setParams().setFallbackStatus(true);
+            tensile_prob.setParams().setWGMXCC(1);
+        }
+
         if(!(*solution->problemPredicate)(tensile_prob))
         {
             if(get_logger_layer_mode() & rocblaslt_layer_mode_log_info)

--- a/tensilelite/Tensile/Hardware.py
+++ b/tensilelite/Tensile/Hardware.py
@@ -27,6 +27,8 @@ from Tensile.Common.Architectures import isaToGfx
 import copy
 
 class HardwarePredicate(Properties.Predicate):
+    # TODO- And also FromISA() is hard to detect CU-fallback case.
+    #       Perhaps we can always use FromHardware(). FromISA() is not used so far.
     @classmethod
     def FromISA(cls, isa):
         gfxArch = isaToGfx(tuple(isa))

--- a/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022-2023 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -231,8 +231,10 @@ namespace TensileLite
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
         int         skFullTiles      = 1;
+        mutable int isStandardCUs    = -1; // -1: unset, 0:false, 1:true
         std::string deviceName;
 
+        virtual bool   isStandardCU() const;
         virtual bool   runsKernelTargeting(Processor p) const;
         virtual size_t id() const
         {

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblem.hpp
@@ -143,6 +143,17 @@ namespace TensileLite
             m_gsu = 0;
         }
 
+        // Fallback means if the problem is running with a CU-fallback sol.
+        void setFallbackStatus(bool cuFallback)
+        {
+            m_fallbackStatus = cuFallback;
+        }
+
+        bool fallbackStatus() const
+        {
+            return m_fallbackStatus;
+        }
+
     private:
         int16_t          m_gsu            = 0; // default value
         bool             m_gsuc           = false; // default value
@@ -153,6 +164,7 @@ namespace TensileLite
         rocisa::DataType m_biasType       = rocisa::DataType::None;
         int              m_factorDim      = 0;
         ActivationType   m_activationType = ActivationType::None;
+        bool             m_fallbackStatus = false; // default value
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -886,7 +886,7 @@ namespace TensileLite
                 virtual bool debugEval(ContractionProblemGemm const& problem,
                                        std::ostream&                 stream) const override
                 {
-                    if (value)
+                    if(value)
                     {
                         bool rv = (*this)(problem);
 
@@ -1535,10 +1535,10 @@ namespace TensileLite
                 {
                     int16_t gsu = problem.getParams().gsu() != 0 ? problem.getParams().gsu() : value[2];
                     // auto gsu will consider workgroup number, so bypassed
-                    if (gsu == -1)
+                    if(gsu == -1)
                         return 1;
 
-                    gsu     = gsu > 1 ? gsu : 1;
+                    gsu = gsu > 1 ? gsu : 1;
                     return (std::ceil(static_cast<float>(problem.freeSizeA(0)) / value[0])
                             * std::ceil(static_cast<float>(problem.freeSizeB(0)) / value[1]) * gsu
                             * problem.batchSize(0))
@@ -1548,7 +1548,7 @@ namespace TensileLite
                                        std::ostream&                 stream) const override
                 {
                     int16_t gsu = problem.getParams().gsu() != 0 ? problem.getParams().gsu() : value[2];
-                    if (gsu == -1)
+                    if(gsu == -1)
                     {
                         bool rv = (*this)(problem);
 
@@ -1558,7 +1558,7 @@ namespace TensileLite
                         return rv;
                     }
 
-                    gsu     = gsu > 1 ? gsu : 1;
+                    gsu = gsu > 1 ? gsu : 1;
                     int workgroupNumber
                         = std::ceil(static_cast<float>(problem.freeSizeA(0)) / value[0])
                           * std::ceil(static_cast<float>(problem.freeSizeB(0)) / value[1]) * gsu
@@ -1629,7 +1629,7 @@ namespace TensileLite
                     size_t minK
                         = (problem.getParams().gsu() != 0 ? problem.getParams().gsu() : value[1]);
                     // auto gsu will consider MinK, so bypassed
-                    if (minK == -1)
+                    if(minK == -1)
                         return 1;
                     if(minK == 1)
                         minK = 0;
@@ -1642,7 +1642,7 @@ namespace TensileLite
                 {
                     size_t minK
                         = (problem.getParams().gsu() != 0 ? problem.getParams().gsu() : value[1]);
-                    if (minK == -1)
+                    if(minK == -1)
                     {
                         bool rv = (*this)(problem);
 
@@ -2699,6 +2699,7 @@ namespace TensileLite
                     HasIndex = false,
                     HasValue = true
                 };
+                // value = [XCC, XCCG]
                 std::array<int, 2> value;
                 size_t             cuCount;
 
@@ -2727,8 +2728,13 @@ namespace TensileLite
 
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
+                    // NB: If this solution is a cu-fallback for this problem.
+                    // We overwrite the XCC to 1 to make sure this can pass.
+                    // But we also have to notice we are passing the correct XCC/XCCG to kernel.
+                    // (i.e. Remember to do setParams().setWGMXCC(1))
+                    size_t XCC     = (problem.getParams().fallbackStatus()) ? 1 : value[0];
                     size_t WGMXCCG = (value[1] == -1) ? cuCount : value[1];
-                    return ((value[0] & (value[0] - 1)) == 0) && WGMXCCG % value[0] == 0;
+                    return ((XCC & (XCC - 1)) == 0) && WGMXCCG % XCC == 0;
                 }
 
                 virtual bool debugEval(ContractionProblemGemm const& problem,

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionProblemPredicates.hpp
@@ -2728,25 +2728,28 @@ namespace TensileLite
 
                 virtual bool operator()(ContractionProblemGemm const& problem) const override
                 {
-                    // NB: If this solution is a cu-fallback for this problem.
+                    // NB: If this solution is a cu-fallback for current hardware.
                     // We overwrite the XCC to 1 to make sure this can pass.
-                    // But we also have to notice we are passing the correct XCC/XCCG to kernel.
-                    // (i.e. Remember to do setParams().setWGMXCC(1))
-                    size_t XCC     = (problem.getParams().fallbackStatus()) ? 1 : value[0];
-                    size_t WGMXCCG = (value[1] == -1) ? cuCount : value[1];
-                    return ((XCC & (XCC - 1)) == 0) && WGMXCCG % XCC == 0;
+                    // But we also have to notice we are passing the correct XCC to kernel.
+                    // (i.e. Remember to do param.setWGMXCC(1) when running the kernel)
+
+                    size_t XCC  = (problem.getParams().fallbackStatus()) ? 1 : value[0];
+                    size_t XCCG = (value[1] == -1) ? cuCount : value[1];
+                    return ((XCC & (XCC - 1)) == 0) && XCCG % XCC == 0;
                 }
 
                 virtual bool debugEval(ContractionProblemGemm const& problem,
                                        std::ostream&                 stream) const override
                 {
+                    size_t XCC  = (problem.getParams().fallbackStatus()) ? 1 : value[0];
+                    size_t XCCG = (value[1] == -1) ? cuCount : value[1];
                     return debugEvalCmp(problem,
                                         stream,
-                                        "cuCount",
-                                        (value[1] == -1) ? cuCount : value[1],
+                                        "WGMXCCG",
+                                        XCCG,
                                         "%",
                                         "WGMXCC",
-                                        value[0],
+                                        XCC,
                                         "==",
                                         0);
                 }

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -531,9 +531,10 @@ namespace TensileLite
         std::string                  kernelName;
         std::string                  solutionName;
         ThreadSafeValue<std::string> codeObjectFilename;
-        bool                         debugKernel   = false;
-        bool                         kernelArgsLog = false;
-        
+        bool                         debugKernel     = false;
+        bool                         kernelArgsLog   = false;
+        mutable int                  isFallbackCUSol = -1; // -1:unset, 0:false, 1:true
+
         std::shared_ptr<Predicates::Predicate<Task>> taskPredicate
             = std::make_shared<Predicates::True<Task>>();
         std::shared_ptr<Predicates::Predicate<Problem>> problemPredicate

--- a/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/ContractionSolution.hpp
@@ -201,6 +201,7 @@ namespace TensileLite
         {
             return kernelName;
         }
+        virtual bool isFallbackForHW(Hardware const&) const;
 
         bool isStreamK() const
         {
@@ -532,6 +533,7 @@ namespace TensileLite
         ThreadSafeValue<std::string> codeObjectFilename;
         bool                         debugKernel   = false;
         bool                         kernelArgsLog = false;
+        
         std::shared_ptr<Predicates::Predicate<Task>> taskPredicate
             = std::make_shared<Predicates::True<Task>>();
         std::shared_ptr<Predicates::Predicate<Problem>> problemPredicate

--- a/tensilelite/Tensile/Source/lib/include/Tensile/Tensile.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/Tensile.hpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -163,8 +163,9 @@ namespace TensileLite
     public:
         virtual ~Solution();
 
-        virtual std::string name() const        = 0;
-        virtual std::string description() const = 0;
+        virtual std::string name() const                           = 0;
+        virtual std::string description() const                    = 0;
+        virtual bool        isFallbackForHW(Hardware const&) const = 0;
     };
 
     /**

--- a/tensilelite/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/tensilelite/Tensile/Source/lib/source/AMDGPU.cpp
@@ -2,7 +2,7 @@
  *
  * MIT License
  *
- * Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (C) 2022-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,13 @@
 
 namespace TensileLite
 {
+    static const std::map<AMDGPU::Processor, std::vector<int>>& NonStandardCUMap()
+    {
+        static const std::map<AMDGPU::Processor, std::vector<int>> NonStandardCU = {
+            {AMDGPU::Processor::gfx90a, {104}}, {AMDGPU::Processor::gfx942, {20, 38, 64, 80, 228}}};
+        return NonStandardCU;
+    }
+
     TENSILE_API std::string AMDGPU::type() const
     {
         return Type();
@@ -48,6 +55,27 @@ namespace TensileLite
     }
 
     TENSILE_API AMDGPU::~AMDGPU() = default;
+
+    TENSILE_API bool AMDGPU::isStandardCU() const
+    {
+        // return the result if we already tested it.
+        if(isStandardCUs != -1)
+            return (isStandardCUs == 1);
+
+        // assume current device is a standard cu device.
+        isStandardCUs = 1;
+
+        auto mapIter = NonStandardCUMap().find(processor);
+        if(mapIter != NonStandardCUMap().end())
+        {
+            auto list = mapIter->second;
+            // current device is a speicalized cu device.
+            if(std::count(list.begin(), list.end(), computeUnitCount) > 0)
+                isStandardCUs = 0;
+        }
+
+        return (isStandardCUs == 1);
+    }
 
     TENSILE_API bool AMDGPU::runsKernelTargeting(AMDGPU::Processor other) const
     {

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -529,6 +529,20 @@ namespace TensileLite
 
     PerfModel perf;
 
+    // check if this solution is a CU-Fallback solution for current hardware
+    bool ContractionSolution::isFallbackForHW(Hardware const& hardware) const
+    {
+        auto hw_pred
+            = static_pointer_cast<Predicates::IsSubclass<Hardware, AMDGPU>>(hardwarePredicate);
+        // TODO: need to check if the CU count is not a general CU
+        if(hw_pred->value->type() == "Processor")
+        {
+            return true;
+        }
+
+        return false;
+    }
+
     // Return magic number.  If magicShift is 0, compute and return it.
     uint32_t ContractionSolution::magicNumberAlg1(uint32_t x, uint32_t* magicShift) const
     {
@@ -1245,15 +1259,19 @@ namespace TensileLite
             }
             else if(internalArgsSupport.version == 2)
             {
+                // NB: get value from param= set in runtime / vs value from sizeMapping: from logic yaml.
+                //     param: default values: [xcc = 0, xccg = 0]. So when we never set xcc/xccg in runtime: we always get from sizeMapping.
+                //     From sizeMapping = from logic yaml. If not set in Config-Yaml, use default value [1, -1]
                 wgmxcc = param.wgmxcc() > 0 ? param.wgmxcc() : sizeMapping.workGroupMappingXCC;
                 wgmxccg
                     = param.wgmxccg() != 0 ? param.wgmxccg() : sizeMapping.workGroupMappingXCCGroup;
-                if(wgmxcc > 1 && wgmxccg == -1)
+                if(wgmxcc >= 1 && wgmxccg == -1)
                 {
                     AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(hardware);
                     assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
                     wgmxccg = pAMDGPU->computeUnitCount;
                 }
+                // std::cout << "\tDEBUG_TEST: [XCC,XCCG] = [" << wgmxcc << "," << wgmxccg << "]\n";
                 internalArg1 = internalArg1 | (wgmxccg << 22) | (wgmxcc << 16) | (mask16 & wgm);
             }
         }
@@ -1346,15 +1364,15 @@ namespace TensileLite
         if(gsu > 0)
             rv.numWorkGroups.y *= gsu;
 
-        size_t skGrid    = 0;
-        auto   tiles     = problem.getNumTiles(sizeMapping, gsu);
+        size_t skGrid = 0;
+        auto   tiles  = problem.getNumTiles(sizeMapping, gsu);
         if(sizeMapping.streamK != 0 || sizeMapping.persistentKernel != 0)
         {
             AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
             assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
             if(sizeMapping.streamK != 0)
             {
-                skGrid = getSKGrid(problem, hardware, tiles);
+                skGrid             = getSKGrid(problem, hardware, tiles);
                 rv.numWorkGroups.x = skGrid;
                 rv.numWorkGroups.y = 1;
                 rv.numWorkGroups.z = 1;
@@ -2995,9 +3013,10 @@ namespace TensileLite
             calculateAutoGSU(problem, &hardware);
             size_t gsu = problem.getParams().gsu() > 0 ? problem.getParams().gsu() : autoGSU;
             size_t gsuMultiplier = gsu > 1 ? gsu : 0;
-            size_t batch = problem.d().sizes()[2];
-            size_t tiles = problem.getNumTiles(sizeMapping, gsu) * batch;
-            size_t tileSize = sizeMapping.macroTile.x * sizeMapping.macroTile.y * sizeMapping.workspaceSizePerElemC;
+            size_t batch         = problem.d().sizes()[2];
+            size_t tiles         = problem.getNumTiles(sizeMapping, gsu) * batch;
+            size_t tileSize      = sizeMapping.macroTile.x * sizeMapping.macroTile.y
+                              * sizeMapping.workspaceSizePerElemC;
             size_t bufSize = gsu > 1 ? tiles * tileSize : 0;
             size += bufSize;
 

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -532,15 +532,18 @@ namespace TensileLite
     // check if this solution is a CU-Fallback solution for current hardware
     bool ContractionSolution::isFallbackForHW(Hardware const& hardware) const
     {
+        // return the result if we already tested it.
+        if(isFallbackCUSol != -1)
+            return (isFallbackCUSol == 1);
+
         auto hw_pred
             = static_pointer_cast<Predicates::IsSubclass<Hardware, AMDGPU>>(hardwarePredicate);
-        // TODO: need to check if the CU count is not a general CU
-        if(hw_pred->value->type() == "Processor")
-        {
-            return true;
-        }
+        auto amdGPU = static_cast<AMDGPU const*>(&hardware);
+        // if solution is from a standard cu lib, but current HW is not, then this is a Fallback sol.
+        isFallbackCUSol
+            = (hw_pred->value->type() == "Processor" && !(amdGPU->isStandardCU())) ? 1 : 0;
 
-        return false;
+        return (isFallbackCUSol == 1);
     }
 
     // Return magic number.  If magicShift is 0, compute and return it.
@@ -1271,7 +1274,6 @@ namespace TensileLite
                     assert(pAMDGPU != nullptr && pAMDGPU->computeUnitCount != 0);
                     wgmxccg = pAMDGPU->computeUnitCount;
                 }
-                // std::cout << "\tDEBUG_TEST: [XCC,XCCG] = [" << wgmxcc << "," << wgmxccg << "]\n";
                 internalArg1 = internalArg1 | (wgmxccg << 22) | (wgmxcc << 16) | (mask16 & wgm);
             }
         }


### PR DESCRIPTION
Resolved:
- SWDEV-528780
- SWDEV-522233
- SWDEV-533436
- SWDEV-533695
------------
#2104 is our first workaround idea. But that PR is huge and hard to rebase in the meantime. And hard to maintain/restore in the near future.

This PR is another idea to dynamically overwrite xcc value when we know the solution is a CU-fallback. Should be a better solution and no need to modify any logic yamls.

Will re-run the tests in the three tickets.
- [x] SWDEV-528780 = SWDEV-522233 (swizzleA) - `./hipblaslt-test --gtest_filter=*matmul_swizzleA*`
- [x] SWDEV-533436 (nightly) - `./hipblaslt-test --gtest_filter=*heuristic_all_solutions*` and then `./hipblaslt-test --gtest_filter=*nightly*`
- [x] Additional test - `./hipblaslt-test --gtest_filter=*groupedgemm*`
- [x] General gtest

The whole testing can be faster on those non-standard CU devices, since lots of "false rejections" happened before this PR due to the XCC predicate. 

----------
### Test Results: (using non-standard CUs)
#### SWDEV-528780 = SWDEV-522233 : filter = matmul_swizzleA
[==========] 384 tests from 1 test suite ran. (27602 ms total)
[  PASSED  ] 384 tests.
hipBLASLt version: 1500
hipBLASLt git version: f52adfb7-dirty
command line: ./hipblaslt-test --gtest_filter=*matmul_swizzleA* 

#### filter = heuristic_all_solutions
[==========] 736 tests from 1 test suite ran. (1241772 ms total)
[  PASSED  ] 736 tests.
hipBLASLt version: 1500
hipBLASLt git version: 3a712cba-dirty
command line: ./hipblaslt-test --gtest_filter=*heuristic_all_solutions* 

#### SWDEV-533436: filter = nightly
[==========] 5272 tests from 1 test suite ran. (2586325 ms total)
[  PASSED  ] 5272 tests.
hipBLASLt version: 1500
hipBLASLt git version: 65338c70-dirty
command line: ./hipblaslt-test --gtest_filter=*nightly* 

#### General gtest
[==========] 54611 tests from 13 test suites ran. (12799729 ms total)
[  PASSED  ] 54611 tests.
hipBLASLt version: 1500
hipBLASLt git version: be6bdced-dirty
command line: ./hipblaslt-test

----------
### Additional Improvement - get solution will be faster on devices with specialized CUs:
#### Single grouped gemm test: 
**Before:**
[==========] 2 tests from 1 test suite ran. (**53014 ms total**)
[  PASSED  ] 2 tests.
hipBLASLt version: 1500
hipBLASLt git version: 3a712cba-dirty
command line: ./hipblaslt-test --gtest_filter=*matmul_groupedgemm_f8_fnuz* 

**After:**
[==========] 2 tests from 1 test suite ran. (**27690 ms total**)
[  PASSED  ] 2 tests.
hipBLASLt version: 1500
hipBLASLt git version: 65338c70-dirty
command line: ./hipblaslt-test --gtest_filter=*matmul_groupedgemm_f8_fnuz* 

This is because lots of "false rejections" happened before this PR due to the XCC predicate. This PR now can find more supported solutions with the ability of cu-fallback detection.