### PR TITLE
Add s_delay_alu

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -3311,6 +3311,8 @@ class KernelWriter(metaclass=abc.ABCMeta):
     ripo.numWaves = kernel["NumThreads"] // kernel["WavefrontSize"]
     if kernel["ProblemType"]["ActivationType"] == "all":
       ripo.removeDupAssign = False
+    if self.states.archCaps["HasSchedMode"]:
+      ripo.insertDelayAlu = True
     passResult = rocIsaPass(moduleKernelBody, ripo)
     kernel["MathClocksUnrolledLoop"] = passResult.cycles
 

--- a/tensilelite/Tensile/Tensile.py
+++ b/tensilelite/Tensile/Tensile.py
@@ -429,6 +429,7 @@ def Tensile(userArgs):
     config["UseCache"] = useCache
     globalParameters["ConfigPath"] = configPaths
 
+    asm_debug = config["GlobalParameters"].get("AsmDebug", False)
     device_id = config["GlobalParameters"].get("Device", int(args.device))
     UseEffLike = config["GlobalParameters"].get("UseEffLike", globalParameters["UseEffLike"])
     UseEffLike = False if isRhel8() else UseEffLike
@@ -457,6 +458,7 @@ def Tensile(userArgs):
         cxxCompiler,
         offloadBundler,
         args.CodeObjectVersion,
+        debug=asm_debug,
     )
     srcToolchain = makeSourceToolchain(
         cxxCompiler,

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -618,7 +618,8 @@ def run():
         cxxCompiler,
         offloadBundler,
         arguments["CodeObjectVersion"],
-        arguments["BuildIdKind"]
+        arguments["BuildIdKind"],
+        arguments["AsmDebug"],
     )
     srcToolchain = makeSourceToolchain(
         cxxCompiler,

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -42,8 +42,8 @@ class AssemblyToolchain(NamedTuple):
    bundler: Bundler
 
 
-def makeAssemblyToolchain(assembler_path, bundler_path, co_version, build_id_kind="sha1"):
-   compiler = Assembler(assembler_path, co_version)
+def makeAssemblyToolchain(assembler_path, bundler_path, co_version, build_id_kind="sha1", debug=False):
+   compiler = Assembler(assembler_path, co_version, debug)
    linker = Linker(assembler_path, build_id_kind)
    bundler = Bundler(bundler_path)
    return AssemblyToolchain(compiler, linker, bundler)

--- a/tensilelite/rocisa/CMakeLists.txt
+++ b/tensilelite/rocisa/CMakeLists.txt
@@ -65,7 +65,8 @@ set(ROCISAPASS_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/pass.cpp
                       ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/graph.cpp
                       ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/composite.cpp
                       ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/cycle.cpp
-                      ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/remove.cpp)
+                      ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/remove.cpp
+                      ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/pass/insert_delay_alu.cpp)
 
 nanobind_add_module(rocisa NOMINSIZE NB_SUPPRESS_WARNINGS
                         ${CMAKE_CURRENT_SOURCE_DIR}/rocisa/src/main.cpp

--- a/tensilelite/rocisa/rocisa/include/enum.hpp
+++ b/tensilelite/rocisa/rocisa/include/enum.hpp
@@ -246,4 +246,76 @@ namespace rocisa
         UPPER      = 3,
         LOWER      = 4
     };
+
+    enum class DelayALUType : int
+    {
+        VALU  = 0,
+        TRANS = 1,
+        SALU  = 2,
+        OTHER = 3,
+    };
+
+    enum class DelayALUSkip : int
+    {
+        SAME   = 0,
+        NEXT   = 1,
+        SKIP_1 = 2,
+        SKIP_2 = 3,
+        SKIP_3 = 4,
+        SKIP_4 = 5,
+    };
+
+    inline std::string toString(DelayALUSkip cnt)
+    {
+        switch(cnt)
+        {
+        case DelayALUSkip::SAME:
+            return "SAME";
+        case DelayALUSkip::NEXT:
+            return "NEXT";
+        case DelayALUSkip::SKIP_1:
+            return "SKIP_1";
+        case DelayALUSkip::SKIP_2:
+            return "SKIP_2";
+        case DelayALUSkip::SKIP_3:
+            return "SKIP_3";
+        case DelayALUSkip::SKIP_4:
+            return "SKIP_4";
+        default:
+            return "";
+        }
+    }
+
+    inline std::string toString(DelayALUType type)
+    {
+        switch(type)
+        {
+        case DelayALUType::VALU:
+            return "VALU";
+        case DelayALUType::TRANS:
+            return "TRANS";
+        case DelayALUType::SALU:
+            return "SALU";
+        default:
+            return "";
+        }
+    }
+
+    inline std::string toString(DelayALUType type, int cnt)
+    {
+        if(!cnt)
+            return "NO_DEP";
+
+        switch(type)
+        {
+        case DelayALUType::VALU:
+        case DelayALUType::TRANS:
+            return toString(type) + "_DEP_" + std::to_string(cnt);
+        case DelayALUType::SALU:
+            return "SALU_CYCLE_" + std::to_string(cnt);
+        case DelayALUType::OTHER:
+        default:
+            return "";
+        }
+    }
 }

