### PR TITLE
Check if rocroller target exists before finding for super build context

### DIFF
--- a/next-cmake/CMakeLists.txt
+++ b/next-cmake/CMakeLists.txt
@@ -195,7 +195,7 @@ if(HIPBLASLT_ENABLE_DEVICE)
     endif()
 endif()
 
-if(HIPBLASLT_ENABLE_ROCROLLER)
+if(HIPBLASLT_ENABLE_ROCROLLER AND NOT TARGET roc::rocroller)
     find_package(rocroller REQUIRED)
     option(YAML_CPP_INSTALL "" ON)
     if(NOT rocroller_FOUND)


### PR DESCRIPTION
- To support super builds, conditionally finds rocRoller only if target doesn't already exist.