### PR TITLE
Argument list too long when invoking ld.lld

### DIFF
--- a/tensilelite/Tensile/Common/GlobalParameters.py
+++ b/tensilelite/Tensile/Common/GlobalParameters.py
@@ -559,10 +559,6 @@ def assignGlobalParameters(config, isaInfoMap: Dict[IsaVersion, IsaInfo]):
             pass
         else:
             raise
-    globalParameters["ROCmLdPath"] = locateExe(
-        os.path.join(globalParameters["ROCmPath"], "lib/llvm/bin"),
-        "ld.lld" if os.name != "nt" else "ld.lld.exe"
-    )
 
     if "AsanBuild" in config:
         globalParameters["AsanBuild"] = config["AsanBuild"]

--- a/tensilelite/Tensile/TensileCreateLibrary/Run.py
+++ b/tensilelite/Tensile/TensileCreateLibrary/Run.py
@@ -309,7 +309,6 @@ def writeSolutionsAndKernels(
         codeObjectFiles += buildAssemblyCodeObjectFiles(
             asmToolchain.linker,
             asmToolchain.bundler,
-            globalParameters["ROCmLdPath"],
             asmKernels,
             destLibPath,
             assemblyTmpPath,
@@ -389,7 +388,6 @@ def writeSolutionsAndKernelsTCL(
     buildAssemblyCodeObjectFiles(
         asmToolchain.linker,
         asmToolchain.bundler,
-        globalParameters["ROCmLdPath"],
         asmKernels,
         destLibPath,
         assemblyTmpPath,

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -49,28 +49,28 @@ def makeAssemblyToolchain(assembler_path, bundler_path, co_version, build_id_kin
    return AssemblyToolchain(compiler, linker, bundler)
 
 
-def _batchObjectFiles(ldPath: str, objFiles: List[str], coPathDest: Union[Path, str], maxObjFiles: int=10000) -> List[str]:
-    numObjFiles = len(objFiles)
+# def _batchObjectFiles(ldPath: str, objFiles: List[str], coPathDest: Union[Path, str], maxObjFiles: int=10000) -> List[str]:
+#     numObjFiles = len(objFiles)
 
-    if numObjFiles <= maxObjFiles:
-      return objFiles
+#     if numObjFiles <= maxObjFiles:
+#       return objFiles
 
-    batchedObjFiles = [objFiles[i:i+maxObjFiles] for i in range(0, numObjFiles, maxObjFiles)]
-    numBatches = int(math.ceil(numObjFiles / maxObjFiles))
+#     batchedObjFiles = [objFiles[i:i+maxObjFiles] for i in range(0, numObjFiles, maxObjFiles)]
+#     numBatches = int(math.ceil(numObjFiles / maxObjFiles))
 
-    newObjFiles = [str(coPathDest) + "." + str(i) for i in range(0, numBatches)]
-    newObjFilesOutput = []
+#     newObjFiles = [str(coPathDest) + "." + str(i) for i in range(0, numBatches)]
+#     newObjFilesOutput = []
 
-    for batch, filename in zip(batchedObjFiles, newObjFiles):
-      if len(batch) > 1:
-        args = [ldPath, "-r"] + batch + [ "-o", filename]
-        print2(f"Linking object files into fewer object files: {' '.join(args)}")
-        subprocess.check_call(args)
-        newObjFilesOutput.append(filename)
-      else:
-        newObjFilesOutput.append(batchedObjFiles[0])
+#     for batch, filename in zip(batchedObjFiles, newObjFiles):
+#       if len(batch) > 1:
+#         args = [ldPath, "-r"] + batch + [ "-o", filename]
+#         print2(f"Linking object files into fewer object files: {' '.join(args)}")
+#         subprocess.check_call(args)
+#         newObjFilesOutput.append(filename)
+#       else:
+#         newObjFilesOutput.append(batchedObjFiles[0])
 
-    return newObjFilesOutput
+#     return newObjFilesOutput
 
 
 def buildAssemblyCodeObjectFiles(
@@ -118,7 +118,7 @@ def buildAssemblyCodeObjectFiles(
           coFileMap[asmDir / (coName + extCoRaw)].add(str(asmDir / (kernel["BaseName"] + extObj)))
 
       for coFileRaw, objFiles in coFileMap.items():
-        objFiles = _batchObjectFiles(ldPath, objFiles, coFileRaw)
+        # objFiles = _batchObjectFiles(ldPath, objFiles, coFileRaw)
         linker(objFiles, str(coFileRaw))
         coFile = destDir / coFileRaw.name.replace(extCoRaw, extCo)
         if compress:

--- a/tensilelite/Tensile/Toolchain/Assembly.py
+++ b/tensilelite/Tensile/Toolchain/Assembly.py
@@ -49,34 +49,9 @@ def makeAssemblyToolchain(assembler_path, bundler_path, co_version, build_id_kin
    return AssemblyToolchain(compiler, linker, bundler)
 
 
-# def _batchObjectFiles(ldPath: str, objFiles: List[str], coPathDest: Union[Path, str], maxObjFiles: int=10000) -> List[str]:
-#     numObjFiles = len(objFiles)
-
-#     if numObjFiles <= maxObjFiles:
-#       return objFiles
-
-#     batchedObjFiles = [objFiles[i:i+maxObjFiles] for i in range(0, numObjFiles, maxObjFiles)]
-#     numBatches = int(math.ceil(numObjFiles / maxObjFiles))
-
-#     newObjFiles = [str(coPathDest) + "." + str(i) for i in range(0, numBatches)]
-#     newObjFilesOutput = []
-
-#     for batch, filename in zip(batchedObjFiles, newObjFiles):
-#       if len(batch) > 1:
-#         args = [ldPath, "-r"] + batch + [ "-o", filename]
-#         print2(f"Linking object files into fewer object files: {' '.join(args)}")
-#         subprocess.check_call(args)
-#         newObjFilesOutput.append(filename)
-#       else:
-#         newObjFilesOutput.append(batchedObjFiles[0])
-
-#     return newObjFilesOutput
-
-
 def buildAssemblyCodeObjectFiles(
       linker: Linker,
       bundler: Bundler,
-      ldPath: str,
       kernels: List[Solution],
       destDir: Union[Path, str],
       asmDir: Union[Path, str],
@@ -118,7 +93,6 @@ def buildAssemblyCodeObjectFiles(
           coFileMap[asmDir / (coName + extCoRaw)].add(str(asmDir / (kernel["BaseName"] + extObj)))
 
       for coFileRaw, objFiles in coFileMap.items():
-        # objFiles = _batchObjectFiles(ldPath, objFiles, coFileRaw)
         linker(objFiles, str(coFileRaw))
         coFile = destDir / coFileRaw.name.replace(extCoRaw, extCo)
         if compress:


### PR DESCRIPTION
Another instance of "argument list too long error" has cropped up. This time the error is stemming from the ld.lld invocation in _batchObjectFiles(), as opposed to the previous amdclang++ linker issue. This PR resolves this issue by eliminating the intermediate linker step that was previously used to try to and circumvent the error that is now solved downstream via a response file.

The problematic configuration file (F8HS_TN_6.yaml) provided by the tuning team, now completes the tuning workflow:
```bash
$ Tensile/bin/Tensile ../../F8HS_TN_6.yaml _build
...
################################################################################
# Finish Analysing data to /home/<user>/hipBLASLt/tensilelite/_build in 3611.340s
################################################################################
```

**Performance**

- Tensile.py (develop; BBS_TN_26.yaml; gfx950): real    75m49.052s
- Tensile.py (feature without ld.lld step; BBS_TN_26.yaml; gfx950): 73m12.025s