--- a/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -279,6 +279,8 @@ inline std::map<std::string, int>
 
     rv["HasNewBarrier"] = tryAssembler(isaVersion, assemblerPath, "s_barrier_wait -1", isDebug);
 
+    rv["s_delay_alu"] = tryAssembler(isaVersion, assemblerPath, "s_delay_alu instid0(VALU_DEP_1)", isDebug);
+
     if(tryAssembler(isaVersion, assemblerPath, "s_waitcnt vmcnt(63)", isDebug))
         rv["MaxVmcnt"] = 63;
     else if(tryAssembler(isaVersion, assemblerPath, "s_waitcnt vmcnt(15)", isDebug))

--- a/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
+++ b/tensilelite/rocisa/rocisa/include/hardware_caps.hpp
@@ -279,7 +279,8 @@ inline std::map<std::string, int>
 
     rv["HasNewBarrier"] = tryAssembler(isaVersion, assemblerPath, "s_barrier_wait -1", isDebug);
 
-    rv["s_delay_alu"] = tryAssembler(isaVersion, assemblerPath, "s_delay_alu instid0(VALU_DEP_1)", isDebug);
+    rv["s_delay_alu"]
+        = tryAssembler(isaVersion, assemblerPath, "s_delay_alu instid0(VALU_DEP_1)", isDebug);
 
     if(tryAssembler(isaVersion, assemblerPath, "s_waitcnt vmcnt(63)", isDebug))
         rv["MaxVmcnt"] = 63;

--- a/tensilelite/rocisa/rocisa/include/instruction/common.hpp
+++ b/tensilelite/rocisa/rocisa/include/instruction/common.hpp
@@ -21,6 +21,7 @@
  *
  * ************************************************************************ */
 #pragma once
+#include "enum.hpp"
 #include "instruction.hpp"
 
 #include <string>
@@ -1920,6 +1921,102 @@ namespace rocisa
         int vm_vsrc;
         int va_vcc;
         int sa_sdst;
+    };
+
+    struct SDelayAlu : public Instruction
+    {
+        SDelayAlu(const rocisa::DelayALUType          instid0type,
+                  const int                           instid0cnt,
+                  std::optional<int>                  instskipCnt = std::nullopt,
+                  std::optional<rocisa::DelayALUType> instid1type = std::nullopt,
+                  std::optional<int>                  instid1cnt  = std::nullopt,
+                  const std::string&                  comment     = "")
+            : Instruction(InstType::INST_NOTYPE, comment)
+            , instid0type(instid0type)
+            , instid0cnt(instid0cnt)
+            , instskipCnt(instskipCnt)
+            , instid1type(instid1type)
+            , instid1cnt(instid1cnt)
+        {
+            setInst("s_delay_alu");
+        }
+
+        SDelayAlu(const SDelayAlu& other)
+            : SDelayAlu(other.instid0type,
+                        other.instid0cnt,
+                        other.instskipCnt,
+                        other.instid1type,
+                        other.instid1cnt,
+                        other.comment)
+        {
+        }
+
+        bool hasInstID1() const
+        {
+            return this->instskipCnt != std::nullopt || this->instid1type != std::nullopt
+                   || this->instid1cnt != std::nullopt;
+        }
+
+        bool setInstID1(const int&          instskipCnt,
+                        const DelayALUType& instid1type,
+                        const int&          instid1cnt)
+        {
+            if(hasInstID1())
+            {
+                return false;
+            }
+
+            this->instskipCnt = instskipCnt;
+            this->instid1type = instid1type;
+            this->instid1cnt  = instid1cnt;
+            return true;
+        }
+
+        std::shared_ptr<Item> clone() const override
+        {
+            return std::make_shared<SDelayAlu>(*this);
+        }
+
+        std::vector<InstructionInput> getParams() const override
+        {
+            if(hasInstID1())
+            {
+                return {static_cast<int>(instid0type),
+                        instid0cnt,
+                        instskipCnt.value_or(-1),
+                        static_cast<int>(instid1type.value_or(DelayALUType::OTHER)),
+                        instid1cnt.value_or(-1)};
+            }
+
+            return {static_cast<int>(instid0type), instid0cnt};
+        }
+
+        std::string toString() const override
+        {
+            if(!getAsmCaps()["s_delay_alu"])
+                return "";
+
+            std::string result;
+            result += " instid0(" + ::rocisa::toString(instid0type, instid0cnt) + ")";
+            if(!hasInstID1())
+            {
+                return formatWithComment(instStr + result);
+            }
+
+            result += " | instskip("
+                      + ::rocisa::toString(static_cast<DelayALUSkip>(instskipCnt.value())) + ")";
+            result += " | instid1(" + ::rocisa::toString(instid1type.value(), instid1cnt.value())
+                      + ")";
+
+            return formatWithComment(instStr + result);
+        }
+
+    private:
+        DelayALUType                instid0type;
+        int                         instid0cnt;
+        std::optional<int>          instskipCnt;
+        std::optional<DelayALUType> instid1type;
+        std::optional<int>          instid1cnt;
     };
 
     struct VAddF16 : public CommonInstruction

