### PR TITLE
[next-cmake] Link against roctx64.

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -121,6 +121,8 @@ if(HIPBLASLT_ENABLE_HOST)
     endif()
     if(HIPBLASLT_ENABLE_MARKER)
         find_library(rocTracer roctx64 REQUIRED)
+    else()
+        set(rocTracer)
     endif()
 endif()
 if(HIPBLASLT_REQUIRE_ROCM_SMI)
@@ -210,6 +212,7 @@ if(HIPBLASLT_ENABLE_HOST)
             hip::device
             rocisa::rocisa-cpp
             ${CMAKE_DL_LIBS}
+            ${rocTracer}
     )
 
     if(HIPBLASLT_ENABLE_ASAN)


### PR DESCRIPTION
Prior, we were finding it but left it out of the link.