### PR TITLE
Add fixed WGM mode for debugging

### DIFF
--- a/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
+++ b/tensilelite/Tensile/Source/lib/include/Tensile/AMDGPU.hpp
@@ -228,6 +228,7 @@ namespace TensileLite
         int         computeUnitCount = 0;
         int         skDynamicGrid    = 6;
         int         skDynamicWGM     = 0;
+        int         skFixedWGM       = 0;
         int         skMaxCUs         = 0;
         int         skGridMultiplier = 1;
         int         skFixedGrid      = 0;
@@ -259,6 +260,13 @@ namespace TensileLite
         const int getSKDynamicWGM() const
         {
             static const char* envStr = std::getenv("TENSILE_STREAMK_DYNAMIC_WGM");
+            static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
+            return value;
+        }
+
+        const int getSKFixedWGM() const
+        {
+            static const char* envStr = std::getenv("TENSILE_STREAMK_FIXED_WGM");
             static const int   value  = (envStr == NULL ? 0 : std::atoi(envStr));
             return value;
         }

--- a/tensilelite/Tensile/Source/lib/source/AMDGPU.cpp
+++ b/tensilelite/Tensile/Source/lib/source/AMDGPU.cpp
@@ -48,6 +48,7 @@ namespace TensileLite
         , deviceName(name)
         , skDynamicGrid(getSKDynamicGrid())
         , skDynamicWGM(getSKDynamicWGM())
+        , skFixedWGM(getSKFixedWGM())
         , skMaxCUs(getSKMaxCUs())
         , skGridMultiplier(getSKGridMultiplier())
         , skFixedGrid(getSKFixedGrid())

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1240,7 +1240,7 @@ namespace TensileLite
         if(internalArgsSupport.useUniversalArgs)
         {
             auto defaultWGM = sizeMapping.workGroupMapping;
-            // Enable Origami dynamic WGM mapping for all kernels
+            // Allow Origami dynamic WGM mapping for all kernels (enabled by setting TENSILE_STREAMK_DYNAMIC_WGM)
             {
                 AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
                 if(pAMDGPU->skFixedWGM != 0)

--- a/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
+++ b/tensilelite/Tensile/Source/lib/source/ContractionSolution.cpp
@@ -1240,10 +1240,12 @@ namespace TensileLite
         if(internalArgsSupport.useUniversalArgs)
         {
             auto defaultWGM = sizeMapping.workGroupMapping;
-            if(sizeMapping.streamK != 0)
+            // Enable Origami dynamic WGM mapping for all kernels
             {
                 AMDGPU const* pAMDGPU = dynamic_cast<AMDGPU const*>(&hardware);
-                if(pAMDGPU->skDynamicWGM == 1)
+                if(pAMDGPU->skFixedWGM != 0)
+                    defaultWGM = pAMDGPU->skFixedWGM;
+                else if(pAMDGPU->skDynamicWGM == 1)
                 {
                     hip::HipAMDGPU const* hipAMDGPU
                         = dynamic_cast<hip::HipAMDGPU const*>(&hardware);


### PR DESCRIPTION
Adds an environment variable that allows you to override the value of WGM. Useful for debugging Origami's dynamic WGM mode. This change also extends dynamic WGM to work with all kernels. Dynamic WGM is off by default, but can be tested by setting the environment variable to enable it.