--- a/tensilelite/rocisa/rocisa/include/instruction/common.hpp
+++ b/tensilelite/rocisa/rocisa/include/instruction/common.hpp
@@ -35,7 +35,7 @@ namespace rocisa
                 const std::shared_ptr<RegisterContainer>& src,
                 const std::string&                        comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_abs_i32");
         }
@@ -643,7 +643,7 @@ namespace rocisa
     {
         SGetPCB64(const std::shared_ptr<Container>& dst, const std::string& comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_getpc_b64");
         }
@@ -917,7 +917,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             if(kernel().wavefront == 32)
             {
@@ -947,7 +947,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_mov_b32");
         }
@@ -969,7 +969,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_mov_b64");
         }
@@ -991,7 +991,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_cmov_b32");
         }
@@ -1013,7 +1013,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_cmov_b64");
         }
@@ -1035,7 +1035,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_ff1_i32_b32");
         }
@@ -1085,7 +1085,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_movk_i32");
         }
@@ -1107,7 +1107,7 @@ namespace rocisa
                       const InstructionInput&           src,
                       const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_sext_i32_i16");
         }
@@ -1129,7 +1129,7 @@ namespace rocisa
                         const InstructionInput&           src,
                         const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_and_saveexec_b32");
         }
@@ -1151,7 +1151,7 @@ namespace rocisa
                         const InstructionInput&           src,
                         const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_and_saveexec_b64");
         }
@@ -1173,7 +1173,7 @@ namespace rocisa
                        const InstructionInput&           src,
                        const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_or_saveexec_b32");
         }
@@ -1195,7 +1195,7 @@ namespace rocisa
                        const InstructionInput&           src,
                        const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_or_saveexec_b64");
         }
@@ -1413,7 +1413,7 @@ namespace rocisa
                    const InstructionInput&           src,
                    const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_getreg_b32");
         }
@@ -1435,7 +1435,7 @@ namespace rocisa
                    const InstructionInput&           src,
                    const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_setreg_b32");
         }
@@ -1457,7 +1457,7 @@ namespace rocisa
                         const InstructionInput&           src,
                         const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("s_setreg_IMM32_b32");
         }
@@ -2027,7 +2027,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_add_f16");
         }
@@ -2052,7 +2052,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, dpp, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, dpp, sdwa, std::nullopt, comment)
         {
             setInst("v_add_f32");
         }
@@ -2086,7 +2086,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_add_f64");
         }
@@ -2110,7 +2110,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             if(getAsmBugs()["ExplicitNC"])
             {
@@ -2172,7 +2172,7 @@ namespace rocisa
                 const std::vector<InstructionInput>& srcs,
                 const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             if(getAsmBugs()["ExplicitNC"])
             {
@@ -2233,7 +2233,7 @@ namespace rocisa
                   const std::vector<InstructionInput>& srcs,
                   const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             this->dst1 = dst1;
             if(getAsmBugs()["ExplicitCO"])
@@ -2293,7 +2293,7 @@ namespace rocisa
                    const std::vector<InstructionInput>& srcs,
                    const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             this->dst1 = dst1;
             if(getAsmBugs()["ExplicitNC"])
@@ -2329,7 +2329,7 @@ namespace rocisa
                   std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                   const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
         {
             setInst("v_pk_add_f16");
         }
@@ -2353,7 +2353,7 @@ namespace rocisa
                    std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                    const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
         {
             setInst("v_pk_add_f32");
         }
@@ -2363,7 +2363,7 @@ namespace rocisa
                    std::optional<VOP3PModifiers>        vop3    = std::nullopt,
                    const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, srcs, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_F32, dst, srcs, std::nullopt, std::nullopt, vop3, comment)
         {
             setInst("v_pk_add_f32");
         }
@@ -2460,7 +2460,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_mul_f16");
         }
