### PR TITLE
Enable multiple vgprs for local r/w + storeswapaddr

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -4028,35 +4028,38 @@ class KernelWriter(metaclass=abc.ABCMeta):
     self.states.a.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsA"] and kernel["NonDTLTailLoopA"]) else 1 * self.states.rpla
     self.states.b.numVgprLocalWriteAddrTailLoop = 0 if not (kernel["DirectToLdsB"] and kernel["NonDTLTailLoopB"]) else 1 * self.states.rpla
 
-    # TODO: Refactor vgpr multiplier calculation
-    # based on comments here: https://github.com/ROCm/hipBLASLt/pull/2061/files#r2085714139
-    if self.states.archCaps["DeviceLDS"] > 65536 and not kernel["StoreSwapAddr"]:
-      need128K = kernel["LdsOffsetA_Blk"]>=131072 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"]
-      need64K = kernel["LdsOffsetA_Blk"]>=65536 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"]
+    numVgprMultiplierA = 1
+    numVgprMultiplierB = 1
+    numVgprMultiplierMetadata = 1
+    if self.states.archCaps["DeviceLDS"] > 65536:
+      need128K = kernel["LdsOffsetA_Blk"]>=131072 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"] and not kernel["StoreSwapAddr"]
+      need64K = kernel["LdsOffsetA_Blk"]>=65536 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"] and not kernel["StoreSwapAddr"]
       if need128K or kernel["LdsNumElementsAlignedA"]>=131072:
-        self.states.a.numVgprLocalReadAddr *= 3
-        self.states.a.numVgprLocalWriteAddr *= 3
-        self.states.a.numVgprLocalWriteAddrTailLoop *= 3
+        numVgprMultiplierA = 3
       elif need64K or kernel["LdsNumElementsAlignedA"]>=65536:
-        self.states.a.numVgprLocalReadAddr *= 2
-        self.states.a.numVgprLocalWriteAddr *= 2
-        self.states.a.numVgprLocalWriteAddrTailLoop *= 2
+        numVgprMultiplierA = 2
 
       if need128K or kernel["LdsNumElementsAlignedB"]>=131072:
-        self.states.b.numVgprLocalReadAddr *= 3
-        self.states.b.numVgprLocalWriteAddr *= 3
-        self.states.b.numVgprLocalWriteAddrTailLoop *= 3
+        numVgprMultiplierB = 3
       elif need64K or kernel["LdsNumElementsAlignedB"]>=65536:
-        self.states.b.numVgprLocalReadAddr *= 2
-        self.states.b.numVgprLocalWriteAddr *= 2
-        self.states.b.numVgprLocalWriteAddrTailLoop *= 2
+        numVgprMultiplierB = 2
 
       if need128K or kernel["LdsNumElementsAlignedMetadata"]>=131072:
-        self.states.m.numVgprLocalReadAddr *= 3
-        self.states.m.numVgprLocalWriteAddr *= 3
+        numVgprMultiplierMetadata = 3
       elif need64K or kernel["LdsNumElementsAlignedMetadata"]>=65536:
-        self.states.m.numVgprLocalReadAddr *= 2
-        self.states.m.numVgprLocalWriteAddr *= 2
+        numVgprMultiplierMetadata = 2
+
+    self.states.a.numVgprLocalReadAddr *= numVgprMultiplierA
+    self.states.a.numVgprLocalWriteAddr *= numVgprMultiplierA
+    self.states.a.numVgprLocalWriteAddrTailLoop *= numVgprMultiplierA
+
+    self.states.b.numVgprLocalReadAddr *= numVgprMultiplierB
+    self.states.b.numVgprLocalWriteAddr *= numVgprMultiplierB
+    self.states.b.numVgprLocalWriteAddrTailLoop *= numVgprMultiplierB
+
+    self.states.m.numVgprLocalReadAddr *= numVgprMultiplierMetadata
+    self.states.m.numVgprLocalWriteAddr *= numVgprMultiplierMetadata
+
 
     if not (kernel["ProblemType"]["Sparse"] and not kernel["DirectToVgprSparseMetadata"]):
       self.states.m.numVgprLocalReadAddr = 0

