### PR TITLE
Docs: Add environment variable reference page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ The hipBLASLt public repository is located at `<https://github.com/ROCm/hipBLASL
 
     * :doc:`Data type support <./reference/data-type-support>`
     * :doc:`hipBLASLt datatypes <./reference/datatypes>`
+    * :doc:`hipBLASLt environment variables <./reference/env-variables>`
     * :doc:`hipBLASLt API <./reference/api-reference>`
     * :doc:`hipBLASLtExt API <./reference/ext-reference>`
     * :doc:`hipBLASLtExt operation API <./reference/ext-ops>`

--- a/docs/reference/env-variables.rst
+++ b/docs/reference/env-variables.rst
@@ -1,0 +1,119 @@
+.. meta::
+  :description: hipBLASLt environment variables reference
+  :keywords: hipBLASLt, ROCm, API, environment variables, environment, reference
+
+.. _environment-variables:
+
+********************************************************************
+hipBLASLt environment variables
+********************************************************************
+
+This section describes the important hipBLASLt environment variables,
+which are grouped by functionality.
+
+Logging and debugging
+=====================
+
+The logging and debugging environment variables for hipBLASLt are collected in the following table.
+For more information, see :doc:`Use logging and heuristics <../how-to/use-logging-heuristics>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 70,30
+
+    * - **Environment variable**
+      - **Value**
+
+    * - | ``HIPBLASLT_LOG_LEVEL``
+        | Controls the verbosity level of hipBLASLt logging output.
+      - | 0: Off (logging disabled, default)
+        | 1: Error (only errors are logged)
+        | 2: Trace (API calls with kernel launches log parameters)
+        | 3: Hints (performance improvement suggestions)
+        | 4: Info (general library execution information)
+        | 5: API trace (detailed API call parameters)
+
+    * - | ``HIPBLASLT_LOG_MASK``
+        | Controls logging output using bit mask flags (can be combined).
+      - | 0: Off
+        | 1: Error
+        | 2: Trace
+        | 4: Hints
+        | 8: Info
+        | 16: API trace
+        | 32: Bench
+        | 64: Profile
+        | 128: Extended profile
+
+    * - | ``HIPBLASLT_LOG_FILE``
+        | Specifies path to logging file. Can contain ``%i`` for process ID replacement.
+      - | Path to log file (for example, ``logfile_%i.log``)
+        | If not defined: log messages printed to stdout
+
+    * - | ``HIPBLASLT_ENABLE_MARKER``
+        | Enables marker trace for ROCProfiler profiling.
+      - | 0 or unset: Disable marker trace
+        | 1: Enable marker trace
+
+
+Offline tuning
+===============
+
+The offline tuning environment variables for hipBLASLt are collected in the following table.
+For more information, see :doc:`Use hipBLASLt offline tuning <../how-to/how-to-use-hipblaslt-offline-tuning>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 70,30
+
+    * - **Environment variable**
+      - **Value**
+
+    * - | ``HIPBLASLT_TUNING_FILE``
+        | Specifies file to store tuning results with best solution indices for GEMM problems.
+      - | Path to tuning file (for example, ``tuning.txt``)
+        | File stores optimal kernel indices for reuse
+
+    * - | ``HIPBLASLT_TUNING_OVERRIDE_FILE``
+        | Specifies file to load tuning results and override default kernel selection.
+      - | Path to tuning file (for example, ``tuning.txt``)
+        | Loads previously saved optimal kernel choices
+
+    * - | ``HIPBLASLT_TUNING_USER_MAX_WORKSPACE``
+        | Sets maximum workspace size constraint during tuning stage.
+      - | Integer value in bytes (default: 128 * 1024 * 1024)
+        | Limits workspace size for solution selection
+
+Stream-K configuration
+======================
+
+The Stream-K configuration environment variables for hipBLASLt are collected in the following table.
+For more information, see :doc:`Use Stream-K with hipBLASLt <../how-to/how-to-use-streamk>`.
+
+.. list-table::
+    :header-rows: 1
+    :widths: 70,30
+
+    * - **Environment variable**
+      - **Value**
+
+    * - | ``TENSILE_SOLUTION_SELECTION_METHOD``
+        | Controls hipBLASLt kernel selection strategy for GEMM operations.
+      - | 0: Default (standard tuned libraries, no Stream-K)
+        | 2: Stream-K (enables Stream-K library for consistent performance)
+
+    * - | ``TENSILE_STREAMK_DYNAMIC_GRID``
+        | Controls Stream-K dynamic grid size selection behavior.
+      - | 0: Disable dynamic grid (use all available compute units)
+        | 3: Default (automatically pick optimal workgroup count)
+
+    * - | ``TENSILE_STREAMK_FIXED_GRID``
+        | Overrides default grid size with specified number of workgroups for Stream-K kernels.
+      - | Integer value specifying number of workgroups
+        | Example: 64 (limits GEMM kernels to 64 workgroups)
+
+    * - | ``TENSILE_STREAMK_MAX_CUS``
+        | Sets maximum number of compute units for Stream-K kernels.
+      - | Integer value specifying maximum compute units
+        | Example: 32 (limits GEMM kernels to 32 compute units)
+        | Default: All available compute units

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -48,6 +48,8 @@ subtrees:
   - file: reference/data-type-support
   - file: reference/datatypes
     title: hipBLASLt datatypes
+  - file: reference/env-variables
+    title: hipBLASLt environment variables
   - file: reference/api-reference
     title: hipBLASLt API
   - file: reference/ext-reference


### PR DESCRIPTION
This is part of the environment variable initiative, where we aim to create a ROCm environment variable index page that contains the links to every component's environment variable page. Do let me know if there are any other environment variables besides the ones that are listed, and whether the description/default values are correct.