@@ -2484,7 +2484,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_mul_f32");
         }
@@ -2494,7 +2494,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>         sdwa    = std::nullopt,
                 const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, srcs, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, srcs, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_mul_f32");
         }
@@ -2518,7 +2518,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_mul_f64");
         }
@@ -2543,7 +2543,7 @@ namespace rocisa
                   std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                   const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
         {
             setInst("v_pk_mul_f16");
         }
@@ -2568,7 +2568,7 @@ namespace rocisa
                    std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                    const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
         {
             setInst("v_pk_mul_f32");
         }
@@ -2593,7 +2593,7 @@ namespace rocisa
                    std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                    const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
         {
             setInst("v_pk_mul_f32");
         }
@@ -2849,7 +2849,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_sub_f32");
         }
@@ -2988,7 +2988,7 @@ namespace rocisa
                 std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
             , addDstToSrc(false)
         {
             if(getAsmCaps()["v_fmac_f32"])
@@ -3043,7 +3043,7 @@ namespace rocisa
                      std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                      const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             if(kernel().isaVersion[0] >= 11)
             {
@@ -3134,7 +3134,7 @@ namespace rocisa
                       std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                       const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             if(kernel().isaVersion[0] >= 11)
             {
@@ -3404,7 +3404,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_exp_f16");
         }
@@ -3426,7 +3426,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_exp_f32");
         }
@@ -3449,7 +3449,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_rcp_f16");
         }
@@ -3471,7 +3471,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_rcp_f32");
         }
@@ -3493,7 +3493,7 @@ namespace rocisa
                      const InstructionInput&           src,
                      const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_rcp_iflag_f32");
         }
@@ -3516,7 +3516,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_rsq_f16");
         }
@@ -3538,7 +3538,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_rsq_f32");
         }
@@ -3560,7 +3560,7 @@ namespace rocisa
                      const InstructionInput&           src,
                      const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_rsq_iflag_f32");
         }
@@ -3584,7 +3584,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_max_f16");
         }
@@ -3608,7 +3608,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_max_f32");
         }
@@ -3632,7 +3632,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_max_f64");
         }
@@ -3656,7 +3656,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_max_i32");
         }
@@ -3681,7 +3681,7 @@ namespace rocisa
                   std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                   const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, vop3, comment)
         {
             setInst("v_pk_max_f16");
         }
@@ -3763,7 +3763,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F16, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_min_f16");
         }
@@ -3787,7 +3787,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_min_f32");
         }
@@ -3811,7 +3811,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_F64, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_min_f64");
         }
@@ -3835,7 +3835,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_I32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_min_i32");
         }
@@ -3914,7 +3914,7 @@ namespace rocisa
                 const InstructionInput&           src,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_not_b32");
         }
@@ -3938,7 +3938,7 @@ namespace rocisa
                std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_or_b32");
         }
@@ -3948,7 +3948,7 @@ namespace rocisa
                std::optional<SDWAModifiers>         sdwa    = std::nullopt,
                const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, srcs, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_B32, dst, srcs, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_or_b32");
         }
@@ -3972,7 +3972,7 @@ namespace rocisa
                 std::optional<SDWAModifiers>      sdwa    = std::nullopt,
                 const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src0, src1}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_xor_b32");
         }
@@ -3994,7 +3994,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_prng_b32");
         }
@@ -4089,7 +4089,7 @@ namespace rocisa
                        const std::vector<InstructionInput>& srcs,
                        const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_lshlrev_b32");
         }
@@ -4211,7 +4211,7 @@ namespace rocisa
                           const std::vector<InstructionInput>& srcs,
                           const std::string&                   comment)
             : CommonInstruction(
-                InstType::INST_B32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_lshl_or_b32");
         }
@@ -4317,7 +4317,7 @@ namespace rocisa
                            const std::vector<InstructionInput>& srcs,
                            const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_add_lshl_u32");
         }
@@ -4406,7 +4406,7 @@ namespace rocisa
                            std::optional<VOP3PModifiers>        vop3    = std::nullopt,
                            const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_U32, dst, srcs, std::nullopt, std::nullopt, vop3, comment)
         {
             setInst("v_lshl_add_u32");
         }
