### PR TITLE
Add missing matrix instruction to Origami

### DIFF
--- a/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
+++ b/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
@@ -90,6 +90,7 @@ namespace TensileLite
                     //----------
                     {MatrixInstruction(32, 32, 64, 8), 64}, // v_mfma_i32_32x32x16_i8
                     {MatrixInstruction(16, 16, 32, 16), 16}, // v_mfma_i32_16x16x32_f16/bf16
+                    {MatrixInstruction(32, 32, 16, 16), 32}, // v_mfma_f32_32x32x16_f16/bf16
                     //----------
                     //TODO these need to be checked.
                     {MatrixInstruction(16, 16, 128, 8), 32}, // V_MFMA_F32_16X16X128_F8

--- a/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
+++ b/tensilelite/Tensile/Source/lib/source/analytical/Hardware.cpp
@@ -65,9 +65,8 @@ namespace TensileLite
                     {MatrixInstruction(16, 16, 8, 32), 16}, // v_mfma_f32_16x16x8_xf32
                     {MatrixInstruction(16, 16, 32, 32), 16}, // v_mfma_f32_16x16x8_xf32
                 }},
-               {Hardware::Architecture::gfx950, //TODO: NEed to make sure these are the right MFMAs
+               {Hardware::Architecture::gfx950, //TODO: Need to make sure these are the right MFMAs
                 {
-                    {MatrixInstruction(16, 16, 32, 8), 16}, // v_mfma_i32_16x16x32_i8
                     {MatrixInstruction(16, 16, 1, 32), 32}, // v_mfma_f32_16x16x1_4b_f32
                     {MatrixInstruction(16, 16, 4, 32), 32}, // v_mfma_f32_16x16x4_f32
                     {MatrixInstruction(16, 16, 4, 64), 32}, // v_mfma_f64_16x16x4_f64


### PR DESCRIPTION
Get rid of:
```
Warning: Latency not found for MI_M=16, MI_N=16, MI_K=128, Element_Size=16. Returning latency value of 32 (really slow).
```