--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -4031,23 +4031,17 @@ class KernelWriter(metaclass=abc.ABCMeta):
     numVgprMultiplierA = 1
     numVgprMultiplierB = 1
     numVgprMultiplierMetadata = 1
-    if self.states.archCaps["DeviceLDS"] > 65536:
-      need128K = kernel["LdsOffsetA_Blk"]>=131072 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"] and not kernel["StoreSwapAddr"]
-      need64K = kernel["LdsOffsetA_Blk"]>=65536 and kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"] and not kernel["StoreSwapAddr"]
-      if need128K or kernel["LdsNumElementsAlignedA"]>=131072:
-        numVgprMultiplierA = 3
-      elif need64K or kernel["LdsNumElementsAlignedA"]>=65536:
-        numVgprMultiplierA = 2
+    maxLDSConstOffset = self.states.regCaps["maxLDSConstOffset"]
 
-      if need128K or kernel["LdsNumElementsAlignedB"]>=131072:
-        numVgprMultiplierB = 3
-      elif need64K or kernel["LdsNumElementsAlignedB"]>=65536:
-        numVgprMultiplierB = 2
+    if self.states.archCaps["DeviceLDS"] > maxLDSConstOffset:
+      hasMultipleBuffer = kernel["ExpandPointerSwap"] and not kernel["1LDSBuffer"] and not kernel["StoreSwapAddr"]
 
-      if need128K or kernel["LdsNumElementsAlignedMetadata"]>=131072:
-        numVgprMultiplierMetadata = 3
-      elif need64K or kernel["LdsNumElementsAlignedMetadata"]>=65536:
-        numVgprMultiplierMetadata = 2
+      numVgprMultiplier = 1 if not hasMultipleBuffer else (kernel["LdsOffsetA_Blk"] // maxLDSConstOffset + 1)
+
+      numVgprMultiplierA = max(numVgprMultiplier, kernel["LdsNumElementsAlignedA"] // maxLDSConstOffset + 1)
+      numVgprMultiplierB = max(numVgprMultiplier, kernel["LdsNumElementsAlignedB"] // maxLDSConstOffset + 1)
+      numVgprMultiplierMetadata = max(numVgprMultiplier, kernel["LdsNumElementsAlignedMetadata"] // maxLDSConstOffset + 1)
+
 
     self.states.a.numVgprLocalReadAddr *= numVgprMultiplierA
     self.states.a.numVgprLocalWriteAddr *= numVgprMultiplierA

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8509,12 +8509,17 @@ class KernelWriterAssembly(KernelWriter):
           src1=sgpr("LocalWriteAddr%s"%tc), \
           comment="swap Red Blk SGPR"))
       else:
-        for i in range(0,numLwa):
-          module.add(VXorB32(
-            dst=vgpr("LocalWriteAddr%s+%u"%(tc,i)), \
+        module.add(VXorB32(
+            dst=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
             src0=src0Val, \
-            src1=vgpr("LocalWriteAddr%s+%u"%(tc,i)), \
+            src1=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
             comment="swap Red Blk"))
+        for i in range(1,numLwa):
+          module.add(VAddU32(
+            dst=vgpr("LocalWriteAddr%s+%u"%(tc,i)), \
+            src0=(i * 0x10000), \
+            src1=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
+            comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
 
     if needSwap:
       #fixme-iui  need to use wrapping increment for double or triple buffering:
@@ -8616,17 +8621,11 @@ class KernelWriterAssembly(KernelWriter):
               src1=sgpr("LocalWriteAddr%s"%tP["tensorChar"]), \
               comment="reset to Red"))
         else:
-          numLwa = 0
-          if tP["isA"]:
-            numLwa = self.states.a.numVgprLocalWriteAddr
-          elif tP["isB"]:
-            numLwa = self.states.b.numVgprLocalWriteAddr
-          for i in range(numLwa):
-            module.add(VAndB32(
-                dst=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], i)), \
-                src0=resetMask, \
-                src1=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], i)), \
-                comment="reset to Red"))
+          module.add(VAndB32(
+            dst=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+            src0=resetMask, \
+            src1=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+            comment="reset to Red"))
     if needMetaReset:
       if kernel["DirectToVgprSparseMetadata"]:
         tP["metadataWriteSwapByteOffset"] = 0
