### PR TITLE
Allow StreamK+DTL by moving streamK sgpr args above DTL sgprs

### DIFF
--- a/tensilelite/Tensile/KernelWriter.py
+++ b/tensilelite/Tensile/KernelWriter.py
@@ -4673,6 +4673,25 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.defineSgpr("Beta", numSgprBeta, numSgprBeta)
       self.states.numSgprBeta = numSgprBeta
 
+    if kernel["StreamK"]:
+      # StreamK args
+      self.defineSgpr("MagicNumberProblemNumGroupTiles0", 1) # Magic number to use for division
+      self.defineSgpr("MagicShiftProblemNumGroupTiles0", 1) # Magic shift/abit to use for division alg 2
+      self.defineSgpr("ItersPerTile", 1)
+      self.defineSgpr("MagicNumberItersPerTile", 1)
+      self.defineSgpr("MagicShiftItersPerTile", 1)
+      self.defineSgpr("MagicNumProblemNumGroupTiles0By1", 1)  # for PKAB, use for Magic Div Alg 2 by (nwg0*nwg1)
+      self.defineSgpr("MagicShiftProblemNumGroupTiles0By1", 1)  # for PKAB, use for Magic Div Alg 2 by (nwg0*nwg1)
+      self.defineSgpr("TotalIters", 1)
+      self.defineSgpr("SKItersPerWG", 1)
+      self.states.numSgprStreamK += 9
+      if kernel["StreamK"] >= 2: # Two-tile SK
+        self.defineSgpr("skGrid", 1)
+        self.defineSgpr("skTiles", 1)
+        self.defineSgpr("skExtraIters", 1)
+        # self.defineSgpr("dpTilesPerWG", 1, kernarg=True)
+        self.states.numSgprStreamK += 3
+
     if kernel["LocalWriteUseSgprA"]:
         self.defineSgpr("LocalWriteAddrA", 1)
     if kernel["LocalWriteUseSgprB"]:
@@ -4695,25 +4714,6 @@ class KernelWriter(metaclass=abc.ABCMeta):
       self.states.numSgprAddressGSUSync += 2
       self.defineSgpr("GSUSync", 1)
       self.states.numSgprAddressGSUSync += 1
-
-    if kernel["StreamK"]:
-      # StreamK args
-      self.defineSgpr("MagicNumberProblemNumGroupTiles0", 1) # Magic number to use for division
-      self.defineSgpr("MagicShiftProblemNumGroupTiles0", 1) # Magic shift/abit to use for division alg 2
-      self.defineSgpr("ItersPerTile", 1)
-      self.defineSgpr("MagicNumberItersPerTile", 1)
-      self.defineSgpr("MagicShiftItersPerTile", 1)
-      self.defineSgpr("MagicNumProblemNumGroupTiles0By1", 1)  # for PKAB, use for Magic Div Alg 2 by (nwg0*nwg1)
-      self.defineSgpr("MagicShiftProblemNumGroupTiles0By1", 1)  # for PKAB, use for Magic Div Alg 2 by (nwg0*nwg1)
-      self.defineSgpr("TotalIters", 1)
-      self.defineSgpr("SKItersPerWG", 1)
-      self.states.numSgprStreamK += 9
-      if kernel["StreamK"] >= 2: # Two-tile SK
-        self.defineSgpr("skGrid", 1)
-        self.defineSgpr("skTiles", 1)
-        self.defineSgpr("skExtraIters", 1)
-        # self.defineSgpr("dpTilesPerWG", 1, kernarg=True)
-        self.states.numSgprStreamK += 3
 
     if kernel["GlobalSplitU"] != 0:
       self.defineSgpr("GSU", 1)  # Can't move to the front because of the preload arguments

--- a/tensilelite/Tensile/SolutionStructs/Solution.py
+++ b/tensilelite/Tensile/SolutionStructs/Solution.py
@@ -779,11 +779,6 @@ class Solution(collections.abc.Mapping):
       reject(state, printRejectionReason, "DirectToLds is for MatrixInstruction only for now (tentative)")
       return False
 
-    # so far, DirectToLds does not work with StreamK (TODO: enable StreamK case)
-    if state["StreamK"]:
-      reject(state, printRejectionReason, "DirectToLds does not support StreamK (tentative)")
-      return False
-
     # ToDo: Review def of lrvw and this check
     # DTL + LocalReadVectorWidth > MIInputPerThread does not work
     # Need support for TailLoop


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/hipBLASLt/pull/2260 into release-staging/rocm-rel-7.0. Opening early to ensure this can get in regardless of monorepo migration.