### PR TITLE
[Flang][ASan]  Switch to LLVM Flang runtime.

### DIFF
--- a/clients/benchmarks/CMakeLists.txt
+++ b/clients/benchmarks/CMakeLists.txt
@@ -89,7 +89,7 @@ if (NOT WIN32)
   if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
     list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
   else()
-    list( APPEND COMMON_LINK_LIBS "-lflang -lflangrti") # for lapack
+    list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
   endif()
 else()
   list( APPEND COMMON_LINK_LIBS "libomp")

--- a/clients/gtest/CMakeLists.txt
+++ b/clients/gtest/CMakeLists.txt
@@ -100,7 +100,7 @@ list( APPEND COMMON_LINK_LIBS "-lm -lstdc++fs")
 if (CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
   list( APPEND COMMON_LINK_LIBS "-lgfortran") # for lapack
 else()
-  list( APPEND COMMON_LINK_LIBS "-lflang -lflangrti") # for lapack
+  list( APPEND COMMON_LINK_LIBS "-lflang_rt.runtime") # for lapack
 endif()
 
 #if (NOT WIN32)


### PR DESCRIPTION
Classic Flang runtime is obsolete and switching to LLVM Flang runtime is invetiable.