### PR TITLE
Use hip f8 header for rocm 6.3+

### DIFF
--- a/library/include/hipblaslt/hipblaslt-types.h
+++ b/library/include/hipblaslt/hipblaslt-types.h
@@ -33,7 +33,7 @@
 #define _HIPBLASLT_TYPES_H_
 
 #if(HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
-    || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3) //tmp before gfx94 use hip f8 header
+    || (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 3) //tmp before gfx94 use hip f8 header
 
 #define HIPBLASLT_USE_F8_FNUZ_BC 1 // Always use custom impl for now
 #define HIPBLASLT_USE_F8_OCP_BC 0 // Always use ocp impl for hip header

--- a/tensilelite/Tensile/Source/TensileTypes.h
+++ b/tensilelite/Tensile/Source/TensileTypes.h
@@ -29,7 +29,7 @@
 #include "tensile_bfloat16.h"
 
 #if (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
-	|| (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3)//tmp before gfx94 use hip f8 header
+	|| (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 3)//tmp before gfx94 use hip f8 header
 
 // Using hip header for both NANOO and OCP data types
 #if defined(__HIPCC__)

--- a/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/DataTypes.hpp
@@ -38,7 +38,7 @@
 #include <Tensile/DataTypes_BFloat16.hpp>
 #include <rocisa/include/enum.hpp>
 #if(HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR == 2 && HIP_VERSION_PATCH > 42130) \
-    || (HIP_VERSION_MAJOR == 6 && HIP_VERSION_MINOR >= 3) //tmp before gfx94 use hip f8 header
+    || (HIP_VERSION_MAJOR >= 6 && HIP_VERSION_MINOR >= 3) //tmp before gfx94 use hip f8 header
 
 // Using hip header for both NANOO and OCP data types
 #if defined(__HIPCC__)


### PR DESCRIPTION
Update macro checks so hip f8 headers is used for rocm6.3+