### PR TITLE
Remove gsu == 1 assertion for streamk

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -700,7 +700,14 @@ namespace TensileLite
 
         if(sizeMapping.streamK != 0)
         {
-            assert(gsu == 1);
+            // SK doesn't care gsu
+            if(gsu > 1)
+            {
+                std::cerr << "Warning: Stream-K Data Parallel does not support GSU > 1, "
+                          << "setting GSU to 1." << std::endl;
+                gsu = 1;
+            }
+
             auto tiles = problem.getNumTiles(sizeMapping, gsu);
 
             // Clamp minimum iters per tile to 1 to allow stream-k index calculation to work in case K==0


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-536351

Was introduced in https://github.com/ROCm/hipBLASLt/commit/c6134263982392229aa1aeefbe9216a75473d152

Partly fixed in https://github.com/ROCm/hipBLASLt/commit/1378c89f1b824a697777825d26ad54d401b3bfe0