@@ -8661,13 +8660,27 @@ class KernelWriterAssembly(KernelWriter):
                                comment="Set LWA to first buffer offset"))
             self.vgprPool.checkIn(tmpvgpr)
         else:
-          numLwa = self.states.m.numVgprLocalWriteAddr
-          for i in range(numLwa):
-            module.add(VAndB32(
-                dst=vgpr("LocalWriteAddr%s+%u"%(tPM["tensorChar"], i)), \
-                src0=resetMask, \
-                src1=vgpr("LocalWriteAddr%s+%u"%(tPM["tensorChar"], i)), \
-                comment="reset to Red"))
+          module.add(VAndB32(
+            dst=vgpr("LocalWriteAddr%s+%u"%(tPM["tensorChar"], 0)), \
+            src0=resetMask, \
+            src1=vgpr("LocalWriteAddr%s+%u"%(tPM["tensorChar"], 0)), \
+            comment="reset to Red"))
+
+
+    numLwa = 0
+    if tP["isA"]:
+      numLwa = self.states.a.numVgprLocalWriteAddr
+    elif tP["isB"]:
+      numLwa = self.states.b.numVgprLocalWriteAddr
+    elif tP["isM"]:
+      numLwa = self.states.m.numVgprLocalWriteAddr
+
+    for i in range(1, numLwa):
+      module.add(VAddU32(
+        dst=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], i)), \
+        src0=(i * 0x10000), \
+        src1=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
     return module
 
   ##############################################################################
@@ -9457,6 +9470,7 @@ class KernelWriterAssembly(KernelWriter):
     if kernel["1LDSBuffer"] or ((tP["isA"] or tP["isB"]) and kernel["DirectToVgpr%s"%tc]): # no local read code if DirectToVgpr is enabled
       return Module("localReadSwapOffsets (Empty)")
     module = Module("localReadSwapOffsets")
+
     if internalPointerSwap or kernel["StoreSwapAddr"]:
       if not kernel["StoreSwapAddr"]:
         tP["localReadSwapByteOffset"] = 0 if tP["localReadSwapByteOffset"] else kernel["LdsOffsetA_Blk"]
@@ -9468,19 +9482,27 @@ class KernelWriterAssembly(KernelWriter):
           src1=vgpr("LocalReadAddr%s"%tc), \
           comment="swap Red Blk"))
     else:
-      numLra = 0
-      if tP["isA"]:
-        numLra = self.states.a.numVgprLocalReadAddr
-      elif tP["isB"]:
-        numLra = self.states.b.numVgprLocalReadAddr
-      elif tP["isM"]:
-        numLra = self.states.m.numVgprLocalReadAddr
-      for i in range(numLra):
-        module.add(VXorB32(
-            dst=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            src0=hex(kernel["LdsOffsetA_Blk"]), \
-            src1=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            comment="swap Red Blk"))
+      module.add(VXorB32(
+        dst=vgpr("LocalReadAddr%s"%tc), \
+        src0=hex(kernel["LdsOffsetA_Blk"]), \
+        src1=vgpr("LocalReadAddr%s"%tc), \
+        comment="swap Red Blk"))
+
+    numLra = 0
+    if tP["isA"]:
+      numLra = self.states.a.numVgprLocalReadAddr
+    elif tP["isB"]:
+      numLra = self.states.b.numVgprLocalReadAddr
+    elif tP["isM"]:
+      numLra = self.states.m.numVgprLocalReadAddr
+
+    for i in range(1,numLra):
+      module.add(VAddU32(
+        dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
+        src0=(i * 0x10000), \
+        src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+
     return module
 
   ##############################################################################
@@ -9513,19 +9535,28 @@ class KernelWriterAssembly(KernelWriter):
                       comment="Set LRA to first buffer offset"))
       self.vgprPool.checkIn(tmpvgpr)
     else:
-      numLra = 0
-      if tP["isA"]:
-        numLra = self.states.a.numVgprLocalReadAddr
-      elif tP["isB"]:
-        numLra = self.states.b.numVgprLocalReadAddr
-      elif tP["isM"]:
-        numLra = self.states.m.numVgprLocalReadAddr
-      for i in range(numLra):
-        module.add(VAndB32(
-            dst=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            src0=hex(kernel["LdsOffsetA_Blk"]-1), \
-            src1=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            comment="reset Red,Blk -> Red"))
+
+      module.add(VAndB32(
+        dst=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], 0)), \
+        src0=hex(kernel["LdsOffsetA_Blk"]-1), \
+        src1=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], 0)), \
+        comment="reset Red,Blk -> Red"))
+
+    numLra = 0
+    if tP["isA"]:
+      numLra = self.states.a.numVgprLocalReadAddr
+    elif tP["isB"]:
+      numLra = self.states.b.numVgprLocalReadAddr
+    elif tP["isM"]:
+      numLra = self.states.m.numVgprLocalReadAddr
+
+    for i in range(1,numLra):
+      module.add(VAddU32(
+        dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
+        src0=(i * 0x10000), \
+        src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+
     return module
 
   ##############################################################################
@@ -9547,12 +9578,17 @@ class KernelWriterAssembly(KernelWriter):
         numLra = self.states.b.numVgprLocalReadAddr
       elif tP["isM"]:
         numLra = self.states.m.numVgprLocalReadAddr
-      for i in range(numLra):
-        module.add(VAndB32(
-            dst=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            src0=hex(kernel["LdsOffset%s_Blk"%tP["tensorChar"]]-1), \
-            src1=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], i)), \
-            comment="init Red,Blk -> Red"))
+      module.add(VAndB32(
+        dst=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], 0)), \
+        src0=hex(kernel["LdsOffset%s_Blk"%tP["tensorChar"]]-1), \
+        src1=vgpr("LocalReadAddr%s+%u"%(tP["tensorChar"], 0)), \
+        comment="init Red,Blk -> Red"))
+      for i in range(1, numLra):
+        module.add(VAddU32(
+          dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
+          src0=(i * 0x10000), \
+          src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+          comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
     return module
 
   ##############################################################################

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8517,9 +8517,9 @@ class KernelWriterAssembly(KernelWriter):
         for i in range(1,numLwa):
           module.add(VAddU32(
             dst=vgpr("LocalWriteAddr%s+%u"%(tc,i)), \
-            src0=(i * 0x10000), \
+            src0=(i * self.states.regCaps["maxLDSConstOffset"]), \
             src1=vgpr("LocalWriteAddr%s"%tc), \
-            comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+            comment="Final Offset Plus %uK"%((i * self.states.regCaps["maxLDSConstOffset"]) / 1024)))
 
     if needSwap:
       #fixme-iui  need to use wrapping increment for double or triple buffering:
@@ -8677,9 +8677,9 @@ class KernelWriterAssembly(KernelWriter):
     for i in range(1, numLwa):
       module.add(VAddU32(
         dst=vgpr("LocalWriteAddr%s+%u"%(tc, i)), \
-        src0=(i * 0x10000), \
+        src0=(i * self.states.regCaps["maxLDSConstOffset"]), \
         src1=vgpr("LocalWriteAddr%s"%tc), \
-        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+        comment="Final Offset Plus %uK"%((i * self.states.regCaps["maxLDSConstOffset"]) / 1024)))
     return module
 
   ##############################################################################
@@ -9498,9 +9498,9 @@ class KernelWriterAssembly(KernelWriter):
     for i in range(1,numLra):
       module.add(VAddU32(
         dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
-        src0=(i * 0x10000), \
+        src0=(i * self.states.regCaps["maxLDSConstOffset"]), \
         src1=vgpr("LocalReadAddr%s"%tc), \
-        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+        comment="Final Offset Plus %uK"%((i * self.states.regCaps["maxLDSConstOffset"]) / 1024)))
 
     return module
 
@@ -9552,9 +9552,9 @@ class KernelWriterAssembly(KernelWriter):
     for i in range(1,numLra):
       module.add(VAddU32(
         dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
-        src0=(i * 0x10000), \
+        src0=(i * self.states.regCaps["maxLDSConstOffset"]), \
         src1=vgpr("LocalReadAddr%s"%tc), \
-        comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+        comment="Final Offset Plus %uK"%((i * self.states.regCaps["maxLDSConstOffset"]) / 1024)))
 
     return module
 
@@ -9585,9 +9585,9 @@ class KernelWriterAssembly(KernelWriter):
       for i in range(1, numLra):
         module.add(VAddU32(
           dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
-          src0=(i * 0x10000), \
+          src0=(i * self.states.regCaps["maxLDSConstOffset"]), \
           src1=vgpr("LocalReadAddr%s"%tc), \
-          comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
+          comment="Final Offset Plus %uK"%((i * self.states.regCaps["maxLDSConstOffset"]) / 1024)))
     return module
 
   ##############################################################################

--- a/tensilelite/Tensile/KernelWriterAssembly.py
+++ b/tensilelite/Tensile/KernelWriterAssembly.py
@@ -8510,15 +8510,15 @@ class KernelWriterAssembly(KernelWriter):
           comment="swap Red Blk SGPR"))
       else:
         module.add(VXorB32(
-            dst=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
+            dst=vgpr("LocalWriteAddr%s"%tc), \
             src0=src0Val, \
-            src1=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
+            src1=vgpr("LocalWriteAddr%s"%tc), \
             comment="swap Red Blk"))
         for i in range(1,numLwa):
           module.add(VAddU32(
             dst=vgpr("LocalWriteAddr%s+%u"%(tc,i)), \
             src0=(i * 0x10000), \
-            src1=vgpr("LocalWriteAddr%s+%u"%(tc,0)), \
+            src1=vgpr("LocalWriteAddr%s"%tc), \
             comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
 
     if needSwap:
@@ -8622,9 +8622,9 @@ class KernelWriterAssembly(KernelWriter):
               comment="reset to Red"))
         else:
           module.add(VAndB32(
-            dst=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+            dst=vgpr("LocalWriteAddr%s"%tc), \
             src0=resetMask, \
-            src1=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+            src1=vgpr("LocalWriteAddr%s"%tc), \
             comment="reset to Red"))
     if needMetaReset:
       if kernel["DirectToVgprSparseMetadata"]:
@@ -8666,7 +8666,6 @@ class KernelWriterAssembly(KernelWriter):
             src1=vgpr("LocalWriteAddr%s+%u"%(tPM["tensorChar"], 0)), \
             comment="reset to Red"))
 
-
     numLwa = 0
     if tP["isA"]:
       numLwa = self.states.a.numVgprLocalWriteAddr
@@ -8677,9 +8676,9 @@ class KernelWriterAssembly(KernelWriter):
 
     for i in range(1, numLwa):
       module.add(VAddU32(
-        dst=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], i)), \
+        dst=vgpr("LocalWriteAddr%s+%u"%(tc, i)), \
         src0=(i * 0x10000), \
-        src1=vgpr("LocalWriteAddr%s+%u"%(tP["tensorChar"], 0)), \
+        src1=vgpr("LocalWriteAddr%s"%tc), \
         comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
     return module
 
@@ -9500,7 +9499,7 @@ class KernelWriterAssembly(KernelWriter):
       module.add(VAddU32(
         dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
         src0=(i * 0x10000), \
-        src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+        src1=vgpr("LocalReadAddr%s"%tc), \
         comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
 
     return module
@@ -9554,7 +9553,7 @@ class KernelWriterAssembly(KernelWriter):
       module.add(VAddU32(
         dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
         src0=(i * 0x10000), \
-        src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+        src1=vgpr("LocalReadAddr%s"%tc), \
         comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
 
     return module
@@ -9587,7 +9586,7 @@ class KernelWriterAssembly(KernelWriter):
         module.add(VAddU32(
           dst=vgpr("LocalReadAddr%s+%u"%(tc,i)), \
           src0=(i * 0x10000), \
-          src1=vgpr("LocalReadAddr%s+%u"%(tc,0)), \
+          src1=vgpr("LocalReadAddr%s"%tc), \
           comment="Final Offset Plus %uK"%((i * 0x10000) / 1024)))
     return module
 


### PR DESCRIPTION
This PR enables multiple vgprs for local r/w and storeswapaddr to occur at the same time.

Previously it was assumed that when `StoreSwapAddr` was enabled we would not need multiple vgprs for > 64KB lds handling. This caused failures when we have multiple buffers (PGR2) with each buffer exceeding 64KB - this case requires both `StoreSwapAddr` and multiple vgprs for local r/w.