@@ -4479,7 +4479,7 @@ namespace rocisa
                 const std::optional<SDWAModifiers>& sdwa    = std::nullopt,
                 const std::string&                  comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, sdwa, std::nullopt, comment)
         {
             setInst("v_mov_b32");
         }
@@ -4501,7 +4501,7 @@ namespace rocisa
                  const InstructionInput&           src,
                  const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_mov_b64");
         }
@@ -4510,7 +4510,7 @@ namespace rocisa
                  const std::vector<InstructionInput>& srcs,
                  const std::string&                   comment = "")
             : CommonInstruction(
-                InstType::INST_B64, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B64, dst, srcs, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_mov_b64");
         }
@@ -4670,7 +4670,7 @@ namespace rocisa
                       std::optional<VOP3PModifiers>     vop3    = std::nullopt,
                       const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
+                  InstType::INST_B32, dst, {src0, src1}, std::nullopt, std::nullopt, vop3, comment)
         {
             setInst("v_pack_b32_f16");
         }
@@ -4692,7 +4692,7 @@ namespace rocisa
                         const InstructionInput&           src,
                         const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_accvgpr_read_b32");
         }
@@ -4741,7 +4741,7 @@ namespace rocisa
                          const InstructionInput&           src,
                          const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_accvgpr_write_b32");
         }
@@ -4763,7 +4763,7 @@ namespace rocisa
                           const InstructionInput&           src,
                           const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_B32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_readfirstlane_b32");
         }
@@ -4785,7 +4785,7 @@ namespace rocisa
                   const InstructionInput&           src,
                   const std::string&                comment = "")
             : CommonInstruction(
-                InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
+                  InstType::INST_F32, dst, {src}, std::nullopt, std::nullopt, std::nullopt, comment)
         {
             setInst("v_rndne_f32");
         }

