### PR TITLE
Fixed a C++20 extension warning

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -532,6 +532,8 @@ namespace TensileLite
     // check if this solution is a CU-Fallback solution for current hardware
     bool ContractionSolution::isFallbackForHW(Hardware const& hardware) const
     {
+        using std::static_pointer_cast;
+
         // return the result if we already tested it.
         if(isFallbackCUSol != -1)
             return (isFallbackCUSol == 1);


### PR DESCRIPTION
Fixed this warning:

> use of function template name with no prior declaration in function call with explicit template arguments is a C++20 extension [-Wc++20-extensions]

A simple fixing just like #972 