### PR TITLE
[next-cmake] Adds missing files and tweaks rocroller integration

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -53,8 +53,8 @@ if(NOT ROCM_FOUND)
   execute_process(COMMAND ${CMAKE_COMMAND} -E tar xzf ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag}.zip
                   WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
   execute_process(COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${PROJECT_EXTERN_DIR}/rocm-cmake .
-                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-${rocm_cmake_tag})
-  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-${rocm_cmake_tag} --target install
+                  WORKING_DIRECTORY ${PROJECT_EXTERN_DIR}/rocm-cmake-build-tools-${rocm_cmake_tag})
+  execute_process(COMMAND ${CMAKE_COMMAND} --build rocm-cmake-build-tools-${rocm_cmake_tag} --target install
                   WORKING_DIRECTORY ${PROJECT_EXTERN_DIR})
 
   find_package( ROCmCMakeBuildTools 0.6 REQUIRED CONFIG PATHS ${PROJECT_EXTERN_DIR}/rocm-cmake )

--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -195,12 +195,33 @@ if(HIPBLASLT_ENABLE_DEVICE)
     endif()
 endif()
 
+if(HIPBLASLT_ENABLE_ROCROLLER)
+    find_package(rocroller REQUIRED)
+    option(YAML_CPP_INSTALL "" ON)
+    if(NOT rocroller_FOUND)
+        set(ROCROLLER_ENABLE_FETCH ON)
+        set(ROCROLLER_BUILD_TESTING OFF)
+        set(ROCROLLER_ENABLE_CLIENT OFF)
+        FetchContent_Declare(
+            rocRoller
+            GIT_REPOSITORY https://github.com/ROCm/rocRoller.git
+            GIT_TAG main
+            SOURCE_SUBDIR next-cmake
+        )
+        FetchContent_MakeAvailable(rocRoller)
+    endif()
+endif()
+
 if(HIPBLASLT_ENABLE_HOST)
     if(HIPBLASLT_BUILD_SHARED_LIBS)
         add_library(hipblaslt SHARED)
     else()
         add_library(hipblaslt STATIC)
         target_compile_definitions(hipblaslt PRIVATE HIPBLASLT_STATIC_LIB)
+    endif()
+    if(HIPBLASLT_ENABLE_ROCROLLER)
+        target_link_libraries(hipblaslt PRIVATE roc::rocroller)
+        target_compile_definitions(hipblaslt PUBLIC HIPBLASLT_USE_ROCROLLER)
     endif()
     rocm_set_soversion(hipblaslt ${hipblaslt_SOVERSION})
     add_library(roc::hipblaslt ALIAS hipblaslt)
@@ -274,11 +295,6 @@ if(HIPBLASLT_ENABLE_HOST)
 
     add_subdirectory(rocisa/rocisa-cpp)
     add_subdirectory(host-library)
-endif()
-
-if(HIPBLASLT_ENABLE_ROCROLLER)
-    target_link_libraries(hipblaslt PRIVATE roc::rocroller)
-    target_compile_definitions(hipblaslt PUBLIC HIPBLASLT_USE_ROCROLLER)
 endif()
 
 if(HIPBLASLT_ENABLE_DEVICE)

--- a/next-cmake/clients/CMakeLists.txt
+++ b/next-cmake/clients/CMakeLists.txt
@@ -57,8 +57,11 @@ target_link_libraries(hipblaslt-clients-common
 target_compile_definitions(hipblaslt-clients-common PRIVATE CLIENTS_NO_FORTRAN) # necessary?
 
 if(HIPBLASLT_ENABLE_ROCROLLER)
+    if(NOT TARGET roc::mxDataGenerator)
+        find_package(mxDataGenerator REQUIRED)
+    endif()
     target_compile_definitions(hipblaslt-clients-common PRIVATE HIPBLASLT_USE_ROCROLLER)
-    target_link_libraries(hipblaslt-clients-common PRIVATE roc::rocroller)
+    target_link_libraries(hipblaslt-clients-common PRIVATE roc::rocroller roc::mxDataGenerator)
 endif()
 if(HIPBLASLT_ENABLE_ASAN)
     hipblaslt_target_configure_sanitizers(hipblaslt-clients-common PUBLIC)

--- a/next-cmake/host-library/include/tensilelite/CMakeLists.txt
+++ b/next-cmake/host-library/include/tensilelite/CMakeLists.txt
@@ -33,6 +33,8 @@ if(HIPBLASLT_ENABLE_HIP)
   add_subdirectory(hip)
 endif()
 
+add_subdirectory(analytical)
+
 set(_CMAKE_CURRENT_SOURCE_DIR "${TEMP_TENSILE_HOST_SOURCE_DIR}/include")
 
 target_sources(hipblaslt

--- a/next-cmake/host-library/include/tensilelite/analytical/CMakeLists.txt
+++ b/next-cmake/host-library/include/tensilelite/analytical/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+set(_CMAKE_CURRENT_SOURCE_DIR "${TEMP_TENSILE_HOST_SOURCE_DIR}/include/Tensile/analytical")
+
+target_sources(hipblaslt
+    PRIVATE
+        "${_CMAKE_CURRENT_SOURCE_DIR}/AnalyticalGemm.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Hardware.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/StreamK.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Utils.hpp"
+)

--- a/next-cmake/host-library/src/tensilelite/CMakeLists.txt
+++ b/next-cmake/host-library/src/tensilelite/CMakeLists.txt
@@ -46,17 +46,6 @@ target_sources(hipblaslt
         "${_CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp"
 )
 
-# Need a todo on this and some of the other tensile flags
-#include(CheckCXXCompilerFlag)
-#check_cxx_compiler_flag("-ffast-math" CXX_FAST_MATH_FLAG_SUPPORTED)
-#if(CXX_FAST_MATH_FLAG_SUPPORTED)
-#    set_source_files_properties(MLPNet.cpp PROPERTIES COMPILE_FLAGS "-ffast-math")
-#endif()
-
-#if(WIN32)
-#target_compile_options( TensileHost PUBLIC -Wno-deprecated-declarations -Wno-ignored-attributes -Wdll-attribute-on-redeclaration -fdelayed-template-parsing )
-#endif()
-
 if(HIPBLASLT_ENABLE_LLVM)
   add_subdirectory(llvm)
 endif()
@@ -68,3 +57,5 @@ endif()
 if(HIPBLASLT_ENABLE_HIP)
   add_subdirectory(hip)
 endif()
+
+add_subdirectory(analytical)

--- a/next-cmake/host-library/src/tensilelite/analytical/CMakeLists.txt
+++ b/next-cmake/host-library/src/tensilelite/analytical/CMakeLists.txt
@@ -1,0 +1,31 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+set(_CMAKE_CURRENT_SOURCE_DIR "${TEMP_TENSILE_HOST_SOURCE_DIR}/source/analytical")
+
+target_sources(hipblaslt
+    PRIVATE
+        "${_CMAKE_CURRENT_SOURCE_DIR}/AnalyticalGemm.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Hardware.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Utils.cpp"
+)


### PR DESCRIPTION
- Adds new files to build resolving missing symbol error
- Use roc namespace for mxDataGenerator
- Attempt to find then fetch rocroller