--- a/tensilelite/rocisa/rocisa/include/pass.hpp
+++ b/tensilelite/rocisa/rocisa/include/pass.hpp
@@ -28,11 +28,11 @@ namespace rocisa
     // External structures and functions
     struct rocIsaPassOption
     {
-        bool insertDelayAlu   = true;
-        bool removeDupFunc    = true;
-        bool removeDupAssign  = true;
-        bool getCycles        = true;
-        int  numWaves         = 0; // is used when getCycles is true
+        bool insertDelayAlu  = true;
+        bool removeDupFunc   = true;
+        bool removeDupAssign = true;
+        bool getCycles       = true;
+        int  numWaves        = 0; // is used when getCycles is true
 
         bool doOpt() const
         {
@@ -49,7 +49,7 @@ namespace rocisa
     std::string getActFuncBranchModuleName();
 
     rocIsaPassResult rocIsaPass(std::shared_ptr<KernelBody>& kernel,
-                                const rocIsaPassOption& option); // Return value is std::move()
+                                const rocIsaPassOption&      option); // Return value is std::move()
 
     // Internal use only
     struct Graph

--- a/tensilelite/rocisa/rocisa/include/pass.hpp
+++ b/tensilelite/rocisa/rocisa/include/pass.hpp
@@ -28,10 +28,11 @@ namespace rocisa
     // External structures and functions
     struct rocIsaPassOption
     {
-        bool removeDupFunc   = true;
-        bool removeDupAssign = true;
-        bool getCycles       = true;
-        int  numWaves        = 0; // is used when getCycles is true
+        bool insertDelayAlu   = true;
+        bool removeDupFunc    = true;
+        bool removeDupAssign  = true;
+        bool getCycles        = true;
+        int  numWaves         = 0; // is used when getCycles is true
 
         bool doOpt() const
         {
@@ -48,7 +49,7 @@ namespace rocisa
     std::string getActFuncBranchModuleName();
 
     rocIsaPassResult rocIsaPass(std::shared_ptr<KernelBody>& kernel,
-                                const rocIsaPassOption& option); // Return value is std::move()d
+                                const rocIsaPassOption& option); // Return value is std::move()
 
     // Internal use only
     struct Graph
@@ -88,6 +89,7 @@ namespace rocisa
         std::shared_ptr<Item> _item;
     };
 
+    void insertDelayAlu(std::shared_ptr<Module> module);
     void removeDuplicatedFunction(std::shared_ptr<Module> module);
     void compositeToInstruction(std::shared_ptr<Module>& module);
     std::unordered_map<std::string, int>

--- a/tensilelite/rocisa/rocisa/include/pass.hpp
+++ b/tensilelite/rocisa/rocisa/include/pass.hpp
@@ -28,7 +28,7 @@ namespace rocisa
     // External structures and functions
     struct rocIsaPassOption
     {
-        bool insertDelayAlu  = true;
+        bool insertDelayAlu  = false;
         bool removeDupFunc   = true;
         bool removeDupAssign = true;
         bool getCycles       = true;

--- a/tensilelite/rocisa/rocisa/src/instruction/common.cpp
+++ b/tensilelite/rocisa/rocisa/src/instruction/common.cpp
@@ -738,6 +738,23 @@ void common_inst(nb::module_ m_common)
         .def("__deepcopy__",
              [](const rocisa::SWaitAlu& self, nb::dict&) { return new rocisa::SWaitAlu(self); });
 
+    nb::class_<rocisa::SDelayAlu, rocisa::Instruction>(m_common, "SDelayAlu")
+        .def(nb::init<rocisa::DelayALUType,
+                      int,
+                      std::optional<int>,
+                      std::optional<rocisa::DelayALUType>,
+                      std::optional<int>,
+                      const std::string&>(),
+             nb::arg("instid0type"),
+             nb::arg("instid0cnt"),
+             nb::arg("instskipCnt") = std::nullopt,
+             nb::arg("instid1type") = std::nullopt,
+             nb::arg("instid1cnt")  = std::nullopt,
+             nb::arg("comment")     = "")
+        .def("getParams", &rocisa::SDelayAlu::getParams)
+        .def("__deepcopy__",
+             [](const rocisa::SDelayAlu& self, nb::dict&) { return new rocisa::SDelayAlu(self); });
+
     nb::class_<rocisa::VAddF16, rocisa::CommonInstruction>(m_common, "VAddF16")
         .def(nb::init<const std::shared_ptr<rocisa::Container>&,
                       const InstructionInput&,

--- a/tensilelite/rocisa/rocisa/src/pass/insert_delay_alu.cpp
+++ b/tensilelite/rocisa/rocisa/src/pass/insert_delay_alu.cpp
@@ -1,0 +1,246 @@
+/* ************************************************************************
+ * Copyright (C) 2025 Advanced Micro Devices, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * ************************************************************************ */
+
+#include "code.hpp"
+#include "enum.hpp"
+#include "instruction/common.hpp"
+
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace rocisa
+{
+    static const std::unordered_map<DelayALUType, unsigned> aluDepMax = {
+        // the maximum number of VALU instructions that can be encoded in a delay ALU instruction
+        {DelayALUType::VALU, 4},
+        // the maximum number of SALU instructions that can be counted backwards from the current instruction
+        {DelayALUType::SALU, 1},
+        // the maximum number of TRANS instructions that can encode in an s_delay_alu instruction
+        {DelayALUType::TRANS, 3},
+        // default case for other types of instructions
+        {DelayALUType::OTHER, 0},
+    };
+
+    static const unsigned SKIP_MAX = 5;
+
+    using _Hash  = decltype([](std::shared_ptr<RegisterContainer> ptr) { return ptr->hash(); });
+    using _Equal = decltype([](const std::shared_ptr<RegisterContainer>& a,
+                               const std::shared_ptr<RegisterContainer>& b) { return *a == *b; });
+
+    // TODO: If there are enough cycles between dependent instructions, inserting a delay ALU may not be necessary.
+    struct DelayInfo
+    {
+        DelayALUType type;
+        unsigned     type_count;
+        unsigned     total_count;
+    };
+
+    static DelayALUType _getDelayAluType(const std::shared_ptr<Instruction>& inst)
+    {
+        auto preStr = inst->preStr();
+        if(preStr.starts_with("v_s_"))
+        {
+            return DelayALUType::TRANS;
+        }
+        else if(preStr.starts_with("v_"))
+        {
+            return DelayALUType::VALU;
+        }
+        else if(preStr.starts_with("s_"))
+        {
+            return DelayALUType::SALU;
+        }
+
+        return DelayALUType::OTHER;
+    }
+
+    auto _getDstSrcRegs(const std::shared_ptr<Instruction>& inst)
+    {
+        std::unordered_set<std::shared_ptr<RegisterContainer>, _Hash, _Equal> dsts;
+        std::unordered_set<std::shared_ptr<RegisterContainer>, _Hash, _Equal> srcs;
+        const std::vector<InstructionInput>*                                  instInputs = nullptr;
+
+        auto commonInst = std::dynamic_pointer_cast<CommonInstruction>(inst);
+        if(commonInst)
+        {
+            if(auto dst = std::dynamic_pointer_cast<RegisterContainer>(commonInst->dst))
+            {
+                dsts.insert(dst);
+            }
+
+            if(auto dst1 = std::dynamic_pointer_cast<RegisterContainer>(commonInst->dst1))
+            {
+                dsts.insert(dst1);
+            }
+
+            instInputs = &commonInst->srcs;
+        }
+
+        auto compositeInst = std::dynamic_pointer_cast<CompositeInstruction>(inst);
+        if(compositeInst)
+        {
+            if(auto dst = std::dynamic_pointer_cast<RegisterContainer>(compositeInst->dst))
+            {
+                dsts.insert(dst);
+            }
+
+            instInputs = &compositeInst->srcs;
+        }
+
+        if(!instInputs)
+        {
+            return std::make_pair(dsts, srcs);
+        }
+
+        for(const auto& src : *instInputs)
+        {
+            if(auto ptr = std::get_if<std::shared_ptr<Container>>(&src))
+            {
+                if(auto reg = std::dynamic_pointer_cast<RegisterContainer>(*ptr))
+                {
+                    srcs.insert(reg);
+                }
+            }
+        }
+
+        return std::make_pair(dsts, srcs);
+    }
+
+    static void _insertDelayAlu(std::shared_ptr<Module> module)
+    {
+        // recursively process each submodule to insert delay ALU instructions
+        for(const auto& item : module->items())
+        {
+            if(auto submodule = std::dynamic_pointer_cast<Module>(item))
+            {
+                _insertDelayAlu(submodule);
+            }
+        }
+
+        auto& items = module->items();
+        if(items.size() < 2)
+        {
+            return; // no need to insert delay ALU
+        }
+
+        std::unordered_map<std::shared_ptr<RegisterContainer>, size_t, _Hash, _Equal>
+                                                     last_dst_inst_idx;
+        std::unordered_map<size_t, DelayInfo>        inst_idx_delay_info;
+        std::unordered_map<DelayALUType, DelayInfo>  delay_info;
+        std::map<size_t, std::shared_ptr<SDelayAlu>> dep_idxs;
+        unsigned                                     total_count = 0;
+        inst_idx_delay_info.reserve(items.size());
+        for(size_t i = 0; i < items.size(); ++i)
+        {
+            auto& item = items[i];
+
+            auto inst = std::dynamic_pointer_cast<Instruction>(item);
+            if(!inst)
+            {
+                continue;
+            }
+
+            DelayALUType alu_type = _getDelayAluType(inst);
+            ++delay_info[alu_type].type_count;
+            ++total_count;
+            inst_idx_delay_info[i]
+                = DelayInfo{alu_type, delay_info[alu_type].type_count, total_count};
+
+            auto [dsts, srcs] = _getDstSrcRegs(inst);
+
+            // TODO: confirm this is best strategy
+            // Prefer registers present in last_dst_inst_idx; if both are present, select the one with the higher index.
+            auto src_it = std::max_element(
+                srcs.begin(), srcs.end(), [&last_dst_inst_idx](const auto& a, const auto& b) {
+                    return last_dst_inst_idx.find(a) != last_dst_inst_idx.end()
+                           && (last_dst_inst_idx.find(b) == last_dst_inst_idx.end()
+                               || last_dst_inst_idx[a] < last_dst_inst_idx[b]);
+                });
+
+            do
+            {
+                if(src_it == srcs.end())
+                {
+                    break;
+                }
+
+                auto src = *src_it;
+                if(last_dst_inst_idx.find(src) == last_dst_inst_idx.end())
+                {
+                    break;
+                }
+
+                size_t last_idx     = last_dst_inst_idx[src];
+                auto   dep_alu_type = inst_idx_delay_info[last_idx].type;
+                auto   inst_cnt     = delay_info[dep_alu_type].type_count
+                                - inst_idx_delay_info[last_idx].type_count;
+                if(inst_cnt > aluDepMax.at(dep_alu_type))
+                {
+                    break;
+                }
+
+                int skip_cnt = -1;
+                // if(!dep_idxs.empty())
+                // {
+                //     skip_cnt = total_count
+                //                - inst_idx_delay_info[dep_idxs.rbegin()->first].total_count - 1;
+                // }
+
+                // If there are no dependencies or the last dependency is already set, we can insert a new delay ALU
+                if(skip_cnt < 0 || skip_cnt >= SKIP_MAX || dep_idxs.rbegin()->second->hasInstID1())
+                {
+                    dep_idxs[i] = std::make_shared<SDelayAlu>(dep_alu_type, inst_cnt);
+                    break;
+                }
+
+                // // pack the current instruction into last delay ALU
+                // dep_idxs.rbegin()->second->setInstID1(skip_cnt, dep_alu_type, inst_cnt);
+            } while(false);
+
+            if(!dsts.empty())
+            {
+                for(const auto& dst : dsts)
+                {
+                    last_dst_inst_idx[dst] = i;
+                }
+            }
+        }
+
+        for(auto it = dep_idxs.rbegin(); it != dep_idxs.rend(); ++it)
+        {
+            auto [idx, inst] = *it;
+            module->add(inst, idx);
+        }
+    }
+
+    void insertDelayAlu(std::shared_ptr<Module> module)
+    {
+        if(!rocIsa::getInstance().getAsmCaps()["s_delay_alu"])
+        {
+            return;
+        }
+
+        _insertDelayAlu(module);
+    }
+} // namespace rocisa

--- a/tensilelite/rocisa/rocisa/src/pass/pass.cpp
+++ b/tensilelite/rocisa/rocisa/src/pass/pass.cpp
@@ -49,6 +49,12 @@ namespace rocisa
                 removeDuplicateAssignment(graph);
             }
         }
+
+        if(option.insertDelayAlu)
+        {
+            insertDelayAlu(kernel->body);
+        }
+
         if(option.getCycles)
             result.cycles = getCycles(kernel->body, option.numWaves);
 
@@ -67,6 +73,7 @@ void init_pass(nb::module_ m)
 
     nb::class_<rocisa::rocIsaPassOption>(m_pass, "rocIsaPassOption")
         .def(nb::init<>())
+        .def_rw("insertDelayAlu", &rocisa::rocIsaPassOption::insertDelayAlu)
         .def_rw("removeDupFunc", &rocisa::rocIsaPassOption::removeDupFunc)
         .def_rw("removeDupAssign", &rocisa::rocIsaPassOption::removeDupAssign)
         .def_rw("getCycles", &rocisa::rocIsaPassOption::getCycles)


### PR DESCRIPTION
We saw a lot of stalls between dependent VALU instructions in the pack code for the NN/NT cases. The changes add delays between those dependent VALUs so that other independent VALUs can run in between. This gave us a 6% performance boost for F8 NN, going from 68% to 74%.

<img width="1102" alt="image" src="https://github.com/user-attachments/assets/0a9d3414-0e26-42c3-b76b-6627a49faed9" />

ASM Example 1:
<img width="830" alt="image" src="https://github.com/user-attachments/assets/23a98b40-7460-4669-b034-6996e3df19ba" />


ASM Example 2:
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/94a8d41a-f8c7-4c45-97fb-b65fddc0d0d9" />

#### hipblaslt-test 
##### gfx1200
```
[----------] Global test environment tear-down
[==========] 38676 tests from 13 test suites ran. (762604 ms total)
[  PASSED  ] 38676 tests.
hipBLASLt version: 1500
hipBLASLt git version: 48b207e2
command line: build/48b207/debug/clients/staging/hipblaslt-test
```

##### gfx1201
```
[----------] Global test environment tear-down
[==========] 38676 tests from 13 test suites ran. (762938 ms total)
[  PASSED  ] 38676 tests.
hipBLASLt version: 1500
hipBLASLt git version: 48b207e2
command line: build/48b207/debug/clients/staging/hipblaslt-test 
```

#### tox
##### gfx1200
```
=========== 19 passed, 141 skipped, 64 warnings in 536.04s (0:08:56) ===========
py3: exit 0 (536.27 seconds) /home/haoschen/projects/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tensile-tox/py3/tmp --junit-xml=/home/haoschen/projects/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tensile-tox/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=1476743
  py3: OK (674.12=setup[8.23]+cmd[0.00,1.98,16.11,1.08,110.45,536.27] seconds)
  congratulations :) (674.17 seconds)
```

##### gfx1201
```
=========== 19 passed, 141 skipped, 64 warnings in 574.18s (0:09:34) ===========
py3: exit 0 (574.73 seconds) /home/AMD/haoschen/projects/hipBLASLt/tensilelite> py.test -v --basetemp=/tmp/.tensile-tox/py3/tmp --junit-xml=/home/AMD/haoschen/projects/hipBLASLt/tensilelite/python_tests.xml --junit-prefix=py3 --color=yes -n 4 --prebuilt-client=/tmp/.tensile-tox/py3/client/0_Build/client/tensile_client Tensile/Tests -m common pid=1851936
  py3: OK (759.32=setup[59.33]+cmd[0.00,9.25,15.37,5.43,95.21,574.73] seconds)
  congratulations :) (759.37 seconds)
```
