### PR TITLE
Replace starts_with with compare due to unsupported C++20 function

### DIFF
--- a/tensilelite/rocisa/rocisa/src/pass/insert_delay_alu.cpp
+++ b/tensilelite/rocisa/rocisa/src/pass/insert_delay_alu.cpp
@@ -59,15 +59,15 @@ namespace rocisa
     static DelayALUType _getDelayAluType(const std::shared_ptr<Instruction>& inst)
     {
         auto preStr = inst->preStr();
-        if(preStr.starts_with("v_s_"))
+        if(!preStr.compare(0, 4, "v_s_"))
         {
             return DelayALUType::TRANS;
         }
-        else if(preStr.starts_with("v_"))
+        else if(!preStr.compare(0, 2, "v_"))
         {
             return DelayALUType::VALU;
         }
-        else if(preStr.starts_with("s_"))
+        else if(!preStr.compare(0, 2, "s_"))
         {
             return DelayALUType::SALU;
         }


### PR DESCRIPTION
SWDEV-536358

hipblaslt-test (rhel 8)
```
[----------] Global test environment tear-down
[==========] 38656 tests from 11 test suites ran. (913130 ms total)
[  PASSED  ] 38656 tests.
hipBLASLt version: 100000
hipBLASLt git version: f9cdf916
command line: /hipBLASLt/build/f9cdf9/debug/clients/staging/hipblaslt-test
bash-4.4# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="8.8 (Ootpa)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="8.8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Red Hat Enterprise Linux 8.8 (Ootpa)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:8::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_BUGZILLA_PRODUCT_VERSION=8.8
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="8.8"
```