### PR TITLE
perf. script: Avoid timeout and make this runnable on gfx950

### DIFF
--- a/clients/scripts/performance/problems/matmul_probset1_bench.yaml
+++ b/clients/scripts/performance/problems/matmul_probset1_bench.yaml
@@ -9,10 +9,15 @@ Definitions:
   #   - { transA: T, transB: N }
   #   - { transA: T, transB: T }
 
+# change to f8 for gfx950, otherwise we'll get "no solution found"
+# This also works for gfx942 since client automatically converts f8 to f8n on gfx942
+Real mix precisions: &fp8fp16_precision_dst_fp16
+  - { a_type: f8_r, b_type: f16_r, c_type: f16_r, d_type: f16_r, compute_type: c_f32_fast_f16_r, scale_type: f32_r}
+
 Tests:
 - name: matmul_f8f16_f16
   function:
-    matmul: *fp8fp16_fnuz_precision_dst_fp16
+    matmul: *fp8fp16_precision_dst_fp16
   matrix_size:
     - { M:  16,    N:  16,    K:  1024  }
     - { M:  16,    N:  16,    K:  8192  }
@@ -57,5 +62,4 @@ Tests:
   algo_method: 0
   api_method: 2
   rotating: 512
-  gpu_arch: '94?'
 ...

--- a/clients/scripts/performance/problems/matmul_probset2_bench.yaml
+++ b/clients/scripts/performance/problems/matmul_probset2_bench.yaml
@@ -97,11 +97,12 @@ Tests:
   algo_method: 0
   api_method: 2
   rotating: 512
-  gpu_arch: '94?'
 
-- name: matmul_fp8n_bf16
+# change to f8 for gfx950, otherwise we'll get "no solution found"
+# This also works for gfx942 since client automatically converts f8 to f8n on gfx942
+- name: matmul_fp8_bf16
   function:
-    matmul: *f8_fnuz_precision_dst_bf16
+    matmul: *f8_precision_dst_bf16
   matrix_size:
     - { M:   896,    N:    16,    K:  5120  }
     - { M:   896,    N:    64,    K:  5120  }
@@ -185,5 +186,4 @@ Tests:
   algo_method: 0
   api_method: 2
   rotating: 512
-  gpu_arch: '94?'
 ...

--- a/clients/scripts/performance/suites.py
+++ b/clients/scripts/performance/suites.py
@@ -56,7 +56,8 @@ lengths = {
 def api_overhead():
     """API overhead"""
 
-    problemlist = [Problem(args={"--cold_iters" : "10" , "--iters" : "10000"})]
+    # iteraion 10000 takes too long time for "getAll", 1000 is enough
+    problemlist = [Problem(args={"--cold_iters" : "10" , "--iters" : "1000"})]
     yield ProblemSet(benchType="api_overhead", name="benchset_1", problems=problemlist)
 
 def amax_example():


### PR DESCRIPTION
- [x] api_overhead: getAllSolution always exceed timeout. Reduced the iteration.
- [x] matmul: fixed no solution found on gfx950 due to f8n type. 

Changing f8n to f8 works on both gfx950 and gfx942 since client.cpp automatically converts f8 to f8n when gfx942 is detected.
Though we may run different problem-sets on different arch in the future. This PR is a temporary change for testing gfx950.