### PR TITLE
[next-cmake] Add source and headers from Origami

### DIFF
--- a/next-cmake/host-library/include/tensilelite/CMakeLists.txt
+++ b/next-cmake/host-library/include/tensilelite/CMakeLists.txt
@@ -21,6 +21,8 @@
 #
 # ########################################################################
 
+add_subdirectory(analytical)
+
 if(HIPBLASLT_ENABLE_LLVM)
   add_subdirectory(llvm)
 endif()

--- a/next-cmake/host-library/include/tensilelite/analytical/CMakeLists.txt
+++ b/next-cmake/host-library/include/tensilelite/analytical/CMakeLists.txt
@@ -1,0 +1,33 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+set(_CMAKE_CURRENT_SOURCE_DIR "${TEMP_TENSILE_HOST_SOURCE_DIR}/include")
+
+target_sources(hipblaslt
+    PRIVATE
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Tensile/analytical/AnalyticalGemm.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Tensile/analytical/Hardware.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Tensile/analytical/StreamK.hpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/Tensile/analytical/Utils.hpp"
+)
+

--- a/next-cmake/host-library/src/tensilelite/CMakeLists.txt
+++ b/next-cmake/host-library/src/tensilelite/CMakeLists.txt
@@ -57,6 +57,8 @@ target_sources(hipblaslt
 #target_compile_options( TensileHost PUBLIC -Wno-deprecated-declarations -Wno-ignored-attributes -Wdll-attribute-on-redeclaration -fdelayed-template-parsing )
 #endif()
 
+add_subdirectory(analytical)
+
 if(HIPBLASLT_ENABLE_LLVM)
   add_subdirectory(llvm)
 endif()

--- a/next-cmake/host-library/src/tensilelite/analytical/CMakeLists.txt
+++ b/next-cmake/host-library/src/tensilelite/analytical/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ########################################################################
+# Copyright (C) 2025 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ########################################################################
+
+set(_CMAKE_CURRENT_SOURCE_DIR "${TEMP_TENSILE_HOST_SOURCE_DIR}/source")
+
+target_sources(hipblaslt
+    PRIVATE
+        "${_CMAKE_CURRENT_SOURCE_DIR}/analytical/AnalyticalGemm.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/analytical/Hardware.cpp"
+        "${_CMAKE_CURRENT_SOURCE_DIR}/analytical/Utils.cpp"
+)
+


### PR DESCRIPTION
Adds TensileLite::analytical symbols to the next-cmake build.