### PR TITLE
[fix] Now non-swizzled stride can be less than lda*A_col

### DIFF
--- a/clients/gtest/matmul_gtest.yaml
+++ b/clients/gtest/matmul_gtest.yaml
@@ -846,6 +846,24 @@ Tests:
   unit_check: 1
   gpu_arch: '942'
 
+- name: matmul_swizzleA_stride0
+  category: pre_checkin
+  function:
+    matmul: *real_precisions_swizzleA_support
+  M: [128, 129]
+  N: [128, 129]
+  K: [128, 129]
+  lda: [129, 2440]
+  batch_count: 5
+  stride_a: 0
+  transA: T
+  transB: N
+  alpha: 1
+  beta: [ 0.0, 2.0 ]
+  bias_vector: [0, 1]
+  unit_check: 1
+  gpu_arch: '942'
+
 - name: matmul_swizzleA
   category: pre_checkin
   function:
@@ -855,7 +873,6 @@ Tests:
   K: [128, 129]
   lda: [129, 2440]
   batch_count: [1, 5]
-  stride_a: 0
   transA: T
   transB: N
   alpha: 1

--- a/clients/include/testing_matmul.hpp
+++ b/clients/include/testing_matmul.hpp
@@ -1376,26 +1376,33 @@ void testing_matmul_with_bias(const Arguments& arg,
         do_batched[i]  = (arg.batch_count > 1);
         num_batches[i] = (do_batched[i] ? arg.batch_count : 1);
 
-        stride_a[i] = (do_batched[i] && arg.stride_a[i] >= lda[i] * A_col[i]) ? arg.stride_a[i]
-                                                                              : lda[i] * A_col[i];
+        stride_a[i] = do_batched[i] ? arg.stride_a[i] : lda[i] * A_col[i];
         stride_b[i] = do_batched[i] ? arg.stride_b[i] : ldb[i] * B_col[i];
         stride_c[i] = do_batched[i] ? arg.stride_c[i] : ldc[i] * N[i];
         stride_d[i] = do_batched[i] ? arg.stride_c[i] : ldd[i] * N[i];
         stride_e[i] = do_batched[i] ? arg.stride_e[i] : lde[i] * N[i];
 
-        size_A[i]    = stride_a[i] * num_batches[i];
+        size_A[i]
+            = stride_a[i] == 0 ? lda[i] * A_col[i] * num_batches[i] : stride_a[i] * num_batches[i];
         size_dA[i]   = size_A[i];
         stride_da[i] = stride_a[i];
         if(arg.swizzle_a && isSwizzleSupported(TiA))
         {
+            //TODO:
+            // 1. support stride_a is 0 when swizzle
+            // 2. support any stride_a for swizzled
+            // 3. support --any_stride for bench when swizzle
+            stride_a[i] = lda[i] * A_col[i];
             stride_da[i] = 0;
             size_t MiM = 16, MiK = 0, __ = 0, PackK = 0;
             calculateKforSwizzling(TiA, arg, MiK, __, PackK);
             size_t K_block = MiK * PackK;
             size_t stride_swizzle
                 = ((M[i] + MiM - 1) / MiM) * MiM * ((K[i] + K_block - 1) / K_block) * K_block;
-            if(do_batched[i] && arg.stride_a[i] >= (int64_t)stride_swizzle)
+            if(do_batched[i] && arg.stride_a[i] > 0 && arg.stride_a[i] != lda[i] * A_col[i])
             {
+                hipblaslt_cerr << "Error stride_a: swizzle_a does not yet support arbitrary stride_a!" << std::endl;
+
                 stride_da[i]   = arg.stride_a[i];
                 stride_swizzle = (size_t)arg.stride_a[i];
             }


### PR DESCRIPTION
[0;32m[----------] [mGlobal test environment tear-down
[0;32m[==========] [m55416 tests from 11 test suites ran. (2748259 ms total)
[0;32m[  PASSED  ] [m55416 tests.
hipBLASLt version: 100100
hipBLASLt git version: 7b272367-dirty
command line: ./hipBLASLt/build/release/clients/staging/hipblaslt-test --gtest_output=xml --gtest_color=yes --gtest_repeat=1 