### PR TITLE
Cherry-pick to release-staging/rocm-rel-7.0: Docs/changelog: Add note about Stream-K support on MI300A (#2240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Full documentation for hipBLASLt is available at [rocm.docs.amd.com/projects/hip
 
 ## hipBLASLt 1.0.0 for ROCm 7.0.0
 
+### Added
+
+* Stream-K GEMM support has been enabled for the `FP32`, `FP16`, `BF16`, `FP8`, and `BF8` data types on the MI300A APU. To activate this feature, set the `TENSILE_SOLUTION_SELECTION_METHOD` environment variable to `2`, for example, `export TENSILE_SOLUTION_SELECTION_METHOD=2`.
+
 ### Changed
 
 * ``HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT`` and ``HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT`` are deprecated, use ``ROCBLASLT_MATMUL_DESC_A_SCALE_MODE`` and ``ROCBLASLT_MATMUL_DESC_B_SCALE_MODE`` attributes to set scalar (``HIPBLASLT_MATMUL_MATRIX_SCALE_SCALAR_32F``) or vector (``HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F``).

--- a/docs/how-to/how-to-use-streamk.rst
+++ b/docs/how-to/how-to-use-streamk.rst
@@ -35,7 +35,13 @@ Set this variable to ``2`` to enable the Stream-K library or leave it set to ``0
    *  The heuristic best kernel is selected from the Stream-K library.
    *  User-driven tuning (tunable ops) considers all kernels from the standard grid, the free-size library, and the Stream-K library.
 
-Configuring the kernel selection strategy
+.. note::
+
+   Stream-K supports a different range of data types on different AMD accelerators. For example, the MI300A APU supports
+   a wider variety of data types, including ``FP32``, ``FP16``, ``BF16``, ``FP8``, and ``BF8``.
+   ``TENSILE_SOLUTION_SELECTION_METHOD=2`` is used to enable Stream-K on all MI300 platforms.
+
+Configuring the kernel launch behavior
 =========================================
 
 You can control The Stream-K kernel launch behavior using the environment variables listed in the following table.


### PR DESCRIPTION
This adds a short note to clarify the Stream-K support on the MI300A along with a release note. It's a docs-only change with no functional impact.

(cherry picked from commit 9103a2bba1afd6f91b4b50c4660976162550f1be)