### PR TITLE
Deprecate HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT and HIPBLASLT…

### DIFF
--- a/clients/include/testing_auxiliary.hpp
+++ b/clients/include/testing_auxiliary.hpp
@@ -367,7 +367,7 @@ void testing_aux_matmul_set_get_attr(const Arguments& arg)
     
     ASSERT_TRUE(d_bias_r == d_bias);
 
-    // for ROCBLASLT_MATMUL_DESC_A_SCALE_POINTER & ROCBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT
+    // for HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER
     // We create a new matmul_descr becasue we don't dont want to set matmulDesc->scaleAType as Scalar in advance.
     // If we set it as Scalar, it will skip some cases, which is not what we desire for.
     const hipblasOperation_t opA = HIPBLAS_OP_T;
@@ -381,10 +381,6 @@ void testing_aux_matmul_set_get_attr(const Arguments& arg)
     float* d_scale_a_r;
     CHECK_HIP_ERROR(hipMalloc(&d_scale_a, sizeof(float)));
     CHECK_HIP_ERROR(hipMemcpy(d_scale_a, &h_scale_a_for_desc_a_scale_pointer, sizeof(float), hipMemcpyHostToDevice));
-    EXPECT_HIPBLAS_STATUS(hipblasLtMatmulDescSetAttribute(
-                            matmul_descr, HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT, &d_scale_a, sizeof(void*)),
-                        HIPBLAS_STATUS_SUCCESS); // this is necessary to cover in set
-
     EXPECT_HIPBLAS_STATUS(hipblasLtMatmulDescSetAttribute(
                             matmul_descr, HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER, &d_scale_a, sizeof(float*)/2),
                         HIPBLAS_STATUS_INVALID_VALUE);
@@ -529,20 +525,12 @@ void testing_aux_matmul_set_get_attr(const Arguments& arg)
     hipStream_t        stream;
     CHECK_HIP_ERROR(hipStreamCreate(&stream));
 
-    // for HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT & ROCBLASLT_MATMUL_DESC_B_SCALE_POINTER 
+    // for HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER
     float h_scale_b = 3.f;
     float* d_scale_b;
     float* d_scale_b_r;
     CHECK_HIP_ERROR(hipMalloc(&d_scale_b, sizeof(float)));
     CHECK_HIP_ERROR(hipMemcpyAsync(d_scale_b, &h_scale_b, sizeof(float), hipMemcpyHostToDevice, stream));
-
-    EXPECT_HIPBLAS_STATUS(hipblasLtMatmulDescSetAttribute(
-                            matmul, HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT, &d_scale_b, sizeof(float*)),
-                        HIPBLAS_STATUS_SUCCESS);
-
-    EXPECT_HIPBLAS_STATUS(hipblasLtMatmulDescSetAttribute(
-                            matmul, HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT, &d_scale_b, sizeof(float*)/2),
-                        HIPBLAS_STATUS_INVALID_VALUE);
 
     EXPECT_HIPBLAS_STATUS(hipblasLtMatmulDescSetAttribute(
                             matmul, HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER, &d_scale_b, sizeof(float*)/2),

--- a/library/include/hipblaslt/hipblaslt.h
+++ b/library/include/hipblaslt/hipblaslt.h
@@ -74,6 +74,11 @@
 #define HIPBLASLT_OPERATION_INVALID static_cast<hipblasOperation_t>(0)
 #define ROCBLASLT_COMPUTE_TYPE_INVALID static_cast<rocblaslt_compute_type>(255)
 
+#define HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT \
+    static_assert(false, "HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT is deprecated and not supported. Please set HIPBLASLT_MATMUL_DESC_A_SCALE_MODE as HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F instead.")
+#define HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT \
+    static_assert(false, "HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT is deprecated and not supported. Please set HIPBLASLT_MATMUL_DESC_B_SCALE_MODE as HIPBLASLT_MATMUL_MATRIX_SCALE_OUTER_VEC_32F instead.")
+
 /*! \ingroup types_module
  *  \brief Specify the enum type to set the postprocessing options for the epilogue.
  */
@@ -187,8 +192,6 @@ typedef enum {
   HIPBLASLT_MATMUL_DESC_B_SCALE_MODE = 32,                   /**<Scaling mode that defines how the matrix scaling factor for matrix B is interpreted. See hipblasLtMatmulMatrixScale_t */
   HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_A_EXT = 100,     /**<Compute input A types. Defines the data type used for the input A of matrix multiply. */
   HIPBLASLT_MATMUL_DESC_COMPUTE_INPUT_TYPE_B_EXT,           /**<Compute input B types. Defines the data type used for the input B of matrix multiply. */
-  HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER_VEC_EXT,        /**<Equivalent to HIPBLASLT_MATMUL_DESC_A_SCALE_POINTER but in vector. Default value: NULL Type: void* /const void* */
-  HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT,        /**<Equivalent to HIPBLASLT_MATMUL_DESC_B_SCALE_POINTER but in vector. Default value: NULL Type: void* /const void* */
   HIPBLASLT_MATMUL_DESC_MAX,
 } hipblasLtMatmulDescAttributes_t;
 


### PR DESCRIPTION
…_MATMUL_DESC_B_SCALE_POINTER_VEC_EXT
user would hit compile error if user still try to use these 2 attributes.
![image](https://github.com/user-attachments/assets/5714bd0c-a433-4207-af83-363498a9b5bd)
